### PR TITLE
Add doc feature requirements for interface traits

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -317,10 +317,14 @@ impl<'a> Gen<'a> {
             quote! {}
         } else {
             let mut tokens = format!(r#"`\"{}\"`"#, to_feature(self.namespace));
-
             let features = cfg_features(cfg, self.namespace);
+
             for features in features {
                 write!(tokens, r#", `\"{}\"`"#, to_feature(features)).unwrap();
+            }
+
+            if cfg.implement {
+                tokens.push_str(r#", `\"implement\"`"#)
             }
 
             format!(r#"#[doc = "*Required features: {tokens}*"]"#).into()

--- a/crates/libs/bindgen/src/implements.rs
+++ b/crates/libs/bindgen/src/implements.rs
@@ -14,6 +14,7 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
     let generic_names = gen.generic_names(generics);
     let named_phantoms = gen.generic_named_phantoms(generics);
     let cfg = gen.reader.type_def_cfg_impl(def, generics);
+    let doc = gen.cfg_doc(&cfg);
     let features = gen.cfg_features(&cfg);
     let mut requires = quote! {};
     let type_ident = quote! { #type_ident<#generic_names> };
@@ -124,6 +125,7 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
 
     if has_unknown_base {
         quote! {
+            #doc
             #features
             pub trait #impl_ident<#generic_names> : Sized #requires where #constraints {
                 #(#method_traits)*
@@ -145,6 +147,7 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
         }
     } else {
         quote! {
+            #doc
             #features
             pub trait #impl_ident : Sized #requires {
                 #(#method_traits)*

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -144,6 +144,7 @@ pub struct SignatureParam {
 pub struct Cfg<'a> {
     pub types: BTreeMap<&'a str, BTreeSet<TypeDef>>,
     pub arches: BTreeSet<&'static str>,
+    pub implement: bool,
 }
 
 impl<'a> Cfg<'a> {
@@ -1176,6 +1177,7 @@ impl<'a> Reader<'a> {
     }
     pub fn type_def_cfg_impl(&self, def: TypeDef, generics: &[Type]) -> Cfg {
         let mut cfg = Cfg::default();
+        cfg.implement = true;
 
         fn combine<'a>(reader: &'a Reader, def: TypeDef, generics: &[Type], cfg: &mut Cfg<'a>) {
             reader.type_def_cfg_combine(def, generics, cfg);

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/impl.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"AI_MachineLearning\"`, `\"implement\"`*"]
 pub trait ILearningModelFeatureDescriptor_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn Description(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -69,6 +70,7 @@ impl ILearningModelFeatureDescriptor_Vtbl {
         iid == &<ILearningModelFeatureDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"AI_MachineLearning\"`, `\"implement\"`*"]
 pub trait ILearningModelFeatureValue_Impl: Sized {
     fn Kind(&self) -> ::windows::core::Result<LearningModelFeatureKind>;
 }
@@ -95,6 +97,7 @@ impl ILearningModelFeatureValue_Vtbl {
         iid == &<ILearningModelFeatureValue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"AI_MachineLearning\"`, `\"implement\"`*"]
 pub trait ILearningModelOperatorProvider_Impl: Sized {}
 impl ::windows::core::RuntimeName for ILearningModelOperatorProvider {
     const NAME: &'static str = "Windows.AI.MachineLearning.ILearningModelOperatorProvider";
@@ -107,6 +110,7 @@ impl ILearningModelOperatorProvider_Vtbl {
         iid == &<ILearningModelOperatorProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"AI_MachineLearning\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait ITensor_Impl: Sized + ILearningModelFeatureValue_Impl {
     fn TensorKind(&self) -> ::windows::core::Result<TensorKind>;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Activation/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Activation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IActivatedEventArgs_Impl: Sized {
     fn Kind(&self) -> ::windows::core::Result<ActivationKind>;
     fn PreviousExecutionState(&self) -> ::windows::core::Result<ApplicationExecutionState>;
@@ -55,6 +56,7 @@ impl IActivatedEventArgs_Vtbl {
         iid == &<IActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"System\"`, `\"implement\"`*"]
 #[cfg(feature = "System")]
 pub trait IActivatedEventArgsWithUser_Impl: Sized + IActivatedEventArgs_Impl {
     fn User(&self) -> ::windows::core::Result<super::super::System::User>;
@@ -84,6 +86,7 @@ impl IActivatedEventArgsWithUser_Vtbl {
         iid == &<IActivatedEventArgsWithUser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IApplicationViewActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn CurrentlyShownApplicationViewId(&self) -> ::windows::core::Result<i32>;
 }
@@ -113,6 +116,7 @@ impl IApplicationViewActivatedEventArgs_Vtbl {
         iid == &<IApplicationViewActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IAppointmentsProviderActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Verb(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -142,6 +146,7 @@ impl IAppointmentsProviderActivatedEventArgs_Vtbl {
         iid == &<IAppointmentsProviderActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Appointments_AppointmentsProvider\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Appointments_AppointmentsProvider")]
 pub trait IAppointmentsProviderAddAppointmentActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IAppointmentsProviderActivatedEventArgs_Impl {
     fn AddAppointmentOperation(&self) -> ::windows::core::Result<super::Appointments::AppointmentsProvider::AddAppointmentOperation>;
@@ -174,6 +179,7 @@ impl IAppointmentsProviderAddAppointmentActivatedEventArgs_Vtbl {
         iid == &<IAppointmentsProviderAddAppointmentActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Appointments_AppointmentsProvider\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Appointments_AppointmentsProvider")]
 pub trait IAppointmentsProviderRemoveAppointmentActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IAppointmentsProviderActivatedEventArgs_Impl {
     fn RemoveAppointmentOperation(&self) -> ::windows::core::Result<super::Appointments::AppointmentsProvider::RemoveAppointmentOperation>;
@@ -206,6 +212,7 @@ impl IAppointmentsProviderRemoveAppointmentActivatedEventArgs_Vtbl {
         iid == &<IAppointmentsProviderRemoveAppointmentActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Appointments_AppointmentsProvider\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Appointments_AppointmentsProvider")]
 pub trait IAppointmentsProviderReplaceAppointmentActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IAppointmentsProviderActivatedEventArgs_Impl {
     fn ReplaceAppointmentOperation(&self) -> ::windows::core::Result<super::Appointments::AppointmentsProvider::ReplaceAppointmentOperation>;
@@ -238,6 +245,7 @@ impl IAppointmentsProviderReplaceAppointmentActivatedEventArgs_Vtbl {
         iid == &<IAppointmentsProviderReplaceAppointmentActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IAppointmentsProviderActivatedEventArgs_Impl {
     fn InstanceStartDate(&self) -> ::windows::core::Result<super::super::Foundation::IReference<super::super::Foundation::DateTime>>;
@@ -298,6 +306,7 @@ impl IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs_Vtbl {
         iid == &<IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IAppointmentsProviderShowTimeFrameActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IAppointmentsProviderActivatedEventArgs_Impl {
     fn TimeToShow(&self) -> ::windows::core::Result<super::super::Foundation::DateTime>;
@@ -344,6 +353,7 @@ impl IAppointmentsProviderShowTimeFrameActivatedEventArgs_Vtbl {
         iid == &<IAppointmentsProviderShowTimeFrameActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Background\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Background")]
 pub trait IBackgroundActivatedEventArgs_Impl: Sized {
     fn TaskInstance(&self) -> ::windows::core::Result<super::Background::IBackgroundTaskInstance>;
@@ -376,6 +386,7 @@ impl IBackgroundActivatedEventArgs_Vtbl {
         iid == &<IBackgroundActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IBarcodeScannerPreviewActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn ConnectionId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -405,6 +416,7 @@ impl IBarcodeScannerPreviewActivatedEventArgs_Vtbl {
         iid == &<IBarcodeScannerPreviewActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Storage_Provider\"`, `\"implement\"`*"]
 #[cfg(feature = "Storage_Provider")]
 pub trait ICachedFileUpdaterActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn CachedFileUpdaterUI(&self) -> ::windows::core::Result<super::super::Storage::Provider::CachedFileUpdaterUI>;
@@ -437,6 +449,7 @@ impl ICachedFileUpdaterActivatedEventArgs_Vtbl {
         iid == &<ICachedFileUpdaterActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait ICameraSettingsActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn VideoDeviceController(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
     fn VideoDeviceExtension(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
@@ -480,6 +493,7 @@ impl ICameraSettingsActivatedEventArgs_Vtbl {
         iid == &<ICameraSettingsActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait ICommandLineActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Operation(&self) -> ::windows::core::Result<CommandLineActivationOperation>;
 }
@@ -509,6 +523,7 @@ impl ICommandLineActivatedEventArgs_Vtbl {
         iid == &<ICommandLineActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IContactActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Verb(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -535,6 +550,7 @@ impl IContactActivatedEventArgs_Vtbl {
         iid == &<IContactActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Contacts")]
 pub trait IContactCallActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContactActivatedEventArgs_Impl {
     fn ServiceId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -595,6 +611,7 @@ impl IContactCallActivatedEventArgs_Vtbl {
         iid == &<IContactCallActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Contacts")]
 pub trait IContactMapActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContactActivatedEventArgs_Impl {
     fn Address(&self) -> ::windows::core::Result<super::Contacts::ContactAddress>;
@@ -641,6 +658,7 @@ impl IContactMapActivatedEventArgs_Vtbl {
         iid == &<IContactMapActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Contacts")]
 pub trait IContactMessageActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContactActivatedEventArgs_Impl {
     fn ServiceId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -701,6 +719,7 @@ impl IContactMessageActivatedEventArgs_Vtbl {
         iid == &<IContactMessageActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Contacts")]
 pub trait IContactPanelActivatedEventArgs_Impl: Sized {
     fn ContactPanel(&self) -> ::windows::core::Result<super::Contacts::ContactPanel>;
@@ -747,6 +766,7 @@ impl IContactPanelActivatedEventArgs_Vtbl {
         iid == &<IContactPanelActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Contacts_Provider\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Contacts_Provider")]
 pub trait IContactPickerActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn ContactPickerUI(&self) -> ::windows::core::Result<super::Contacts::Provider::ContactPickerUI>;
@@ -779,6 +799,7 @@ impl IContactPickerActivatedEventArgs_Vtbl {
         iid == &<IContactPickerActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Contacts")]
 pub trait IContactPostActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContactActivatedEventArgs_Impl {
     fn ServiceId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -839,6 +860,7 @@ impl IContactPostActivatedEventArgs_Vtbl {
         iid == &<IContactPostActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Contacts")]
 pub trait IContactVideoCallActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContactActivatedEventArgs_Impl {
     fn ServiceId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -899,6 +921,7 @@ impl IContactVideoCallActivatedEventArgs_Vtbl {
         iid == &<IContactVideoCallActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IContactsProviderActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Verb(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -925,6 +948,7 @@ impl IContactsProviderActivatedEventArgs_Vtbl {
         iid == &<IContactsProviderActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IContinuationActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn ContinuationData(&self) -> ::windows::core::Result<super::super::Foundation::Collections::ValueSet>;
@@ -957,6 +981,7 @@ impl IContinuationActivatedEventArgs_Vtbl {
         iid == &<IContinuationActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IDeviceActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn DeviceInformationId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn Verb(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -1000,6 +1025,7 @@ impl IDeviceActivatedEventArgs_Vtbl {
         iid == &<IDeviceActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Devices_Enumeration\"`, `\"implement\"`*"]
 #[cfg(feature = "Devices_Enumeration")]
 pub trait IDevicePairingActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn DeviceInformation(&self) -> ::windows::core::Result<super::super::Devices::Enumeration::DeviceInformation>;
@@ -1032,6 +1058,7 @@ impl IDevicePairingActivatedEventArgs_Vtbl {
         iid == &<IDevicePairingActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IDialReceiverActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + ILaunchActivatedEventArgs_Impl {
     fn AppName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -1061,6 +1088,7 @@ impl IDialReceiverActivatedEventArgs_Vtbl {
         iid == &<IDialReceiverActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"Storage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage"))]
 pub trait IFileActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Files(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVectorView<super::super::Storage::IStorageItem>>;
@@ -1107,6 +1135,7 @@ impl IFileActivatedEventArgs_Vtbl {
         iid == &<IFileActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IFileActivatedEventArgsWithCallerPackageFamilyName_Impl: Sized + IActivatedEventArgs_Impl {
     fn CallerPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -1136,6 +1165,7 @@ impl IFileActivatedEventArgsWithCallerPackageFamilyName_Vtbl {
         iid == &<IFileActivatedEventArgsWithCallerPackageFamilyName as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"Storage_Search\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage_Search"))]
 pub trait IFileActivatedEventArgsWithNeighboringFiles_Impl: Sized + IActivatedEventArgs_Impl + IFileActivatedEventArgs_Impl {
     fn NeighboringFilesQuery(&self) -> ::windows::core::Result<super::super::Storage::Search::StorageFileQueryResult>;
@@ -1168,6 +1198,7 @@ impl IFileActivatedEventArgsWithNeighboringFiles_Vtbl {
         iid == &<IFileActivatedEventArgsWithNeighboringFiles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Storage_Pickers_Provider\"`, `\"implement\"`*"]
 #[cfg(feature = "Storage_Pickers_Provider")]
 pub trait IFileOpenPickerActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn FileOpenPickerUI(&self) -> ::windows::core::Result<super::super::Storage::Pickers::Provider::FileOpenPickerUI>;
@@ -1200,6 +1231,7 @@ impl IFileOpenPickerActivatedEventArgs_Vtbl {
         iid == &<IFileOpenPickerActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IFileOpenPickerActivatedEventArgs2_Impl: Sized {
     fn CallerPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -1229,6 +1261,7 @@ impl IFileOpenPickerActivatedEventArgs2_Vtbl {
         iid == &<IFileOpenPickerActivatedEventArgs2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"Storage\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage", feature = "deprecated"))]
 pub trait IFileOpenPickerContinuationEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContinuationActivatedEventArgs_Impl {
     fn Files(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVectorView<super::super::Storage::StorageFile>>;
@@ -1261,6 +1294,7 @@ impl IFileOpenPickerContinuationEventArgs_Vtbl {
         iid == &<IFileOpenPickerContinuationEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Storage_Pickers_Provider\"`, `\"implement\"`*"]
 #[cfg(feature = "Storage_Pickers_Provider")]
 pub trait IFileSavePickerActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn FileSavePickerUI(&self) -> ::windows::core::Result<super::super::Storage::Pickers::Provider::FileSavePickerUI>;
@@ -1293,6 +1327,7 @@ impl IFileSavePickerActivatedEventArgs_Vtbl {
         iid == &<IFileSavePickerActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IFileSavePickerActivatedEventArgs2_Impl: Sized {
     fn CallerPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn EnterpriseId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -1336,6 +1371,7 @@ impl IFileSavePickerActivatedEventArgs2_Vtbl {
         iid == &<IFileSavePickerActivatedEventArgs2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"Storage\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage", feature = "deprecated"))]
 pub trait IFileSavePickerContinuationEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContinuationActivatedEventArgs_Impl {
     fn File(&self) -> ::windows::core::Result<super::super::Storage::StorageFile>;
@@ -1368,6 +1404,7 @@ impl IFileSavePickerContinuationEventArgs_Vtbl {
         iid == &<IFileSavePickerContinuationEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"Storage\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage", feature = "deprecated"))]
 pub trait IFolderPickerContinuationEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContinuationActivatedEventArgs_Impl {
     fn Folder(&self) -> ::windows::core::Result<super::super::Storage::StorageFolder>;
@@ -1400,6 +1437,7 @@ impl IFolderPickerContinuationEventArgs_Vtbl {
         iid == &<IFolderPickerContinuationEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait ILaunchActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Arguments(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn TileId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -1443,6 +1481,7 @@ impl ILaunchActivatedEventArgs_Vtbl {
         iid == &<ILaunchActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait ILaunchActivatedEventArgs2_Impl: Sized + IActivatedEventArgs_Impl + ILaunchActivatedEventArgs_Impl {
     fn TileActivatedInfo(&self) -> ::windows::core::Result<TileActivatedInfo>;
 }
@@ -1472,6 +1511,7 @@ impl ILaunchActivatedEventArgs2_Vtbl {
         iid == &<ILaunchActivatedEventArgs2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait ILockScreenActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Info(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
 }
@@ -1498,6 +1538,7 @@ impl ILockScreenActivatedEventArgs_Vtbl {
         iid == &<ILockScreenActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Calls\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Calls")]
 pub trait ILockScreenCallActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl + ILaunchActivatedEventArgs_Impl {
     fn CallUI(&self) -> ::windows::core::Result<super::Calls::LockScreenCallUI>;
@@ -1530,6 +1571,7 @@ impl ILockScreenCallActivatedEventArgs_Vtbl {
         iid == &<ILockScreenCallActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IPhoneCallActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn LineId(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -1556,6 +1598,7 @@ impl IPhoneCallActivatedEventArgs_Vtbl {
         iid == &<IPhoneCallActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IPickerReturnedActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn PickerOperationId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -1585,6 +1628,7 @@ impl IPickerReturnedActivatedEventArgs_Vtbl {
         iid == &<IPickerReturnedActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IPrelaunchActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn PrelaunchActivated(&self) -> ::windows::core::Result<bool>;
 }
@@ -1614,6 +1658,7 @@ impl IPrelaunchActivatedEventArgs_Vtbl {
         iid == &<IPrelaunchActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Devices_Printers_Extensions\"`, `\"implement\"`*"]
 #[cfg(feature = "Devices_Printers_Extensions")]
 pub trait IPrint3DWorkflowActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Workflow(&self) -> ::windows::core::Result<super::super::Devices::Printers::Extensions::Print3DWorkflow>;
@@ -1646,6 +1691,7 @@ impl IPrint3DWorkflowActivatedEventArgs_Vtbl {
         iid == &<IPrint3DWorkflowActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Devices_Printers_Extensions\"`, `\"implement\"`*"]
 #[cfg(feature = "Devices_Printers_Extensions")]
 pub trait IPrintTaskSettingsActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Configuration(&self) -> ::windows::core::Result<super::super::Devices::Printers::Extensions::PrintTaskConfiguration>;
@@ -1678,6 +1724,7 @@ impl IPrintTaskSettingsActivatedEventArgs_Vtbl {
         iid == &<IPrintTaskSettingsActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IProtocolActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Uri(&self) -> ::windows::core::Result<super::super::Foundation::Uri>;
@@ -1707,6 +1754,7 @@ impl IProtocolActivatedEventArgs_Vtbl {
         iid == &<IProtocolActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData_Impl: Sized + IActivatedEventArgs_Impl {
     fn CallerPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -1753,6 +1801,7 @@ impl IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData_Vtbl {
         iid == &<IProtocolActivatedEventArgsWithCallerPackageFamilyNameAndData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"System\"`, `\"implement\"`*"]
 #[cfg(feature = "System")]
 pub trait IProtocolForResultsActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn ProtocolForResultsOperation(&self) -> ::windows::core::Result<super::super::System::ProtocolForResultsOperation>;
@@ -1785,6 +1834,7 @@ impl IProtocolForResultsActivatedEventArgs_Vtbl {
         iid == &<IProtocolForResultsActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IRestrictedLaunchActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn SharedContext(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
 }
@@ -1814,6 +1864,7 @@ impl IRestrictedLaunchActivatedEventArgs_Vtbl {
         iid == &<IRestrictedLaunchActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait ISearchActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn QueryText(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn Language(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -1857,6 +1908,7 @@ impl ISearchActivatedEventArgs_Vtbl {
         iid == &<ISearchActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Search\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_Search")]
 pub trait ISearchActivatedEventArgsWithLinguisticDetails_Impl: Sized {
     fn LinguisticDetails(&self) -> ::windows::core::Result<super::Search::SearchPaneQueryLinguisticDetails>;
@@ -1889,6 +1941,7 @@ impl ISearchActivatedEventArgsWithLinguisticDetails_Vtbl {
         iid == &<ISearchActivatedEventArgsWithLinguisticDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_DataTransfer_ShareTarget\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_DataTransfer_ShareTarget")]
 pub trait IShareTargetActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn ShareOperation(&self) -> ::windows::core::Result<super::DataTransfer::ShareTarget::ShareOperation>;
@@ -1921,6 +1974,7 @@ impl IShareTargetActivatedEventArgs_Vtbl {
         iid == &<IShareTargetActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"implement\"`*"]
 pub trait IStartupTaskActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn TaskId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -1947,6 +2001,7 @@ impl IStartupTaskActivatedEventArgs_Vtbl {
         iid == &<IStartupTaskActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IToastNotificationActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Argument(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -1993,6 +2048,7 @@ impl IToastNotificationActivatedEventArgs_Vtbl {
         iid == &<IToastNotificationActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_UserDataAccounts_Provider\"`, `\"implement\"`*"]
 #[cfg(feature = "ApplicationModel_UserDataAccounts_Provider")]
 pub trait IUserDataAccountProviderActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Operation(&self) -> ::windows::core::Result<super::UserDataAccounts::Provider::IUserDataAccountProviderOperation>;
@@ -2025,6 +2081,7 @@ impl IUserDataAccountProviderActivatedEventArgs_Vtbl {
         iid == &<IUserDataAccountProviderActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"UI_ViewManagement\"`, `\"implement\"`*"]
 #[cfg(feature = "UI_ViewManagement")]
 pub trait IViewSwitcherProvider_Impl: Sized + IActivatedEventArgs_Impl {
     fn ViewSwitcher(&self) -> ::windows::core::Result<super::super::UI::ViewManagement::ActivationViewSwitcher>;
@@ -2057,6 +2114,7 @@ impl IViewSwitcherProvider_Vtbl {
         iid == &<IViewSwitcherProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Media_SpeechRecognition\"`, `\"implement\"`*"]
 #[cfg(feature = "Media_SpeechRecognition")]
 pub trait IVoiceCommandActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Result(&self) -> ::windows::core::Result<super::super::Media::SpeechRecognition::SpeechRecognitionResult>;
@@ -2086,6 +2144,7 @@ impl IVoiceCommandActivatedEventArgs_Vtbl {
         iid == &<IVoiceCommandActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"ApplicationModel_Wallet\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "ApplicationModel_Wallet", feature = "deprecated"))]
 pub trait IWalletActionActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn ItemId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -2146,6 +2205,7 @@ impl IWalletActionActivatedEventArgs_Vtbl {
         iid == &<IWalletActionActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Security_Authentication_Web_Provider\"`, `\"implement\"`*"]
 #[cfg(feature = "Security_Authentication_Web_Provider")]
 pub trait IWebAccountProviderActivatedEventArgs_Impl: Sized + IActivatedEventArgs_Impl {
     fn Operation(&self) -> ::windows::core::Result<super::super::Security::Authentication::Web::Provider::IWebAccountProviderOperation>;
@@ -2178,6 +2238,7 @@ impl IWebAccountProviderActivatedEventArgs_Vtbl {
         iid == &<IWebAccountProviderActivatedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Activation\"`, `\"Foundation_Collections\"`, `\"Security_Authentication_Web\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Security_Authentication_Web"))]
 pub trait IWebAuthenticationBrokerContinuationEventArgs_Impl: Sized + IActivatedEventArgs_Impl + IContinuationActivatedEventArgs_Impl {
     fn WebAuthenticationResult(&self) -> ::windows::core::Result<super::super::Security::Authentication::Web::WebAuthenticationResult>;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_Appointments\"`, `\"implement\"`*"]
 pub trait IAppointmentParticipant_Impl: Sized {
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn SetDisplayName(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"implement\"`*"]
 pub trait IBackgroundCondition_Impl: Sized {}
 impl ::windows::core::RuntimeName for IBackgroundCondition {
     const NAME: &'static str = "Windows.ApplicationModel.Background.IBackgroundCondition";
@@ -10,6 +11,7 @@ impl IBackgroundCondition_Vtbl {
         iid == &<IBackgroundCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"implement\"`*"]
 pub trait IBackgroundTask_Impl: Sized {
     fn Run(&self, taskinstance: &::core::option::Option<IBackgroundTaskInstance>) -> ::windows::core::Result<()>;
 }
@@ -29,6 +31,7 @@ impl IBackgroundTask_Vtbl {
         iid == &<IBackgroundTask as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IBackgroundTaskInstance_Impl: Sized {
     fn InstanceId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -159,6 +162,7 @@ impl IBackgroundTaskInstance_Vtbl {
         iid == &<IBackgroundTaskInstance as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IBackgroundTaskInstance2_Impl: Sized + IBackgroundTaskInstance_Impl {
     fn GetThrottleCount(&self, counter: BackgroundTaskThrottleCounter) -> ::windows::core::Result<u32>;
@@ -191,6 +195,7 @@ impl IBackgroundTaskInstance2_Vtbl {
         iid == &<IBackgroundTaskInstance2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"Foundation\"`, `\"System\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "System"))]
 pub trait IBackgroundTaskInstance4_Impl: Sized + IBackgroundTaskInstance_Impl {
     fn User(&self) -> ::windows::core::Result<super::super::System::User>;
@@ -220,6 +225,7 @@ impl IBackgroundTaskInstance4_Vtbl {
         iid == &<IBackgroundTaskInstance4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IBackgroundTaskRegistration_Impl: Sized {
     fn TaskId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -315,6 +321,7 @@ impl IBackgroundTaskRegistration_Vtbl {
         iid == &<IBackgroundTaskRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IBackgroundTaskRegistration2_Impl: Sized + IBackgroundTaskRegistration_Impl {
     fn Trigger(&self) -> ::windows::core::Result<IBackgroundTrigger>;
@@ -344,6 +351,7 @@ impl IBackgroundTaskRegistration2_Vtbl {
         iid == &<IBackgroundTaskRegistration2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IBackgroundTaskRegistration3_Impl: Sized + IBackgroundTaskRegistration_Impl {
     fn TaskGroup(&self) -> ::windows::core::Result<BackgroundTaskRegistrationGroup>;
@@ -376,6 +384,7 @@ impl IBackgroundTaskRegistration3_Vtbl {
         iid == &<IBackgroundTaskRegistration3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Background\"`, `\"implement\"`*"]
 pub trait IBackgroundTrigger_Impl: Sized {}
 impl ::windows::core::RuntimeName for IBackgroundTrigger {
     const NAME: &'static str = "Windows.ApplicationModel.Background.IBackgroundTrigger";

--- a/crates/libs/windows/src/Windows/ApplicationModel/Chat/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Chat/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_Chat\"`, `\"implement\"`*"]
 pub trait IChatItem_Impl: Sized {
     fn ItemKind(&self) -> ::windows::core::Result<ChatItemKind>;
 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 pub trait IContactField_Impl: Sized {
     fn Type(&self) -> ::windows::core::Result<ContactFieldType>;
     fn Category(&self) -> ::windows::core::Result<ContactFieldCategory>;
@@ -69,6 +70,7 @@ impl IContactField_Vtbl {
         iid == &<IContactField as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 pub trait IContactFieldFactory_Impl: Sized {
     fn CreateField_Default(&self, value: &::windows::core::HSTRING, r#type: ContactFieldType) -> ::windows::core::Result<ContactField>;
     fn CreateField_Category(&self, value: &::windows::core::HSTRING, r#type: ContactFieldType, category: ContactFieldCategory) -> ::windows::core::Result<ContactField>;
@@ -126,6 +128,7 @@ impl IContactFieldFactory_Vtbl {
         iid == &<IContactFieldFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Contacts\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IContactInstantMessageFieldFactory_Impl: Sized {
     fn CreateInstantMessage_Default(&self, username: &::windows::core::HSTRING) -> ::windows::core::Result<ContactInstantMessageField>;
@@ -186,6 +189,7 @@ impl IContactInstantMessageFieldFactory_Vtbl {
         iid == &<IContactInstantMessageFieldFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Contacts\"`, `\"implement\"`*"]
 pub trait IContactLocationFieldFactory_Impl: Sized {
     fn CreateLocation_Default(&self, unstructuredaddress: &::windows::core::HSTRING) -> ::windows::core::Result<ContactLocationField>;
     fn CreateLocation_Category(&self, unstructuredaddress: &::windows::core::HSTRING, category: ContactFieldCategory) -> ::windows::core::Result<ContactLocationField>;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Core/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ICoreApplicationUnhandledError_Impl: Sized {
     fn UnhandledErrorDetected(&self, handler: &::core::option::Option<super::super::Foundation::EventHandler<UnhandledErrorDetectedEventArgs>>) -> ::windows::core::Result<super::super::Foundation::EventRegistrationToken>;
@@ -37,6 +38,7 @@ impl ICoreApplicationUnhandledError_Vtbl {
         iid == &<ICoreApplicationUnhandledError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Core\"`, `\"UI_Core\"`, `\"implement\"`*"]
 #[cfg(feature = "UI_Core")]
 pub trait IFrameworkView_Impl: Sized {
     fn Initialize(&self, applicationview: &::core::option::Option<CoreApplicationView>) -> ::windows::core::Result<()>;
@@ -90,6 +92,7 @@ impl IFrameworkView_Vtbl {
         iid == &<IFrameworkView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel_Core\"`, `\"implement\"`*"]
 pub trait IFrameworkViewSource_Impl: Sized {
     fn CreateView(&self) -> ::windows::core::Result<IFrameworkView>;
 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_DataTransfer_DragDrop_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ICoreDropOperationTarget_Impl: Sized {
     fn EnterAsync(&self, draginfo: &::core::option::Option<CoreDragInfo>, draguioverride: &::core::option::Option<CoreDragUIOverride>) -> ::windows::core::Result<super::super::super::super::Foundation::IAsyncOperation<super::super::DataPackageOperation>>;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_Search\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait ISearchPaneQueryChangedEventArgs_Impl: Sized {
     fn QueryText(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_UserActivities\"`, `\"implement\"`*"]
 pub trait IUserActivityContentInfo_Impl: Sized {
     fn ToJson(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel_UserDataAccounts_Provider\"`, `\"implement\"`*"]
 pub trait IUserDataAccountProviderOperation_Impl: Sized {
     fn Kind(&self) -> ::windows::core::Result<UserDataAccountProviderOperationKind>;
 }

--- a/crates/libs/windows/src/Windows/ApplicationModel/impl.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"ApplicationModel\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IEnteredBackgroundEventArgs_Impl: Sized {
     fn GetDeferral(&self) -> ::windows::core::Result<super::Foundation::Deferral>;
@@ -30,6 +31,7 @@ impl IEnteredBackgroundEventArgs_Vtbl {
         iid == &<IEnteredBackgroundEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ILeavingBackgroundEventArgs_Impl: Sized {
     fn GetDeferral(&self) -> ::windows::core::Result<super::Foundation::Deferral>;
@@ -62,6 +64,7 @@ impl ILeavingBackgroundEventArgs_Vtbl {
         iid == &<ILeavingBackgroundEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel\"`, `\"implement\"`*"]
 pub trait IPackageCatalogStatics2_Impl: Sized {
     fn OpenForPackage(&self, package: &::core::option::Option<Package>) -> ::windows::core::Result<PackageCatalog>;
 }
@@ -91,6 +94,7 @@ impl IPackageCatalogStatics2_Vtbl {
         iid == &<IPackageCatalogStatics2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel\"`, `\"implement\"`*"]
 pub trait ISuspendingDeferral_Impl: Sized {
     fn Complete(&self) -> ::windows::core::Result<()>;
 }
@@ -110,6 +114,7 @@ impl ISuspendingDeferral_Vtbl {
         iid == &<ISuspendingDeferral as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel\"`, `\"implement\"`*"]
 pub trait ISuspendingEventArgs_Impl: Sized {
     fn SuspendingOperation(&self) -> ::windows::core::Result<SuspendingOperation>;
 }
@@ -139,6 +144,7 @@ impl ISuspendingEventArgs_Vtbl {
         iid == &<ISuspendingEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"ApplicationModel\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ISuspendingOperation_Impl: Sized {
     fn GetDeferral(&self) -> ::windows::core::Result<SuspendingDeferral>;

--- a/crates/libs/windows/src/Windows/Data/Json/impl.rs
+++ b/crates/libs/windows/src/Windows/Data/Json/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Data_Json\"`, `\"implement\"`*"]
 pub trait IJsonValue_Impl: Sized {
     fn ValueType(&self) -> ::windows::core::Result<JsonValueType>;
     fn Stringify(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Data/Xml/Dom/impl.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Dom/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Data_Xml_Dom\"`, `\"implement\"`*"]
 pub trait IXmlCharacterData_Impl: Sized + IXmlNode_Impl + IXmlNodeSelector_Impl + IXmlNodeSerializer_Impl {
     fn Data(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn SetData(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
@@ -90,6 +91,7 @@ impl IXmlCharacterData_Vtbl {
         iid == &<IXmlCharacterData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Data_Xml_Dom\"`, `\"implement\"`*"]
 pub trait IXmlNode_Impl: Sized + IXmlNodeSelector_Impl + IXmlNodeSerializer_Impl {
     fn NodeValue(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
     fn SetNodeValue(&self, value: &::core::option::Option<::windows::core::IInspectable>) -> ::windows::core::Result<()>;
@@ -406,6 +408,7 @@ impl IXmlNode_Vtbl {
         iid == &<IXmlNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Data_Xml_Dom\"`, `\"implement\"`*"]
 pub trait IXmlNodeSelector_Impl: Sized {
     fn SelectSingleNode(&self, xpath: &::windows::core::HSTRING) -> ::windows::core::Result<IXmlNode>;
     fn SelectNodes(&self, xpath: &::windows::core::HSTRING) -> ::windows::core::Result<XmlNodeList>;
@@ -477,6 +480,7 @@ impl IXmlNodeSelector_Vtbl {
         iid == &<IXmlNodeSelector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Data_Xml_Dom\"`, `\"implement\"`*"]
 pub trait IXmlNodeSerializer_Impl: Sized {
     fn GetXml(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn InnerText(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -527,6 +531,7 @@ impl IXmlNodeSerializer_Vtbl {
         iid == &<IXmlNodeSerializer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Data_Xml_Dom\"`, `\"implement\"`*"]
 pub trait IXmlText_Impl: Sized + IXmlCharacterData_Impl + IXmlNode_Impl + IXmlNodeSelector_Impl + IXmlNodeSerializer_Impl {
     fn SplitText(&self, offset: u32) -> ::windows::core::Result<IXmlText>;
 }

--- a/crates/libs/windows/src/Windows/Devices/Adc/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Adc_Provider\"`, `\"implement\"`*"]
 pub trait IAdcControllerProvider_Impl: Sized {
     fn ChannelCount(&self) -> ::windows::core::Result<i32>;
     fn ResolutionInBits(&self) -> ::windows::core::Result<i32>;
@@ -132,6 +133,7 @@ impl IAdcControllerProvider_Vtbl {
         iid == &<IAdcControllerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Adc_Provider\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IAdcProvider_Impl: Sized {
     fn GetControllers(&self) -> ::windows::core::Result<super::super::super::Foundation::Collections::IVectorView<IAdcControllerProvider>>;

--- a/crates/libs/windows/src/Windows/Devices/Custom/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Custom/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Custom\"`, `\"implement\"`*"]
 pub trait IIOControlCode_Impl: Sized {
     fn AccessMode(&self) -> ::windows::core::Result<IOControlAccessMode>;
     fn BufferingMethod(&self) -> ::windows::core::Result<IOControlBufferingMethod>;

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Enumeration\"`, `\"implement\"`*"]
 pub trait IDevicePairingSettings_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDevicePairingSettings {
     const NAME: &'static str = "Windows.Devices.Enumeration.IDevicePairingSettings";

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Geolocation\"`, `\"implement\"`*"]
 pub trait IGeoshape_Impl: Sized {
     fn GeoshapeType(&self) -> ::windows::core::Result<GeoshapeType>;
     fn SpatialReferenceId(&self) -> ::windows::core::Result<u32>;

--- a/crates/libs/windows/src/Windows/Devices/Gpio/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Gpio_Provider\"`, `\"implement\"`*"]
 pub trait IGpioControllerProvider_Impl: Sized {
     fn PinCount(&self) -> ::windows::core::Result<i32>;
     fn OpenPinProvider(&self, pin: i32, sharingmode: ProviderGpioSharingMode) -> ::windows::core::Result<IGpioPinProvider>;
@@ -41,6 +42,7 @@ impl IGpioControllerProvider_Vtbl {
         iid == &<IGpioControllerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Gpio_Provider\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IGpioPinProvider_Impl: Sized {
     fn ValueChanged(&self, handler: &::core::option::Option<super::super::super::Foundation::TypedEventHandler<IGpioPinProvider, GpioPinProviderValueChangedEventArgs>>) -> ::windows::core::Result<super::super::super::Foundation::EventRegistrationToken>;
@@ -185,6 +187,7 @@ impl IGpioPinProvider_Vtbl {
         iid == &<IGpioPinProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Gpio_Provider\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IGpioProvider_Impl: Sized {
     fn GetControllers(&self) -> ::windows::core::Result<super::super::super::Foundation::Collections::IVectorView<IGpioControllerProvider>>;

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_I2c_Provider\"`, `\"implement\"`*"]
 pub trait II2cControllerProvider_Impl: Sized {
     fn GetDeviceProvider(&self, settings: &::core::option::Option<ProviderI2cConnectionSettings>) -> ::windows::core::Result<II2cDeviceProvider>;
 }
@@ -27,6 +28,7 @@ impl II2cControllerProvider_Vtbl {
         iid == &<II2cControllerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_I2c_Provider\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait II2cDeviceProvider_Impl: Sized + super::super::super::Foundation::IClosable_Impl {
     fn DeviceId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -122,6 +124,7 @@ impl II2cDeviceProvider_Vtbl {
         iid == &<II2cDeviceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_I2c_Provider\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait II2cProvider_Impl: Sized {
     fn GetControllersAsync(&self) -> ::windows::core::Result<super::super::super::Foundation::IAsyncOperation<super::super::super::Foundation::Collections::IVectorView<II2cControllerProvider>>>;

--- a/crates/libs/windows/src/Windows/Devices/I2c/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_I2c\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait II2cDeviceStatics_Impl: Sized {
     fn GetDeviceSelector(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Devices/Lights/Effects/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/Effects/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Lights_Effects\"`, `\"implement\"`*"]
 pub trait ILampArrayEffect_Impl: Sized {
     fn ZIndex(&self) -> ::windows::core::Result<i32>;
     fn SetZIndex(&self, value: i32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Devices/Midi/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Midi/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Midi\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IMidiMessage_Impl: Sized {
     fn Timestamp(&self) -> ::windows::core::Result<super::super::Foundation::TimeSpan>;
@@ -58,6 +59,7 @@ impl IMidiMessage_Vtbl {
         iid == &<IMidiMessage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Midi\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IMidiOutPort_Impl: Sized + super::super::Foundation::IClosable_Impl {
     fn SendMessage(&self, midimessage: &::core::option::Option<IMidiMessage>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_PointOfService\"`, `\"implement\"`*"]
 pub trait ICashDrawerEventSourceEventArgs_Impl: Sized {
     fn CashDrawer(&self) -> ::windows::core::Result<CashDrawer>;
 }
@@ -27,6 +28,7 @@ impl ICashDrawerEventSourceEventArgs_Vtbl {
         iid == &<ICashDrawerEventSourceEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_PointOfService\"`, `\"implement\"`*"]
 pub trait ICommonClaimedPosPrinterStation_Impl: Sized {
     fn SetCharactersPerLine(&self, value: u32) -> ::windows::core::Result<()>;
     fn CharactersPerLine(&self) -> ::windows::core::Result<u32>;
@@ -273,6 +275,7 @@ impl ICommonClaimedPosPrinterStation_Vtbl {
         iid == &<ICommonClaimedPosPrinterStation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_PointOfService\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait ICommonPosPrintStationCapabilities_Impl: Sized {
     fn IsPrinterPresent(&self) -> ::windows::core::Result<bool>;
@@ -473,6 +476,7 @@ impl ICommonPosPrintStationCapabilities_Vtbl {
         iid == &<ICommonPosPrintStationCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_PointOfService\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait ICommonReceiptSlipCapabilities_Impl: Sized + ICommonPosPrintStationCapabilities_Impl {
     fn IsBarcodeSupported(&self) -> ::windows::core::Result<bool>;
@@ -617,6 +621,7 @@ impl ICommonReceiptSlipCapabilities_Vtbl {
         iid == &<ICommonReceiptSlipCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_PointOfService\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPosPrinterJob_Impl: Sized {
     fn Print(&self, data: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
@@ -670,6 +675,7 @@ impl IPosPrinterJob_Vtbl {
         iid == &<IPosPrinterJob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_PointOfService\"`, `\"Foundation\"`, `\"Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Graphics_Imaging"))]
 pub trait IReceiptOrSlipJob_Impl: Sized + IPosPrinterJob_Impl {
     fn SetBarcodeRotation(&self, value: PosPrinterRotation) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Devices/Pwm/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Pwm/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Pwm_Provider\"`, `\"implement\"`*"]
 pub trait IPwmControllerProvider_Impl: Sized {
     fn PinCount(&self) -> ::windows::core::Result<i32>;
     fn ActualFrequency(&self) -> ::windows::core::Result<f64>;
@@ -118,6 +119,7 @@ impl IPwmControllerProvider_Vtbl {
         iid == &<IPwmControllerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Pwm_Provider\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IPwmProvider_Impl: Sized {
     fn GetControllers(&self) -> ::windows::core::Result<super::super::super::Foundation::Collections::IVectorView<IPwmControllerProvider>>;

--- a/crates/libs/windows/src/Windows/Devices/Scanners/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Scanners/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Scanners\"`, `\"implement\"`*"]
 pub trait IImageScannerFormatConfiguration_Impl: Sized {
     fn DefaultFormat(&self) -> ::windows::core::Result<ImageScannerFormat>;
     fn Format(&self) -> ::windows::core::Result<ImageScannerFormat>;
@@ -62,6 +63,7 @@ impl IImageScannerFormatConfiguration_Vtbl {
         iid == &<IImageScannerFormatConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Scanners\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IImageScannerSourceConfiguration_Impl: Sized + IImageScannerFormatConfiguration_Impl {
     fn MinScanArea(&self) -> ::windows::core::Result<super::super::Foundation::Size>;

--- a/crates/libs/windows/src/Windows/Devices/Sensors/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Sensors\"`, `\"implement\"`*"]
 pub trait ISensorDataThreshold_Impl: Sized {}
 impl ::windows::core::RuntimeName for ISensorDataThreshold {
     const NAME: &'static str = "Windows.Devices.Sensors.ISensorDataThreshold";

--- a/crates/libs/windows/src/Windows/Devices/Sms/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Sms\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait ISmsBinaryMessage_Impl: Sized + ISmsMessage_Impl {
     fn Format(&self) -> ::windows::core::Result<SmsDataFormat>;
@@ -59,6 +60,7 @@ impl ISmsBinaryMessage_Vtbl {
         iid == &<ISmsBinaryMessage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Sms\"`, `\"Foundation\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 pub trait ISmsDevice_Impl: Sized {
     fn SendMessageAsync(&self, message: &::core::option::Option<ISmsMessage>) -> ::windows::core::Result<SendSmsMessageOperation>;
@@ -203,6 +205,7 @@ impl ISmsDevice_Vtbl {
         iid == &<ISmsDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Sms\"`, `\"implement\"`*"]
 pub trait ISmsMessage_Impl: Sized {
     fn Id(&self) -> ::windows::core::Result<u32>;
     fn MessageClass(&self) -> ::windows::core::Result<SmsMessageClass>;
@@ -246,6 +249,7 @@ impl ISmsMessage_Vtbl {
         iid == &<ISmsMessage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Sms\"`, `\"implement\"`*"]
 pub trait ISmsMessageBase_Impl: Sized {
     fn MessageType(&self) -> ::windows::core::Result<SmsMessageType>;
     fn DeviceId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -331,6 +335,7 @@ impl ISmsMessageBase_Vtbl {
         iid == &<ISmsMessageBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Sms\"`, `\"Foundation_Collections\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 pub trait ISmsTextMessage_Impl: Sized + ISmsMessage_Impl {
     fn Timestamp(&self) -> ::windows::core::Result<super::super::Foundation::DateTime>;

--- a/crates/libs/windows/src/Windows/Devices/Spi/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Spi_Provider\"`, `\"implement\"`*"]
 pub trait ISpiControllerProvider_Impl: Sized {
     fn GetDeviceProvider(&self, settings: &::core::option::Option<ProviderSpiConnectionSettings>) -> ::windows::core::Result<ISpiDeviceProvider>;
 }
@@ -27,6 +28,7 @@ impl ISpiControllerProvider_Vtbl {
         iid == &<ISpiControllerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Spi_Provider\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ISpiDeviceProvider_Impl: Sized + super::super::super::Foundation::IClosable_Impl {
     fn DeviceId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -101,6 +103,7 @@ impl ISpiDeviceProvider_Vtbl {
         iid == &<ISpiDeviceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Devices_Spi_Provider\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait ISpiProvider_Impl: Sized {
     fn GetControllersAsync(&self) -> ::windows::core::Result<super::super::super::Foundation::IAsyncOperation<super::super::super::Foundation::Collections::IVectorView<ISpiControllerProvider>>>;

--- a/crates/libs/windows/src/Windows/Devices/Spi/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices_Spi\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ISpiDeviceStatics_Impl: Sized {
     fn GetDeviceSelector(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Devices/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Devices\"`, `\"Devices_Adc_Provider\"`, `\"Devices_Gpio_Provider\"`, `\"Devices_I2c_Provider\"`, `\"Devices_Pwm_Provider\"`, `\"Devices_Spi_Provider\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Devices_Adc_Provider", feature = "Devices_Gpio_Provider", feature = "Devices_I2c_Provider", feature = "Devices_Pwm_Provider", feature = "Devices_Spi_Provider"))]
 pub trait ILowLevelDevicesAggregateProvider_Impl: Sized {
     fn AdcControllerProvider(&self) -> ::windows::core::Result<Adc::Provider::IAdcControllerProvider>;

--- a/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IIterable_Impl<T>: Sized
 where
     T: ::windows::core::RuntimeType + 'static,
@@ -31,6 +32,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IIterable_Vtbl<T> {
         iid == &<IIterable<T> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IIterator_Impl<T>: Sized
 where
     T: ::windows::core::RuntimeType + 'static,
@@ -106,6 +108,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IIterator_Vtbl<T> {
         iid == &<IIterator<T> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IKeyValuePair_Impl<K, V>: Sized
 where
     K: ::windows::core::RuntimeType + 'static,
@@ -155,6 +158,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
         iid == &<IKeyValuePair<K, V> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IMap_Impl<K, V>: Sized + IIterable_Impl<IKeyValuePair<K, V>>
 where
     K: ::windows::core::RuntimeType + 'static,
@@ -260,6 +264,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
         iid == &<IMap<K, V> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IMapChangedEventArgs_Impl<K>: Sized
 where
     K: ::windows::core::RuntimeType + 'static,
@@ -307,6 +312,7 @@ impl<K: ::windows::core::RuntimeType + 'static> IMapChangedEventArgs_Vtbl<K> {
         iid == &<IMapChangedEventArgs<K> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IMapView_Impl<K, V>: Sized + IIterable_Impl<IKeyValuePair<K, V>>
 where
     K: ::windows::core::RuntimeType + 'static,
@@ -377,6 +383,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
         iid == &<IMapView<K, V> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IObservableMap_Impl<K, V>: Sized + IIterable_Impl<IKeyValuePair<K, V>> + IMap_Impl<K, V>
 where
     K: ::windows::core::RuntimeType + 'static,
@@ -419,6 +426,7 @@ impl<K: ::windows::core::RuntimeType + 'static, V: ::windows::core::RuntimeType 
         iid == &<IObservableMap<K, V> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IObservableVector_Impl<T>: Sized + IIterable_Impl<T> + IVector_Impl<T>
 where
     T: ::windows::core::RuntimeType + 'static,
@@ -459,6 +467,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IObservableVector_Vtbl<T> {
         iid == &<IObservableVector<T> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IPropertySet_Impl: Sized + IIterable_Impl<IKeyValuePair<::windows::core::HSTRING, ::windows::core::IInspectable>> + IMap_Impl<::windows::core::HSTRING, ::windows::core::IInspectable> + IObservableMap_Impl<::windows::core::HSTRING, ::windows::core::IInspectable> {}
 impl ::windows::core::RuntimeName for IPropertySet {
     const NAME: &'static str = "Windows.Foundation.Collections.IPropertySet";
@@ -471,6 +480,7 @@ impl IPropertySet_Vtbl {
         iid == &<IPropertySet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IVector_Impl<T>: Sized + IIterable_Impl<T>
 where
     T: ::windows::core::RuntimeType + 'static,
@@ -609,6 +619,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IVector_Vtbl<T> {
         iid == &<IVector<T> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IVectorChangedEventArgs_Impl: Sized {
     fn CollectionChange(&self) -> ::windows::core::Result<CollectionChange>;
     fn Index(&self) -> ::windows::core::Result<u32>;
@@ -652,6 +663,7 @@ impl IVectorChangedEventArgs_Vtbl {
         iid == &<IVectorChangedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Collections\"`, `\"implement\"`*"]
 pub trait IVectorView_Impl<T>: Sized + IIterable_Impl<T>
 where
     T: ::windows::core::RuntimeType + 'static,

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Foundation_Diagnostics\"`, `\"implement\"`*"]
 pub trait IErrorReportingSettings_Impl: Sized {
     fn SetErrorOptions(&self, value: ErrorOptions) -> ::windows::core::Result<()>;
     fn GetErrorOptions(&self) -> ::windows::core::Result<ErrorOptions>;
@@ -34,6 +35,7 @@ impl IErrorReportingSettings_Vtbl {
         iid == &<IErrorReportingSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Diagnostics\"`, `\"Storage\"`, `\"implement\"`*"]
 #[cfg(feature = "Storage")]
 pub trait IFileLoggingSession_Impl: Sized + super::IClosable_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -122,6 +124,7 @@ impl IFileLoggingSession_Vtbl {
         iid == &<IFileLoggingSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Diagnostics\"`, `\"implement\"`*"]
 pub trait ILoggingChannel_Impl: Sized + super::IClosable_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn Enabled(&self) -> ::windows::core::Result<bool>;
@@ -228,6 +231,7 @@ impl ILoggingChannel_Vtbl {
         iid == &<ILoggingChannel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Diagnostics\"`, `\"Storage\"`, `\"implement\"`*"]
 #[cfg(feature = "Storage")]
 pub trait ILoggingSession_Impl: Sized + super::IClosable_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -295,6 +299,7 @@ impl ILoggingSession_Vtbl {
         iid == &<ILoggingSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation_Diagnostics\"`, `\"implement\"`*"]
 pub trait ILoggingTarget_Impl: Sized {
     fn IsEnabled(&self) -> ::windows::core::Result<bool>;
     fn IsEnabledWithLevel(&self, level: LoggingLevel) -> ::windows::core::Result<bool>;

--- a/crates/libs/windows/src/Windows/Foundation/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IAsyncAction_Impl: Sized + IAsyncInfo_Impl {
     fn SetCompleted(&self, handler: &::core::option::Option<AsyncActionCompletedHandler>) -> ::windows::core::Result<()>;
     fn Completed(&self) -> ::windows::core::Result<AsyncActionCompletedHandler>;
@@ -41,6 +42,7 @@ impl IAsyncAction_Vtbl {
         iid == &<IAsyncAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IAsyncActionWithProgress_Impl<TProgress>: Sized + IAsyncInfo_Impl
 where
     TProgress: ::windows::core::RuntimeType + 'static,
@@ -109,6 +111,7 @@ impl<TProgress: ::windows::core::RuntimeType + 'static> IAsyncActionWithProgress
         iid == &<IAsyncActionWithProgress<TProgress> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IAsyncInfo_Impl: Sized {
     fn Id(&self) -> ::windows::core::Result<u32>;
     fn Status(&self) -> ::windows::core::Result<AsyncStatus>;
@@ -180,6 +183,7 @@ impl IAsyncInfo_Vtbl {
         iid == &<IAsyncInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IAsyncOperation_Impl<TResult>: Sized + IAsyncInfo_Impl
 where
     TResult: ::windows::core::RuntimeType + 'static,
@@ -234,6 +238,7 @@ impl<TResult: ::windows::core::RuntimeType + 'static> IAsyncOperation_Vtbl<TResu
         iid == &<IAsyncOperation<TResult> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IAsyncOperationWithProgress_Impl<TResult, TProgress>: Sized + IAsyncInfo_Impl
 where
     TResult: ::windows::core::RuntimeType + 'static,
@@ -311,6 +316,7 @@ impl<TResult: ::windows::core::RuntimeType + 'static, TProgress: ::windows::core
         iid == &<IAsyncOperationWithProgress<TResult, TProgress> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IClosable_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
 }
@@ -330,6 +336,7 @@ impl IClosable_Vtbl {
         iid == &<IClosable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IGetActivationFactory_Impl: Sized {
     fn GetActivationFactory(&self, activatableclassid: &::windows::core::HSTRING) -> ::windows::core::Result<::windows::core::IInspectable>;
 }
@@ -359,6 +366,7 @@ impl IGetActivationFactory_Vtbl {
         iid == &<IGetActivationFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IMemoryBuffer_Impl: Sized + IClosable_Impl {
     fn CreateReference(&self) -> ::windows::core::Result<IMemoryBufferReference>;
 }
@@ -385,6 +393,7 @@ impl IMemoryBuffer_Vtbl {
         iid == &<IMemoryBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IMemoryBufferReference_Impl: Sized + IClosable_Impl {
     fn Capacity(&self) -> ::windows::core::Result<u32>;
     fn Closed(&self, handler: &::core::option::Option<TypedEventHandler<IMemoryBufferReference, ::windows::core::IInspectable>>) -> ::windows::core::Result<EventRegistrationToken>;
@@ -435,6 +444,7 @@ impl IMemoryBufferReference_Vtbl {
         iid == &<IMemoryBufferReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IPropertyValue_Impl: Sized {
     fn Type(&self) -> ::windows::core::Result<PropertyType>;
     fn IsNumericScalar(&self) -> ::windows::core::Result<bool>;
@@ -863,6 +873,7 @@ impl IPropertyValue_Vtbl {
         iid == &<IPropertyValue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IReference_Impl<T>: Sized + IPropertyValue_Impl
 where
     T: ::windows::core::RuntimeType + 'static,
@@ -896,6 +907,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IReference_Vtbl<T> {
         iid == &<IReference<T> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IReferenceArray_Impl<T>: Sized + IPropertyValue_Impl
 where
     T: ::windows::core::RuntimeType + 'static,
@@ -930,6 +942,7 @@ impl<T: ::windows::core::RuntimeType + 'static> IReferenceArray_Vtbl<T> {
         iid == &<IReferenceArray<T> as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IStringable_Impl: Sized {
     fn ToString(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -956,6 +969,7 @@ impl IStringable_Vtbl {
         iid == &<IStringable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Foundation\"`, `\"implement\"`*"]
 pub trait IWwwFormUrlDecoderEntry_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn Value(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Gaming_Input_Custom\"`, `\"implement\"`*"]
 pub trait ICustomGameControllerFactory_Impl: Sized {
     fn CreateGameController(&self, provider: &::core::option::Option<IGameControllerProvider>) -> ::windows::core::Result<::windows::core::IInspectable>;
     fn OnGameControllerAdded(&self, value: &::core::option::Option<super::IGameController>) -> ::windows::core::Result<()>;
@@ -41,6 +42,7 @@ impl ICustomGameControllerFactory_Vtbl {
         iid == &<ICustomGameControllerFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Gaming_Input_Custom\"`, `\"implement\"`*"]
 pub trait IGameControllerInputSink_Impl: Sized {
     fn OnInputResumed(&self, timestamp: u64) -> ::windows::core::Result<()>;
     fn OnInputSuspended(&self, timestamp: u64) -> ::windows::core::Result<()>;
@@ -70,6 +72,7 @@ impl IGameControllerInputSink_Vtbl {
         iid == &<IGameControllerInputSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Gaming_Input_Custom\"`, `\"implement\"`*"]
 pub trait IGameControllerProvider_Impl: Sized {
     fn FirmwareVersionInfo(&self) -> ::windows::core::Result<GameControllerVersionInfo>;
     fn HardwareProductId(&self) -> ::windows::core::Result<u16>;
@@ -155,6 +158,7 @@ impl IGameControllerProvider_Vtbl {
         iid == &<IGameControllerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Gaming_Input_Custom\"`, `\"implement\"`*"]
 pub trait IGipGameControllerInputSink_Impl: Sized + IGameControllerInputSink_Impl {
     fn OnKeyReceived(&self, timestamp: u64, keycode: u8, ispressed: bool) -> ::windows::core::Result<()>;
     fn OnMessageReceived(&self, timestamp: u64, messageclass: GipMessageClass, messageid: u8, sequenceid: u8, messagebuffer: &[u8]) -> ::windows::core::Result<()>;
@@ -184,6 +188,7 @@ impl IGipGameControllerInputSink_Vtbl {
         iid == &<IGipGameControllerInputSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Gaming_Input_Custom\"`, `\"implement\"`*"]
 pub trait IHidGameControllerInputSink_Impl: Sized + IGameControllerInputSink_Impl {
     fn OnInputReportReceived(&self, timestamp: u64, reportid: u8, reportbuffer: &[u8]) -> ::windows::core::Result<()>;
 }
@@ -206,6 +211,7 @@ impl IHidGameControllerInputSink_Vtbl {
         iid == &<IHidGameControllerInputSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Gaming_Input_Custom\"`, `\"implement\"`*"]
 pub trait IXusbGameControllerInputSink_Impl: Sized + IGameControllerInputSink_Impl {
     fn OnInputReceived(&self, timestamp: u64, reportid: u8, inputbuffer: &[u8]) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Gaming_Input_ForceFeedback\"`, `\"implement\"`*"]
 pub trait IForceFeedbackEffect_Impl: Sized {
     fn Gain(&self) -> ::windows::core::Result<f64>;
     fn SetGain(&self, value: f64) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Gaming/Input/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Gaming_Input\"`, `\"Foundation\"`, `\"System\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "System"))]
 pub trait IGameController_Impl: Sized {
     fn HeadsetConnected(&self, value: &::core::option::Option<super::super::Foundation::TypedEventHandler<IGameController, Headset>>) -> ::windows::core::Result<super::super::Foundation::EventRegistrationToken>;
@@ -121,6 +122,7 @@ impl IGameController_Vtbl {
         iid == &<IGameController as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Gaming_Input\"`, `\"Devices_Power\"`, `\"implement\"`*"]
 #[cfg(feature = "Devices_Power")]
 pub trait IGameControllerBatteryInfo_Impl: Sized {
     fn TryGetBatteryReport(&self) -> ::windows::core::Result<super::super::Devices::Power::BatteryReport>;

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Gaming_Preview_GamesEnumeration\"`, `\"ApplicationModel\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(all(feature = "ApplicationModel", feature = "Foundation_Collections"))]
 pub trait IGameListEntry_Impl: Sized {
     fn DisplayInfo(&self) -> ::windows::core::Result<super::super::super::ApplicationModel::AppDisplayInfo>;

--- a/crates/libs/windows/src/Windows/Globalization/NumberFormatting/impl.rs
+++ b/crates/libs/windows/src/Windows/Globalization/NumberFormatting/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"implement\"`*"]
 pub trait INumberFormatter_Impl: Sized {
     fn FormatInt(&self, value: i64) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn FormatUInt(&self, value: u64) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -55,6 +56,7 @@ impl INumberFormatter_Vtbl {
         iid == &<INumberFormatter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"implement\"`*"]
 pub trait INumberFormatter2_Impl: Sized {
     fn FormatInt(&self, value: i64) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn FormatUInt(&self, value: u64) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -112,6 +114,7 @@ impl INumberFormatter2_Vtbl {
         iid == &<INumberFormatter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait INumberFormatterOptions_Impl: Sized {
     fn Languages(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVectorView<::windows::core::HSTRING>>;
@@ -291,6 +294,7 @@ impl INumberFormatterOptions_Vtbl {
         iid == &<INumberFormatterOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait INumberParser_Impl: Sized {
     fn ParseInt(&self, text: &::windows::core::HSTRING) -> ::windows::core::Result<super::super::Foundation::IReference<i64>>;
@@ -351,6 +355,7 @@ impl INumberParser_Vtbl {
         iid == &<INumberParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"implement\"`*"]
 pub trait INumberRounder_Impl: Sized {
     fn RoundInt32(&self, value: i32) -> ::windows::core::Result<i32>;
     fn RoundUInt32(&self, value: u32) -> ::windows::core::Result<u32>;
@@ -450,6 +455,7 @@ impl INumberRounder_Vtbl {
         iid == &<INumberRounder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"implement\"`*"]
 pub trait INumberRounderOption_Impl: Sized {
     fn NumberRounder(&self) -> ::windows::core::Result<INumberRounder>;
     fn SetNumberRounder(&self, value: &::core::option::Option<INumberRounder>) -> ::windows::core::Result<()>;
@@ -486,6 +492,7 @@ impl INumberRounderOption_Vtbl {
         iid == &<INumberRounderOption as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"implement\"`*"]
 pub trait ISignedZeroOption_Impl: Sized {
     fn IsZeroSigned(&self) -> ::windows::core::Result<bool>;
     fn SetIsZeroSigned(&self, value: bool) -> ::windows::core::Result<()>;
@@ -522,6 +529,7 @@ impl ISignedZeroOption_Vtbl {
         iid == &<ISignedZeroOption as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Globalization_NumberFormatting\"`, `\"implement\"`*"]
 pub trait ISignificantDigitsOption_Impl: Sized {
     fn SignificantDigits(&self) -> ::windows::core::Result<i32>;
     fn SetSignificantDigits(&self, value: i32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Graphics_DirectX_Direct3D11\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IDirect3DDevice_Impl: Sized + super::super::super::Foundation::IClosable_Impl {
     fn Trim(&self) -> ::windows::core::Result<()>;
@@ -20,6 +21,7 @@ impl IDirect3DDevice_Vtbl {
         iid == &<IDirect3DDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_DirectX_Direct3D11\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IDirect3DSurface_Impl: Sized + super::super::super::Foundation::IClosable_Impl {
     fn Description(&self) -> ::windows::core::Result<Direct3DSurfaceDescription>;

--- a/crates/libs/windows/src/Windows/Graphics/Effects/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Effects/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Graphics_Effects\"`, `\"implement\"`*"]
 pub trait IGraphicsEffect_Impl: Sized + IGraphicsEffectSource_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn SetName(&self, name: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
@@ -34,6 +35,7 @@ impl IGraphicsEffect_Vtbl {
         iid == &<IGraphicsEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Effects\"`, `\"implement\"`*"]
 pub trait IGraphicsEffectSource_Impl: Sized {}
 impl ::windows::core::RuntimeName for IGraphicsEffectSource {
     const NAME: &'static str = "Windows.Graphics.Effects.IGraphicsEffectSource";

--- a/crates/libs/windows/src/Windows/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Imaging/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Graphics_Imaging\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IBitmapFrame_Impl: Sized {
     fn GetThumbnailAsync(&self) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<ImageStream>>;
@@ -184,6 +185,7 @@ impl IBitmapFrame_Vtbl {
         iid == &<IBitmapFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Imaging\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IBitmapFrameWithSoftwareBitmap_Impl: Sized + IBitmapFrame_Impl {
     fn GetSoftwareBitmapAsync(&self) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<SoftwareBitmap>>;
@@ -244,6 +246,7 @@ impl IBitmapFrameWithSoftwareBitmap_Vtbl {
         iid == &<IBitmapFrameWithSoftwareBitmap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Imaging\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IBitmapPropertiesView_Impl: Sized {
     fn GetPropertiesAsync(&self, propertiestoretrieve: &::core::option::Option<super::super::Foundation::Collections::IIterable<::windows::core::HSTRING>>) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<BitmapPropertySet>>;

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Graphics_Printing_OptionDetails\"`, `\"implement\"`*"]
 pub trait IPrintCustomOptionDetails_Impl: Sized + IPrintOptionDetails_Impl {
     fn SetDisplayName(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -34,6 +35,7 @@ impl IPrintCustomOptionDetails_Vtbl {
         iid == &<IPrintCustomOptionDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Printing_OptionDetails\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IPrintItemListOptionDetails_Impl: Sized + IPrintOptionDetails_Impl {
     fn Items(&self) -> ::windows::core::Result<super::super::super::Foundation::Collections::IVectorView<::windows::core::IInspectable>>;
@@ -63,6 +65,7 @@ impl IPrintItemListOptionDetails_Vtbl {
         iid == &<IPrintItemListOptionDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Printing_OptionDetails\"`, `\"implement\"`*"]
 pub trait IPrintNumberOptionDetails_Impl: Sized + IPrintOptionDetails_Impl {
     fn MinValue(&self) -> ::windows::core::Result<u32>;
     fn MaxValue(&self) -> ::windows::core::Result<u32>;
@@ -106,6 +109,7 @@ impl IPrintNumberOptionDetails_Vtbl {
         iid == &<IPrintNumberOptionDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Printing_OptionDetails\"`, `\"implement\"`*"]
 pub trait IPrintOptionDetails_Impl: Sized {
     fn OptionId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn OptionType(&self) -> ::windows::core::Result<PrintOptionType>;
@@ -219,6 +223,7 @@ impl IPrintOptionDetails_Vtbl {
         iid == &<IPrintOptionDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Printing_OptionDetails\"`, `\"implement\"`*"]
 pub trait IPrintTextOptionDetails_Impl: Sized + IPrintOptionDetails_Impl {
     fn MaxCharacters(&self) -> ::windows::core::Result<u32>;
 }

--- a/crates/libs/windows/src/Windows/Graphics/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintDocumentSource_Impl: Sized {}
 impl ::windows::core::RuntimeName for IPrintDocumentSource {
     const NAME: &'static str = "Windows.Graphics.Printing.IPrintDocumentSource";
@@ -10,6 +11,7 @@ impl IPrintDocumentSource_Vtbl {
         iid == &<IPrintDocumentSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Printing\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPrintTaskOptionsCore_Impl: Sized {
     fn GetPageDescription(&self, jobpagenumber: u32) -> ::windows::core::Result<PrintPageDescription>;
@@ -42,6 +44,7 @@ impl IPrintTaskOptionsCore_Vtbl {
         iid == &<IPrintTaskOptionsCore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintTaskOptionsCoreProperties_Impl: Sized {
     fn SetMediaSize(&self, value: PrintMediaSize) -> ::windows::core::Result<()>;
     fn MediaSize(&self) -> ::windows::core::Result<PrintMediaSize>;
@@ -316,6 +319,7 @@ impl IPrintTaskOptionsCoreProperties_Vtbl {
         iid == &<IPrintTaskOptionsCoreProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Graphics_Printing\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IPrintTaskOptionsCoreUIConfiguration_Impl: Sized {
     fn DisplayedOptions(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVector<::windows::core::HSTRING>>;

--- a/crates/libs/windows/src/Windows/Graphics/impl.rs
+++ b/crates/libs/windows/src/Windows/Graphics/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Graphics\"`, `\"implement\"`*"]
 pub trait IGeometrySource2D_Impl: Sized {}
 impl ::windows::core::RuntimeName for IGeometrySource2D {
     const NAME: &'static str = "Windows.Graphics.IGeometrySource2D";

--- a/crates/libs/windows/src/Windows/Media/Audio/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_Audio\"`, `\"Foundation_Collections\"`, `\"Media_Effects\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Effects", feature = "Media_MediaProperties"))]
 pub trait IAudioInputNode_Impl: Sized + IAudioNode_Impl + super::super::Foundation::IClosable_Impl {
     fn OutgoingConnections(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVectorView<AudioGraphConnection>>;
@@ -51,6 +52,7 @@ impl IAudioInputNode_Vtbl {
         iid == &<IAudioInputNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Audio\"`, `\"Foundation_Collections\"`, `\"Media_Effects\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Effects", feature = "Media_MediaProperties"))]
 pub trait IAudioInputNode2_Impl: Sized + IAudioInputNode_Impl + IAudioNode_Impl + super::super::Foundation::IClosable_Impl {
     fn Emitter(&self) -> ::windows::core::Result<AudioNodeEmitter>;
@@ -80,6 +82,7 @@ impl IAudioInputNode2_Vtbl {
         iid == &<IAudioInputNode2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Audio\"`, `\"Foundation_Collections\"`, `\"Media_Effects\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Effects", feature = "Media_MediaProperties"))]
 pub trait IAudioNode_Impl: Sized + super::super::Foundation::IClosable_Impl {
     fn EffectDefinitions(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVector<super::Effects::IAudioEffectDefinition>>;
@@ -203,6 +206,7 @@ impl IAudioNode_Vtbl {
         iid == &<IAudioNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Audio\"`, `\"Foundation_Collections\"`, `\"Media_Effects\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Effects", feature = "Media_MediaProperties"))]
 pub trait IAudioNodeWithListener_Impl: Sized + IAudioNode_Impl + super::super::Foundation::IClosable_Impl {
     fn SetListener(&self, value: &::core::option::Option<AudioNodeListener>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Media/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IMediaCue_Impl: Sized {
     fn SetStartTime(&self, value: &super::super::Foundation::TimeSpan) -> ::windows::core::Result<()>;
@@ -79,6 +80,7 @@ impl IMediaCue_Vtbl {
         iid == &<IMediaCue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Core\"`, `\"implement\"`*"]
 pub trait IMediaSource_Impl: Sized {}
 impl ::windows::core::RuntimeName for IMediaSource {
     const NAME: &'static str = "Windows.Media.Core.IMediaSource";
@@ -91,6 +93,7 @@ impl IMediaSource_Vtbl {
         iid == &<IMediaSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Core\"`, `\"implement\"`*"]
 pub trait IMediaStreamDescriptor_Impl: Sized {
     fn IsSelected(&self) -> ::windows::core::Result<bool>;
     fn SetName(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
@@ -162,6 +165,7 @@ impl IMediaStreamDescriptor_Vtbl {
         iid == &<IMediaStreamDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Core\"`, `\"implement\"`*"]
 pub trait IMediaStreamDescriptor2_Impl: Sized + IMediaStreamDescriptor_Impl {
     fn SetLabel(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
     fn Label(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -198,6 +202,7 @@ impl IMediaStreamDescriptor2_Vtbl {
         iid == &<IMediaStreamDescriptor2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Core\"`, `\"implement\"`*"]
 pub trait IMediaTrack_Impl: Sized {
     fn Id(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn Language(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -276,6 +281,7 @@ impl IMediaTrack_Vtbl {
         iid == &<IMediaTrack as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ISingleSelectMediaTrackList_Impl: Sized {
     fn SelectedIndexChanged(&self, handler: &::core::option::Option<super::super::Foundation::TypedEventHandler<ISingleSelectMediaTrackList, ::windows::core::IInspectable>>) -> ::windows::core::Result<super::super::Foundation::EventRegistrationToken>;
@@ -336,6 +342,7 @@ impl ISingleSelectMediaTrackList_Vtbl {
         iid == &<ISingleSelectMediaTrackList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Core\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait ITimedMetadataTrackProvider_Impl: Sized {
     fn TimedMetadataTracks(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVectorView<TimedMetadataTrack>>;

--- a/crates/libs/windows/src/Windows/Media/Devices/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_Devices\"`, `\"implement\"`*"]
 pub trait IDefaultAudioDeviceChangedEventArgs_Impl: Sized {
     fn Id(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn Role(&self) -> ::windows::core::Result<AudioDeviceRole>;
@@ -41,6 +42,7 @@ impl IDefaultAudioDeviceChangedEventArgs_Vtbl {
         iid == &<IDefaultAudioDeviceChangedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Devices\"`, `\"Foundation_Collections\"`, `\"Media_Capture\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Capture", feature = "Media_MediaProperties"))]
 pub trait IMediaDeviceController_Impl: Sized {
     fn GetAvailableMediaStreamProperties(&self, mediastreamtype: super::Capture::MediaStreamType) -> ::windows::core::Result<super::super::Foundation::Collections::IVectorView<super::MediaProperties::IMediaEncodingProperties>>;

--- a/crates/libs/windows/src/Windows/Media/Effects/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Effects/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_Effects\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IAudioEffectDefinition_Impl: Sized {
     fn ActivatableClassId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -44,6 +45,7 @@ impl IAudioEffectDefinition_Vtbl {
         iid == &<IAudioEffectDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Effects\"`, `\"Foundation_Collections\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_MediaProperties"))]
 pub trait IBasicAudioEffect_Impl: Sized + super::IMediaExtension_Impl {
     fn UseInputFrameForOutput(&self) -> ::windows::core::Result<bool>;
@@ -118,6 +120,7 @@ impl IBasicAudioEffect_Vtbl {
         iid == &<IBasicAudioEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Effects\"`, `\"Foundation_Collections\"`, `\"Graphics_DirectX_Direct3D11\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Graphics_DirectX_Direct3D11", feature = "Media_MediaProperties"))]
 pub trait IBasicVideoEffect_Impl: Sized + super::IMediaExtension_Impl {
     fn IsReadOnly(&self) -> ::windows::core::Result<bool>;
@@ -220,6 +223,7 @@ impl IBasicVideoEffect_Vtbl {
         iid == &<IBasicVideoEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Effects\"`, `\"Foundation_Collections\"`, `\"Graphics_DirectX_Direct3D11\"`, `\"Media_MediaProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Graphics_DirectX_Direct3D11", feature = "Media_MediaProperties"))]
 pub trait IVideoCompositor_Impl: Sized + super::IMediaExtension_Impl {
     fn TimeIndependent(&self) -> ::windows::core::Result<bool>;
@@ -280,6 +284,7 @@ impl IVideoCompositor_Vtbl {
         iid == &<IVideoCompositor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Effects\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IVideoCompositorDefinition_Impl: Sized {
     fn ActivatableClassId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -326,6 +331,7 @@ impl IVideoCompositorDefinition_Vtbl {
         iid == &<IVideoCompositorDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Effects\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IVideoEffectDefinition_Impl: Sized {
     fn ActivatableClassId(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_MediaProperties\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IMediaEncodingProperties_Impl: Sized {
     fn Properties(&self) -> ::windows::core::Result<MediaPropertySet>;

--- a/crates/libs/windows/src/Windows/Media/Playback/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Playback/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_Playback\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait IMediaEnginePlaybackSource_Impl: Sized {
     fn CurrentItem(&self) -> ::windows::core::Result<MediaPlaybackItem>;
@@ -37,6 +38,7 @@ impl IMediaEnginePlaybackSource_Vtbl {
         iid == &<IMediaEnginePlaybackSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Playback\"`, `\"implement\"`*"]
 pub trait IMediaPlaybackSource_Impl: Sized {}
 impl ::windows::core::RuntimeName for IMediaPlaybackSource {
     const NAME: &'static str = "Windows.Media.Playback.IMediaPlaybackSource";

--- a/crates/libs/windows/src/Windows/Media/Protection/PlayReady/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/PlayReady/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDClosedCaptionDataReceivedEventArgs_Impl: Sized {
     fn ClosedCaptionDataFormat(&self) -> ::windows::core::Result<NDClosedCaptionFormat>;
@@ -59,6 +60,7 @@ impl INDClosedCaptionDataReceivedEventArgs_Vtbl {
         iid == &<INDClosedCaptionDataReceivedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDCustomData_Impl: Sized {
     fn CustomDataTypeID(&self) -> ::windows::core::Result<::windows::core::Array<u8>>;
@@ -107,6 +109,7 @@ impl INDCustomData_Vtbl {
         iid == &<INDCustomData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 pub trait INDDownloadEngine_Impl: Sized {
     fn Open(&self, uri: &::core::option::Option<super::super::super::Foundation::Uri>, sessionidbytes: &[u8]) -> ::windows::core::Result<()>;
@@ -216,6 +219,7 @@ impl INDDownloadEngine_Vtbl {
         iid == &<INDDownloadEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDDownloadEngineNotifier_Impl: Sized {
     fn OnStreamOpened(&self) -> ::windows::core::Result<()>;
@@ -276,6 +280,7 @@ impl INDDownloadEngineNotifier_Vtbl {
         iid == &<INDDownloadEngineNotifier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDLicenseFetchCompletedEventArgs_Impl: Sized {
     fn ResponseCustomData(&self) -> ::windows::core::Result<INDCustomData>;
@@ -308,6 +313,7 @@ impl INDLicenseFetchCompletedEventArgs_Vtbl {
         iid == &<INDLicenseFetchCompletedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDLicenseFetchDescriptor_Impl: Sized {
     fn ContentIDType(&self) -> ::windows::core::Result<NDContentIDType>;
@@ -376,6 +382,7 @@ impl INDLicenseFetchDescriptor_Vtbl {
         iid == &<INDLicenseFetchDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDLicenseFetchResult_Impl: Sized {
     fn ResponseCustomData(&self) -> ::windows::core::Result<INDCustomData>;
@@ -408,6 +415,7 @@ impl INDLicenseFetchResult_Vtbl {
         iid == &<INDLicenseFetchResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 pub trait INDMessenger_Impl: Sized {
     fn SendRegistrationRequestAsync(&self, sessionidbytes: &[u8], challengedatabytes: &[u8]) -> ::windows::core::Result<super::super::super::Foundation::IAsyncOperation<INDSendResult>>;
@@ -482,6 +490,7 @@ impl INDMessenger_Vtbl {
         iid == &<INDMessenger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDProximityDetectionCompletedEventArgs_Impl: Sized {
     fn ProximityDetectionRetryCount(&self) -> ::windows::core::Result<u32>;
@@ -514,6 +523,7 @@ impl INDProximityDetectionCompletedEventArgs_Vtbl {
         iid == &<INDProximityDetectionCompletedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDRegistrationCompletedEventArgs_Impl: Sized {
     fn ResponseCustomData(&self) -> ::windows::core::Result<INDCustomData>;
@@ -581,6 +591,7 @@ impl INDRegistrationCompletedEventArgs_Vtbl {
         iid == &<INDRegistrationCompletedEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(feature = "deprecated")]
 pub trait INDSendResult_Impl: Sized {
     fn Response(&self) -> ::windows::core::Result<::windows::core::Array<u8>>;
@@ -611,6 +622,7 @@ impl INDSendResult_Vtbl {
         iid == &<INDSendResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Media_Core\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Media_Core", feature = "deprecated"))]
 pub trait INDStartResult_Impl: Sized {
     fn MediaStreamSource(&self) -> ::windows::core::Result<super::super::Core::MediaStreamSource>;
@@ -643,6 +655,7 @@ impl INDStartResult_Vtbl {
         iid == &<INDStartResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation_Collections\"`, `\"Storage\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage", feature = "deprecated"))]
 pub trait INDStorageFileHelper_Impl: Sized {
     fn GetFileURLs(&self, file: &::core::option::Option<super::super::super::Storage::IStorageFile>) -> ::windows::core::Result<super::super::super::Foundation::Collections::IVector<::windows::core::HSTRING>>;
@@ -672,6 +685,7 @@ impl INDStorageFileHelper_Vtbl {
         iid == &<INDStorageFileHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Media_Core\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Media_Core", feature = "deprecated"))]
 pub trait INDStreamParser_Impl: Sized {
     fn ParseData(&self, databytes: &[u8]) -> ::windows::core::Result<()>;
@@ -739,6 +753,7 @@ impl INDStreamParser_Vtbl {
         iid == &<INDStreamParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation_Collections\"`, `\"Media_Core\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core", feature = "deprecated"))]
 pub trait INDStreamParserNotifier_Impl: Sized {
     fn OnContentIDReceived(&self, licensefetchdescriptor: &::core::option::Option<INDLicenseFetchDescriptor>) -> ::windows::core::Result<()>;
@@ -785,6 +800,7 @@ impl INDStreamParserNotifier_Vtbl {
         iid == &<INDStreamParserNotifier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"deprecated\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "deprecated"))]
 pub trait INDTransmitterProperties_Impl: Sized {
     fn CertificateType(&self) -> ::windows::core::Result<NDCertificateType>;
@@ -960,6 +976,7 @@ impl INDTransmitterProperties_Vtbl {
         iid == &<INDTransmitterProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPlayReadyDomain_Impl: Sized {
     fn AccountId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1048,6 +1065,7 @@ impl IPlayReadyDomain_Vtbl {
         iid == &<IPlayReadyDomain as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPlayReadyLicense_Impl: Sized {
     fn FullyEvaluated(&self) -> ::windows::core::Result<bool>;
@@ -1164,6 +1182,7 @@ impl IPlayReadyLicense_Vtbl {
         iid == &<IPlayReadyLicense as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPlayReadyLicenseAcquisitionServiceRequest_Impl: Sized + super::IMediaProtectionServiceRequest_Impl + IPlayReadyServiceRequest_Impl {
     fn ContentHeader(&self) -> ::windows::core::Result<PlayReadyContentHeader>;
@@ -1224,6 +1243,7 @@ impl IPlayReadyLicenseAcquisitionServiceRequest_Vtbl {
         iid == &<IPlayReadyLicenseAcquisitionServiceRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"implement\"`*"]
 pub trait IPlayReadyLicenseSession_Impl: Sized {
     fn CreateLAServiceRequest(&self) -> ::windows::core::Result<IPlayReadyLicenseAcquisitionServiceRequest>;
     fn ConfigureMediaProtectionManager(&self, mpm: &::core::option::Option<super::MediaProtectionManager>) -> ::windows::core::Result<()>;
@@ -1260,6 +1280,7 @@ impl IPlayReadyLicenseSession_Vtbl {
         iid == &<IPlayReadyLicenseSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IPlayReadyLicenseSession2_Impl: Sized + IPlayReadyLicenseSession_Impl {
     fn CreateLicenseIterable(&self, contentheader: &::core::option::Option<PlayReadyContentHeader>, fullyevaluated: bool) -> ::windows::core::Result<PlayReadyLicenseIterable>;
@@ -1292,6 +1313,7 @@ impl IPlayReadyLicenseSession2_Vtbl {
         iid == &<IPlayReadyLicenseSession2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPlayReadySecureStopServiceRequest_Impl: Sized + super::IMediaProtectionServiceRequest_Impl + IPlayReadyServiceRequest_Impl {
     fn SessionID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1381,6 +1403,7 @@ impl IPlayReadySecureStopServiceRequest_Vtbl {
         iid == &<IPlayReadySecureStopServiceRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media_Protection_PlayReady\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPlayReadyServiceRequest_Impl: Sized + super::IMediaProtectionServiceRequest_Impl {
     fn Uri(&self) -> ::windows::core::Result<super::super::super::Foundation::Uri>;

--- a/crates/libs/windows/src/Windows/Media/Protection/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_Protection\"`, `\"implement\"`*"]
 pub trait IMediaProtectionServiceRequest_Impl: Sized {
     fn ProtectionSystem(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn Type(&self) -> ::windows::core::Result<::windows::core::GUID>;

--- a/crates/libs/windows/src/Windows/Media/SpeechRecognition/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechRecognition/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media_SpeechRecognition\"`, `\"implement\"`*"]
 pub trait ISpeechRecognitionConstraint_Impl: Sized {
     fn IsEnabled(&self) -> ::windows::core::Result<bool>;
     fn SetIsEnabled(&self, value: bool) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Media\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IMediaExtension_Impl: Sized {
     fn SetProperties(&self, configuration: &::core::option::Option<super::Foundation::Collections::IPropertySet>) -> ::windows::core::Result<()>;
@@ -20,6 +21,7 @@ impl IMediaExtension_Vtbl {
         iid == &<IMediaExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IMediaFrame_Impl: Sized + super::Foundation::IClosable_Impl {
     fn Type(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -164,6 +166,7 @@ impl IMediaFrame_Vtbl {
         iid == &<IMediaFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IMediaMarker_Impl: Sized {
     fn Time(&self) -> ::windows::core::Result<super::Foundation::TimeSpan>;
@@ -224,6 +227,7 @@ impl IMediaMarker_Vtbl {
         iid == &<IMediaMarker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Media\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IMediaMarkers_Impl: Sized {
     fn Markers(&self) -> ::windows::core::Result<super::Foundation::Collections::IVectorView<IMediaMarker>>;

--- a/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/impl.rs
+++ b/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Networking_BackgroundTransfer\"`, `\"Security_Credentials\"`, `\"implement\"`*"]
 #[cfg(feature = "Security_Credentials")]
 pub trait IBackgroundTransferBase_Impl: Sized {
     fn SetRequestHeader(&self, headername: &::windows::core::HSTRING, headervalue: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
@@ -128,6 +129,7 @@ impl IBackgroundTransferBase_Vtbl {
         iid == &<IBackgroundTransferBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_BackgroundTransfer\"`, `\"implement\"`*"]
 pub trait IBackgroundTransferContentPartFactory_Impl: Sized {
     fn CreateWithName(&self, name: &::windows::core::HSTRING) -> ::windows::core::Result<BackgroundTransferContentPart>;
     fn CreateWithNameAndFileName(&self, name: &::windows::core::HSTRING, filename: &::windows::core::HSTRING) -> ::windows::core::Result<BackgroundTransferContentPart>;
@@ -171,6 +173,7 @@ impl IBackgroundTransferContentPartFactory_Vtbl {
         iid == &<IBackgroundTransferContentPartFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_BackgroundTransfer\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IBackgroundTransferOperation_Impl: Sized {
     fn Guid(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -294,6 +297,7 @@ impl IBackgroundTransferOperation_Vtbl {
         iid == &<IBackgroundTransferOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_BackgroundTransfer\"`, `\"implement\"`*"]
 pub trait IBackgroundTransferOperationPriority_Impl: Sized {
     fn Priority(&self) -> ::windows::core::Result<BackgroundTransferPriority>;
     fn SetPriority(&self, value: BackgroundTransferPriority) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Networking/Sockets/impl.rs
+++ b/crates/libs/windows/src/Windows/Networking/Sockets/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Networking_Sockets\"`, `\"implement\"`*"]
 pub trait IControlChannelTriggerEventDetails_Impl: Sized {
     fn ControlChannelTrigger(&self) -> ::windows::core::Result<ControlChannelTrigger>;
 }
@@ -27,6 +28,7 @@ impl IControlChannelTriggerEventDetails_Vtbl {
         iid == &<IControlChannelTriggerEventDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Sockets\"`, `\"implement\"`*"]
 pub trait IControlChannelTriggerResetEventDetails_Impl: Sized {
     fn ResetReason(&self) -> ::windows::core::Result<ControlChannelTriggerResetReason>;
     fn HardwareSlotReset(&self) -> ::windows::core::Result<bool>;
@@ -84,6 +86,7 @@ impl IControlChannelTriggerResetEventDetails_Vtbl {
         iid == &<IControlChannelTriggerResetEventDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Sockets\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IWebSocket_Impl: Sized + super::super::Foundation::IClosable_Impl {
     fn OutputStream(&self) -> ::windows::core::Result<super::super::Storage::Streams::IOutputStream>;
@@ -165,6 +168,7 @@ impl IWebSocket_Vtbl {
         iid == &<IWebSocket as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Sockets\"`, `\"Foundation_Collections\"`, `\"Security_Credentials\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Security_Credentials"))]
 pub trait IWebSocketControl_Impl: Sized {
     fn OutboundBufferSizeInBytes(&self) -> ::windows::core::Result<u32>;
@@ -260,6 +264,7 @@ impl IWebSocketControl_Vtbl {
         iid == &<IWebSocketControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Sockets\"`, `\"Foundation_Collections\"`, `\"Security_Credentials\"`, `\"Security_Cryptography_Certificates\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Security_Credentials", feature = "Security_Cryptography_Certificates"))]
 pub trait IWebSocketControl2_Impl: Sized + IWebSocketControl_Impl {
     fn IgnorableServerCertificateErrors(&self) -> ::windows::core::Result<super::super::Foundation::Collections::IVector<super::super::Security::Cryptography::Certificates::ChainValidationResult>>;
@@ -292,6 +297,7 @@ impl IWebSocketControl2_Vtbl {
         iid == &<IWebSocketControl2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Sockets\"`, `\"implement\"`*"]
 pub trait IWebSocketInformation_Impl: Sized {
     fn LocalAddress(&self) -> ::windows::core::Result<super::HostName>;
     fn BandwidthStatistics(&self) -> ::windows::core::Result<BandwidthStatistics>;
@@ -349,6 +355,7 @@ impl IWebSocketInformation_Vtbl {
         iid == &<IWebSocketInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Sockets\"`, `\"Foundation_Collections\"`, `\"Security_Cryptography_Certificates\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Security_Cryptography_Certificates"))]
 pub trait IWebSocketInformation2_Impl: Sized + IWebSocketInformation_Impl {
     fn ServerCertificate(&self) -> ::windows::core::Result<super::super::Security::Cryptography::Certificates::Certificate>;

--- a/crates/libs/windows/src/Windows/Networking/Vpn/impl.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"implement\"`*"]
 pub trait IVpnChannelStatics_Impl: Sized {
     fn ProcessEventAsync(&self, thirdpartyplugin: &::core::option::Option<::windows::core::IInspectable>, event: &::core::option::Option<::windows::core::IInspectable>) -> ::windows::core::Result<()>;
 }
@@ -20,6 +21,7 @@ impl IVpnChannelStatics_Vtbl {
         iid == &<IVpnChannelStatics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"Security_Credentials\"`, `\"Security_Cryptography_Certificates\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Security_Credentials", feature = "Security_Cryptography_Certificates"))]
 pub trait IVpnCredential_Impl: Sized {
     fn PasskeyCredential(&self) -> ::windows::core::Result<super::super::Security::Credentials::PasswordCredential>;
@@ -94,6 +96,7 @@ impl IVpnCredential_Vtbl {
         iid == &<IVpnCredential as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"implement\"`*"]
 pub trait IVpnCustomPrompt_Impl: Sized {
     fn SetLabel(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
     fn Label(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -172,6 +175,7 @@ impl IVpnCustomPrompt_Vtbl {
         iid == &<IVpnCustomPrompt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"implement\"`*"]
 pub trait IVpnCustomPromptElement_Impl: Sized {
     fn SetDisplayName(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -250,6 +254,7 @@ impl IVpnCustomPromptElement_Vtbl {
         iid == &<IVpnCustomPromptElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IVpnDomainNameInfoFactory_Impl: Sized {
     fn CreateVpnDomainNameInfo(&self, name: &::windows::core::HSTRING, nametype: VpnDomainNameType, dnsserverlist: &::core::option::Option<super::super::Foundation::Collections::IIterable<super::HostName>>, proxyserverlist: &::core::option::Option<super::super::Foundation::Collections::IIterable<super::HostName>>) -> ::windows::core::Result<VpnDomainNameInfo>;
@@ -282,6 +287,7 @@ impl IVpnDomainNameInfoFactory_Vtbl {
         iid == &<IVpnDomainNameInfoFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"implement\"`*"]
 pub trait IVpnInterfaceIdFactory_Impl: Sized {
     fn CreateVpnInterfaceId(&self, address: &[u8]) -> ::windows::core::Result<VpnInterfaceId>;
 }
@@ -311,6 +317,7 @@ impl IVpnInterfaceIdFactory_Vtbl {
         iid == &<IVpnInterfaceIdFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IVpnNamespaceInfoFactory_Impl: Sized {
     fn CreateVpnNamespaceInfo(&self, name: &::windows::core::HSTRING, dnsserverlist: &::core::option::Option<super::super::Foundation::Collections::IVector<super::HostName>>, proxyserverlist: &::core::option::Option<super::super::Foundation::Collections::IVector<super::HostName>>) -> ::windows::core::Result<VpnNamespaceInfo>;
@@ -343,6 +350,7 @@ impl IVpnNamespaceInfoFactory_Vtbl {
         iid == &<IVpnNamespaceInfoFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"implement\"`*"]
 pub trait IVpnPacketBufferFactory_Impl: Sized {
     fn CreateVpnPacketBuffer(&self, parentbuffer: &::core::option::Option<VpnPacketBuffer>, offset: u32, length: u32) -> ::windows::core::Result<VpnPacketBuffer>;
 }
@@ -372,6 +380,7 @@ impl IVpnPacketBufferFactory_Vtbl {
         iid == &<IVpnPacketBufferFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"implement\"`*"]
 pub trait IVpnPlugIn_Impl: Sized {
     fn Connect(&self, channel: &::core::option::Option<VpnChannel>) -> ::windows::core::Result<()>;
     fn Disconnect(&self, channel: &::core::option::Option<VpnChannel>) -> ::windows::core::Result<()>;
@@ -422,6 +431,7 @@ impl IVpnPlugIn_Vtbl {
         iid == &<IVpnPlugIn as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IVpnProfile_Impl: Sized {
     fn ProfileName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -559,6 +569,7 @@ impl IVpnProfile_Vtbl {
         iid == &<IVpnProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Networking_Vpn\"`, `\"implement\"`*"]
 pub trait IVpnRouteFactory_Impl: Sized {
     fn CreateVpnRoute(&self, address: &::core::option::Option<super::HostName>, prefixsize: u8) -> ::windows::core::Result<VpnRoute>;
 }

--- a/crates/libs/windows/src/Windows/Phone/Notification/Management/impl.rs
+++ b/crates/libs/windows/src/Windows/Phone/Notification/Management/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Phone_Notification_Management\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IAccessoryNotificationTriggerDetails_Impl: Sized {
     fn TimeCreated(&self) -> ::windows::core::Result<super::super::super::Foundation::DateTime>;

--- a/crates/libs/windows/src/Windows/Phone/PersonalInformation/impl.rs
+++ b/crates/libs/windows/src/Windows/Phone/PersonalInformation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Phone_PersonalInformation\"`, `\"Foundation_Collections\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage_Streams"))]
 pub trait IContactInformation_Impl: Sized {
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -205,6 +206,7 @@ impl IContactInformation_Vtbl {
         iid == &<IContactInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Phone_PersonalInformation\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IContactInformation2_Impl: Sized {
     fn DisplayPictureDate(&self) -> ::windows::core::Result<super::super::Foundation::DateTime>;

--- a/crates/libs/windows/src/Windows/Phone/StartScreen/impl.rs
+++ b/crates/libs/windows/src/Windows/Phone/StartScreen/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Phone_StartScreen\"`, `\"UI_Notifications\"`, `\"implement\"`*"]
 #[cfg(feature = "UI_Notifications")]
 pub trait IToastNotificationManagerStatics3_Impl: Sized {
     fn CreateToastNotifierForSecondaryTile(&self, tileid: &::windows::core::HSTRING) -> ::windows::core::Result<super::super::UI::Notifications::ToastNotifier>;

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`, `\"Security_Authentication_Web_Core\"`, `\"implement\"`*"]
 #[cfg(feature = "Security_Authentication_Web_Core")]
 pub trait IWebAccountProviderBaseReportOperation_Impl: Sized {
     fn ReportCompleted(&self) -> ::windows::core::Result<()>;
@@ -30,6 +31,7 @@ impl IWebAccountProviderBaseReportOperation_Vtbl {
         iid == &<IWebAccountProviderBaseReportOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`, `\"implement\"`*"]
 pub trait IWebAccountProviderOperation_Impl: Sized {
     fn Kind(&self) -> ::windows::core::Result<WebAccountProviderOperationKind>;
 }
@@ -56,6 +58,7 @@ impl IWebAccountProviderOperation_Vtbl {
         iid == &<IWebAccountProviderOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`, `\"Security_Authentication_Web_Core\"`, `\"implement\"`*"]
 #[cfg(feature = "Security_Authentication_Web_Core")]
 pub trait IWebAccountProviderSilentReportOperation_Impl: Sized + IWebAccountProviderBaseReportOperation_Impl {
     fn ReportUserInteractionRequired(&self) -> ::windows::core::Result<()>;
@@ -88,6 +91,7 @@ impl IWebAccountProviderSilentReportOperation_Vtbl {
         iid == &<IWebAccountProviderSilentReportOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`, `\"implement\"`*"]
 pub trait IWebAccountProviderTokenObjects_Impl: Sized {
     fn Operation(&self) -> ::windows::core::Result<IWebAccountProviderOperation>;
 }
@@ -117,6 +121,7 @@ impl IWebAccountProviderTokenObjects_Vtbl {
         iid == &<IWebAccountProviderTokenObjects as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`, `\"System\"`, `\"implement\"`*"]
 #[cfg(feature = "System")]
 pub trait IWebAccountProviderTokenObjects2_Impl: Sized + IWebAccountProviderTokenObjects_Impl {
     fn User(&self) -> ::windows::core::Result<super::super::super::super::System::User>;
@@ -146,6 +151,7 @@ impl IWebAccountProviderTokenObjects2_Vtbl {
         iid == &<IWebAccountProviderTokenObjects2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IWebAccountProviderTokenOperation_Impl: Sized + IWebAccountProviderOperation_Impl {
     fn ProviderRequest(&self) -> ::windows::core::Result<WebProviderTokenRequest>;
@@ -213,6 +219,7 @@ impl IWebAccountProviderTokenOperation_Vtbl {
         iid == &<IWebAccountProviderTokenOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Security_Authentication_Web_Provider\"`, `\"Security_Authentication_Web_Core\"`, `\"implement\"`*"]
 #[cfg(feature = "Security_Authentication_Web_Core")]
 pub trait IWebAccountProviderUIReportOperation_Impl: Sized + IWebAccountProviderBaseReportOperation_Impl {
     fn ReportUserCanceled(&self) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Security/Credentials/impl.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Security_Credentials\"`, `\"implement\"`*"]
 pub trait IWebAccount_Impl: Sized {
     fn WebAccountProvider(&self) -> ::windows::core::Result<WebAccountProvider>;
     fn UserName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Storage_AccessCache\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IStorageItemAccessList_Impl: Sized {
     fn AddOverloadDefaultMetadata(&self, file: &::core::option::Option<super::IStorageItem>) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Storage/BulkAccess/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/BulkAccess/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Storage_BulkAccess\"`, `\"Foundation\"`, `\"Storage_FileProperties\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_FileProperties", feature = "Storage_Streams"))]
 pub trait IStorageItemInformation_Impl: Sized {
     fn MusicProperties(&self) -> ::windows::core::Result<super::FileProperties::MusicProperties>;

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Storage_FileProperties\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IStorageItemExtraProperties_Impl: Sized {
     fn RetrievePropertiesAsync(&self, propertiestoretrieve: &::core::option::Option<super::super::Foundation::Collections::IIterable<::windows::core::HSTRING>>) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<super::super::Foundation::Collections::IMap<::windows::core::HSTRING, ::windows::core::IInspectable>>>;

--- a/crates/libs/windows/src/Windows/Storage/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Storage_Provider\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IStorageProviderItemPropertySource_Impl: Sized {
     fn GetItemProperties(&self, itempath: &::windows::core::HSTRING) -> ::windows::core::Result<super::super::Foundation::Collections::IIterable<StorageProviderItemProperty>>;
@@ -30,6 +31,7 @@ impl IStorageProviderItemPropertySource_Vtbl {
         iid == &<IStorageProviderItemPropertySource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Provider\"`, `\"implement\"`*"]
 pub trait IStorageProviderPropertyCapabilities_Impl: Sized {
     fn IsPropertySupported(&self, propertycanonicalname: &::windows::core::HSTRING) -> ::windows::core::Result<bool>;
 }
@@ -59,6 +61,7 @@ impl IStorageProviderPropertyCapabilities_Vtbl {
         iid == &<IStorageProviderPropertyCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Provider\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IStorageProviderStatusUISource_Impl: Sized {
     fn GetStatusUI(&self) -> ::windows::core::Result<StorageProviderStatusUI>;
@@ -112,6 +115,7 @@ impl IStorageProviderStatusUISource_Vtbl {
         iid == &<IStorageProviderStatusUISource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Provider\"`, `\"implement\"`*"]
 pub trait IStorageProviderStatusUISourceFactory_Impl: Sized {
     fn GetStatusUISource(&self, syncrootid: &::windows::core::HSTRING) -> ::windows::core::Result<IStorageProviderStatusUISource>;
 }
@@ -141,6 +145,7 @@ impl IStorageProviderStatusUISourceFactory_Vtbl {
         iid == &<IStorageProviderStatusUISourceFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Provider\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IStorageProviderUICommand_Impl: Sized {
     fn Label(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -222,6 +227,7 @@ impl IStorageProviderUICommand_Vtbl {
         iid == &<IStorageProviderUICommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Provider\"`, `\"implement\"`*"]
 pub trait IStorageProviderUriSource_Impl: Sized {
     fn GetPathForContentUri(&self, contenturi: &::windows::core::HSTRING, result: &::core::option::Option<StorageProviderGetPathForContentUriResult>) -> ::windows::core::Result<()>;
     fn GetContentInfoForPath(&self, path: &::windows::core::HSTRING, result: &::core::option::Option<StorageProviderGetContentInfoForPathResult>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Storage/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/Search/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Storage_Search\"`, `\"Foundation_Collections\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage_Streams"))]
 pub trait IIndexableContent_Impl: Sized {
     fn Id(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -93,6 +94,7 @@ impl IIndexableContent_Vtbl {
         iid == &<IIndexableContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Search\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IStorageFolderQueryOperations_Impl: Sized {
     fn GetIndexedStateAsync(&self) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<IndexedState>>;
@@ -349,6 +351,7 @@ impl IStorageFolderQueryOperations_Vtbl {
         iid == &<IStorageFolderQueryOperations as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Search\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IStorageQueryResultBase_Impl: Sized {
     fn GetItemCountAsync(&self) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<u32>>;

--- a/crates/libs/windows/src/Windows/Storage/Streams/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"implement\"`*"]
 pub trait IBuffer_Impl: Sized {
     fn Capacity(&self) -> ::windows::core::Result<u32>;
     fn Length(&self) -> ::windows::core::Result<u32>;
@@ -48,6 +49,7 @@ impl IBuffer_Vtbl {
         iid == &<IBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"implement\"`*"]
 pub trait IContentTypeProvider_Impl: Sized {
     fn ContentType(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -74,6 +76,7 @@ impl IContentTypeProvider_Vtbl {
         iid == &<IContentTypeProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IDataReader_Impl: Sized {
     fn UnconsumedBufferLength(&self) -> ::windows::core::Result<u32>;
@@ -428,6 +431,7 @@ impl IDataReader_Vtbl {
         iid == &<IDataReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IDataWriter_Impl: Sized {
     fn UnstoredBufferLength(&self) -> ::windows::core::Result<u32>;
@@ -698,6 +702,7 @@ impl IDataWriter_Vtbl {
         iid == &<IDataWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IInputStream_Impl: Sized + super::super::Foundation::IClosable_Impl {
     fn ReadAsync(&self, buffer: &::core::option::Option<IBuffer>, count: u32, options: InputStreamOptions) -> ::windows::core::Result<super::super::Foundation::IAsyncOperationWithProgress<IBuffer, u32>>;
@@ -727,6 +732,7 @@ impl IInputStream_Vtbl {
         iid == &<IInputStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IInputStreamReference_Impl: Sized {
     fn OpenSequentialReadAsync(&self) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<IInputStream>>;
@@ -759,6 +765,7 @@ impl IInputStreamReference_Vtbl {
         iid == &<IInputStreamReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IOutputStream_Impl: Sized + super::super::Foundation::IClosable_Impl {
     fn WriteAsync(&self, buffer: &::core::option::Option<IBuffer>) -> ::windows::core::Result<super::super::Foundation::IAsyncOperationWithProgress<u32, u32>>;
@@ -805,6 +812,7 @@ impl IOutputStream_Vtbl {
         iid == &<IOutputStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IPropertySetSerializer_Impl: Sized {
     fn Serialize(&self, propertyset: &::core::option::Option<super::super::Foundation::Collections::IPropertySet>) -> ::windows::core::Result<IBuffer>;
@@ -844,6 +852,7 @@ impl IPropertySetSerializer_Vtbl {
         iid == &<IPropertySetSerializer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IRandomAccessStream_Impl: Sized + super::super::Foundation::IClosable_Impl + IInputStream_Impl + IOutputStream_Impl {
     fn Size(&self) -> ::windows::core::Result<u64>;
@@ -974,6 +983,7 @@ impl IRandomAccessStream_Vtbl {
         iid == &<IRandomAccessStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IRandomAccessStreamReference_Impl: Sized {
     fn OpenReadAsync(&self) -> ::windows::core::Result<super::super::Foundation::IAsyncOperation<IRandomAccessStreamWithContentType>>;
@@ -1006,6 +1016,7 @@ impl IRandomAccessStreamReference_Vtbl {
         iid == &<IRandomAccessStreamReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage_Streams\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IRandomAccessStreamWithContentType_Impl: Sized + super::super::Foundation::IClosable_Impl + IContentTypeProvider_Impl + IInputStream_Impl + IOutputStream_Impl + IRandomAccessStream_Impl {}
 #[cfg(feature = "Foundation")]

--- a/crates/libs/windows/src/Windows/Storage/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"Storage_FileProperties\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_FileProperties", feature = "Storage_Streams"))]
 pub trait IStorageFile_Impl: Sized + Streams::IInputStreamReference_Impl + Streams::IRandomAccessStreamReference_Impl + IStorageItem_Impl {
     fn FileType(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -184,6 +185,7 @@ impl IStorageFile_Vtbl {
         iid == &<IStorageFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IStorageFile2_Impl: Sized {
     fn OpenWithOptionsAsync(&self, accessmode: FileAccessMode, options: StorageOpenOptions) -> ::windows::core::Result<super::Foundation::IAsyncOperation<Streams::IRandomAccessStream>>;
@@ -230,6 +232,7 @@ impl IStorageFile2_Vtbl {
         iid == &<IStorageFile2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"implement\"`*"]
 pub trait IStorageFilePropertiesWithAvailability_Impl: Sized {
     fn IsAvailable(&self) -> ::windows::core::Result<bool>;
 }
@@ -259,6 +262,7 @@ impl IStorageFilePropertiesWithAvailability_Vtbl {
         iid == &<IStorageFilePropertiesWithAvailability as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation_Collections\"`, `\"Storage_FileProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage_FileProperties"))]
 pub trait IStorageFolder_Impl: Sized + IStorageItem_Impl {
     fn CreateFileAsyncOverloadDefaultOptions(&self, desiredname: &::windows::core::HSTRING) -> ::windows::core::Result<super::Foundation::IAsyncOperation<StorageFile>>;
@@ -417,6 +421,7 @@ impl IStorageFolder_Vtbl {
         iid == &<IStorageFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IStorageFolder2_Impl: Sized {
     fn TryGetItemAsync(&self, name: &::windows::core::HSTRING) -> ::windows::core::Result<super::Foundation::IAsyncOperation<IStorageItem>>;
@@ -449,6 +454,7 @@ impl IStorageFolder2_Vtbl {
         iid == &<IStorageFolder2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"Storage_FileProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_FileProperties"))]
 pub trait IStorageItem_Impl: Sized {
     fn RenameAsyncOverloadDefaultOptions(&self, desiredname: &::windows::core::HSTRING) -> ::windows::core::Result<super::Foundation::IAsyncAction>;
@@ -607,6 +613,7 @@ impl IStorageItem_Vtbl {
         iid == &<IStorageItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"Storage_FileProperties\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_FileProperties"))]
 pub trait IStorageItem2_Impl: Sized + IStorageItem_Impl {
     fn GetParentAsync(&self) -> ::windows::core::Result<super::Foundation::IAsyncOperation<StorageFolder>>;
@@ -653,6 +660,7 @@ impl IStorageItem2_Vtbl {
         iid == &<IStorageItem2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"Storage_FileProperties\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_FileProperties", feature = "Storage_Streams"))]
 pub trait IStorageItemProperties_Impl: Sized {
     fn GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(&self, mode: FileProperties::ThumbnailMode) -> ::windows::core::Result<super::Foundation::IAsyncOperation<FileProperties::StorageItemThumbnail>>;
@@ -769,6 +777,7 @@ impl IStorageItemProperties_Vtbl {
         iid == &<IStorageItemProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"Storage_FileProperties\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_FileProperties", feature = "Storage_Streams"))]
 pub trait IStorageItemProperties2_Impl: Sized + IStorageItemProperties_Impl {
     fn GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptions(&self, mode: FileProperties::ThumbnailMode) -> ::windows::core::Result<super::Foundation::IAsyncOperation<FileProperties::StorageItemThumbnail>>;
@@ -829,6 +838,7 @@ impl IStorageItemProperties2_Vtbl {
         iid == &<IStorageItemProperties2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"Foundation\"`, `\"Storage_FileProperties\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_FileProperties", feature = "Storage_Streams"))]
 pub trait IStorageItemPropertiesWithProvider_Impl: Sized + IStorageItemProperties_Impl {
     fn Provider(&self) -> ::windows::core::Result<StorageProvider>;
@@ -861,6 +871,7 @@ impl IStorageItemPropertiesWithProvider_Vtbl {
         iid == &<IStorageItemPropertiesWithProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Storage\"`, `\"implement\"`*"]
 pub trait IStreamedFileDataRequest_Impl: Sized {
     fn FailAndClose(&self, failuremode: StreamedFileFailureMode) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/impl.rs
+++ b/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"System_Implementation_FileExplorer\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ISysStorageProviderEventSource_Impl: Sized {
     fn EventReceived(&self, handler: &::core::option::Option<super::super::super::Foundation::TypedEventHandler<ISysStorageProviderEventSource, SysStorageProviderEventReceivedEventArgs>>) -> ::windows::core::Result<super::super::super::Foundation::EventRegistrationToken>;
@@ -37,6 +38,7 @@ impl ISysStorageProviderEventSource_Vtbl {
         iid == &<ISysStorageProviderEventSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"System_Implementation_FileExplorer\"`, `\"implement\"`*"]
 pub trait ISysStorageProviderHandlerFactory_Impl: Sized {
     fn GetHttpRequestProvider(&self, syncrootid: &::windows::core::HSTRING) -> ::windows::core::Result<ISysStorageProviderHttpRequestProvider>;
     fn GetEventSource(&self, syncrootid: &::windows::core::HSTRING, eventname: &::windows::core::HSTRING) -> ::windows::core::Result<ISysStorageProviderEventSource>;
@@ -80,6 +82,7 @@ impl ISysStorageProviderHandlerFactory_Vtbl {
         iid == &<ISysStorageProviderHandlerFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"System_Implementation_FileExplorer\"`, `\"Foundation\"`, `\"Web_Http\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Web_Http"))]
 pub trait ISysStorageProviderHttpRequestProvider_Impl: Sized {
     fn SendRequestAsync(&self, request: &::core::option::Option<super::super::super::Web::Http::HttpRequestMessage>) -> ::windows::core::Result<super::super::super::Foundation::IAsyncOperation<super::super::super::Web::Http::HttpResponseMessage>>;

--- a/crates/libs/windows/src/Windows/System/RemoteSystems/impl.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteSystems/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"System_RemoteSystems\"`, `\"implement\"`*"]
 pub trait IRemoteSystemFilter_Impl: Sized {}
 impl ::windows::core::RuntimeName for IRemoteSystemFilter {
     const NAME: &'static str = "Windows.System.RemoteSystems.IRemoteSystemFilter";

--- a/crates/libs/windows/src/Windows/System/impl.rs
+++ b/crates/libs/windows/src/Windows/System/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"System\"`, `\"UI_ViewManagement\"`, `\"implement\"`*"]
 #[cfg(feature = "UI_ViewManagement")]
 pub trait ILauncherViewOptions_Impl: Sized {
     fn DesiredRemainingView(&self) -> ::windows::core::Result<super::UI::ViewManagement::ViewSizePreference>;

--- a/crates/libs/windows/src/Windows/UI/Composition/Interactions/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Interactions/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Composition_Interactions\"`, `\"implement\"`*"]
 pub trait ICompositionInteractionSource_Impl: Sized {}
 impl ::windows::core::RuntimeName for ICompositionInteractionSource {
     const NAME: &'static str = "Windows.UI.Composition.Interactions.ICompositionInteractionSource";
@@ -10,6 +11,7 @@ impl ICompositionInteractionSource_Vtbl {
         iid == &<ICompositionInteractionSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Composition_Interactions\"`, `\"implement\"`*"]
 pub trait IInteractionTrackerOwner_Impl: Sized {
     fn CustomAnimationStateEntered(&self, sender: &::core::option::Option<InteractionTracker>, args: &::core::option::Option<InteractionTrackerCustomAnimationStateEnteredArgs>) -> ::windows::core::Result<()>;
     fn IdleStateEntered(&self, sender: &::core::option::Option<InteractionTracker>, args: &::core::option::Option<InteractionTrackerIdleStateEnteredArgs>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/UI/Composition/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Composition\"`, `\"implement\"`*"]
 pub trait IAnimationObject_Impl: Sized {
     fn PopulatePropertyInfo(&self, propertyname: &::windows::core::HSTRING, propertyinfo: &::core::option::Option<AnimationPropertyInfo>) -> ::windows::core::Result<()>;
 }
@@ -20,6 +21,7 @@ impl IAnimationObject_Vtbl {
         iid == &<IAnimationObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Composition\"`, `\"implement\"`*"]
 pub trait ICompositionAnimationBase_Impl: Sized {}
 impl ::windows::core::RuntimeName for ICompositionAnimationBase {
     const NAME: &'static str = "Windows.UI.Composition.ICompositionAnimationBase";
@@ -32,6 +34,7 @@ impl ICompositionAnimationBase_Vtbl {
         iid == &<ICompositionAnimationBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Composition\"`, `\"implement\"`*"]
 pub trait ICompositionSupportsSystemBackdrop_Impl: Sized {
     fn SystemBackdrop(&self) -> ::windows::core::Result<CompositionBrush>;
     fn SetSystemBackdrop(&self, value: &::core::option::Option<CompositionBrush>) -> ::windows::core::Result<()>;
@@ -68,6 +71,7 @@ impl ICompositionSupportsSystemBackdrop_Vtbl {
         iid == &<ICompositionSupportsSystemBackdrop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Composition\"`, `\"implement\"`*"]
 pub trait ICompositionSurface_Impl: Sized {}
 impl ::windows::core::RuntimeName for ICompositionSurface {
     const NAME: &'static str = "Windows.UI.Composition.ICompositionSurface";
@@ -80,6 +84,7 @@ impl ICompositionSurface_Vtbl {
         iid == &<ICompositionSurface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Composition\"`, `\"implement\"`*"]
 pub trait ICompositionSurfaceFacade_Impl: Sized {
     fn GetRealSurface(&self) -> ::windows::core::Result<ICompositionSurface>;
 }
@@ -109,6 +114,7 @@ impl ICompositionSurfaceFacade_Vtbl {
         iid == &<ICompositionSurfaceFacade as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Composition\"`, `\"implement\"`*"]
 pub trait IVisualElement_Impl: Sized {}
 impl ::windows::core::RuntimeName for IVisualElement {
     const NAME: &'static str = "Windows.UI.Composition.IVisualElement";
@@ -121,6 +127,7 @@ impl IVisualElement_Vtbl {
         iid == &<IVisualElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Composition\"`, `\"implement\"`*"]
 pub trait IVisualElement2_Impl: Sized {
     fn GetVisualInternal(&self) -> ::windows::core::Result<Visual>;
 }

--- a/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Core_AnimationMetrics\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPropertyAnimation_Impl: Sized {
     fn Type(&self) -> ::windows::core::Result<PropertyAnimationType>;

--- a/crates/libs/windows/src/Windows/UI/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ICoreAcceleratorKeys_Impl: Sized {
     fn AcceleratorKeyActivated(&self, handler: &::core::option::Option<super::super::Foundation::TypedEventHandler<CoreDispatcher, AcceleratorKeyEventArgs>>) -> ::windows::core::Result<super::super::Foundation::EventRegistrationToken>;
@@ -37,6 +38,7 @@ impl ICoreAcceleratorKeys_Vtbl {
         iid == &<ICoreAcceleratorKeys as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ICoreInputSourceBase_Impl: Sized {
     fn Dispatcher(&self) -> ::windows::core::Result<CoreDispatcher>;
@@ -111,6 +113,7 @@ impl ICoreInputSourceBase_Vtbl {
         iid == &<ICoreInputSourceBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ICorePointerInputSource_Impl: Sized {
     fn ReleasePointerCapture(&self) -> ::windows::core::Result<()>;
@@ -339,6 +342,7 @@ impl ICorePointerInputSource_Vtbl {
         iid == &<ICorePointerInputSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Core\"`, `\"Foundation\"`, `\"System\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "System"))]
 pub trait ICorePointerInputSource2_Impl: Sized + ICorePointerInputSource_Impl {
     fn DispatcherQueue(&self) -> ::windows::core::Result<super::super::System::DispatcherQueue>;
@@ -371,6 +375,7 @@ impl ICorePointerInputSource2_Vtbl {
         iid == &<ICorePointerInputSource2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Core\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait ICorePointerRedirector_Impl: Sized {
     fn PointerRoutedAway(&self, handler: &::core::option::Option<super::super::Foundation::TypedEventHandler<ICorePointerRedirector, PointerEventArgs>>) -> ::windows::core::Result<super::super::Foundation::EventRegistrationToken>;
@@ -452,6 +457,7 @@ impl ICorePointerRedirector_Vtbl {
         iid == &<ICorePointerRedirector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Core\"`, `\"Foundation_Collections\"`, `\"System\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "System"))]
 pub trait ICoreWindow_Impl: Sized {
     fn AutomationHostProvider(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
@@ -1030,6 +1036,7 @@ impl ICoreWindow_Vtbl {
         iid == &<ICoreWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Core\"`, `\"implement\"`*"]
 pub trait ICoreWindowEventArgs_Impl: Sized {
     fn Handled(&self) -> ::windows::core::Result<bool>;
     fn SetHandled(&self, value: bool) -> ::windows::core::Result<()>;
@@ -1066,6 +1073,7 @@ impl ICoreWindowEventArgs_Vtbl {
         iid == &<ICoreWindowEventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Core\"`, `\"implement\"`*"]
 pub trait IInitializeWithCoreWindow_Impl: Sized {
     fn Initialize(&self, window: &::core::option::Option<CoreWindow>) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Input_Inking_Analysis\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IInkAnalysisNode_Impl: Sized {
     fn Id(&self) -> ::windows::core::Result<u32>;
@@ -114,6 +115,7 @@ impl IInkAnalysisNode_Vtbl {
         iid == &<IInkAnalysisNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Input_Inking_Analysis\"`, `\"implement\"`*"]
 pub trait IInkAnalyzerFactory_Impl: Sized {
     fn CreateAnalyzer(&self) -> ::windows::core::Result<InkAnalyzer>;
 }

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Input_Inking\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IInkPointFactory_Impl: Sized {
     fn CreateInkPoint(&self, position: &super::super::super::Foundation::Point, pressure: f32) -> ::windows::core::Result<InkPoint>;
@@ -30,6 +31,7 @@ impl IInkPointFactory_Vtbl {
         iid == &<IInkPointFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Input_Inking\"`, `\"implement\"`*"]
 pub trait IInkPresenterRulerFactory_Impl: Sized {
     fn Create(&self, inkpresenter: &::core::option::Option<InkPresenter>) -> ::windows::core::Result<InkPresenterRuler>;
 }
@@ -56,6 +58,7 @@ impl IInkPresenterRulerFactory_Vtbl {
         iid == &<IInkPresenterRulerFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Input_Inking\"`, `\"Foundation_Numerics\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Numerics")]
 pub trait IInkPresenterStencil_Impl: Sized {
     fn Kind(&self) -> ::windows::core::Result<InkPresenterStencilKind>;
@@ -172,6 +175,7 @@ impl IInkPresenterStencil_Vtbl {
         iid == &<IInkPresenterStencil as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Input_Inking\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IInkRecognizerContainer_Impl: Sized {
     fn SetDefaultRecognizer(&self, recognizer: &::core::option::Option<InkRecognizer>) -> ::windows::core::Result<()>;
@@ -225,6 +229,7 @@ impl IInkRecognizerContainer_Vtbl {
         iid == &<IInkRecognizerContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Input_Inking\"`, `\"Foundation_Collections\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Collections", feature = "Storage_Streams"))]
 pub trait IInkStrokeContainer_Impl: Sized {
     fn BoundingRect(&self) -> ::windows::core::Result<super::super::super::Foundation::Rect>;

--- a/crates/libs/windows/src/Windows/UI/Input/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Input\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IPointerPointTransform_Impl: Sized {
     fn Inverse(&self) -> ::windows::core::Result<IPointerPointTransform>;

--- a/crates/libs/windows/src/Windows/UI/Notifications/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Notifications\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Collections")]
 pub trait IAdaptiveNotificationContent_Impl: Sized {
     fn Kind(&self) -> ::windows::core::Result<AdaptiveNotificationContentKind>;

--- a/crates/libs/windows/src/Windows/UI/Popups/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Popups\"`, `\"implement\"`*"]
 pub trait IUICommand_Impl: Sized {
     fn Label(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn SetLabel(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/UI/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Shell/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Shell\"`, `\"implement\"`*"]
 pub trait IAdaptiveCard_Impl: Sized {
     fn ToJson(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -24,6 +25,7 @@ impl IAdaptiveCard_Vtbl {
         iid == &<IAdaptiveCard as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Shell\"`, `\"implement\"`*"]
 pub trait IAdaptiveCardBuilderStatics_Impl: Sized {
     fn CreateAdaptiveCardFromJson(&self, value: &::windows::core::HSTRING) -> ::windows::core::Result<IAdaptiveCard>;
 }

--- a/crates/libs/windows/src/Windows/UI/Text/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_Text\"`, `\"implement\"`*"]
 pub trait ITextCharacterFormat_Impl: Sized {
     fn AllCaps(&self) -> ::windows::core::Result<FormatEffect>;
     fn SetAllCaps(&self, value: FormatEffect) -> ::windows::core::Result<()>;
@@ -545,6 +546,7 @@ impl ITextCharacterFormat_Vtbl {
         iid == &<ITextCharacterFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Text\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait ITextDocument_Impl: Sized {
     fn CaretType(&self) -> ::windows::core::Result<CaretType>;
@@ -850,6 +852,7 @@ impl ITextDocument_Vtbl {
         iid == &<ITextDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Text\"`, `\"implement\"`*"]
 pub trait ITextParagraphFormat_Impl: Sized {
     fn Alignment(&self) -> ::windows::core::Result<ParagraphAlignment>;
     fn SetAlignment(&self, value: ParagraphAlignment) -> ::windows::core::Result<()>;
@@ -1369,6 +1372,7 @@ impl ITextParagraphFormat_Vtbl {
         iid == &<ITextParagraphFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Text\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait ITextRange_Impl: Sized {
     fn Character(&self) -> ::windows::core::Result<u16>;
@@ -1926,6 +1930,7 @@ impl ITextRange_Vtbl {
         iid == &<ITextRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_Text\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait ITextSelection_Impl: Sized + ITextRange_Impl {
     fn Options(&self) -> ::windows::core::Result<SelectionOptions>;

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_UIAutomation_Core\"`, `\"implement\"`*"]
 pub trait ICoreAutomationConnectionBoundObjectProvider_Impl: Sized {
     fn IsComThreadingRequired(&self) -> ::windows::core::Result<bool>;
 }
@@ -27,6 +28,7 @@ impl ICoreAutomationConnectionBoundObjectProvider_Vtbl {
         iid == &<ICoreAutomationConnectionBoundObjectProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_UIAutomation_Core\"`, `\"implement\"`*"]
 pub trait ICoreAutomationRemoteOperationExtensionProvider_Impl: Sized {
     fn CallExtension(&self, extensionid: &::windows::core::GUID, context: &::core::option::Option<CoreAutomationRemoteOperationContext>, operandids: &[AutomationRemoteOperationOperandId]) -> ::windows::core::Result<()>;
     fn IsExtensionSupported(&self, extensionid: &::windows::core::GUID) -> ::windows::core::Result<bool>;

--- a/crates/libs/windows/src/Windows/UI/WebUI/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/Core/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_WebUI_Core\"`, `\"implement\"`*"]
 pub trait IWebUICommandBarElement_Impl: Sized {}
 impl ::windows::core::RuntimeName for IWebUICommandBarElement {
     const NAME: &'static str = "Windows.UI.WebUI.Core.IWebUICommandBarElement";
@@ -10,6 +11,7 @@ impl IWebUICommandBarElement_Vtbl {
         iid == &<IWebUICommandBarElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_WebUI_Core\"`, `\"implement\"`*"]
 pub trait IWebUICommandBarIcon_Impl: Sized {}
 impl ::windows::core::RuntimeName for IWebUICommandBarIcon {
     const NAME: &'static str = "Windows.UI.WebUI.Core.IWebUICommandBarIcon";

--- a/crates/libs/windows/src/Windows/UI/WebUI/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"UI_WebUI\"`, `\"implement\"`*"]
 pub trait IActivatedEventArgsDeferral_Impl: Sized {
     fn ActivatedOperation(&self) -> ::windows::core::Result<ActivatedOperation>;
 }
@@ -27,6 +28,7 @@ impl IActivatedEventArgsDeferral_Vtbl {
         iid == &<IActivatedEventArgsDeferral as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_WebUI\"`, `\"implement\"`*"]
 pub trait IWebUIBackgroundTaskInstance_Impl: Sized {
     fn Succeeded(&self) -> ::windows::core::Result<bool>;
     fn SetSucceeded(&self, succeeded: bool) -> ::windows::core::Result<()>;
@@ -63,6 +65,7 @@ impl IWebUIBackgroundTaskInstance_Vtbl {
         iid == &<IWebUIBackgroundTaskInstance as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"UI_WebUI\"`, `\"implement\"`*"]
 pub trait IWebUINavigatedEventArgs_Impl: Sized {
     fn NavigatedOperation(&self) -> ::windows::core::Result<WebUINavigatedOperation>;
 }

--- a/crates/libs/windows/src/Windows/Web/Http/Filters/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Filters/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Web_Http_Filters\"`, `\"Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation")]
 pub trait IHttpFilter_Impl: Sized + super::super::super::Foundation::IClosable_Impl {
     fn SendRequestAsync(&self, request: &::core::option::Option<super::HttpRequestMessage>) -> ::windows::core::Result<super::super::super::Foundation::IAsyncOperationWithProgress<super::HttpResponseMessage, super::HttpProgress>>;

--- a/crates/libs/windows/src/Windows/Web/Http/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Web_Http\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"Web_Http_Headers\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams", feature = "Web_Http_Headers"))]
 pub trait IHttpContent_Impl: Sized + super::super::Foundation::IClosable_Impl {
     fn Headers(&self) -> ::windows::core::Result<Headers::HttpContentHeaderCollection>;

--- a/crates/libs/windows/src/Windows/Web/Syndication/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/Syndication/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Web_Syndication\"`, `\"Foundation\"`, `\"Security_Credentials\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Security_Credentials"))]
 pub trait ISyndicationClient_Impl: Sized {
     fn ServerCredential(&self) -> ::windows::core::Result<super::super::Security::Credentials::PasswordCredential>;
@@ -142,6 +143,7 @@ impl ISyndicationClient_Vtbl {
         iid == &<ISyndicationClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Web_Syndication\"`, `\"Data_Xml_Dom\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Data_Xml_Dom", feature = "Foundation_Collections"))]
 pub trait ISyndicationNode_Impl: Sized {
     fn NodeName(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -307,6 +309,7 @@ impl ISyndicationNode_Vtbl {
         iid == &<ISyndicationNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Web_Syndication\"`, `\"Data_Xml_Dom\"`, `\"Foundation_Collections\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Data_Xml_Dom", feature = "Foundation_Collections"))]
 pub trait ISyndicationText_Impl: Sized + ISyndicationNode_Impl {
     fn Text(&self) -> ::windows::core::Result<::windows::core::HSTRING>;

--- a/crates/libs/windows/src/Windows/Web/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Web_UI\"`, `\"ApplicationModel_DataTransfer\"`, `\"Foundation_Collections\"`, `\"Storage_Streams\"`, `\"UI\"`, `\"Web_Http\"`, `\"implement\"`*"]
 #[cfg(all(feature = "ApplicationModel_DataTransfer", feature = "Foundation_Collections", feature = "Storage_Streams", feature = "UI", feature = "Web_Http"))]
 pub trait IWebViewControl_Impl: Sized {
     fn Source(&self) -> ::windows::core::Result<super::super::Foundation::Uri>;
@@ -618,6 +619,7 @@ impl IWebViewControl_Vtbl {
         iid == &<IWebViewControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Web_UI\"`, `\"implement\"`*"]
 pub trait IWebViewControl2_Impl: Sized {
     fn AddInitializeScript(&self, script: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Web/impl.rs
+++ b/crates/libs/windows/src/Windows/Web/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Web\"`, `\"Foundation\"`, `\"Storage_Streams\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Storage_Streams"))]
 pub trait IUriToStreamResolver_Impl: Sized {
     fn UriToStreamAsync(&self, uri: &::core::option::Option<super::Foundation::Uri>) -> ::windows::core::Result<super::Foundation::IAsyncOperation<super::Storage::Streams::IInputStream>>;

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IDMLBindingTable_Impl: Sized + IDMLDeviceChild_Impl {
     fn BindInputs(&self, bindingcount: u32, bindings: *const DML_BINDING_DESC);
@@ -49,6 +50,7 @@ impl IDMLBindingTable_Vtbl {
         iid == &<IDMLBindingTable as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID || iid == &<IDMLDeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IDMLCommandRecorder_Impl: Sized + IDMLDeviceChild_Impl {
     fn RecordDispatch(&self, commandlist: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12CommandList>, dispatchable: &::core::option::Option<IDMLDispatchable>, bindings: &::core::option::Option<IDMLBindingTable>);
@@ -69,6 +71,7 @@ impl IDMLCommandRecorder_Vtbl {
         iid == &<IDMLCommandRecorder as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID || iid == &<IDMLDeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"implement\"`*"]
 pub trait IDMLCompiledOperator_Impl: Sized + IDMLDispatchable_Impl {}
 impl ::windows::core::RuntimeName for IDMLCompiledOperator {}
 impl IDMLCompiledOperator_Vtbl {
@@ -79,6 +82,7 @@ impl IDMLCompiledOperator_Vtbl {
         iid == &<IDMLCompiledOperator as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID || iid == &<IDMLDeviceChild as ::windows::core::Interface>::IID || iid == &<IDMLPageable as ::windows::core::Interface>::IID || iid == &<IDMLDispatchable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDMLDebugDevice_Impl: Sized {
     fn SetMuteDebugOutput(&self, mute: super::super::super::Foundation::BOOL);
@@ -99,6 +103,7 @@ impl IDMLDebugDevice_Vtbl {
         iid == &<IDMLDebugDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IDMLDevice_Impl: Sized + IDMLObject_Impl {
     fn CheckFeatureSupport(&self, feature: DML_FEATURE, featurequerydatasize: u32, featurequerydata: *const ::core::ffi::c_void, featuresupportdatasize: u32, featuresupportdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -185,6 +190,7 @@ impl IDMLDevice_Vtbl {
         iid == &<IDMLDevice as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IDMLDevice1_Impl: Sized + IDMLDevice_Impl {
     fn CompileGraph(&self, desc: *const DML_GRAPH_DESC, flags: DML_EXECUTION_FLAGS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -205,6 +211,7 @@ impl IDMLDevice1_Vtbl {
         iid == &<IDMLDevice1 as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID || iid == &<IDMLDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"implement\"`*"]
 pub trait IDMLDeviceChild_Impl: Sized + IDMLObject_Impl {
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -222,6 +229,7 @@ impl IDMLDeviceChild_Vtbl {
         iid == &<IDMLDeviceChild as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"implement\"`*"]
 pub trait IDMLDispatchable_Impl: Sized + IDMLPageable_Impl {
     fn GetBindingProperties(&self) -> DML_BINDING_PROPERTIES;
 }
@@ -239,6 +247,7 @@ impl IDMLDispatchable_Vtbl {
         iid == &<IDMLDispatchable as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID || iid == &<IDMLDeviceChild as ::windows::core::Interface>::IID || iid == &<IDMLPageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"implement\"`*"]
 pub trait IDMLObject_Impl: Sized {
     fn GetPrivateData(&self, guid: *const ::windows::core::GUID, datasize: *mut u32, data: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn SetPrivateData(&self, guid: *const ::windows::core::GUID, datasize: u32, data: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -280,6 +289,7 @@ impl IDMLObject_Vtbl {
         iid == &<IDMLObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"implement\"`*"]
 pub trait IDMLOperator_Impl: Sized + IDMLDeviceChild_Impl {}
 impl ::windows::core::RuntimeName for IDMLOperator {}
 impl IDMLOperator_Vtbl {
@@ -290,6 +300,7 @@ impl IDMLOperator_Vtbl {
         iid == &<IDMLOperator as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID || iid == &<IDMLDeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"implement\"`*"]
 pub trait IDMLOperatorInitializer_Impl: Sized + IDMLDispatchable_Impl {
     fn Reset(&self, operatorcount: u32, operators: *const ::core::option::Option<IDMLCompiledOperator>) -> ::windows::core::Result<()>;
 }
@@ -307,6 +318,7 @@ impl IDMLOperatorInitializer_Vtbl {
         iid == &<IDMLOperatorInitializer as ::windows::core::Interface>::IID || iid == &<IDMLObject as ::windows::core::Interface>::IID || iid == &<IDMLDeviceChild as ::windows::core::Interface>::IID || iid == &<IDMLPageable as ::windows::core::Interface>::IID || iid == &<IDMLDispatchable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_DirectML\"`, `\"implement\"`*"]
 pub trait IDMLPageable_Impl: Sized + IDMLDeviceChild_Impl {}
 impl ::windows::core::RuntimeName for IDMLPageable {}
 impl IDMLPageable_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorAttributes_Impl: Sized {
     fn GetAttributeElementCount(&self, name: &::windows::core::PCSTR, r#type: MLOperatorAttributeType) -> ::windows::core::Result<u32>;
     fn GetAttribute(&self, name: &::windows::core::PCSTR, r#type: MLOperatorAttributeType, elementcount: u32, elementbytesize: usize, value: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -51,6 +52,7 @@ impl IMLOperatorAttributes_Vtbl {
         iid == &<IMLOperatorAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorKernel_Impl: Sized {
     fn Compute(&self, context: &::core::option::Option<IMLOperatorKernelContext>) -> ::windows::core::Result<()>;
 }
@@ -68,6 +70,7 @@ impl IMLOperatorKernel_Vtbl {
         iid == &<IMLOperatorKernel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorKernelContext_Impl: Sized {
     fn GetInputTensor(&self, inputindex: u32, tensor: *mut ::core::option::Option<IMLOperatorTensor>) -> ::windows::core::Result<()>;
     fn GetOutputTensor(&self, outputindex: u32, dimensioncount: u32, dimensionsizes: *const u32, tensor: *mut ::core::option::Option<IMLOperatorTensor>) -> ::windows::core::Result<()>;
@@ -122,6 +125,7 @@ impl IMLOperatorKernelContext_Vtbl {
         iid == &<IMLOperatorKernelContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorKernelCreationContext_Impl: Sized + IMLOperatorAttributes_Impl {
     fn GetInputCount(&self) -> u32;
     fn GetOutputCount(&self) -> u32;
@@ -216,6 +220,7 @@ impl IMLOperatorKernelCreationContext_Vtbl {
         iid == &<IMLOperatorKernelCreationContext as ::windows::core::Interface>::IID || iid == &<IMLOperatorAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorKernelFactory_Impl: Sized {
     fn CreateKernel(&self, context: &::core::option::Option<IMLOperatorKernelCreationContext>) -> ::windows::core::Result<IMLOperatorKernel>;
 }
@@ -239,6 +244,7 @@ impl IMLOperatorKernelFactory_Vtbl {
         iid == &<IMLOperatorKernelFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorRegistry_Impl: Sized {
     fn RegisterOperatorSetSchema(&self, operatorsetid: *const MLOperatorSetId, baselineversion: i32, schema: *const *const MLOperatorSchemaDescription, schemacount: u32, typeinferrer: &::core::option::Option<IMLOperatorTypeInferrer>, shapeinferrer: &::core::option::Option<IMLOperatorShapeInferrer>) -> ::windows::core::Result<()>;
     fn RegisterOperatorKernel(&self, operatorkernel: *const MLOperatorKernelDescription, operatorkernelfactory: &::core::option::Option<IMLOperatorKernelFactory>, shapeinferrer: &::core::option::Option<IMLOperatorShapeInferrer>) -> ::windows::core::Result<()>;
@@ -266,6 +272,7 @@ impl IMLOperatorRegistry_Vtbl {
         iid == &<IMLOperatorRegistry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorShapeInferenceContext_Impl: Sized + IMLOperatorAttributes_Impl {
     fn GetInputCount(&self) -> u32;
     fn GetOutputCount(&self) -> u32;
@@ -347,6 +354,7 @@ impl IMLOperatorShapeInferenceContext_Vtbl {
         iid == &<IMLOperatorShapeInferenceContext as ::windows::core::Interface>::IID || iid == &<IMLOperatorAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorShapeInferrer_Impl: Sized {
     fn InferOutputShapes(&self, context: &::core::option::Option<IMLOperatorShapeInferenceContext>) -> ::windows::core::Result<()>;
 }
@@ -364,6 +372,7 @@ impl IMLOperatorShapeInferrer_Vtbl {
         iid == &<IMLOperatorShapeInferrer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorTensor_Impl: Sized {
     fn GetDimensionCount(&self) -> u32;
     fn GetShape(&self, dimensioncount: u32, dimensions: *mut u32) -> ::windows::core::Result<()>;
@@ -426,6 +435,7 @@ impl IMLOperatorTensor_Vtbl {
         iid == &<IMLOperatorTensor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorTensorShapeDescription_Impl: Sized {
     fn GetInputTensorDimensionCount(&self, inputindex: u32) -> ::windows::core::Result<u32>;
     fn GetInputTensorShape(&self, inputindex: u32, dimensioncount: u32, dimensions: *mut u32) -> ::windows::core::Result<()>;
@@ -486,6 +496,7 @@ impl IMLOperatorTensorShapeDescription_Vtbl {
         iid == &<IMLOperatorTensorShapeDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorTypeInferenceContext_Impl: Sized + IMLOperatorAttributes_Impl {
     fn GetInputCount(&self) -> u32;
     fn GetOutputCount(&self) -> u32;
@@ -547,6 +558,7 @@ impl IMLOperatorTypeInferenceContext_Vtbl {
         iid == &<IMLOperatorTypeInferenceContext as ::windows::core::Interface>::IID || iid == &<IMLOperatorAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IMLOperatorTypeInferrer_Impl: Sized {
     fn InferOutputTypes(&self, context: &::core::option::Option<IMLOperatorTypeInferenceContext>) -> ::windows::core::Result<()>;
 }
@@ -564,6 +576,7 @@ impl IMLOperatorTypeInferrer_Vtbl {
         iid == &<IMLOperatorTypeInferrer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IWinMLEvaluationContext_Impl: Sized {
     fn BindValue(&self, pdescriptor: *const WINML_BINDING_DESC) -> ::windows::core::Result<()>;
@@ -607,6 +620,7 @@ impl IWinMLEvaluationContext_Vtbl {
         iid == &<IWinMLEvaluationContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWinMLModel_Impl: Sized {
     fn GetDescription(&self) -> ::windows::core::Result<*mut WINML_MODEL_DESC>;
@@ -669,6 +683,7 @@ impl IWinMLModel_Vtbl {
         iid == &<IWinMLModel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IWinMLRuntime_Impl: Sized {
     fn LoadModel(&self, path: &::windows::core::PCWSTR) -> ::windows::core::Result<IWinMLModel>;
@@ -718,6 +733,7 @@ impl IWinMLRuntime_Vtbl {
         iid == &<IWinMLRuntime as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 pub trait IWinMLRuntimeFactory_Impl: Sized {
     fn CreateRuntime(&self, runtimetype: WINML_RUNTIME_TYPE) -> ::windows::core::Result<IWinMLRuntime>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IITDatabase_Impl: Sized {
     fn Open(&self, lpszhost: &::windows::core::PCWSTR, lpszmoniker: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
@@ -49,6 +50,7 @@ impl IITDatabase_Vtbl {
         iid == &<IITDatabase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IITPropList_Impl: Sized + super::super::System::Com::IPersistStreamInit_Impl {
     fn Set(&self, propid: u32, lpszwstring: &::windows::core::PCWSTR, dwoperation: u32) -> ::windows::core::Result<()>;
@@ -191,6 +193,7 @@ impl IITPropList_Vtbl {
         iid == &<IITPropList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersistStreamInit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IITResultSet_Impl: Sized {
     fn SetColumnPriority(&self, lcolumnindex: i32, columnpriority: PRIORITY) -> ::windows::core::Result<()>;
@@ -417,6 +420,7 @@ impl IITResultSet_Vtbl {
         iid == &<IITResultSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IITWordWheel_Impl: Sized {
     fn Open(&self, lpitdb: &::core::option::Option<IITDatabase>, lpszmoniker: &::windows::core::PCWSTR, dwflags: WORD_WHEEL_OPEN_FLAGS) -> ::windows::core::Result<()>;
@@ -524,6 +528,7 @@ impl IITWordWheel_Vtbl {
         iid == &<IITWordWheel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`, `\"implement\"`*"]
 pub trait IStemSink_Impl: Sized {
     fn PutAltWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
     fn PutWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
@@ -551,6 +556,7 @@ impl IStemSink_Vtbl {
         iid == &<IStemSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IStemmerConfig_Impl: Sized {
     fn SetLocaleInfo(&self, dwcodepageid: u32, lcid: u32) -> ::windows::core::Result<()>;
@@ -602,6 +608,7 @@ impl IStemmerConfig_Vtbl {
         iid == &<IStemmerConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`, `\"Win32_System_Com\"`, `\"Win32_System_Search\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search"))]
 pub trait IWordBreakerConfig_Impl: Sized {
     fn SetLocaleInfo(&self, dwcodepageid: u32, lcid: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMXAttributes_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn addAttribute(&self, struri: &::windows::core::BSTR, strlocalname: &::windows::core::BSTR, strqname: &::windows::core::BSTR, strtype: &::windows::core::BSTR, strvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -91,6 +92,7 @@ impl IMXAttributes_Vtbl {
         iid == &<IMXAttributes as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMXNamespaceManager_Impl: Sized {
     fn putAllowOverride(&self, foverride: super::super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -183,6 +185,7 @@ impl IMXNamespaceManager_Vtbl {
         iid == &<IMXNamespaceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMXNamespacePrefixes_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_item(&self, index: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -238,6 +241,7 @@ impl IMXNamespacePrefixes_Vtbl {
         iid == &<IMXNamespacePrefixes as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMXReaderControl_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn abort(&self) -> ::windows::core::Result<()>;
@@ -275,6 +279,7 @@ impl IMXReaderControl_Vtbl {
         iid == &<IMXReaderControl as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMXSchemaDeclHandler_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn schemaElementDecl(&self, oschemaelement: &::core::option::Option<ISchemaElement>) -> ::windows::core::Result<()>;
@@ -298,6 +303,7 @@ impl IMXSchemaDeclHandler_Vtbl {
         iid == &<IMXSchemaDeclHandler as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMXWriter_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Setoutput(&self, vardestination: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -481,6 +487,7 @@ impl IMXWriter_Vtbl {
         iid == &<IMXWriter as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMXXMLFilter_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn getFeature(&self, strname: &::windows::core::BSTR) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;
@@ -617,6 +624,7 @@ impl IMXXMLFilter_Vtbl {
         iid == &<IMXXMLFilter as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait ISAXAttributes_Impl: Sized {
     fn getLength(&self) -> ::windows::core::Result<i32>;
     fn getURI(&self, nindex: i32, ppwchuri: *mut *mut u16, pcchuri: *mut i32) -> ::windows::core::Result<()>;
@@ -739,6 +747,7 @@ impl ISAXAttributes_Vtbl {
         iid == &<ISAXAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait ISAXContentHandler_Impl: Sized {
     fn putDocumentLocator(&self, plocator: &::core::option::Option<ISAXLocator>) -> ::windows::core::Result<()>;
     fn startDocument(&self) -> ::windows::core::Result<()>;
@@ -829,6 +838,7 @@ impl ISAXContentHandler_Vtbl {
         iid == &<ISAXContentHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait ISAXDTDHandler_Impl: Sized {
     fn notationDecl(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchpublicid: &::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: &::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::Result<()>;
     fn unparsedEntityDecl(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchpublicid: &::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: &::windows::core::PCWSTR, cchsystemid: i32, pwchnotationname: &::windows::core::PCWSTR, cchnotationname: i32) -> ::windows::core::Result<()>;
@@ -856,6 +866,7 @@ impl ISAXDTDHandler_Vtbl {
         iid == &<ISAXDTDHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait ISAXDeclHandler_Impl: Sized {
     fn elementDecl(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchmodel: &::windows::core::PCWSTR, cchmodel: i32) -> ::windows::core::Result<()>;
     fn attributeDecl(&self, pwchelementname: &::windows::core::PCWSTR, cchelementname: i32, pwchattributename: &::windows::core::PCWSTR, cchattributename: i32, pwchtype: &::windows::core::PCWSTR, cchtype: i32, pwchvaluedefault: &::windows::core::PCWSTR, cchvaluedefault: i32, pwchvalue: &::windows::core::PCWSTR, cchvalue: i32) -> ::windows::core::Result<()>;
@@ -897,6 +908,7 @@ impl ISAXDeclHandler_Vtbl {
         iid == &<ISAXDeclHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISAXEntityResolver_Impl: Sized {
     fn resolveEntity(&self, pwchpublicid: &::windows::core::PCWSTR, pwchsystemid: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
@@ -923,6 +935,7 @@ impl ISAXEntityResolver_Vtbl {
         iid == &<ISAXEntityResolver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait ISAXErrorHandler_Impl: Sized {
     fn error(&self, plocator: &::core::option::Option<ISAXLocator>, pwcherrormessage: &::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn fatalError(&self, plocator: &::core::option::Option<ISAXLocator>, pwcherrormessage: &::windows::core::PCWSTR, hrerrorcode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -957,6 +970,7 @@ impl ISAXErrorHandler_Vtbl {
         iid == &<ISAXErrorHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait ISAXLexicalHandler_Impl: Sized {
     fn startDTD(&self, pwchname: &::windows::core::PCWSTR, cchname: i32, pwchpublicid: &::windows::core::PCWSTR, cchpublicid: i32, pwchsystemid: &::windows::core::PCWSTR, cchsystemid: i32) -> ::windows::core::Result<()>;
     fn endDTD(&self) -> ::windows::core::Result<()>;
@@ -1019,6 +1033,7 @@ impl ISAXLexicalHandler_Vtbl {
         iid == &<ISAXLexicalHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait ISAXLocator_Impl: Sized {
     fn getColumnNumber(&self) -> ::windows::core::Result<i32>;
     fn getLineNumber(&self) -> ::windows::core::Result<i32>;
@@ -1084,6 +1099,7 @@ impl ISAXLocator_Vtbl {
         iid == &<ISAXLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISAXXMLFilter_Impl: Sized + ISAXXMLReader_Impl {
     fn getParent(&self) -> ::windows::core::Result<ISAXXMLReader>;
@@ -1120,6 +1136,7 @@ impl ISAXXMLFilter_Vtbl {
         iid == &<ISAXXMLFilter as ::windows::core::Interface>::IID || iid == &<ISAXXMLReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISAXXMLReader_Impl: Sized {
     fn getFeature(&self, pwchname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;
@@ -1310,6 +1327,7 @@ impl ISAXXMLReader_Vtbl {
         iid == &<ISAXXMLReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchema_Impl: Sized + ISchemaItem_Impl {
     fn targetNamespace(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1443,6 +1461,7 @@ impl ISchema_Vtbl {
         iid == &<ISchema as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaAny_Impl: Sized + ISchemaParticle_Impl {
     fn namespaces(&self) -> ::windows::core::Result<ISchemaStringCollection>;
@@ -1485,6 +1504,7 @@ impl ISchemaAny_Vtbl {
         iid == &<ISchemaAny as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID || iid == &<ISchemaParticle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaAttribute_Impl: Sized + ISchemaItem_Impl {
     fn r#type(&self) -> ::windows::core::Result<ISchemaType>;
@@ -1579,6 +1599,7 @@ impl ISchemaAttribute_Vtbl {
         iid == &<ISchemaAttribute as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaAttributeGroup_Impl: Sized + ISchemaItem_Impl {
     fn anyAttribute(&self) -> ::windows::core::Result<ISchemaAny>;
@@ -1621,6 +1642,7 @@ impl ISchemaAttributeGroup_Vtbl {
         iid == &<ISchemaAttributeGroup as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaComplexType_Impl: Sized + ISchemaType_Impl {
     fn isAbstract(&self) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;
@@ -1715,6 +1737,7 @@ impl ISchemaComplexType_Vtbl {
         iid == &<ISchemaComplexType as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID || iid == &<ISchemaType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaElement_Impl: Sized + ISchemaParticle_Impl {
     fn r#type(&self) -> ::windows::core::Result<ISchemaType>;
@@ -1874,6 +1897,7 @@ impl ISchemaElement_Vtbl {
         iid == &<ISchemaElement as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID || iid == &<ISchemaParticle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaIdentityConstraint_Impl: Sized + ISchemaItem_Impl {
     fn selector(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1929,6 +1953,7 @@ impl ISchemaIdentityConstraint_Vtbl {
         iid == &<ISchemaIdentityConstraint as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaItem_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2036,6 +2061,7 @@ impl ISchemaItem_Vtbl {
         iid == &<ISchemaItem as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaItemCollection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_item(&self, index: i32) -> ::windows::core::Result<ISchemaItem>;
@@ -2117,6 +2143,7 @@ impl ISchemaItemCollection_Vtbl {
         iid == &<ISchemaItemCollection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaModelGroup_Impl: Sized + ISchemaParticle_Impl {
     fn particles(&self) -> ::windows::core::Result<ISchemaItemCollection>;
@@ -2143,6 +2170,7 @@ impl ISchemaModelGroup_Vtbl {
         iid == &<ISchemaModelGroup as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID || iid == &<ISchemaParticle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaNotation_Impl: Sized + ISchemaItem_Impl {
     fn systemIdentifier(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2185,6 +2213,7 @@ impl ISchemaNotation_Vtbl {
         iid == &<ISchemaNotation as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaParticle_Impl: Sized + ISchemaItem_Impl {
     fn minOccurs(&self) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
@@ -2227,6 +2256,7 @@ impl ISchemaParticle_Vtbl {
         iid == &<ISchemaParticle as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaStringCollection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_item(&self, index: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2282,6 +2312,7 @@ impl ISchemaStringCollection_Vtbl {
         iid == &<ISchemaStringCollection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchemaType_Impl: Sized + ISchemaItem_Impl {
     fn baseTypes(&self) -> ::windows::core::Result<ISchemaItemCollection>;
@@ -2519,6 +2550,7 @@ impl ISchemaType_Vtbl {
         iid == &<ISchemaType as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISchemaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IServerXMLHTTPRequest_Impl: Sized + IXMLHTTPRequest_Impl {
     fn setTimeouts(&self, resolvetimeout: i32, connecttimeout: i32, sendtimeout: i32, receivetimeout: i32) -> ::windows::core::Result<()>;
@@ -2575,6 +2607,7 @@ impl IServerXMLHTTPRequest_Vtbl {
         iid == &<IServerXMLHTTPRequest as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLHTTPRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IServerXMLHTTPRequest2_Impl: Sized + IServerXMLHTTPRequest_Impl {
     fn setProxy(&self, proxysetting: SXH_PROXY_SETTING, varproxyserver: &super::super::super::System::Com::VARIANT, varbypasslist: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2605,6 +2638,7 @@ impl IServerXMLHTTPRequest2_Vtbl {
         iid == &<IServerXMLHTTPRequest2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLHTTPRequest as ::windows::core::Interface>::IID || iid == &<IServerXMLHTTPRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBMXNamespaceManager_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn SetallowOverride(&self, foverride: super::super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -2728,6 +2762,7 @@ impl IVBMXNamespaceManager_Vtbl {
         iid == &<IVBMXNamespaceManager as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXAttributes_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn length(&self) -> ::windows::core::Result<i32>;
@@ -2900,6 +2935,7 @@ impl IVBSAXAttributes_Vtbl {
         iid == &<IVBSAXAttributes as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXContentHandler_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn putref_documentLocator(&self, olocator: &::core::option::Option<IVBSAXLocator>) -> ::windows::core::Result<()>;
@@ -2993,6 +3029,7 @@ impl IVBSAXContentHandler_Vtbl {
         iid == &<IVBSAXContentHandler as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXDTDHandler_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn notationDecl(&self, strname: *mut ::windows::core::BSTR, strpublicid: *mut ::windows::core::BSTR, strsystemid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3023,6 +3060,7 @@ impl IVBSAXDTDHandler_Vtbl {
         iid == &<IVBSAXDTDHandler as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXDeclHandler_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn elementDecl(&self, strname: *mut ::windows::core::BSTR, strmodel: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3067,6 +3105,7 @@ impl IVBSAXDeclHandler_Vtbl {
         iid == &<IVBSAXDeclHandler as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXEntityResolver_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn resolveEntity(&self, strpublicid: *mut ::windows::core::BSTR, strsystemid: *mut ::windows::core::BSTR, varinput: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -3090,6 +3129,7 @@ impl IVBSAXEntityResolver_Vtbl {
         iid == &<IVBSAXEntityResolver as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXErrorHandler_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn error(&self, olocator: &::core::option::Option<IVBSAXLocator>, strerrormessage: *mut ::windows::core::BSTR, nerrorcode: i32) -> ::windows::core::Result<()>;
@@ -3127,6 +3167,7 @@ impl IVBSAXErrorHandler_Vtbl {
         iid == &<IVBSAXErrorHandler as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXLexicalHandler_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn startDTD(&self, strname: *mut ::windows::core::BSTR, strpublicid: *mut ::windows::core::BSTR, strsystemid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3192,6 +3233,7 @@ impl IVBSAXLexicalHandler_Vtbl {
         iid == &<IVBSAXLexicalHandler as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXLocator_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn columnNumber(&self) -> ::windows::core::Result<i32>;
@@ -3260,6 +3302,7 @@ impl IVBSAXLocator_Vtbl {
         iid == &<IVBSAXLocator as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXXMLFilter_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn parent(&self) -> ::windows::core::Result<IVBSAXXMLReader>;
@@ -3296,6 +3339,7 @@ impl IVBSAXXMLFilter_Vtbl {
         iid == &<IVBSAXXMLFilter as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVBSAXXMLReader_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn getFeature(&self, strname: &::windows::core::BSTR) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;
@@ -3486,6 +3530,7 @@ impl IVBSAXXMLReader_Vtbl {
         iid == &<IVBSAXXMLReader as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLAttribute_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3528,6 +3573,7 @@ impl IXMLAttribute_Vtbl {
         iid == &<IXMLAttribute as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMAttribute_Impl: Sized + IXMLDOMNode_Impl {
     fn name(&self, attributename: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3565,6 +3611,7 @@ impl IXMLDOMAttribute_Vtbl {
         iid == &<IXMLDOMAttribute as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMCDATASection_Impl: Sized + IXMLDOMText_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -3578,6 +3625,7 @@ impl IXMLDOMCDATASection_Vtbl {
         iid == &<IXMLDOMCDATASection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID || iid == &<IXMLDOMCharacterData as ::windows::core::Interface>::IID || iid == &<IXMLDOMText as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMCharacterData_Impl: Sized + IXMLDOMNode_Impl {
     fn data(&self, data: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3650,6 +3698,7 @@ impl IXMLDOMCharacterData_Vtbl {
         iid == &<IXMLDOMCharacterData as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMComment_Impl: Sized + IXMLDOMCharacterData_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -3663,6 +3712,7 @@ impl IXMLDOMComment_Vtbl {
         iid == &<IXMLDOMComment as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID || iid == &<IXMLDOMCharacterData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMDocument_Impl: Sized + IXMLDOMNode_Impl {
     fn doctype(&self) -> ::windows::core::Result<IXMLDOMDocumentType>;
@@ -4000,6 +4050,7 @@ impl IXMLDOMDocument_Vtbl {
         iid == &<IXMLDOMDocument as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMDocument2_Impl: Sized + IXMLDOMDocument_Impl {
     fn namespaces(&self) -> ::windows::core::Result<IXMLDOMSchemaCollection>;
@@ -4082,6 +4133,7 @@ impl IXMLDOMDocument2_Vtbl {
         iid == &<IXMLDOMDocument2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID || iid == &<IXMLDOMDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMDocument3_Impl: Sized + IXMLDOMDocument2_Impl {
     fn validateNode(&self, node: &::core::option::Option<IXMLDOMNode>) -> ::windows::core::Result<IXMLDOMParseError>;
@@ -4124,6 +4176,7 @@ impl IXMLDOMDocument3_Vtbl {
         iid == &<IXMLDOMDocument3 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID || iid == &<IXMLDOMDocument as ::windows::core::Interface>::IID || iid == &<IXMLDOMDocument2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMDocumentFragment_Impl: Sized + IXMLDOMNode_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -4137,6 +4190,7 @@ impl IXMLDOMDocumentFragment_Vtbl {
         iid == &<IXMLDOMDocumentFragment as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMDocumentType_Impl: Sized + IXMLDOMNode_Impl {
     fn name(&self, rootname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4186,6 +4240,7 @@ impl IXMLDOMDocumentType_Vtbl {
         iid == &<IXMLDOMDocumentType as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMElement_Impl: Sized + IXMLDOMNode_Impl {
     fn tagName(&self, tagname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4289,6 +4344,7 @@ impl IXMLDOMElement_Vtbl {
         iid == &<IXMLDOMElement as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMEntity_Impl: Sized + IXMLDOMNode_Impl {
     fn publicId(&self, publicid: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -4326,6 +4382,7 @@ impl IXMLDOMEntity_Vtbl {
         iid == &<IXMLDOMEntity as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMEntityReference_Impl: Sized + IXMLDOMNode_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -4339,6 +4396,7 @@ impl IXMLDOMEntityReference_Vtbl {
         iid == &<IXMLDOMEntityReference as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMImplementation_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn hasFeature(&self, feature: &::windows::core::BSTR, version: &::windows::core::BSTR, hasfeature: *mut super::super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -4359,6 +4417,7 @@ impl IXMLDOMImplementation_Vtbl {
         iid == &<IXMLDOMImplementation as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMNamedNodeMap_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn getNamedItem(&self, name: &::windows::core::BSTR) -> ::windows::core::Result<IXMLDOMNode>;
@@ -4493,6 +4552,7 @@ impl IXMLDOMNamedNodeMap_Vtbl {
         iid == &<IXMLDOMNamedNodeMap as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMNode_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn nodeName(&self, name: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4857,6 +4917,7 @@ impl IXMLDOMNode_Vtbl {
         iid == &<IXMLDOMNode as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMNodeList_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_item(&self, index: i32) -> ::windows::core::Result<IXMLDOMNode>;
@@ -4926,6 +4987,7 @@ impl IXMLDOMNodeList_Vtbl {
         iid == &<IXMLDOMNodeList as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMNotation_Impl: Sized + IXMLDOMNode_Impl {
     fn publicId(&self, publicid: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -4956,6 +5018,7 @@ impl IXMLDOMNotation_Vtbl {
         iid == &<IXMLDOMNotation as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMParseError_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn errorCode(&self, errorcode: *mut i32) -> ::windows::core::Result<()>;
@@ -5021,6 +5084,7 @@ impl IXMLDOMParseError_Vtbl {
         iid == &<IXMLDOMParseError as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMParseError2_Impl: Sized + IXMLDOMParseError_Impl {
     fn errorXPath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5089,6 +5153,7 @@ impl IXMLDOMParseError2_Vtbl {
         iid == &<IXMLDOMParseError2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMParseError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMParseErrorCollection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_item(&self, index: i32) -> ::windows::core::Result<IXMLDOMParseError2>;
@@ -5164,6 +5229,7 @@ impl IXMLDOMParseErrorCollection_Vtbl {
         iid == &<IXMLDOMParseErrorCollection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMProcessingInstruction_Impl: Sized + IXMLDOMNode_Impl {
     fn target(&self, name: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -5201,6 +5267,7 @@ impl IXMLDOMProcessingInstruction_Vtbl {
         iid == &<IXMLDOMProcessingInstruction as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMSchemaCollection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn add(&self, namespaceuri: &::windows::core::BSTR, var: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -5290,6 +5357,7 @@ impl IXMLDOMSchemaCollection_Vtbl {
         iid == &<IXMLDOMSchemaCollection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMSchemaCollection2_Impl: Sized + IXMLDOMSchemaCollection_Impl {
     fn validate(&self) -> ::windows::core::Result<()>;
@@ -5359,6 +5427,7 @@ impl IXMLDOMSchemaCollection2_Vtbl {
         iid == &<IXMLDOMSchemaCollection2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMSchemaCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMSelection_Impl: Sized + IXMLDOMNodeList_Impl {
     fn expr(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5494,6 +5563,7 @@ impl IXMLDOMSelection_Vtbl {
         iid == &<IXMLDOMSelection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNodeList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDOMText_Impl: Sized + IXMLDOMCharacterData_Impl {
     fn splitText(&self, offset: i32) -> ::windows::core::Result<IXMLDOMText>;
@@ -5520,6 +5590,7 @@ impl IXMLDOMText_Vtbl {
         iid == &<IXMLDOMText as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID || iid == &<IXMLDOMCharacterData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDSOControl_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn XMLDocument(&self) -> ::windows::core::Result<IXMLDOMDocument>;
@@ -5577,6 +5648,7 @@ impl IXMLDSOControl_Vtbl {
         iid == &<IXMLDSOControl as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDocument_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn root(&self) -> ::windows::core::Result<IXMLElement>;
@@ -5763,6 +5835,7 @@ impl IXMLDocument_Vtbl {
         iid == &<IXMLDocument as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLDocument2_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn root(&self) -> ::windows::core::Result<IXMLElement2>;
@@ -5969,6 +6042,7 @@ impl IXMLDocument2_Vtbl {
         iid == &<IXMLDocument2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLElement_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn tagName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6105,6 +6179,7 @@ impl IXMLElement_Vtbl {
         iid == &<IXMLElement as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLElement2_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn tagName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6254,6 +6329,7 @@ impl IXMLElement2_Vtbl {
         iid == &<IXMLElement2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLElementCollection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Setlength(&self, v: i32) -> ::windows::core::Result<()>;
@@ -6316,6 +6392,7 @@ impl IXMLElementCollection_Vtbl {
         iid == &<IXMLElementCollection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 pub trait IXMLError_Impl: Sized {
     fn GetErrorInfo(&self, perrorreturn: *mut XML_ERROR) -> ::windows::core::Result<()>;
 }
@@ -6333,6 +6410,7 @@ impl IXMLError_Vtbl {
         iid == &<IXMLError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLHTTPRequest_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn open(&self, bstrmethod: &::windows::core::BSTR, bstrurl: &::windows::core::BSTR, varasync: &super::super::super::System::Com::VARIANT, bstruser: &super::super::super::System::Com::VARIANT, bstrpassword: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -6501,6 +6579,7 @@ impl IXMLHTTPRequest_Vtbl {
         iid == &<IXMLHTTPRequest as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXMLHTTPRequest2_Impl: Sized {
     fn Open(&self, pwszmethod: &::windows::core::PCWSTR, pwszurl: &::windows::core::PCWSTR, pstatuscallback: &::core::option::Option<IXMLHTTPRequest2Callback>, pwszusername: &::windows::core::PCWSTR, pwszpassword: &::windows::core::PCWSTR, pwszproxyusername: &::windows::core::PCWSTR, pwszproxypassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -6605,6 +6684,7 @@ impl IXMLHTTPRequest2_Vtbl {
         iid == &<IXMLHTTPRequest2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IXMLHTTPRequest2Callback_Impl: Sized {
     fn OnRedirect(&self, pxhr: &::core::option::Option<IXMLHTTPRequest2>, pwszredirecturl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -6656,6 +6736,7 @@ impl IXMLHTTPRequest2Callback_Vtbl {
         iid == &<IXMLHTTPRequest2Callback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXMLHTTPRequest3_Impl: Sized + IXMLHTTPRequest2_Impl {
     fn SetClientCertificate(&self, cbclientcertificatehash: u32, pbclientcertificatehash: *const u8, pwszpin: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -6676,6 +6757,7 @@ impl IXMLHTTPRequest3_Vtbl {
         iid == &<IXMLHTTPRequest3 as ::windows::core::Interface>::IID || iid == &<IXMLHTTPRequest2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IXMLHTTPRequest3Callback_Impl: Sized + IXMLHTTPRequest2Callback_Impl {
     fn OnServerCertificateReceived(&self, pxhr: &::core::option::Option<IXMLHTTPRequest3>, dwcertificateerrors: u32, cservercertificatechain: u32, rgservercertificatechain: *const XHR_CERT) -> ::windows::core::Result<()>;
@@ -6706,6 +6788,7 @@ impl IXMLHTTPRequest3Callback_Vtbl {
         iid == &<IXMLHTTPRequest3Callback as ::windows::core::Interface>::IID || iid == &<IXMLHTTPRequest2Callback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXMLHttpRequest_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn open(&self, bstrmethod: &::windows::core::BSTR, bstrurl: &::windows::core::BSTR, varasync: &super::super::super::System::Com::VARIANT, bstruser: &super::super::super::System::Com::VARIANT, bstrpassword: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -6874,6 +6957,7 @@ impl IXMLHttpRequest_Vtbl {
         iid == &<IXMLHttpRequest as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXSLProcessor_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Setinput(&self, var: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -7036,6 +7120,7 @@ impl IXSLProcessor_Vtbl {
         iid == &<IXSLProcessor as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXSLTemplate_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn putref_stylesheet(&self, stylesheet: &::core::option::Option<IXMLDOMNode>) -> ::windows::core::Result<()>;
@@ -7085,6 +7170,7 @@ impl IXSLTemplate_Vtbl {
         iid == &<IXSLTemplate as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXTLRuntime_Impl: Sized + IXMLDOMNode_Impl {
     fn uniqueID(&self, pnode: &::core::option::Option<IXMLDOMNode>, pid: *mut i32) -> ::windows::core::Result<()>;
@@ -7164,6 +7250,7 @@ impl IXTLRuntime_Vtbl {
         iid == &<IXTLRuntime as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IXMLDOMNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait XMLDOMDocumentEvents_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Data_Xml_XmlLite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXmlReader_Impl: Sized {
     fn SetInput(&self, pinput: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -211,6 +212,7 @@ impl IXmlReader_Vtbl {
         iid == &<IXmlReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_XmlLite\"`, `\"implement\"`*"]
 pub trait IXmlResolver_Impl: Sized {
     fn ResolveUri(&self, pwszbaseuri: &::windows::core::PCWSTR, pwszpublicidentifier: &::windows::core::PCWSTR, pwszsystemidentifier: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -234,6 +236,7 @@ impl IXmlResolver_Vtbl {
         iid == &<IXmlResolver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_XmlLite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXmlWriter_Impl: Sized {
     fn SetOutput(&self, poutput: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -459,6 +462,7 @@ impl IXmlWriter_Vtbl {
         iid == &<IXmlWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Data_Xml_XmlLite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXmlWriterLite_Impl: Sized {
     fn SetOutput(&self, poutput: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_DeviceAccess\"`, `\"implement\"`*"]
 pub trait ICreateDeviceAccessAsync_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn Wait(&self, timeout: u32) -> ::windows::core::Result<()>;
@@ -39,6 +40,7 @@ impl ICreateDeviceAccessAsync_Vtbl {
         iid == &<ICreateDeviceAccessAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_DeviceAccess\"`, `\"implement\"`*"]
 pub trait IDeviceIoControl_Impl: Sized {
     fn DeviceIoControlSync(&self, iocontrolcode: u32, inputbuffer: *const u8, inputbuffersize: u32, outputbuffer: *mut u8, outputbuffersize: u32, bytesreturned: *mut u32) -> ::windows::core::Result<()>;
     fn DeviceIoControlAsync(&self, iocontrolcode: u32, inputbuffer: *const u8, inputbuffersize: u32, outputbuffer: *mut u8, outputbuffersize: u32, requestcompletioncallback: &::core::option::Option<IDeviceRequestCompletionCallback>, cancelcontext: *mut usize) -> ::windows::core::Result<()>;
@@ -73,6 +75,7 @@ impl IDeviceIoControl_Vtbl {
         iid == &<IDeviceIoControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_DeviceAccess\"`, `\"implement\"`*"]
 pub trait IDeviceRequestCompletionCallback_Impl: Sized {
     fn Invoke(&self, requestresult: ::windows::core::HRESULT, bytesreturned: u32) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_Display\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICloneViewHelper_Impl: Sized {
     fn GetConnectedIDs(&self, wszadaptorname: &::windows::core::PCWSTR, pulcount: *mut u32, pulid: *mut u32, ulflags: u32) -> ::windows::core::Result<()>;
@@ -42,6 +43,7 @@ impl ICloneViewHelper_Vtbl {
         iid == &<ICloneViewHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Display\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IViewHelper_Impl: Sized {
     fn GetConnectedIDs(&self, wszadaptorname: &::windows::core::PCWSTR, pulcount: *mut u32, pulid: *mut u32, ulflags: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPAddressFamilyControl_Impl: Sized {
     fn SetAddressFamily(&self, dwflags: i32) -> ::windows::core::Result<()>;
     fn GetAddressFamily(&self) -> ::windows::core::Result<i32>;
@@ -31,6 +32,7 @@ impl IUPnPAddressFamilyControl_Vtbl {
         iid == &<IUPnPAddressFamilyControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPAsyncResult_Impl: Sized {
     fn AsyncOperationComplete(&self, ullrequestid: u64) -> ::windows::core::Result<()>;
 }
@@ -48,6 +50,7 @@ impl IUPnPAsyncResult_Vtbl {
         iid == &<IUPnPAsyncResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPDescriptionDocument_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn ReadyState(&self) -> ::windows::core::Result<i32>;
@@ -137,6 +140,7 @@ impl IUPnPDescriptionDocument_Vtbl {
         iid == &<IUPnPDescriptionDocument as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPDescriptionDocumentCallback_Impl: Sized {
     fn LoadComplete(&self, hrloadresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -154,6 +158,7 @@ impl IUPnPDescriptionDocumentCallback_Vtbl {
         iid == &<IUPnPDescriptionDocumentCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPDevice_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn IsRootDevice(&self) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;
@@ -417,6 +422,7 @@ impl IUPnPDevice_Vtbl {
         iid == &<IUPnPDevice as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUPnPDeviceControl_Impl: Sized {
     fn Initialize(&self, bstrxmldesc: &::windows::core::BSTR, bstrdeviceidentifier: &::windows::core::BSTR, bstrinitstring: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -453,6 +459,7 @@ impl IUPnPDeviceControl_Vtbl {
         iid == &<IUPnPDeviceControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPDeviceControlHttpHeaders_Impl: Sized {
     fn GetAdditionalResponseHeaders(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -479,6 +486,7 @@ impl IUPnPDeviceControlHttpHeaders_Vtbl {
         iid == &<IUPnPDeviceControlHttpHeaders as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPDeviceDocumentAccess_Impl: Sized {
     fn GetDocumentURL(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -502,6 +510,7 @@ impl IUPnPDeviceDocumentAccess_Vtbl {
         iid == &<IUPnPDeviceDocumentAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPDeviceDocumentAccessEx_Impl: Sized {
     fn GetDocument(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -525,6 +534,7 @@ impl IUPnPDeviceDocumentAccessEx_Vtbl {
         iid == &<IUPnPDeviceDocumentAccessEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPDeviceFinder_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn FindByType(&self, bstrtypeuri: &::windows::core::BSTR, dwflags: u32) -> ::windows::core::Result<IUPnPDevices>;
@@ -594,6 +604,7 @@ impl IUPnPDeviceFinder_Vtbl {
         iid == &<IUPnPDeviceFinder as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUPnPDeviceFinderAddCallbackWithInterface_Impl: Sized {
     fn DeviceAddedWithInterface(&self, lfinddata: i32, pdevice: &::core::option::Option<IUPnPDevice>, pguidinterface: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -614,6 +625,7 @@ impl IUPnPDeviceFinderAddCallbackWithInterface_Vtbl {
         iid == &<IUPnPDeviceFinderAddCallbackWithInterface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUPnPDeviceFinderCallback_Impl: Sized {
     fn DeviceAdded(&self, lfinddata: i32, pdevice: &::core::option::Option<IUPnPDevice>) -> ::windows::core::Result<()>;
@@ -651,6 +663,7 @@ impl IUPnPDeviceFinderCallback_Vtbl {
         iid == &<IUPnPDeviceFinderCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPDeviceProvider_Impl: Sized {
     fn Start(&self, bstrinitstring: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -674,6 +687,7 @@ impl IUPnPDeviceProvider_Vtbl {
         iid == &<IUPnPDeviceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPDevices_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -729,6 +743,7 @@ impl IUPnPDevices_Vtbl {
         iid == &<IUPnPDevices as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPEventSink_Impl: Sized {
     fn OnStateChanged(&self, cchanges: u32, rgdispidchanges: *const i32) -> ::windows::core::Result<()>;
@@ -759,6 +774,7 @@ impl IUPnPEventSink_Vtbl {
         iid == &<IUPnPEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPEventSource_Impl: Sized {
     fn Advise(&self, pessubscriber: &::core::option::Option<IUPnPEventSink>) -> ::windows::core::Result<()>;
     fn Unadvise(&self, pessubscriber: &::core::option::Option<IUPnPEventSink>) -> ::windows::core::Result<()>;
@@ -786,6 +802,7 @@ impl IUPnPEventSource_Vtbl {
         iid == &<IUPnPEventSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPHttpHeaderControl_Impl: Sized {
     fn AddRequestHeaders(&self, bstrhttpheaders: &::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -803,6 +820,7 @@ impl IUPnPHttpHeaderControl_Vtbl {
         iid == &<IUPnPHttpHeaderControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUPnPRegistrar_Impl: Sized {
     fn RegisterDevice(&self, bstrxmldesc: &::windows::core::BSTR, bstrprogiddevicecontrolclass: &::windows::core::BSTR, bstrinitstring: &::windows::core::BSTR, bstrcontainerid: &::windows::core::BSTR, bstrresourcepath: &::windows::core::BSTR, nlifetime: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -879,6 +897,7 @@ impl IUPnPRegistrar_Vtbl {
         iid == &<IUPnPRegistrar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPRemoteEndpointInfo_Impl: Sized {
     fn GetDwordValue(&self, bstrvaluename: &::windows::core::BSTR) -> ::windows::core::Result<u32>;
     fn GetStringValue(&self, bstrvaluename: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -931,6 +950,7 @@ impl IUPnPRemoteEndpointInfo_Vtbl {
         iid == &<IUPnPRemoteEndpointInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPReregistrar_Impl: Sized {
     fn ReregisterDevice(&self, bstrdeviceidentifier: &::windows::core::BSTR, bstrxmldesc: &::windows::core::BSTR, bstrprogiddevicecontrolclass: &::windows::core::BSTR, bstrinitstring: &::windows::core::BSTR, bstrcontainerid: &::windows::core::BSTR, bstrresourcepath: &::windows::core::BSTR, nlifetime: i32) -> ::windows::core::Result<()>;
     fn ReregisterRunningDevice(&self, bstrdeviceidentifier: &::windows::core::BSTR, bstrxmldesc: &::windows::core::BSTR, punkdevicecontrol: &::core::option::Option<::windows::core::IUnknown>, bstrinitstring: &::windows::core::BSTR, bstrresourcepath: &::windows::core::BSTR, nlifetime: i32) -> ::windows::core::Result<()>;
@@ -958,6 +978,7 @@ impl IUPnPReregistrar_Vtbl {
         iid == &<IUPnPReregistrar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPService_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn QueryStateVariable(&self, bstrvariablename: &::windows::core::BSTR) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
@@ -1040,6 +1061,7 @@ impl IUPnPService_Vtbl {
         iid == &<IUPnPService as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPServiceAsync_Impl: Sized {
     fn BeginInvokeAction(&self, bstractionname: &::windows::core::BSTR, vinactionargs: &super::super::super::System::Com::VARIANT, pasyncresult: &::core::option::Option<IUPnPAsyncResult>) -> ::windows::core::Result<u64>;
@@ -1149,6 +1171,7 @@ impl IUPnPServiceAsync_Vtbl {
         iid == &<IUPnPServiceAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPServiceCallback_Impl: Sized {
     fn StateVariableChanged(&self, pus: &::core::option::Option<IUPnPService>, pcwszstatevarname: &::windows::core::PCWSTR, vavalue: &super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -1179,6 +1202,7 @@ impl IUPnPServiceCallback_Vtbl {
         iid == &<IUPnPServiceCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPServiceDocumentAccess_Impl: Sized {
     fn GetDocumentURL(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetDocument(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1218,6 +1242,7 @@ impl IUPnPServiceDocumentAccess_Vtbl {
         iid == &<IUPnPServiceDocumentAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"implement\"`*"]
 pub trait IUPnPServiceEnumProperty_Impl: Sized {
     fn SetServiceEnumProperty(&self, dwmask: u32) -> ::windows::core::Result<()>;
 }
@@ -1235,6 +1260,7 @@ impl IUPnPServiceEnumProperty_Vtbl {
         iid == &<IUPnPServiceEnumProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Enumeration_Pnp\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPServices_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccount_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AccountName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -60,6 +61,7 @@ impl IFaxAccount_Vtbl {
         iid == &<IFaxAccount as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountFolders_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OutgoingQueue(&self) -> ::windows::core::Result<IFaxAccountOutgoingQueue>;
@@ -128,6 +130,7 @@ impl IFaxAccountFolders_Vtbl {
         iid == &<IFaxAccountFolders as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountIncomingArchive_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SizeLow(&self) -> ::windows::core::Result<i32>;
@@ -203,6 +206,7 @@ impl IFaxAccountIncomingArchive_Vtbl {
         iid == &<IFaxAccountIncomingArchive as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountIncomingQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetJobs(&self) -> ::windows::core::Result<IFaxIncomingJobs>;
@@ -245,6 +249,7 @@ impl IFaxAccountIncomingQueue_Vtbl {
         iid == &<IFaxAccountIncomingQueue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountNotify_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OnIncomingJobAdded(&self, pfaxaccount: &::core::option::Option<IFaxAccount>, bstrjobid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -338,6 +343,7 @@ impl IFaxAccountNotify_Vtbl {
         iid == &<IFaxAccountNotify as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountOutgoingArchive_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SizeLow(&self) -> ::windows::core::Result<i32>;
@@ -413,6 +419,7 @@ impl IFaxAccountOutgoingArchive_Vtbl {
         iid == &<IFaxAccountOutgoingArchive as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountOutgoingQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetJobs(&self) -> ::windows::core::Result<IFaxOutgoingJobs>;
@@ -455,6 +462,7 @@ impl IFaxAccountOutgoingQueue_Vtbl {
         iid == &<IFaxAccountOutgoingQueue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccountSet_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetAccounts(&self) -> ::windows::core::Result<IFaxAccounts>;
@@ -517,6 +525,7 @@ impl IFaxAccountSet_Vtbl {
         iid == &<IFaxAccountSet as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxAccounts_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -572,6 +581,7 @@ impl IFaxAccounts_Vtbl {
         iid == &<IFaxAccounts as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxActivity_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IncomingMessages(&self) -> ::windows::core::Result<i32>;
@@ -647,6 +657,7 @@ impl IFaxActivity_Vtbl {
         iid == &<IFaxActivity as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxActivityLogging_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LogIncoming(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -737,6 +748,7 @@ impl IFaxActivityLogging_Vtbl {
         iid == &<IFaxActivityLogging as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxConfiguration_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UseArchive(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -1173,6 +1185,7 @@ impl IFaxConfiguration_Vtbl {
         iid == &<IFaxConfiguration as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxDevice_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<i32>;
@@ -1461,6 +1474,7 @@ impl IFaxDevice_Vtbl {
         iid == &<IFaxDevice as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxDeviceIds_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1537,6 +1551,7 @@ impl IFaxDeviceIds_Vtbl {
         iid == &<IFaxDeviceIds as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxDeviceProvider_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FriendlyName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1709,6 +1724,7 @@ impl IFaxDeviceProvider_Vtbl {
         iid == &<IFaxDeviceProvider as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxDeviceProviders_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1764,6 +1780,7 @@ impl IFaxDeviceProviders_Vtbl {
         iid == &<IFaxDeviceProviders as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxDevices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1832,6 +1849,7 @@ impl IFaxDevices_Vtbl {
         iid == &<IFaxDevices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxDocument_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Body(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2200,6 +2218,7 @@ impl IFaxDocument_Vtbl {
         iid == &<IFaxDocument as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxDocument2_Impl: Sized + IFaxDocument_Impl {
     fn SubmissionId(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2263,6 +2282,7 @@ impl IFaxDocument2_Vtbl {
         iid == &<IFaxDocument2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFaxDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxEventLogging_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn InitEventsLevel(&self) -> ::windows::core::Result<FAX_LOG_LEVEL_ENUM>;
@@ -2373,6 +2393,7 @@ impl IFaxEventLogging_Vtbl {
         iid == &<IFaxEventLogging as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxFolders_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OutgoingQueue(&self) -> ::windows::core::Result<IFaxOutgoingQueue>;
@@ -2441,6 +2462,7 @@ impl IFaxFolders_Vtbl {
         iid == &<IFaxFolders as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxInboundRouting_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetExtensions(&self) -> ::windows::core::Result<IFaxInboundRoutingExtensions>;
@@ -2483,6 +2505,7 @@ impl IFaxInboundRouting_Vtbl {
         iid == &<IFaxInboundRouting as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxInboundRoutingExtension_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FriendlyName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2642,6 +2665,7 @@ impl IFaxInboundRoutingExtension_Vtbl {
         iid == &<IFaxInboundRoutingExtension as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxInboundRoutingExtensions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -2697,6 +2721,7 @@ impl IFaxInboundRoutingExtensions_Vtbl {
         iid == &<IFaxInboundRoutingExtensions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxInboundRoutingMethod_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2812,6 +2837,7 @@ impl IFaxInboundRoutingMethod_Vtbl {
         iid == &<IFaxInboundRoutingMethod as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxInboundRoutingMethods_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -2867,6 +2893,7 @@ impl IFaxInboundRoutingMethods_Vtbl {
         iid == &<IFaxInboundRoutingMethods as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxIncomingArchive_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UseArchive(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3069,6 +3096,7 @@ impl IFaxIncomingArchive_Vtbl {
         iid == &<IFaxIncomingArchive as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxIncomingJob_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Size(&self) -> ::windows::core::Result<i32>;
@@ -3314,6 +3342,7 @@ impl IFaxIncomingJob_Vtbl {
         iid == &<IFaxIncomingJob as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxIncomingJobs_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3369,6 +3398,7 @@ impl IFaxIncomingJobs_Vtbl {
         iid == &<IFaxIncomingJobs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxIncomingMessage_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3542,6 +3572,7 @@ impl IFaxIncomingMessage_Vtbl {
         iid == &<IFaxIncomingMessage as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxIncomingMessage2_Impl: Sized + IFaxIncomingMessage_Impl {
     fn Subject(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3712,6 +3743,7 @@ impl IFaxIncomingMessage2_Vtbl {
         iid == &<IFaxIncomingMessage2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFaxIncomingMessage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxIncomingMessageIterator_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Message(&self) -> ::windows::core::Result<IFaxIncomingMessage>;
@@ -3788,6 +3820,7 @@ impl IFaxIncomingMessageIterator_Vtbl {
         iid == &<IFaxIncomingMessageIterator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxIncomingQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Blocked(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3864,6 +3897,7 @@ impl IFaxIncomingQueue_Vtbl {
         iid == &<IFaxIncomingQueue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxJobStatus_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Status(&self) -> ::windows::core::Result<FAX_JOB_STATUS_ENUM>;
@@ -4101,6 +4135,7 @@ impl IFaxJobStatus_Vtbl {
         iid == &<IFaxJobStatus as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxLoggingOptions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EventLogging(&self) -> ::windows::core::Result<IFaxEventLogging>;
@@ -4143,6 +4178,7 @@ impl IFaxLoggingOptions_Vtbl {
         iid == &<IFaxLoggingOptions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutboundRouting_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetGroups(&self) -> ::windows::core::Result<IFaxOutboundRoutingGroups>;
@@ -4185,6 +4221,7 @@ impl IFaxOutboundRouting_Vtbl {
         iid == &<IFaxOutboundRouting as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutboundRoutingGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4240,6 +4277,7 @@ impl IFaxOutboundRoutingGroup_Vtbl {
         iid == &<IFaxOutboundRoutingGroup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutboundRoutingGroups_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -4315,6 +4353,7 @@ impl IFaxOutboundRoutingGroups_Vtbl {
         iid == &<IFaxOutboundRoutingGroups as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutboundRoutingRule_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CountryCode(&self) -> ::windows::core::Result<i32>;
@@ -4444,6 +4483,7 @@ impl IFaxOutboundRoutingRule_Vtbl {
         iid == &<IFaxOutboundRoutingRule as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutboundRoutingRules_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -4539,6 +4579,7 @@ impl IFaxOutboundRoutingRules_Vtbl {
         iid == &<IFaxOutboundRoutingRules as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingArchive_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UseArchive(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -4741,6 +4782,7 @@ impl IFaxOutgoingArchive_Vtbl {
         iid == &<IFaxOutgoingArchive as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingJob_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Subject(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5124,6 +5166,7 @@ impl IFaxOutgoingJob_Vtbl {
         iid == &<IFaxOutgoingJob as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingJob2_Impl: Sized + IFaxOutgoingJob_Impl {
     fn HasCoverPage(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -5179,6 +5222,7 @@ impl IFaxOutgoingJob2_Vtbl {
         iid == &<IFaxOutgoingJob2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFaxOutgoingJob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingJobs_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -5234,6 +5278,7 @@ impl IFaxOutgoingJobs_Vtbl {
         iid == &<IFaxOutgoingJobs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingMessage_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SubmissionId(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5485,6 +5530,7 @@ impl IFaxOutgoingMessage_Vtbl {
         iid == &<IFaxOutgoingMessage as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingMessage2_Impl: Sized + IFaxOutgoingMessage_Impl {
     fn HasCoverPage(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -5574,6 +5620,7 @@ impl IFaxOutgoingMessage2_Vtbl {
         iid == &<IFaxOutgoingMessage2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFaxOutgoingMessage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingMessageIterator_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Message(&self) -> ::windows::core::Result<IFaxOutgoingMessage>;
@@ -5650,6 +5697,7 @@ impl IFaxOutgoingMessageIterator_Vtbl {
         iid == &<IFaxOutgoingMessageIterator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxOutgoingQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Blocked(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -5906,6 +5954,7 @@ impl IFaxOutgoingQueue_Vtbl {
         iid == &<IFaxOutgoingQueue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxReceiptOptions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AuthenticationType(&self) -> ::windows::core::Result<FAX_SMTP_AUTHENTICATION_TYPE_ENUM>;
@@ -6096,6 +6145,7 @@ impl IFaxReceiptOptions_Vtbl {
         iid == &<IFaxReceiptOptions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxRecipient_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FaxNumber(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6152,6 +6202,7 @@ impl IFaxRecipient_Vtbl {
         iid == &<IFaxRecipient as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxRecipients_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -6227,6 +6278,7 @@ impl IFaxRecipients_Vtbl {
         iid == &<IFaxRecipients as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxSecurity_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Descriptor(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -6310,6 +6362,7 @@ impl IFaxSecurity_Vtbl {
         iid == &<IFaxSecurity as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxSecurity2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Descriptor(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -6393,6 +6446,7 @@ impl IFaxSecurity2_Vtbl {
         iid == &<IFaxSecurity2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxSender_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn BillingCode(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6743,6 +6797,7 @@ impl IFaxSender_Vtbl {
         iid == &<IFaxSender as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxServer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Connect(&self, bstrservername: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -7049,6 +7104,7 @@ impl IFaxServer_Vtbl {
         iid == &<IFaxServer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxServer2_Impl: Sized + IFaxServer_Impl {
     fn Configuration(&self) -> ::windows::core::Result<IFaxConfiguration>;
@@ -7117,6 +7173,7 @@ impl IFaxServer2_Vtbl {
         iid == &<IFaxServer2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFaxServer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxServerNotify_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7130,6 +7187,7 @@ impl IFaxServerNotify_Vtbl {
         iid == &<IFaxServerNotify as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFaxServerNotify2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OnIncomingJobAdded(&self, pfaxserver: &::core::option::Option<IFaxServer2>, bstrjobid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -7328,6 +7386,7 @@ impl IFaxServerNotify2_Vtbl {
         iid == &<IFaxServerNotify2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_IO\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 pub trait IStiDevice_Impl: Sized {
     fn Initialize(&self, hinst: super::super::Foundation::HINSTANCE, pwszdevicename: &::windows::core::PCWSTR, dwversion: u32, dwmode: u32) -> ::windows::core::Result<()>;
@@ -7481,6 +7540,7 @@ impl IStiDevice_Vtbl {
         iid == &<IStiDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_IO\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 pub trait IStiDeviceControl_Impl: Sized {
     fn Initialize(&self, dwdevicetype: u32, dwmode: u32, pwszportname: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
@@ -7574,6 +7634,7 @@ impl IStiDeviceControl_Vtbl {
         iid == &<IStiDeviceControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"Win32_System_IO\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO", feature = "Win32_System_Registry"))]
 pub trait IStiUSD_Impl: Sized {
     fn Initialize(&self, pheldcb: &::core::option::Option<IStiDeviceControl>, dwstiversion: u32, hparameterskey: super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
@@ -7726,6 +7787,7 @@ impl IStiUSD_Vtbl {
         iid == &<IStiUSD as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Fax\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStillImageW_Impl: Sized {
     fn Initialize(&self, hinst: super::super::Foundation::HINSTANCE, dwversion: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFunctionDiscovery_Impl: Sized {
     fn GetInstanceCollection(&self, pszcategory: &::windows::core::PCWSTR, pszsubcategory: &::windows::core::PCWSTR, fincludeallsubcategories: super::super::Foundation::BOOL) -> ::windows::core::Result<IFunctionInstanceCollection>;
@@ -74,6 +75,7 @@ impl IFunctionDiscovery_Vtbl {
         iid == &<IFunctionDiscovery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IFunctionDiscoveryNotification_Impl: Sized {
     fn OnUpdate(&self, enumqueryupdateaction: QueryUpdateAction, fdqcquerycontext: u64, pifunctioninstance: &::core::option::Option<IFunctionInstance>) -> ::windows::core::Result<()>;
@@ -111,6 +113,7 @@ impl IFunctionDiscoveryNotification_Vtbl {
         iid == &<IFunctionDiscoveryNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFunctionDiscoveryProvider_Impl: Sized {
     fn Initialize(&self, pifunctiondiscoveryproviderfactory: &::core::option::Option<IFunctionDiscoveryProviderFactory>, pifunctiondiscoverynotification: &::core::option::Option<IFunctionDiscoveryNotification>, lciduserdefault: u32) -> ::windows::core::Result<u32>;
@@ -207,6 +210,7 @@ impl IFunctionDiscoveryProvider_Vtbl {
         iid == &<IFunctionDiscoveryProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFunctionDiscoveryProviderFactory_Impl: Sized {
     fn CreatePropertyStore(&self) -> ::windows::core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
@@ -262,6 +266,7 @@ impl IFunctionDiscoveryProviderFactory_Vtbl {
         iid == &<IFunctionDiscoveryProviderFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFunctionDiscoveryProviderQuery_Impl: Sized {
     fn IsInstanceQuery(&self, pisinstancequery: *mut super::super::Foundation::BOOL, ppszconstraintvalue: *mut *mut u16) -> ::windows::core::Result<()>;
@@ -318,6 +323,7 @@ impl IFunctionDiscoveryProviderQuery_Vtbl {
         iid == &<IFunctionDiscoveryProviderQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IFunctionDiscoveryServiceProvider_Impl: Sized {
     fn Initialize(&self, pifunctioninstance: &::core::option::Option<IFunctionInstance>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -338,6 +344,7 @@ impl IFunctionDiscoveryServiceProvider_Vtbl {
         iid == &<IFunctionDiscoveryServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFunctionInstance_Impl: Sized + super::super::System::Com::IServiceProvider_Impl {
     fn GetID(&self) -> ::windows::core::Result<*mut u16>;
@@ -400,6 +407,7 @@ impl IFunctionInstance_Vtbl {
         iid == &<IFunctionInstance as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IFunctionInstanceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -483,6 +491,7 @@ impl IFunctionInstanceCollection_Vtbl {
         iid == &<IFunctionInstanceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFunctionInstanceCollectionQuery_Impl: Sized {
     fn AddQueryConstraint(&self, pszconstraintname: &::windows::core::PCWSTR, pszconstraintvalue: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -526,6 +535,7 @@ impl IFunctionInstanceCollectionQuery_Vtbl {
         iid == &<IFunctionInstanceCollectionQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IFunctionInstanceQuery_Impl: Sized {
     fn Execute(&self) -> ::windows::core::Result<IFunctionInstance>;
@@ -552,6 +562,7 @@ impl IFunctionInstanceQuery_Vtbl {
         iid == &<IFunctionInstanceQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"implement\"`*"]
 pub trait IPNPXAssociation_Impl: Sized {
     fn Associate(&self, pszsubcategory: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Unassociate(&self, pszsubcategory: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -586,6 +597,7 @@ impl IPNPXAssociation_Vtbl {
         iid == &<IPNPXAssociation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"implement\"`*"]
 pub trait IPNPXDeviceAssociation_Impl: Sized {
     fn Associate(&self, pszsubcategory: &::windows::core::PCWSTR, pifunctiondiscoverynotification: &::core::option::Option<IFunctionDiscoveryNotification>) -> ::windows::core::Result<()>;
     fn Unassociate(&self, pszsubcategory: &::windows::core::PCWSTR, pifunctiondiscoverynotification: &::core::option::Option<IFunctionDiscoveryNotification>) -> ::windows::core::Result<()>;
@@ -620,6 +632,7 @@ impl IPNPXDeviceAssociation_Vtbl {
         iid == &<IPNPXDeviceAssociation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IPropertyStoreCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -703,6 +716,7 @@ impl IPropertyStoreCollection_Vtbl {
         iid == &<IPropertyStoreCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IProviderProperties_Impl: Sized {
     fn GetCount(&self, pifunctioninstance: &::core::option::Option<IFunctionInstance>, iproviderinstancecontext: isize) -> ::windows::core::Result<u32>;
@@ -765,6 +779,7 @@ impl IProviderProperties_Vtbl {
         iid == &<IProviderProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IProviderPropertyConstraintCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -829,6 +844,7 @@ impl IProviderPropertyConstraintCollection_Vtbl {
         iid == &<IProviderPropertyConstraintCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IProviderPublishing_Impl: Sized {
     fn CreateInstance(&self, enumvisibilityflags: SystemVisibilityFlags, pszsubcategory: &::windows::core::PCWSTR, pszproviderinstanceidentity: &::windows::core::PCWSTR) -> ::windows::core::Result<IFunctionInstance>;
@@ -865,6 +881,7 @@ impl IProviderPublishing_Vtbl {
         iid == &<IProviderPublishing as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_FunctionDiscovery\"`, `\"implement\"`*"]
 pub trait IProviderQueryConstraintCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn Get(&self, pszconstraintname: &::windows::core::PCWSTR) -> ::windows::core::Result<*mut u16>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ICivicAddressReport_Impl: Sized + ILocationReport_Impl {
     fn GetAddressLine1(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -105,6 +106,7 @@ impl ICivicAddressReport_Vtbl {
         iid == &<ICivicAddressReport as ::windows::core::Interface>::IID || iid == &<ILocationReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICivicAddressReportFactory_Impl: Sized + ILocationReportFactory_Impl {
     fn CivicAddressReport(&self) -> ::windows::core::Result<IDispCivicAddressReport>;
@@ -131,6 +133,7 @@ impl ICivicAddressReportFactory_Vtbl {
         iid == &<ICivicAddressReportFactory as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocationReportFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"implement\"`*"]
 pub trait IDefaultLocation_Impl: Sized {
     fn SetReport(&self, reporttype: *const ::windows::core::GUID, plocationreport: &::core::option::Option<ILocationReport>) -> ::windows::core::Result<()>;
     fn GetReport(&self, reporttype: *const ::windows::core::GUID) -> ::windows::core::Result<ILocationReport>;
@@ -164,6 +167,7 @@ impl IDefaultLocation_Vtbl {
         iid == &<IDefaultLocation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDispCivicAddressReport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AddressLine1(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -284,6 +288,7 @@ impl IDispCivicAddressReport_Vtbl {
         iid == &<IDispCivicAddressReport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDispLatLongReport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Latitude(&self) -> ::windows::core::Result<f64>;
@@ -378,6 +383,7 @@ impl IDispLatLongReport_Vtbl {
         iid == &<IDispLatLongReport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ILatLongReport_Impl: Sized + ILocationReport_Impl {
     fn GetLatitude(&self) -> ::windows::core::Result<f64>;
@@ -459,6 +465,7 @@ impl ILatLongReport_Vtbl {
         iid == &<ILatLongReport as ::windows::core::Interface>::IID || iid == &<ILocationReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ILatLongReportFactory_Impl: Sized + ILocationReportFactory_Impl {
     fn LatLongReport(&self) -> ::windows::core::Result<IDispLatLongReport>;
@@ -485,6 +492,7 @@ impl ILatLongReportFactory_Vtbl {
         iid == &<ILatLongReportFactory as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocationReportFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Devices_Sensors\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Devices_Sensors", feature = "Win32_Foundation"))]
 pub trait ILocation_Impl: Sized {
     fn RegisterForReport(&self, pevents: &::core::option::Option<ILocationEvents>, reporttype: *const ::windows::core::GUID, dwrequestedreportinterval: u32) -> ::windows::core::Result<()>;
@@ -588,6 +596,7 @@ impl ILocation_Vtbl {
         iid == &<ILocation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"implement\"`*"]
 pub trait ILocationEvents_Impl: Sized {
     fn OnLocationChanged(&self, reporttype: *const ::windows::core::GUID, plocationreport: &::core::option::Option<ILocationReport>) -> ::windows::core::Result<()>;
     fn OnStatusChanged(&self, reporttype: *const ::windows::core::GUID, newstatus: LOCATION_REPORT_STATUS) -> ::windows::core::Result<()>;
@@ -615,6 +624,7 @@ impl ILocationEvents_Vtbl {
         iid == &<ILocationEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"implement\"`*"]
 pub trait ILocationPower_Impl: Sized {
     fn Connect(&self) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
@@ -642,6 +652,7 @@ impl ILocationPower_Vtbl {
         iid == &<ILocationPower as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ILocationReport_Impl: Sized {
     fn GetSensorID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -697,6 +708,7 @@ impl ILocationReport_Vtbl {
         iid == &<ILocationReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ILocationReportFactory_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ListenForReports(&self, requestedreportinterval: u32) -> ::windows::core::Result<()>;
@@ -787,6 +799,7 @@ impl ILocationReportFactory_Vtbl {
         iid == &<ILocationReportFactory as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ICivicAddressReportFactoryEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -800,6 +813,7 @@ impl _ICivicAddressReportFactoryEvents_Vtbl {
         iid == &<_ICivicAddressReportFactoryEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Geolocation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ILatLongReportFactoryEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInput2A_Impl: Sized + IDirectInputA_Impl {
     fn FindDevice(&self, param0: *const ::windows::core::GUID, param1: &::windows::core::PCSTR, param2: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl IDirectInput2A_Vtbl {
         iid == &<IDirectInput2A as ::windows::core::Interface>::IID || iid == &<IDirectInputA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInput2W_Impl: Sized + IDirectInputW_Impl {
     fn FindDevice(&self, param0: *const ::windows::core::GUID, param1: &::windows::core::PCWSTR, param2: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -38,6 +40,7 @@ impl IDirectInput2W_Vtbl {
         iid == &<IDirectInput2W as ::windows::core::Interface>::IID || iid == &<IDirectInputW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInput7A_Impl: Sized + IDirectInput2A_Impl {
     fn CreateDeviceEx(&self, param0: *const ::windows::core::GUID, param1: *const ::windows::core::GUID, param2: *mut *mut ::core::ffi::c_void, param3: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -58,6 +61,7 @@ impl IDirectInput7A_Vtbl {
         iid == &<IDirectInput7A as ::windows::core::Interface>::IID || iid == &<IDirectInputA as ::windows::core::Interface>::IID || iid == &<IDirectInput2A as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInput7W_Impl: Sized + IDirectInput2W_Impl {
     fn CreateDeviceEx(&self, param0: *const ::windows::core::GUID, param1: *const ::windows::core::GUID, param2: *mut *mut ::core::ffi::c_void, param3: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -78,6 +82,7 @@ impl IDirectInput7W_Vtbl {
         iid == &<IDirectInput7W as ::windows::core::Interface>::IID || iid == &<IDirectInputW as ::windows::core::Interface>::IID || iid == &<IDirectInput2W as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInput8A_Impl: Sized {
     fn CreateDevice(&self, param0: *const ::windows::core::GUID, param1: *mut ::core::option::Option<IDirectInputDevice8A>, param2: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -150,6 +155,7 @@ impl IDirectInput8A_Vtbl {
         iid == &<IDirectInput8A as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInput8W_Impl: Sized {
     fn CreateDevice(&self, param0: *const ::windows::core::GUID, param1: *mut ::core::option::Option<IDirectInputDevice8W>, param2: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -222,6 +228,7 @@ impl IDirectInput8W_Vtbl {
         iid == &<IDirectInput8W as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputA_Impl: Sized {
     fn CreateDevice(&self, param0: *const ::windows::core::GUID, param1: *mut ::core::option::Option<IDirectInputDeviceA>, param2: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -273,6 +280,7 @@ impl IDirectInputA_Vtbl {
         iid == &<IDirectInputA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDevice2A_Impl: Sized + IDirectInputDeviceA_Impl {
     fn CreateEffect(&self, param0: *const ::windows::core::GUID, param1: *mut DIEFFECT, param2: *mut ::core::option::Option<IDirectInputEffect>, param3: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -352,6 +360,7 @@ impl IDirectInputDevice2A_Vtbl {
         iid == &<IDirectInputDevice2A as ::windows::core::Interface>::IID || iid == &<IDirectInputDeviceA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDevice2W_Impl: Sized + IDirectInputDeviceW_Impl {
     fn CreateEffect(&self, param0: *const ::windows::core::GUID, param1: *mut DIEFFECT, param2: *mut ::core::option::Option<IDirectInputEffect>, param3: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -431,6 +440,7 @@ impl IDirectInputDevice2W_Vtbl {
         iid == &<IDirectInputDevice2W as ::windows::core::Interface>::IID || iid == &<IDirectInputDeviceW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDevice7A_Impl: Sized + IDirectInputDevice2A_Impl {
     fn EnumEffectsInFile(&self, param0: &::windows::core::PCSTR, param1: LPDIENUMEFFECTSINFILECALLBACK, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::Result<()>;
@@ -461,6 +471,7 @@ impl IDirectInputDevice7A_Vtbl {
         iid == &<IDirectInputDevice7A as ::windows::core::Interface>::IID || iid == &<IDirectInputDeviceA as ::windows::core::Interface>::IID || iid == &<IDirectInputDevice2A as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDevice7W_Impl: Sized + IDirectInputDevice2W_Impl {
     fn EnumEffectsInFile(&self, param0: &::windows::core::PCWSTR, param1: LPDIENUMEFFECTSINFILECALLBACK, param2: *mut ::core::ffi::c_void, param3: u32) -> ::windows::core::Result<()>;
@@ -491,6 +502,7 @@ impl IDirectInputDevice7W_Vtbl {
         iid == &<IDirectInputDevice7W as ::windows::core::Interface>::IID || iid == &<IDirectInputDeviceW as ::windows::core::Interface>::IID || iid == &<IDirectInputDevice2W as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDevice8A_Impl: Sized {
     fn GetCapabilities(&self, param0: *mut DIDEVCAPS) -> ::windows::core::Result<()>;
@@ -710,6 +722,7 @@ impl IDirectInputDevice8A_Vtbl {
         iid == &<IDirectInputDevice8A as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDevice8W_Impl: Sized {
     fn GetCapabilities(&self, param0: *mut DIDEVCAPS) -> ::windows::core::Result<()>;
@@ -929,6 +942,7 @@ impl IDirectInputDevice8W_Vtbl {
         iid == &<IDirectInputDevice8W as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDeviceA_Impl: Sized {
     fn GetCapabilities(&self, param0: *mut DIDEVCAPS) -> ::windows::core::Result<()>;
@@ -1050,6 +1064,7 @@ impl IDirectInputDeviceA_Vtbl {
         iid == &<IDirectInputDeviceA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputDeviceW_Impl: Sized {
     fn GetCapabilities(&self, param0: *mut DIDEVCAPS) -> ::windows::core::Result<()>;
@@ -1171,6 +1186,7 @@ impl IDirectInputDeviceW_Vtbl {
         iid == &<IDirectInputDeviceW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputEffect_Impl: Sized {
     fn Initialize(&self, param0: super::super::Foundation::HINSTANCE, param1: u32, param2: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1257,6 +1273,7 @@ impl IDirectInputEffect_Vtbl {
         iid == &<IDirectInputEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"implement\"`*"]
 pub trait IDirectInputEffectDriver_Impl: Sized {
     fn DeviceID(&self, param0: u32, param1: u32, param2: u32, param3: u32, param4: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetVersions(&self, param0: *mut DIDRIVERVERSIONS) -> ::windows::core::Result<()>;
@@ -1347,6 +1364,7 @@ impl IDirectInputEffectDriver_Vtbl {
         iid == &<IDirectInputEffectDriver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait IDirectInputJoyConfig_Impl: Sized {
     fn Acquire(&self) -> ::windows::core::Result<()>;
@@ -1475,6 +1493,7 @@ impl IDirectInputJoyConfig_Vtbl {
         iid == &<IDirectInputJoyConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait IDirectInputJoyConfig8_Impl: Sized {
     fn Acquire(&self) -> ::windows::core::Result<()>;
@@ -1603,6 +1622,7 @@ impl IDirectInputJoyConfig8_Vtbl {
         iid == &<IDirectInputJoyConfig8 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectInputW_Impl: Sized {
     fn CreateDevice(&self, param0: *const ::windows::core::GUID, param1: *mut ::core::option::Option<IDirectInputDeviceW>, param2: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IEnumWIA_DEV_CAPS_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut WIA_DEV_CAP, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -58,6 +59,7 @@ impl IEnumWIA_DEV_CAPS_Vtbl {
         iid == &<IEnumWIA_DEV_CAPS as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IEnumWIA_DEV_INFO_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IWiaPropertyStorage>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -118,6 +120,7 @@ impl IEnumWIA_DEV_INFO_Vtbl {
         iid == &<IEnumWIA_DEV_INFO as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IEnumWIA_FORMAT_INFO_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut WIA_FORMAT_INFO, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -178,6 +181,7 @@ impl IEnumWIA_FORMAT_INFO_Vtbl {
         iid == &<IEnumWIA_FORMAT_INFO as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IEnumWiaItem_Impl: Sized {
     fn Next(&self, celt: u32, ppiwiaitem: *mut ::core::option::Option<IWiaItem>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -238,6 +242,7 @@ impl IEnumWiaItem_Vtbl {
         iid == &<IEnumWiaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IEnumWiaItem2_Impl: Sized {
     fn Next(&self, celt: u32, ppiwiaitem2: *mut ::core::option::Option<IWiaItem2>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -298,6 +303,7 @@ impl IEnumWiaItem2_Vtbl {
         iid == &<IEnumWiaItem2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaAppErrorHandler_Impl: Sized {
     fn GetWindow(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -334,6 +340,7 @@ impl IWiaAppErrorHandler_Vtbl {
         iid == &<IWiaAppErrorHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaDataCallback_Impl: Sized {
     fn BandedDataCallback(&self, lmessage: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, lreserved: i32, lreslength: i32, pbbuffer: *mut u8) -> ::windows::core::Result<()>;
 }
@@ -351,6 +358,7 @@ impl IWiaDataCallback_Vtbl {
         iid == &<IWiaDataCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWiaDataTransfer_Impl: Sized {
     fn idtGetData(&self, pmedium: *mut super::super::System::Com::STGMEDIUM, piwiadatacallback: &::core::option::Option<IWiaDataCallback>) -> ::windows::core::Result<()>;
@@ -414,6 +422,7 @@ impl IWiaDataTransfer_Vtbl {
         iid == &<IWiaDataTransfer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaDevMgr_Impl: Sized {
     fn EnumDeviceInfo(&self, lflag: i32) -> ::windows::core::Result<IEnumWIA_DEV_INFO>;
@@ -511,6 +520,7 @@ impl IWiaDevMgr_Vtbl {
         iid == &<IWiaDevMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaDevMgr2_Impl: Sized {
     fn EnumDeviceInfo(&self, lflags: i32) -> ::windows::core::Result<IEnumWIA_DEV_INFO>;
@@ -601,6 +611,7 @@ impl IWiaDevMgr2_Vtbl {
         iid == &<IWiaDevMgr2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaDrvItem_Impl: Sized {
     fn GetItemFlags(&self) -> ::windows::core::Result<i32>;
     fn GetDeviceSpecContext(&self) -> ::windows::core::Result<*mut u8>;
@@ -765,6 +776,7 @@ impl IWiaDrvItem_Vtbl {
         iid == &<IWiaDrvItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaErrorHandler_Impl: Sized {
     fn ReportStatus(&self, lflags: i32, hwndparent: super::super::Foundation::HWND, pwiaitem2: &::core::option::Option<IWiaItem2>, hrstatus: ::windows::core::HRESULT, lpercentcomplete: i32) -> ::windows::core::Result<()>;
@@ -801,6 +813,7 @@ impl IWiaErrorHandler_Vtbl {
         iid == &<IWiaErrorHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaEventCallback_Impl: Sized {
     fn ImageEventCallback(&self, peventguid: *const ::windows::core::GUID, bstreventdescription: &::windows::core::BSTR, bstrdeviceid: &::windows::core::BSTR, bstrdevicedescription: &::windows::core::BSTR, dwdevicetype: u32, bstrfullitemname: &::windows::core::BSTR, puleventtype: *mut u32, ulreserved: u32) -> ::windows::core::Result<()>;
 }
@@ -818,6 +831,7 @@ impl IWiaEventCallback_Vtbl {
         iid == &<IWiaEventCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWiaImageFilter_Impl: Sized {
     fn InitializeFilter(&self, pwiaitem2: &::core::option::Option<IWiaItem2>, pwiatransfercallback: &::core::option::Option<IWiaTransferCallback>) -> ::windows::core::Result<()>;
@@ -862,6 +876,7 @@ impl IWiaImageFilter_Vtbl {
         iid == &<IWiaImageFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaItem_Impl: Sized {
     fn GetItemType(&self) -> ::windows::core::Result<i32>;
@@ -1043,6 +1058,7 @@ impl IWiaItem_Vtbl {
         iid == &<IWiaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaItem2_Impl: Sized {
     fn CreateChildItem(&self, litemflags: i32, lcreationflags: i32, bstritemname: &::windows::core::BSTR) -> ::windows::core::Result<IWiaItem2>;
@@ -1231,6 +1247,7 @@ impl IWiaItem2_Vtbl {
         iid == &<IWiaItem2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaItemExtras_Impl: Sized {
     fn GetExtendedErrorInfo(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn Escape(&self, dwescapecode: u32, lpindata: *const u8, cbindatasize: u32, poutdata: *mut u8, dwoutdatasize: u32, pdwactualdatasize: *mut u32) -> ::windows::core::Result<()>;
@@ -1271,6 +1288,7 @@ impl IWiaItemExtras_Vtbl {
         iid == &<IWiaItemExtras as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaLog_Impl: Sized {
     fn InitializeLog(&self, hinstance: i32) -> ::windows::core::Result<()>;
     fn hResult(&self, hresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1305,6 +1323,7 @@ impl IWiaLog_Vtbl {
         iid == &<IWiaLog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaLogEx_Impl: Sized {
     fn InitializeLogEx(&self, hinstance: *const u8) -> ::windows::core::Result<()>;
     fn hResult(&self, hresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1353,6 +1372,7 @@ impl IWiaLogEx_Vtbl {
         iid == &<IWiaLogEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWiaMiniDrv_Impl: Sized {
     fn drvInitializeWia(&self, __midl__iwiaminidrv0000: *const u8, __midl__iwiaminidrv0001: i32, __midl__iwiaminidrv0002: &::windows::core::BSTR, __midl__iwiaminidrv0003: &::windows::core::BSTR, __midl__iwiaminidrv0004: &::core::option::Option<::windows::core::IUnknown>, __midl__iwiaminidrv0005: &::core::option::Option<::windows::core::IUnknown>, __midl__iwiaminidrv0006: *mut ::core::option::Option<IWiaDrvItem>, __midl__iwiaminidrv0007: *mut ::core::option::Option<::windows::core::IUnknown>, __midl__iwiaminidrv0008: *mut i32) -> ::windows::core::Result<()>;
@@ -1537,6 +1557,7 @@ impl IWiaMiniDrv_Vtbl {
         iid == &<IWiaMiniDrv as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaMiniDrvCallBack_Impl: Sized {
     fn MiniDrvCallback(&self, lreason: i32, lstatus: i32, lpercentcomplete: i32, loffset: i32, llength: i32, ptranctx: *const MINIDRV_TRANSFER_CONTEXT, lreserved: i32) -> ::windows::core::Result<()>;
@@ -1557,6 +1578,7 @@ impl IWiaMiniDrvCallBack_Vtbl {
         iid == &<IWiaMiniDrvCallBack as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWiaMiniDrvTransferCallback_Impl: Sized {
     fn GetNextStream(&self, lflags: i32, bstritemname: &::windows::core::BSTR, bstrfullitemname: &::windows::core::BSTR, ppistream: *mut ::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -1587,6 +1609,7 @@ impl IWiaMiniDrvTransferCallback_Vtbl {
         iid == &<IWiaMiniDrvTransferCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaNotifyDevMgr_Impl: Sized {
     fn NewDeviceArrival(&self) -> ::windows::core::Result<()>;
 }
@@ -1604,6 +1627,7 @@ impl IWiaNotifyDevMgr_Vtbl {
         iid == &<IWiaNotifyDevMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"implement\"`*"]
 pub trait IWiaPreview_Impl: Sized {
     fn GetNewPreview(&self, lflags: i32, pwiaitem2: &::core::option::Option<IWiaItem2>, pwiatransfercallback: &::core::option::Option<IWiaTransferCallback>) -> ::windows::core::Result<()>;
     fn UpdatePreview(&self, lflags: i32, pchildwiaitem2: &::core::option::Option<IWiaItem2>, pwiatransfercallback: &::core::option::Option<IWiaTransferCallback>) -> ::windows::core::Result<()>;
@@ -1645,6 +1669,7 @@ impl IWiaPreview_Vtbl {
         iid == &<IWiaPreview as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWiaPropertyStorage_Impl: Sized {
     fn ReadMultiple(&self, cpspec: u32, rgpspec: *const super::super::System::Com::StructuredStorage::PROPSPEC, rgpropvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -1791,6 +1816,7 @@ impl IWiaPropertyStorage_Vtbl {
         iid == &<IWiaPropertyStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWiaSegmentationFilter_Impl: Sized {
     fn DetectRegions(&self, lflags: i32, pinputstream: &::core::option::Option<super::super::System::Com::IStream>, pwiaitem2: &::core::option::Option<IWiaItem2>) -> ::windows::core::Result<()>;
@@ -1811,6 +1837,7 @@ impl IWiaSegmentationFilter_Vtbl {
         iid == &<IWiaSegmentationFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWiaTransfer_Impl: Sized {
     fn Download(&self, lflags: i32, piwiatransfercallback: &::core::option::Option<IWiaTransferCallback>) -> ::windows::core::Result<()>;
@@ -1861,6 +1888,7 @@ impl IWiaTransfer_Vtbl {
         iid == &<IWiaTransfer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWiaTransferCallback_Impl: Sized {
     fn TransferCallback(&self, lflags: i32, pwiatransferparams: *const WiaTransferParams) -> ::windows::core::Result<()>;
@@ -1891,6 +1919,7 @@ impl IWiaTransferCallback_Vtbl {
         iid == &<IWiaTransferCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IWiaUIExtension_Impl: Sized {
     fn DeviceDialog(&self, pdevicedialogdata: *const DEVICEDIALOGDATA) -> ::windows::core::Result<()>;
@@ -1928,6 +1957,7 @@ impl IWiaUIExtension_Vtbl {
         iid == &<IWiaUIExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IWiaUIExtension2_Impl: Sized {
     fn DeviceDialog(&self, pdevicedialogdata: *const DEVICEDIALOGDATA2) -> ::windows::core::Result<()>;
@@ -1958,6 +1988,7 @@ impl IWiaUIExtension2_Vtbl {
         iid == &<IWiaUIExtension2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWiaVideo_Impl: Sized {
     fn PreviewVisible(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IConnectionRequestCallback_Impl: Sized {
     fn OnComplete(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IConnectionRequestCallback_Vtbl {
         iid == &<IConnectionRequestCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IEnumPortableDeviceConnectors_Impl: Sized {
     fn Next(&self, crequested: u32, pconnectors: *mut ::core::option::Option<IPortableDeviceConnector>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cconnectors: u32) -> ::windows::core::Result<()>;
@@ -62,6 +64,7 @@ impl IEnumPortableDeviceConnectors_Vtbl {
         iid == &<IEnumPortableDeviceConnectors as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IEnumPortableDeviceObjectIDs_Impl: Sized {
     fn Next(&self, cobjects: u32, pobjids: *mut ::windows::core::PWSTR, pcfetched: *mut u32) -> ::windows::core::HRESULT;
     fn Skip(&self, cobjects: u32) -> ::windows::core::HRESULT;
@@ -116,6 +119,7 @@ impl IEnumPortableDeviceObjectIDs_Vtbl {
         iid == &<IEnumPortableDeviceObjectIDs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IMediaRadioManager_Impl: Sized {
     fn GetRadioInstances(&self) -> ::windows::core::Result<IRadioInstanceCollection>;
     fn OnSystemRadioStateChange(&self, sysradiostate: SYSTEM_RADIO_STATE, utimeoutsec: u32) -> ::windows::core::Result<()>;
@@ -149,6 +153,7 @@ impl IMediaRadioManager_Vtbl {
         iid == &<IMediaRadioManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IMediaRadioManagerNotifySink_Impl: Sized {
     fn OnInstanceAdd(&self, pradioinstance: &::core::option::Option<IRadioInstance>) -> ::windows::core::Result<()>;
     fn OnInstanceRemove(&self, bstrradioinstanceid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -183,6 +188,7 @@ impl IMediaRadioManagerNotifySink_Vtbl {
         iid == &<IMediaRadioManagerNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDevice_Impl: Sized {
     fn Open(&self, pszpnpdeviceid: &::windows::core::PCWSTR, pclientinfo: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<()>;
     fn SendCommand(&self, dwflags: u32, pparameters: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<IPortableDeviceValues>;
@@ -289,6 +295,7 @@ impl IPortableDevice_Vtbl {
         iid == &<IPortableDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IPortableDeviceCapabilities_Impl: Sized {
     fn GetSupportedCommands(&self) -> ::windows::core::Result<IPortableDeviceKeyCollection>;
@@ -442,6 +449,7 @@ impl IPortableDeviceCapabilities_Vtbl {
         iid == &<IPortableDeviceCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_Devices_Properties\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Devices_Properties")]
 pub trait IPortableDeviceConnector_Impl: Sized {
     fn Connect(&self, pcallback: &::core::option::Option<IConnectionRequestCallback>) -> ::windows::core::Result<()>;
@@ -506,6 +514,7 @@ impl IPortableDeviceConnector_Vtbl {
         iid == &<IPortableDeviceConnector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IPortableDeviceContent_Impl: Sized {
     fn EnumObjects(&self, dwflags: u32, pszparentobjectid: &::windows::core::PCWSTR, pfilter: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<IEnumPortableDeviceObjectIDs>;
@@ -616,6 +625,7 @@ impl IPortableDeviceContent_Vtbl {
         iid == &<IPortableDeviceContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IPortableDeviceContent2_Impl: Sized + IPortableDeviceContent_Impl {
     fn UpdateObjectWithPropertiesAndData(&self, pszobjectid: &::windows::core::PCWSTR, pproperties: &::core::option::Option<IPortableDeviceValues>, ppdata: *mut ::core::option::Option<super::super::System::Com::IStream>, pdwoptimalwritebuffersize: *mut u32) -> ::windows::core::Result<()>;
@@ -639,6 +649,7 @@ impl IPortableDeviceContent2_Vtbl {
         iid == &<IPortableDeviceContent2 as ::windows::core::Interface>::IID || iid == &<IPortableDeviceContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPortableDeviceDataStream_Impl: Sized + super::super::System::Com::IStream_Impl {
     fn GetObjectID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -675,6 +686,7 @@ impl IPortableDeviceDataStream_Vtbl {
         iid == &<IPortableDeviceDataStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IPortableDeviceDispatchFactory_Impl: Sized {
     fn GetDeviceDispatch(&self, pszpnpdeviceid: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -701,6 +713,7 @@ impl IPortableDeviceDispatchFactory_Vtbl {
         iid == &<IPortableDeviceDispatchFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceEventCallback_Impl: Sized {
     fn OnEvent(&self, peventparameters: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<()>;
 }
@@ -718,6 +731,7 @@ impl IPortableDeviceEventCallback_Vtbl {
         iid == &<IPortableDeviceEventCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IPortableDeviceKeyCollection_Impl: Sized {
     fn GetCount(&self, pcelems: *const u32) -> ::windows::core::Result<()>;
@@ -769,6 +783,7 @@ impl IPortableDeviceKeyCollection_Vtbl {
         iid == &<IPortableDeviceKeyCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceManager_Impl: Sized {
     fn GetDevices(&self, ppnpdeviceids: *mut ::windows::core::PWSTR, pcpnpdeviceids: *mut u32) -> ::windows::core::Result<()>;
     fn RefreshDeviceList(&self) -> ::windows::core::Result<()>;
@@ -831,6 +846,7 @@ impl IPortableDeviceManager_Vtbl {
         iid == &<IPortableDeviceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPortableDevicePropVariantCollection_Impl: Sized {
     fn GetCount(&self, pcelems: *const u32) -> ::windows::core::Result<()>;
@@ -902,6 +918,7 @@ impl IPortableDevicePropVariantCollection_Vtbl {
         iid == &<IPortableDevicePropVariantCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IPortableDeviceProperties_Impl: Sized {
     fn GetSupportedProperties(&self, pszobjectid: &::windows::core::PCWSTR) -> ::windows::core::Result<IPortableDeviceKeyCollection>;
@@ -984,6 +1001,7 @@ impl IPortableDeviceProperties_Vtbl {
         iid == &<IPortableDeviceProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDevicePropertiesBulk_Impl: Sized {
     fn QueueGetValuesByObjectList(&self, pobjectids: &::core::option::Option<IPortableDevicePropVariantCollection>, pkeys: &::core::option::Option<IPortableDeviceKeyCollection>, pcallback: &::core::option::Option<IPortableDevicePropertiesBulkCallback>) -> ::windows::core::Result<::windows::core::GUID>;
     fn QueueGetValuesByObjectFormat(&self, pguidobjectformat: *const ::windows::core::GUID, pszparentobjectid: &::windows::core::PCWSTR, dwdepth: u32, pkeys: &::core::option::Option<IPortableDeviceKeyCollection>, pcallback: &::core::option::Option<IPortableDevicePropertiesBulkCallback>) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1050,6 +1068,7 @@ impl IPortableDevicePropertiesBulk_Vtbl {
         iid == &<IPortableDevicePropertiesBulk as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDevicePropertiesBulkCallback_Impl: Sized {
     fn OnStart(&self, pcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnProgress(&self, pcontext: *const ::windows::core::GUID, presults: &::core::option::Option<IPortableDeviceValuesCollection>) -> ::windows::core::Result<()>;
@@ -1084,6 +1103,7 @@ impl IPortableDevicePropertiesBulkCallback_Vtbl {
         iid == &<IPortableDevicePropertiesBulkCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IPortableDeviceResources_Impl: Sized {
     fn GetSupportedResources(&self, pszobjectid: &::windows::core::PCWSTR) -> ::windows::core::Result<IPortableDeviceKeyCollection>;
@@ -1154,6 +1174,7 @@ impl IPortableDeviceResources_Vtbl {
         iid == &<IPortableDeviceResources as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceService_Impl: Sized {
     fn Open(&self, pszpnpserviceid: &::windows::core::PCWSTR, pclientinfo: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<()>;
     fn Capabilities(&self) -> ::windows::core::Result<IPortableDeviceServiceCapabilities>;
@@ -1286,6 +1307,7 @@ impl IPortableDeviceService_Vtbl {
         iid == &<IPortableDeviceService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceServiceActivation_Impl: Sized {
     fn OpenAsync(&self, pszpnpserviceid: &::windows::core::PCWSTR, pclientinfo: &::core::option::Option<IPortableDeviceValues>, pcallback: &::core::option::Option<IPortableDeviceServiceOpenCallback>) -> ::windows::core::Result<()>;
     fn CancelOpenAsync(&self) -> ::windows::core::Result<()>;
@@ -1313,6 +1335,7 @@ impl IPortableDeviceServiceActivation_Vtbl {
         iid == &<IPortableDeviceServiceActivation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IPortableDeviceServiceCapabilities_Impl: Sized {
     fn GetSupportedMethods(&self) -> ::windows::core::Result<IPortableDevicePropVariantCollection>;
@@ -1531,6 +1554,7 @@ impl IPortableDeviceServiceCapabilities_Vtbl {
         iid == &<IPortableDeviceServiceCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceServiceManager_Impl: Sized {
     fn GetDeviceServices(&self, pszpnpdeviceid: &::windows::core::PCWSTR, guidservicecategory: *const ::windows::core::GUID, pservices: *mut ::windows::core::PWSTR, pcservices: *mut u32) -> ::windows::core::Result<()>;
     fn GetDeviceForService(&self, pszpnpserviceid: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1564,6 +1588,7 @@ impl IPortableDeviceServiceManager_Vtbl {
         iid == &<IPortableDeviceServiceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceServiceMethodCallback_Impl: Sized {
     fn OnComplete(&self, hrstatus: ::windows::core::HRESULT, presults: &::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<()>;
 }
@@ -1581,6 +1606,7 @@ impl IPortableDeviceServiceMethodCallback_Vtbl {
         iid == &<IPortableDeviceServiceMethodCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceServiceMethods_Impl: Sized {
     fn Invoke(&self, method: *const ::windows::core::GUID, pparameters: &::core::option::Option<IPortableDeviceValues>, ppresults: *mut ::core::option::Option<IPortableDeviceValues>) -> ::windows::core::Result<()>;
     fn InvokeAsync(&self, method: *const ::windows::core::GUID, pparameters: &::core::option::Option<IPortableDeviceValues>, pcallback: &::core::option::Option<IPortableDeviceServiceMethodCallback>) -> ::windows::core::Result<()>;
@@ -1615,6 +1641,7 @@ impl IPortableDeviceServiceMethods_Vtbl {
         iid == &<IPortableDeviceServiceMethods as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceServiceOpenCallback_Impl: Sized {
     fn OnComplete(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -1632,6 +1659,7 @@ impl IPortableDeviceServiceOpenCallback_Vtbl {
         iid == &<IPortableDeviceServiceOpenCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceUnitsStream_Impl: Sized {
     fn SeekInUnits(&self, dlibmove: i64, units: WPD_STREAM_UNITS, dworigin: u32, plibnewposition: *mut u64) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
@@ -1659,6 +1687,7 @@ impl IPortableDeviceUnitsStream_Vtbl {
         iid == &<IPortableDeviceUnitsStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IPortableDeviceValues_Impl: Sized {
     fn GetCount(&self, pcelt: *const u32) -> ::windows::core::Result<()>;
@@ -2051,6 +2080,7 @@ impl IPortableDeviceValues_Vtbl {
         iid == &<IPortableDeviceValues as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IPortableDeviceValuesCollection_Impl: Sized {
     fn GetCount(&self, pcelems: *const u32) -> ::windows::core::Result<()>;
     fn GetAt(&self, dwindex: u32) -> ::windows::core::Result<IPortableDeviceValues>;
@@ -2105,6 +2135,7 @@ impl IPortableDeviceValuesCollection_Vtbl {
         iid == &<IPortableDeviceValuesCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPortableDeviceWebControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetDeviceFromId(&self, deviceid: &::windows::core::BSTR) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -2141,6 +2172,7 @@ impl IPortableDeviceWebControl_Vtbl {
         iid == &<IPortableDeviceWebControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRadioInstance_Impl: Sized {
     fn GetRadioManagerSignature(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2230,6 +2262,7 @@ impl IRadioInstance_Vtbl {
         iid == &<IRadioInstance as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IRadioInstanceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, uindex: u32) -> ::windows::core::Result<IRadioInstance>;
@@ -2269,6 +2302,7 @@ impl IRadioInstanceCollection_Vtbl {
         iid == &<IRadioInstanceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 pub trait IWpdSerializer_Impl: Sized {
     fn GetIPortableDeviceValuesFromBuffer(&self, pbuffer: *const u8, dwinputbufferlength: u32) -> ::windows::core::Result<IPortableDeviceValues>;
     fn WriteIPortableDeviceValuesToBuffer(&self, dwoutputbufferlength: u32, presults: &::core::option::Option<IPortableDeviceValues>, pbuffer: *mut u8, pdwbyteswritten: *mut u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_Sensors\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ILocationPermissions_Impl: Sized {
     fn GetGlobalLocationPermission(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -34,6 +35,7 @@ impl ILocationPermissions_Vtbl {
         iid == &<ILocationPermissions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Sensors\"`, `\"Win32_Devices_PortableDevices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Devices_PortableDevices", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISensor_Impl: Sized {
     fn GetID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -227,6 +229,7 @@ impl ISensor_Vtbl {
         iid == &<ISensor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Sensors\"`, `\"implement\"`*"]
 pub trait ISensorCollection_Impl: Sized {
     fn GetAt(&self, ulindex: u32) -> ::windows::core::Result<ISensor>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -294,6 +297,7 @@ impl ISensorCollection_Vtbl {
         iid == &<ISensorCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Sensors\"`, `\"Win32_Devices_PortableDevices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Devices_PortableDevices", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISensorDataReport_Impl: Sized {
     fn GetTimestamp(&self) -> ::windows::core::Result<super::super::Foundation::SYSTEMTIME>;
@@ -349,6 +353,7 @@ impl ISensorDataReport_Vtbl {
         iid == &<ISensorDataReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Sensors\"`, `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Devices_PortableDevices")]
 pub trait ISensorEvents_Impl: Sized {
     fn OnStateChanged(&self, psensor: &::core::option::Option<ISensor>, state: SensorState) -> ::windows::core::Result<()>;
@@ -393,6 +398,7 @@ impl ISensorEvents_Vtbl {
         iid == &<ISensorEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Sensors\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISensorManager_Impl: Sized {
     fn GetSensorsByCategory(&self, sensorcategory: *const ::windows::core::GUID) -> ::windows::core::Result<ISensorCollection>;
@@ -462,6 +468,7 @@ impl ISensorManager_Vtbl {
         iid == &<ISensorManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Sensors\"`, `\"implement\"`*"]
 pub trait ISensorManagerEvents_Impl: Sized {
     fn OnSensorEnter(&self, psensor: &::core::option::Option<ISensor>, state: SensorState) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Tapi/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumACDGroup_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITACDGroup>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -48,6 +49,7 @@ impl IEnumACDGroup_Vtbl {
         iid == &<IEnumACDGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumAddress_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITAddress>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -98,6 +100,7 @@ impl IEnumAddress_Vtbl {
         iid == &<IEnumAddress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumAgent_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITAgent>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -148,6 +151,7 @@ impl IEnumAgent_Vtbl {
         iid == &<IEnumAgent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumAgentHandler_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITAgentHandler>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -198,6 +202,7 @@ impl IEnumAgentHandler_Vtbl {
         iid == &<IEnumAgentHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumAgentSession_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITAgentSession>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -248,6 +253,7 @@ impl IEnumAgentSession_Vtbl {
         iid == &<IEnumAgentSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"implement\"`*"]
 pub trait IEnumBstr_Impl: Sized {
     fn Next(&self, celt: u32, ppstrings: *mut ::windows::core::BSTR, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -295,6 +301,7 @@ impl IEnumBstr_Vtbl {
         iid == &<IEnumBstr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumCall_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITCallInfo>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -345,6 +352,7 @@ impl IEnumCall_Vtbl {
         iid == &<IEnumCall as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumCallHub_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITCallHub>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -395,6 +403,7 @@ impl IEnumCallHub_Vtbl {
         iid == &<IEnumCallHub as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumCallingCard_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITCallingCard>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -445,6 +454,7 @@ impl IEnumCallingCard_Vtbl {
         iid == &<IEnumCallingCard as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"implement\"`*"]
 pub trait IEnumDialableAddrs_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::windows::core::BSTR, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -492,6 +502,7 @@ impl IEnumDialableAddrs_Vtbl {
         iid == &<IEnumDialableAddrs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumDirectory_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITDirectory>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -542,6 +553,7 @@ impl IEnumDirectory_Vtbl {
         iid == &<IEnumDirectory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumDirectoryObject_Impl: Sized {
     fn Next(&self, celt: u32, pval: *mut ::core::option::Option<ITDirectoryObject>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -592,6 +604,7 @@ impl IEnumDirectoryObject_Vtbl {
         iid == &<IEnumDirectoryObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumLocation_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITLocationInfo>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -642,6 +655,7 @@ impl IEnumLocation_Vtbl {
         iid == &<IEnumLocation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumMcastScope_Impl: Sized {
     fn Next(&self, celt: u32, ppscopes: *mut ::core::option::Option<IMcastScope>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -692,6 +706,7 @@ impl IEnumMcastScope_Vtbl {
         iid == &<IEnumMcastScope as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumPhone_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITPhone>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -742,6 +757,7 @@ impl IEnumPhone_Vtbl {
         iid == &<IEnumPhone as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumPluggableSuperclassInfo_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITPluggableTerminalSuperclassInfo>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -792,6 +808,7 @@ impl IEnumPluggableSuperclassInfo_Vtbl {
         iid == &<IEnumPluggableSuperclassInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumPluggableTerminalClassInfo_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITPluggableTerminalClassInfo>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -842,6 +859,7 @@ impl IEnumPluggableTerminalClassInfo_Vtbl {
         iid == &<IEnumPluggableTerminalClassInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumQueue_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITQueue>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -892,6 +910,7 @@ impl IEnumQueue_Vtbl {
         iid == &<IEnumQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumStream_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITStream>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -942,6 +961,7 @@ impl IEnumStream_Vtbl {
         iid == &<IEnumStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumSubStream_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITSubStream>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -992,6 +1012,7 @@ impl IEnumSubStream_Vtbl {
         iid == &<IEnumSubStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumTerminal_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<ITTerminal>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1042,6 +1063,7 @@ impl IEnumTerminal_Vtbl {
         iid == &<IEnumTerminal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"implement\"`*"]
 pub trait IEnumTerminalClass_Impl: Sized {
     fn Next(&self, celt: u32, pelements: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1089,6 +1111,7 @@ impl IEnumTerminalClass_Vtbl {
         iid == &<IEnumTerminalClass as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMcastAddressAllocation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Scopes(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1190,6 +1213,7 @@ impl IMcastAddressAllocation_Vtbl {
         iid == &<IMcastAddressAllocation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMcastLeaseInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RequestID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1324,6 +1348,7 @@ impl IMcastLeaseInfo_Vtbl {
         iid == &<IMcastLeaseInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMcastScope_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ScopeID(&self) -> ::windows::core::Result<i32>;
@@ -1405,6 +1430,7 @@ impl IMcastScope_Vtbl {
         iid == &<IMcastScope as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITACDGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1460,6 +1486,7 @@ impl ITACDGroup_Vtbl {
         iid == &<ITACDGroup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITACDGroupEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Group(&self) -> ::windows::core::Result<ITACDGroup>;
@@ -1502,6 +1529,7 @@ impl ITACDGroupEvent_Vtbl {
         iid == &<ITACDGroupEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait ITAMMediaFormat_Impl: Sized {
     fn MediaFormat(&self) -> ::windows::core::Result<*mut super::super::Media::MediaFoundation::AM_MEDIA_TYPE>;
@@ -1538,6 +1566,7 @@ impl ITAMMediaFormat_Vtbl {
         iid == &<ITAMMediaFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITASRTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Terminal(&self) -> ::windows::core::Result<ITTerminal>;
@@ -1593,6 +1622,7 @@ impl ITASRTerminalEvent_Vtbl {
         iid == &<ITASRTerminalEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAddress_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn State(&self) -> ::windows::core::Result<ADDRESS_STATE>;
@@ -1786,6 +1816,7 @@ impl ITAddress_Vtbl {
         iid == &<ITAddress as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAddress2_Impl: Sized + ITAddress_Impl {
     fn Phones(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1914,6 +1945,7 @@ impl ITAddress2_Vtbl {
         iid == &<ITAddress2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITAddress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAddressCapabilities_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_AddressCapability(&self, addresscap: ADDRESS_CAPABILITY) -> ::windows::core::Result<i32>;
@@ -2034,6 +2066,7 @@ impl ITAddressCapabilities_Vtbl {
         iid == &<ITAddressCapabilities as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAddressDeviceSpecificEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Address(&self) -> ::windows::core::Result<ITAddress>;
@@ -2115,6 +2148,7 @@ impl ITAddressDeviceSpecificEvent_Vtbl {
         iid == &<ITAddressDeviceSpecificEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAddressEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Address(&self) -> ::windows::core::Result<ITAddress>;
@@ -2170,6 +2204,7 @@ impl ITAddressEvent_Vtbl {
         iid == &<ITAddressEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAddressTranslation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TranslateAddress(&self, paddresstotranslate: &::windows::core::BSTR, lcard: i32, ltranslateoptions: i32) -> ::windows::core::Result<ITAddressTranslationInfo>;
@@ -2258,6 +2293,7 @@ impl ITAddressTranslation_Vtbl {
         iid == &<ITAddressTranslation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAddressTranslationInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DialableString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2339,6 +2375,7 @@ impl ITAddressTranslationInfo_Vtbl {
         iid == &<ITAddressTranslationInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAgent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EnumerateAgentSessions(&self) -> ::windows::core::Result<IEnumAgentSession>;
@@ -2564,6 +2601,7 @@ impl ITAgent_Vtbl {
         iid == &<ITAgent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAgentEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Agent(&self) -> ::windows::core::Result<ITAgent>;
@@ -2606,6 +2644,7 @@ impl ITAgentEvent_Vtbl {
         iid == &<ITAgentEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAgentHandler_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2713,6 +2752,7 @@ impl ITAgentHandler_Vtbl {
         iid == &<ITAgentHandler as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAgentHandlerEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AgentHandler(&self) -> ::windows::core::Result<ITAgentHandler>;
@@ -2755,6 +2795,7 @@ impl ITAgentHandlerEvent_Vtbl {
         iid == &<ITAgentHandlerEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAgentSession_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Agent(&self) -> ::windows::core::Result<ITAgent>;
@@ -2986,6 +3027,7 @@ impl ITAgentSession_Vtbl {
         iid == &<ITAgentSession as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAgentSessionEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<ITAgentSession>;
@@ -3028,6 +3070,7 @@ impl ITAgentSessionEvent_Vtbl {
         iid == &<ITAgentSessionEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow"))]
 pub trait ITAllocatorProperties_Impl: Sized {
     fn SetAllocatorProperties(&self, pallocproperties: *const super::super::Media::DirectShow::ALLOCATOR_PROPERTIES) -> ::windows::core::Result<()>;
@@ -3104,6 +3147,7 @@ impl ITAllocatorProperties_Vtbl {
         iid == &<ITAllocatorProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITAutomatedPhoneControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartTone(&self, tone: PHONE_TONE, lduration: i32) -> ::windows::core::Result<()>;
@@ -3434,6 +3478,7 @@ impl ITAutomatedPhoneControl_Vtbl {
         iid == &<ITAutomatedPhoneControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITBasicAudioTerminal_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetVolume(&self, lvolume: i32) -> ::windows::core::Result<()>;
@@ -3490,6 +3535,7 @@ impl ITBasicAudioTerminal_Vtbl {
         iid == &<ITBasicAudioTerminal as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITBasicCallControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Connect(&self, fsync: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3638,6 +3684,7 @@ impl ITBasicCallControl_Vtbl {
         iid == &<ITBasicCallControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITBasicCallControl2_Impl: Sized + ITBasicCallControl_Impl {
     fn RequestTerminal(&self, bstrterminalclassguid: &::windows::core::BSTR, lmediatype: i32, direction: TERMINAL_DIRECTION) -> ::windows::core::Result<ITTerminal>;
@@ -3681,6 +3728,7 @@ impl ITBasicCallControl2_Vtbl {
         iid == &<ITBasicCallControl2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITBasicCallControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallHub_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Clear(&self) -> ::windows::core::Result<()>;
@@ -3756,6 +3804,7 @@ impl ITCallHub_Vtbl {
         iid == &<ITCallHub as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallHubEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Event(&self) -> ::windows::core::Result<CALLHUB_EVENT>;
@@ -3811,6 +3860,7 @@ impl ITCallHubEvent_Vtbl {
         iid == &<ITCallHubEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Address(&self) -> ::windows::core::Result<ITAddress>;
@@ -3960,6 +4010,7 @@ impl ITCallInfo_Vtbl {
         iid == &<ITCallInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallInfo2_Impl: Sized + ITCallInfo_Impl {
     fn get_EventFilter(&self, tapievent: TAPI_EVENT, lsubevent: i32) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3996,6 +4047,7 @@ impl ITCallInfo2_Vtbl {
         iid == &<ITCallInfo2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITCallInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallInfoChangeEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -4051,6 +4103,7 @@ impl ITCallInfoChangeEvent_Vtbl {
         iid == &<ITCallInfoChangeEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallMediaEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -4145,6 +4198,7 @@ impl ITCallMediaEvent_Vtbl {
         iid == &<ITCallMediaEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallNotificationEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -4200,6 +4254,7 @@ impl ITCallNotificationEvent_Vtbl {
         iid == &<ITCallNotificationEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallStateEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -4268,6 +4323,7 @@ impl ITCallStateEvent_Vtbl {
         iid == &<ITCallStateEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCallingCard_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn PermanentCardID(&self) -> ::windows::core::Result<i32>;
@@ -4375,6 +4431,7 @@ impl ITCallingCard_Vtbl {
         iid == &<ITCallingCard as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4430,6 +4487,7 @@ impl ITCollection_Vtbl {
         iid == &<ITCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCollection2_Impl: Sized + ITCollection_Impl {
     fn Add(&self, index: i32, pvariant: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -4456,6 +4514,7 @@ impl ITCollection2_Vtbl {
         iid == &<ITCollection2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITCustomTone_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Frequency(&self) -> ::windows::core::Result<i32>;
@@ -4552,6 +4611,7 @@ impl ITCustomTone_Vtbl {
         iid == &<ITCustomTone as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDetectTone_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AppSpecific(&self) -> ::windows::core::Result<i32>;
@@ -4628,6 +4688,7 @@ impl ITDetectTone_Vtbl {
         iid == &<ITDetectTone as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDigitDetectionEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -4709,6 +4770,7 @@ impl ITDigitDetectionEvent_Vtbl {
         iid == &<ITDigitDetectionEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDigitGenerationEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -4777,6 +4839,7 @@ impl ITDigitGenerationEvent_Vtbl {
         iid == &<ITDigitGenerationEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDigitsGatheredEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -4858,6 +4921,7 @@ impl ITDigitsGatheredEvent_Vtbl {
         iid == &<ITDigitsGatheredEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDirectory_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DirectoryType(&self) -> ::windows::core::Result<DIRECTORY_TYPE>;
@@ -5008,6 +5072,7 @@ impl ITDirectory_Vtbl {
         iid == &<ITDirectory as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDirectoryObject_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ObjectType(&self) -> ::windows::core::Result<DIRECTORY_OBJECT_TYPE>;
@@ -5103,6 +5168,7 @@ impl ITDirectoryObject_Vtbl {
         iid == &<ITDirectoryObject as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDirectoryObjectConference_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Protocol(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5272,6 +5338,7 @@ impl ITDirectoryObjectConference_Vtbl {
         iid == &<ITDirectoryObjectConference as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDirectoryObjectUser_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IPPhonePrimary(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5308,6 +5375,7 @@ impl ITDirectoryObjectUser_Vtbl {
         iid == &<ITDirectoryObjectUser as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITDispatchMapper_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn QueryDispatchInterface(&self, piid: &::windows::core::BSTR, pinterfacetomap: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -5337,6 +5405,7 @@ impl ITDispatchMapper_Vtbl {
         iid == &<ITDispatchMapper as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITFileTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Terminal(&self) -> ::windows::core::Result<ITTerminal>;
@@ -5431,6 +5500,7 @@ impl ITFileTerminalEvent_Vtbl {
         iid == &<ITFileTerminalEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITFileTrack_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Format(&self) -> ::windows::core::Result<*mut super::super::Media::MediaFoundation::AM_MEDIA_TYPE>;
@@ -5513,6 +5583,7 @@ impl ITFileTrack_Vtbl {
         iid == &<ITFileTrack as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITForwardInformation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetNumRingsNoAnswer(&self, lnumrings: i32) -> ::windows::core::Result<()>;
@@ -5596,6 +5667,7 @@ impl ITForwardInformation_Vtbl {
         iid == &<ITForwardInformation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITForwardInformation2_Impl: Sized + ITForwardInformation_Impl {
     fn SetForwardType2(&self, forwardtype: i32, pdestaddress: &::windows::core::BSTR, destaddresstype: i32, pcalleraddress: &::windows::core::BSTR, calleraddresstype: i32) -> ::windows::core::Result<()>;
@@ -5652,6 +5724,7 @@ impl ITForwardInformation2_Vtbl {
         iid == &<ITForwardInformation2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITForwardInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITILSConfig_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Port(&self) -> ::windows::core::Result<i32>;
@@ -5688,6 +5761,7 @@ impl ITILSConfig_Vtbl {
         iid == &<ITILSConfig as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"implement\"`*"]
 pub trait ITLegacyAddressMediaControl_Impl: Sized {
     fn GetID(&self, pdeviceclass: &::windows::core::BSTR, pdwsize: *mut u32, ppdeviceid: *mut *mut u8) -> ::windows::core::Result<()>;
     fn GetDevConfig(&self, pdeviceclass: &::windows::core::BSTR, pdwsize: *mut u32, ppdeviceconfig: *mut *mut u8) -> ::windows::core::Result<()>;
@@ -5722,6 +5796,7 @@ impl ITLegacyAddressMediaControl_Vtbl {
         iid == &<ITLegacyAddressMediaControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITLegacyAddressMediaControl2_Impl: Sized + ITLegacyAddressMediaControl_Impl {
     fn ConfigDialog(&self, hwndowner: super::super::Foundation::HWND, pdeviceclass: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -5752,6 +5827,7 @@ impl ITLegacyAddressMediaControl2_Vtbl {
         iid == &<ITLegacyAddressMediaControl2 as ::windows::core::Interface>::IID || iid == &<ITLegacyAddressMediaControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITLegacyCallMediaControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DetectDigits(&self, digitmode: i32) -> ::windows::core::Result<()>;
@@ -5803,6 +5879,7 @@ impl ITLegacyCallMediaControl_Vtbl {
         iid == &<ITLegacyCallMediaControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITLegacyCallMediaControl2_Impl: Sized + ITLegacyCallMediaControl_Impl {
     fn GenerateDigits2(&self, pdigits: &::windows::core::BSTR, digitmode: i32, lduration: i32) -> ::windows::core::Result<()>;
@@ -5907,6 +5984,7 @@ impl ITLegacyCallMediaControl2_Vtbl {
         iid == &<ITLegacyCallMediaControl2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITLegacyCallMediaControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITLegacyWaveSupport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsFullDuplex(&self) -> ::windows::core::Result<FULLDUPLEX_SUPPORT>;
@@ -5933,6 +6011,7 @@ impl ITLegacyWaveSupport_Vtbl {
         iid == &<ITLegacyWaveSupport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITLocationInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn PermanentLocationID(&self) -> ::windows::core::Result<i32>;
@@ -6092,6 +6171,7 @@ impl ITLocationInfo_Vtbl {
         iid == &<ITLocationInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"implement\"`*"]
 pub trait ITMSPAddress_Impl: Sized {
     fn Initialize(&self, hevent: *const i32) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
@@ -6153,6 +6233,7 @@ impl ITMSPAddress_Vtbl {
         iid == &<ITMSPAddress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITMediaControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Start(&self) -> ::windows::core::Result<()>;
@@ -6203,6 +6284,7 @@ impl ITMediaControl_Vtbl {
         iid == &<ITMediaControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITMediaPlayback_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetPlayList(&self, playlistvariant: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -6239,6 +6321,7 @@ impl ITMediaPlayback_Vtbl {
         iid == &<ITMediaPlayback as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITMediaRecord_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetFileName(&self, bstrfilename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6275,6 +6358,7 @@ impl ITMediaRecord_Vtbl {
         iid == &<ITMediaRecord as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITMediaSupport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MediaTypes(&self) -> ::windows::core::Result<i32>;
@@ -6317,6 +6401,7 @@ impl ITMediaSupport_Vtbl {
         iid == &<ITMediaSupport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITMultiTrackTerminal_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TrackTerminals(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -6405,6 +6490,7 @@ impl ITMultiTrackTerminal_Vtbl {
         iid == &<ITMultiTrackTerminal as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITPhone_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Open(&self, privilege: PHONE_PRIVILEGE) -> ::windows::core::Result<()>;
@@ -6772,6 +6858,7 @@ impl ITPhone_Vtbl {
         iid == &<ITPhone as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITPhoneDeviceSpecificEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Phone(&self) -> ::windows::core::Result<ITPhone>;
@@ -6840,6 +6927,7 @@ impl ITPhoneDeviceSpecificEvent_Vtbl {
         iid == &<ITPhoneDeviceSpecificEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITPhoneEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Phone(&self) -> ::windows::core::Result<ITPhone>;
@@ -6973,6 +7061,7 @@ impl ITPhoneEvent_Vtbl {
         iid == &<ITPhoneEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITPluggableTerminalClassInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7080,6 +7169,7 @@ impl ITPluggableTerminalClassInfo_Vtbl {
         iid == &<ITPluggableTerminalClassInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITPluggableTerminalEventSink_Impl: Sized {
     fn FireEvent(&self, pmspeventinfo: *const MSP_EVENT_INFO) -> ::windows::core::Result<()>;
@@ -7100,6 +7190,7 @@ impl ITPluggableTerminalEventSink_Vtbl {
         iid == &<ITPluggableTerminalEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"implement\"`*"]
 pub trait ITPluggableTerminalEventSinkRegistration_Impl: Sized {
     fn RegisterSink(&self, peventsink: &::core::option::Option<ITPluggableTerminalEventSink>) -> ::windows::core::Result<()>;
     fn UnregisterSink(&self) -> ::windows::core::Result<()>;
@@ -7127,6 +7218,7 @@ impl ITPluggableTerminalEventSinkRegistration_Vtbl {
         iid == &<ITPluggableTerminalEventSinkRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITPluggableTerminalSuperclassInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7169,6 +7261,7 @@ impl ITPluggableTerminalSuperclassInfo_Vtbl {
         iid == &<ITPluggableTerminalSuperclassInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITPrivateEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Address(&self) -> ::windows::core::Result<ITAddress>;
@@ -7250,6 +7343,7 @@ impl ITPrivateEvent_Vtbl {
         iid == &<ITPrivateEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITQOSEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -7305,6 +7399,7 @@ impl ITQOSEvent_Vtbl {
         iid == &<ITQOSEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetMeasurementPeriod(&self, lperiod: i32) -> ::windows::core::Result<()>;
@@ -7471,6 +7566,7 @@ impl ITQueue_Vtbl {
         iid == &<ITQueue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITQueueEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Queue(&self) -> ::windows::core::Result<ITQueue>;
@@ -7513,6 +7609,7 @@ impl ITQueueEvent_Vtbl {
         iid == &<ITQueueEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITRendezvous_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DefaultDirectories(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -7581,6 +7678,7 @@ impl ITRendezvous_Vtbl {
         iid == &<ITRendezvous as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITRequest_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MakeCall(&self, pdestaddress: &::windows::core::BSTR, pappname: &::windows::core::BSTR, pcalledparty: &::windows::core::BSTR, pcomment: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -7601,6 +7699,7 @@ impl ITRequest_Vtbl {
         iid == &<ITRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITRequestEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RegistrationInstance(&self) -> ::windows::core::Result<i32>;
@@ -7695,6 +7794,7 @@ impl ITRequestEvent_Vtbl {
         iid == &<ITRequestEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITScriptableAudioFormat_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Channels(&self) -> ::windows::core::Result<i32>;
@@ -7831,6 +7931,7 @@ impl ITScriptableAudioFormat_Vtbl {
         iid == &<ITScriptableAudioFormat as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITStaticAudioTerminal_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn WaveId(&self) -> ::windows::core::Result<i32>;
@@ -7857,6 +7958,7 @@ impl ITStaticAudioTerminal_Vtbl {
         iid == &<ITStaticAudioTerminal as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITStream_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MediaType(&self) -> ::windows::core::Result<i32>;
@@ -7973,6 +8075,7 @@ impl ITStream_Vtbl {
         iid == &<ITStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITStreamControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateStream(&self, lmediatype: i32, td: TERMINAL_DIRECTION) -> ::windows::core::Result<ITStream>;
@@ -8035,6 +8138,7 @@ impl ITStreamControl_Vtbl {
         iid == &<ITStreamControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITSubStream_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartSubStream(&self) -> ::windows::core::Result<()>;
@@ -8125,6 +8229,7 @@ impl ITSubStream_Vtbl {
         iid == &<ITSubStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITSubStreamControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateSubStream(&self) -> ::windows::core::Result<ITSubStream>;
@@ -8187,6 +8292,7 @@ impl ITSubStreamControl_Vtbl {
         iid == &<ITSubStreamControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTAPI_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self) -> ::windows::core::Result<()>;
@@ -8363,6 +8469,7 @@ impl ITTAPI_Vtbl {
         iid == &<ITTAPI as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTAPI2_Impl: Sized + ITTAPI_Impl {
     fn Phones(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -8418,6 +8525,7 @@ impl ITTAPI2_Vtbl {
         iid == &<ITTAPI2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITTAPI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTAPICallCenter_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EnumerateAgentHandlers(&self) -> ::windows::core::Result<IEnumAgentHandler>;
@@ -8460,6 +8568,7 @@ impl ITTAPICallCenter_Vtbl {
         iid == &<ITTAPICallCenter as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTAPIDispatchEventNotification_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -8473,6 +8582,7 @@ impl ITTAPIDispatchEventNotification_Vtbl {
         iid == &<ITTAPIDispatchEventNotification as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITTAPIEventNotification_Impl: Sized {
     fn Event(&self, tapievent: TAPI_EVENT, pevent: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -8493,6 +8603,7 @@ impl ITTAPIEventNotification_Vtbl {
         iid == &<ITTAPIEventNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTAPIObjectEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TAPIObject(&self) -> ::windows::core::Result<ITTAPI>;
@@ -8561,6 +8672,7 @@ impl ITTAPIObjectEvent_Vtbl {
         iid == &<ITTAPIObjectEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTAPIObjectEvent2_Impl: Sized + ITTAPIObjectEvent_Impl {
     fn Phone(&self) -> ::windows::core::Result<ITPhone>;
@@ -8587,6 +8699,7 @@ impl ITTAPIObjectEvent2_Vtbl {
         iid == &<ITTAPIObjectEvent2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITTAPIObjectEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTTSTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Terminal(&self) -> ::windows::core::Result<ITTerminal>;
@@ -8642,6 +8755,7 @@ impl ITTTSTerminalEvent_Vtbl {
         iid == &<ITTTSTerminalEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTerminal_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -8736,6 +8850,7 @@ impl ITTerminal_Vtbl {
         iid == &<ITTerminal as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTerminalSupport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StaticTerminals(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -8830,6 +8945,7 @@ impl ITTerminalSupport_Vtbl {
         iid == &<ITTerminalSupport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITTerminalSupport2_Impl: Sized + ITTerminalSupport_Impl {
     fn PluggableSuperclasses(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -8898,6 +9014,7 @@ impl ITTerminalSupport2_Vtbl {
         iid == &<ITTerminalSupport2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITTerminalSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITToneDetectionEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Call(&self) -> ::windows::core::Result<ITCallInfo>;
@@ -8966,6 +9083,7 @@ impl ITToneDetectionEvent_Vtbl {
         iid == &<ITToneDetectionEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITToneTerminalEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Terminal(&self) -> ::windows::core::Result<ITTerminal>;
@@ -9021,6 +9139,7 @@ impl ITToneTerminalEvent_Vtbl {
         iid == &<ITToneTerminalEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_Tapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_AddressBook\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_AddressBook", feature = "Win32_System_Com"))]
 pub trait ITnef_Impl: Sized {
     fn AddProps(&self, ulflags: u32, ulelemid: u32, lpvdata: *mut ::core::ffi::c_void, lpproplist: *mut super::super::System::AddressBook::SPropTagArray) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/WebServicesOnDevices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDAddress_Impl: Sized {
     fn Serialize(&self, pszbuffer: ::windows::core::PWSTR, cchlength: u32, fsafe: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -28,6 +29,7 @@ impl IWSDAddress_Vtbl {
         iid == &<IWSDAddress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDAsyncCallback_Impl: Sized {
     fn AsyncOperationComplete(&self, pasyncresult: &::core::option::Option<IWSDAsyncResult>, pasyncstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -45,6 +47,7 @@ impl IWSDAsyncCallback_Vtbl {
         iid == &<IWSDAsyncCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDAsyncResult_Impl: Sized {
     fn SetCallback(&self, pcallback: &::core::option::Option<IWSDAsyncCallback>, pasyncstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -128,6 +131,7 @@ impl IWSDAsyncResult_Vtbl {
         iid == &<IWSDAsyncResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDAttachment_Impl: Sized {}
 impl ::windows::core::RuntimeName for IWSDAttachment {}
 impl IWSDAttachment_Vtbl {
@@ -138,6 +142,7 @@ impl IWSDAttachment_Vtbl {
         iid == &<IWSDAttachment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDDeviceHost_Impl: Sized {
     fn Init(&self, pszlocalid: &::windows::core::PCWSTR, pcontext: &::core::option::Option<IWSDXMLContext>, pphostaddresses: *const ::core::option::Option<IWSDAddress>, dwhostaddresscount: u32) -> ::windows::core::Result<()>;
@@ -238,6 +243,7 @@ impl IWSDDeviceHost_Vtbl {
         iid == &<IWSDDeviceHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDDeviceHostNotify_Impl: Sized {
     fn GetService(&self, pszserviceid: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -261,6 +267,7 @@ impl IWSDDeviceHostNotify_Vtbl {
         iid == &<IWSDDeviceHostNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDDeviceProxy_Impl: Sized {
     fn Init(&self, pszdeviceid: &::windows::core::PCWSTR, pdeviceaddress: &::core::option::Option<IWSDAddress>, pszlocalid: &::windows::core::PCWSTR, pcontext: &::core::option::Option<IWSDXMLContext>, psponsor: &::core::option::Option<IWSDDeviceProxy>) -> ::windows::core::Result<()>;
     fn BeginGetMetadata(&self) -> ::windows::core::Result<IWSDAsyncResult>;
@@ -392,6 +399,7 @@ impl IWSDDeviceProxy_Vtbl {
         iid == &<IWSDDeviceProxy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDEndpointProxy_Impl: Sized {
     fn SendOneWayRequest(&self, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION) -> ::windows::core::Result<()>;
@@ -475,6 +483,7 @@ impl IWSDEndpointProxy_Vtbl {
         iid == &<IWSDEndpointProxy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDEventingStatus_Impl: Sized {
     fn SubscriptionRenewed(&self, pszsubscriptionaction: &::windows::core::PCWSTR);
     fn SubscriptionRenewalFailed(&self, pszsubscriptionaction: &::windows::core::PCWSTR, hr: ::windows::core::HRESULT);
@@ -509,6 +518,7 @@ impl IWSDEventingStatus_Vtbl {
         iid == &<IWSDEventingStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDHttpAddress_Impl: Sized + IWSDTransportAddress_Impl {
     fn GetSecure(&self) -> ::windows::core::Result<()>;
@@ -559,6 +569,7 @@ impl IWSDHttpAddress_Vtbl {
         iid == &<IWSDHttpAddress as ::windows::core::Interface>::IID || iid == &<IWSDAddress as ::windows::core::Interface>::IID || iid == &<IWSDTransportAddress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDHttpAuthParameters_Impl: Sized {
     fn GetClientAccessToken(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -601,6 +612,7 @@ impl IWSDHttpAuthParameters_Vtbl {
         iid == &<IWSDHttpAuthParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDHttpMessageParameters_Impl: Sized + IWSDMessageParameters_Impl {
     fn SetInboundHttpHeaders(&self, pszheaders: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetInboundHttpHeaders(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -701,6 +713,7 @@ impl IWSDHttpMessageParameters_Vtbl {
         iid == &<IWSDHttpMessageParameters as ::windows::core::Interface>::IID || iid == &<IWSDMessageParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDInboundAttachment_Impl: Sized + IWSDAttachment_Impl {
     fn Read(&self, pbuffer: *mut u8, dwbytestoread: u32, pdwnumberofbytesread: *mut u32) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -724,6 +737,7 @@ impl IWSDInboundAttachment_Vtbl {
         iid == &<IWSDInboundAttachment as ::windows::core::Interface>::IID || iid == &<IWSDAttachment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDMessageParameters_Impl: Sized {
     fn GetLocalAddress(&self) -> ::windows::core::Result<IWSDAddress>;
     fn SetLocalAddress(&self, paddress: &::core::option::Option<IWSDAddress>) -> ::windows::core::Result<()>;
@@ -790,6 +804,7 @@ impl IWSDMessageParameters_Vtbl {
         iid == &<IWSDMessageParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDMetadataExchange_Impl: Sized {
     fn GetMetadata(&self) -> ::windows::core::Result<*mut WSD_METADATA_SECTION_LIST>;
 }
@@ -813,6 +828,7 @@ impl IWSDMetadataExchange_Vtbl {
         iid == &<IWSDMetadataExchange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDOutboundAttachment_Impl: Sized + IWSDAttachment_Impl {
     fn Write(&self, pbuffer: *const u8, dwbytestowrite: u32) -> ::windows::core::Result<u32>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -853,6 +869,7 @@ impl IWSDOutboundAttachment_Vtbl {
         iid == &<IWSDOutboundAttachment as ::windows::core::Interface>::IID || iid == &<IWSDAttachment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Cryptography\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 pub trait IWSDSSLClientCertificate_Impl: Sized {
     fn GetClientCertificate(&self) -> ::windows::core::Result<*mut super::super::Security::Cryptography::CERT_CONTEXT>;
@@ -895,6 +912,7 @@ impl IWSDSSLClientCertificate_Vtbl {
         iid == &<IWSDSSLClientCertificate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDScopeMatchingRule_Impl: Sized {
     fn GetScopeRule(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -937,6 +955,7 @@ impl IWSDScopeMatchingRule_Vtbl {
         iid == &<IWSDScopeMatchingRule as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDServiceMessaging_Impl: Sized {
     fn SendResponse(&self, pbody: *const ::core::ffi::c_void, poperation: *const WSD_OPERATION, pmessageparameters: &::core::option::Option<IWSDMessageParameters>) -> ::windows::core::Result<()>;
     fn FaultRequest(&self, prequestheader: *const WSD_SOAP_HEADER, pmessageparameters: &::core::option::Option<IWSDMessageParameters>, pfault: *const WSD_SOAP_FAULT) -> ::windows::core::Result<()>;
@@ -964,6 +983,7 @@ impl IWSDServiceMessaging_Vtbl {
         iid == &<IWSDServiceMessaging as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDServiceProxy_Impl: Sized + IWSDMetadataExchange_Impl {
     fn BeginGetMetadata(&self) -> ::windows::core::Result<IWSDAsyncResult>;
     fn EndGetMetadata(&self, presult: &::core::option::Option<IWSDAsyncResult>) -> ::windows::core::Result<*mut WSD_METADATA_SECTION_LIST>;
@@ -1050,6 +1070,7 @@ impl IWSDServiceProxy_Vtbl {
         iid == &<IWSDServiceProxy as ::windows::core::Interface>::IID || iid == &<IWSDMetadataExchange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDServiceProxyEventing_Impl: Sized + IWSDServiceProxy_Impl {
     fn SubscribeToMultipleOperations(&self, poperations: *const WSD_OPERATION, dwoperationcount: u32, punknown: &::core::option::Option<::windows::core::IUnknown>, pexpires: *const WSD_EVENTING_EXPIRES, pany: *const WSDXML_ELEMENT, ppexpires: *mut *mut WSD_EVENTING_EXPIRES, ppany: *mut *mut WSDXML_ELEMENT) -> ::windows::core::Result<()>;
@@ -1174,6 +1195,7 @@ impl IWSDServiceProxyEventing_Vtbl {
         iid == &<IWSDServiceProxyEventing as ::windows::core::Interface>::IID || iid == &<IWSDMetadataExchange as ::windows::core::Interface>::IID || iid == &<IWSDServiceProxy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDSignatureProperty_Impl: Sized {
     fn IsMessageSigned(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -1237,6 +1259,7 @@ impl IWSDSignatureProperty_Vtbl {
         iid == &<IWSDSignatureProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWSDTransportAddress_Impl: Sized + IWSDAddress_Impl {
     fn GetPort(&self) -> ::windows::core::Result<u16>;
@@ -1306,6 +1329,7 @@ impl IWSDTransportAddress_Vtbl {
         iid == &<IWSDTransportAddress as ::windows::core::Interface>::IID || iid == &<IWSDAddress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"Win32_Foundation\"`, `\"Win32_Networking_WinSock\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
 pub trait IWSDUdpAddress_Impl: Sized + IWSDTransportAddress_Impl {
     fn SetSockaddr(&self, psockaddr: *const super::super::Networking::WinSock::SOCKADDR_STORAGE) -> ::windows::core::Result<()>;
@@ -1416,6 +1440,7 @@ impl IWSDUdpAddress_Vtbl {
         iid == &<IWSDUdpAddress as ::windows::core::Interface>::IID || iid == &<IWSDAddress as ::windows::core::Interface>::IID || iid == &<IWSDTransportAddress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDUdpMessageParameters_Impl: Sized + IWSDMessageParameters_Impl {
     fn SetRetransmitParams(&self, pparams: *const WSDUdpRetransmitParams) -> ::windows::core::Result<()>;
     fn GetRetransmitParams(&self) -> ::windows::core::Result<WSDUdpRetransmitParams>;
@@ -1449,6 +1474,7 @@ impl IWSDUdpMessageParameters_Vtbl {
         iid == &<IWSDUdpMessageParameters as ::windows::core::Interface>::IID || iid == &<IWSDMessageParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDXMLContext_Impl: Sized {
     fn AddNamespace(&self, pszuri: &::windows::core::PCWSTR, pszsuggestedprefix: &::windows::core::PCWSTR, ppnamespace: *mut *mut WSDXML_NAMESPACE) -> ::windows::core::Result<()>;
     fn AddNameToNamespace(&self, pszuri: &::windows::core::PCWSTR, pszname: &::windows::core::PCWSTR, ppname: *mut *mut WSDXML_NAME) -> ::windows::core::Result<()>;
@@ -1490,6 +1516,7 @@ impl IWSDXMLContext_Vtbl {
         iid == &<IWSDXMLContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDiscoveredService_Impl: Sized {
     fn GetEndpointReference(&self) -> ::windows::core::Result<*mut WSD_ENDPOINT_REFERENCE>;
     fn GetTypes(&self) -> ::windows::core::Result<*mut WSD_NAME_LIST>;
@@ -1640,6 +1667,7 @@ impl IWSDiscoveredService_Vtbl {
         iid == &<IWSDiscoveredService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDiscoveryProvider_Impl: Sized {
     fn SetAddressFamily(&self, dwaddressfamily: u32) -> ::windows::core::Result<()>;
     fn Attach(&self, psink: &::core::option::Option<IWSDiscoveryProviderNotify>) -> ::windows::core::Result<()>;
@@ -1708,6 +1736,7 @@ impl IWSDiscoveryProvider_Vtbl {
         iid == &<IWSDiscoveryProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDiscoveryProviderNotify_Impl: Sized {
     fn Add(&self, pservice: &::core::option::Option<IWSDiscoveredService>) -> ::windows::core::Result<()>;
     fn Remove(&self, pservice: &::core::option::Option<IWSDiscoveredService>) -> ::windows::core::Result<()>;
@@ -1749,6 +1778,7 @@ impl IWSDiscoveryProviderNotify_Vtbl {
         iid == &<IWSDiscoveryProviderNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDiscoveryPublisher_Impl: Sized {
     fn SetAddressFamily(&self, dwaddressfamily: u32) -> ::windows::core::Result<()>;
     fn RegisterNotificationSink(&self, psink: &::core::option::Option<IWSDiscoveryPublisherNotify>) -> ::windows::core::Result<()>;
@@ -1908,6 +1938,7 @@ impl IWSDiscoveryPublisher_Vtbl {
         iid == &<IWSDiscoveryPublisher as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Devices_WebServicesOnDevices\"`, `\"implement\"`*"]
 pub trait IWSDiscoveryPublisherNotify_Impl: Sized {
     fn ProbeHandler(&self, psoap: *const WSD_SOAP_MESSAGE, pmessageparameters: &::core::option::Option<IWSDMessageParameters>) -> ::windows::core::Result<()>;
     fn ResolveHandler(&self, psoap: *const WSD_SOAP_MESSAGE, pmessageparameters: &::core::option::Option<IWSDMessageParameters>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Gaming/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Gaming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IGameExplorer_Impl: Sized {
     fn AddGame(&self, bstrgdfbinarypath: &::windows::core::BSTR, bstrgameinstalldirectory: &::windows::core::BSTR, installscope: GAME_INSTALL_SCOPE, pguidinstanceid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -48,6 +49,7 @@ impl IGameExplorer_Vtbl {
         iid == &<IGameExplorer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Gaming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IGameExplorer2_Impl: Sized {
     fn InstallGame(&self, binarygdfpath: &::windows::core::PCWSTR, installdirectory: &::windows::core::PCWSTR, installscope: GAME_INSTALL_SCOPE) -> ::windows::core::Result<()>;
@@ -91,6 +93,7 @@ impl IGameExplorer2_Vtbl {
         iid == &<IGameExplorer2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Gaming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IGameStatistics_Impl: Sized {
     fn GetMaxCategoryLength(&self) -> ::windows::core::Result<u32>;
@@ -233,6 +236,7 @@ impl IGameStatistics_Vtbl {
         iid == &<IGameStatistics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Gaming\"`, `\"implement\"`*"]
 pub trait IGameStatisticsMgr_Impl: Sized {
     fn GetGameStatistics(&self, gdfbinarypath: &::windows::core::PCWSTR, opentype: GAMESTATS_OPEN_TYPE, popenresult: *mut GAMESTATS_OPEN_RESULT, ppistats: *mut ::core::option::Option<IGameStatistics>) -> ::windows::core::Result<()>;
     fn RemoveGameStatistics(&self, gdfbinarypath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -260,6 +264,7 @@ impl IGameStatisticsMgr_Vtbl {
         iid == &<IGameStatisticsMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Gaming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXblIdpAuthManager_Impl: Sized {
     fn SetGamerAccount(&self, msaaccountid: &::windows::core::PCWSTR, xuid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -336,6 +341,7 @@ impl IXblIdpAuthManager_Vtbl {
         iid == &<IXblIdpAuthManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Gaming\"`, `\"implement\"`*"]
 pub trait IXblIdpAuthTokenResult_Impl: Sized {
     fn GetStatus(&self) -> ::windows::core::Result<XBL_IDP_AUTH_TOKEN_STATUS>;
     fn GetErrorCode(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
@@ -609,6 +615,7 @@ impl IXblIdpAuthTokenResult_Vtbl {
         iid == &<IXblIdpAuthTokenResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Gaming\"`, `\"implement\"`*"]
 pub trait IXblIdpAuthTokenResult2_Impl: Sized {
     fn GetModernGamertag(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetModernGamertagSuffix(&self) -> ::windows::core::Result<::windows::core::PWSTR>;

--- a/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IComprehensiveSpellCheckProvider_Impl: Sized {
     fn ComprehensiveCheck(&self, text: &::windows::core::PCWSTR) -> ::windows::core::Result<IEnumSpellingError>;
 }
@@ -21,6 +22,7 @@ impl IComprehensiveSpellCheckProvider_Vtbl {
         iid == &<IComprehensiveSpellCheckProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IEnumCodePage_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumCodePage>;
     fn Next(&self, celt: u32, rgelt: *mut MIMECPINFO, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -68,6 +70,7 @@ impl IEnumCodePage_Vtbl {
         iid == &<IEnumCodePage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IEnumRfc1766_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumRfc1766>;
     fn Next(&self, celt: u32, rgelt: *mut RFC1766INFO, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -115,6 +118,7 @@ impl IEnumRfc1766_Vtbl {
         iid == &<IEnumRfc1766 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IEnumScript_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumScript>;
     fn Next(&self, celt: u32, rgelt: *mut SCRIPTINFO, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -162,6 +166,7 @@ impl IEnumScript_Vtbl {
         iid == &<IEnumScript as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IEnumSpellingError_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<ISpellingError>;
 }
@@ -185,6 +190,7 @@ impl IEnumSpellingError_Vtbl {
         iid == &<IEnumSpellingError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IMLangCodePages_Impl: Sized {
     fn GetCharCodePages(&self, chsrc: u16) -> ::windows::core::Result<u32>;
     fn GetStrCodePages(&self, pszsrc: &::windows::core::PCWSTR, cchsrc: i32, dwprioritycodepages: u32, pdwcodepages: *mut u32, pcchcodepages: *mut i32) -> ::windows::core::Result<()>;
@@ -244,6 +250,7 @@ impl IMLangCodePages_Vtbl {
         iid == &<IMLangCodePages as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IMLangConvertCharset_Impl: Sized {
     fn Initialize(&self, uisrccodepage: u32, uidstcodepage: u32, dwproperty: u32) -> ::windows::core::Result<()>;
     fn GetSourceCodePage(&self) -> ::windows::core::Result<u32>;
@@ -324,6 +331,7 @@ impl IMLangConvertCharset_Vtbl {
         iid == &<IMLangConvertCharset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IMLangFontLink_Impl: Sized + IMLangCodePages_Impl {
     fn GetFontCodePages(&self, hdc: super::Graphics::Gdi::HDC, hfont: super::Graphics::Gdi::HFONT, pdwcodepages: *mut u32) -> ::windows::core::Result<()>;
@@ -368,6 +376,7 @@ impl IMLangFontLink_Vtbl {
         iid == &<IMLangFontLink as ::windows::core::Interface>::IID || iid == &<IMLangCodePages as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IMLangFontLink2_Impl: Sized + IMLangCodePages_Impl {
     fn GetFontCodePages(&self, hdc: super::Graphics::Gdi::HDC, hfont: super::Graphics::Gdi::HFONT, pdwcodepages: *mut u32) -> ::windows::core::Result<()>;
@@ -439,6 +448,7 @@ impl IMLangFontLink2_Vtbl {
         iid == &<IMLangFontLink2 as ::windows::core::Interface>::IID || iid == &<IMLangCodePages as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IMLangLineBreakConsole_Impl: Sized {
     fn BreakLineML(&self, psrcmlstr: &::core::option::Option<IMLangString>, lsrcpos: i32, lsrclen: i32, cmincolumns: i32, cmaxcolumns: i32, pllinelen: *mut i32, plskiplen: *mut i32) -> ::windows::core::Result<()>;
     fn BreakLineW(&self, locale: u32, pszsrc: &::windows::core::PCWSTR, cchsrc: i32, cmaxcolumns: i32, pcchline: *mut i32, pcchskip: *mut i32) -> ::windows::core::Result<()>;
@@ -473,6 +483,7 @@ impl IMLangLineBreakConsole_Vtbl {
         iid == &<IMLangLineBreakConsole as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMLangString_Impl: Sized {
     fn Sync(&self, fnoaccess: super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -517,6 +528,7 @@ impl IMLangString_Vtbl {
         iid == &<IMLangString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMLangStringAStr_Impl: Sized + IMLangString_Impl {
     fn SetAStr(&self, ldestpos: i32, ldestlen: i32, ucodepage: u32, pszsrc: &::windows::core::PCSTR, cchsrc: i32, pcchactual: *mut i32, plactuallen: *mut i32) -> ::windows::core::Result<()>;
@@ -589,6 +601,7 @@ impl IMLangStringAStr_Vtbl {
         iid == &<IMLangStringAStr as ::windows::core::Interface>::IID || iid == &<IMLangString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMLangStringBufA_Impl: Sized {
     fn GetStatus(&self, plflags: *mut i32, pcchbuf: *mut i32) -> ::windows::core::Result<()>;
@@ -640,6 +653,7 @@ impl IMLangStringBufA_Vtbl {
         iid == &<IMLangStringBufA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IMLangStringBufW_Impl: Sized {
     fn GetStatus(&self, plflags: *mut i32, pcchbuf: *mut i32) -> ::windows::core::Result<()>;
     fn LockBuf(&self, cchoffset: i32, cchmaxlock: i32, ppszbuf: *mut *mut u16, pcchbuf: *mut i32) -> ::windows::core::Result<()>;
@@ -688,6 +702,7 @@ impl IMLangStringBufW_Vtbl {
         iid == &<IMLangStringBufW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMLangStringWStr_Impl: Sized + IMLangString_Impl {
     fn SetWStr(&self, ldestpos: i32, ldestlen: i32, pszsrc: &::windows::core::PCWSTR, cchsrc: i32, pcchactual: *mut i32, plactuallen: *mut i32) -> ::windows::core::Result<()>;
@@ -760,6 +775,7 @@ impl IMLangStringWStr_Vtbl {
         iid == &<IMLangStringWStr as ::windows::core::Interface>::IID || iid == &<IMLangString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IMultiLanguage_Impl: Sized {
     fn GetNumberOfCodePageInfo(&self) -> ::windows::core::Result<u32>;
     fn GetCodePageInfo(&self, uicodepage: u32) -> ::windows::core::Result<MIMECPINFO>;
@@ -932,6 +948,7 @@ impl IMultiLanguage_Vtbl {
         iid == &<IMultiLanguage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMultiLanguage2_Impl: Sized {
     fn GetNumberOfCodePageInfo(&self) -> ::windows::core::Result<u32>;
@@ -1203,6 +1220,7 @@ impl IMultiLanguage2_Vtbl {
         iid == &<IMultiLanguage2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMultiLanguage3_Impl: Sized + IMultiLanguage2_Impl {
     fn DetectOutboundCodePage(&self, dwflags: u32, lpwidecharstr: &::windows::core::PCWSTR, cchwidechar: u32, puipreferredcodepages: *const u32, npreferredcodepages: u32, puidetectedcodepages: *mut u32, pndetectedcodepages: *mut u32, lpspecialchar: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1233,6 +1251,7 @@ impl IMultiLanguage3_Vtbl {
         iid == &<IMultiLanguage3 as ::windows::core::Interface>::IID || iid == &<IMultiLanguage2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOptionDescription_Impl: Sized {
     fn Id(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1301,6 +1320,7 @@ impl IOptionDescription_Vtbl {
         iid == &<IOptionDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISpellCheckProvider_Impl: Sized {
     fn LanguageTag(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1435,6 +1455,7 @@ impl ISpellCheckProvider_Vtbl {
         iid == &<ISpellCheckProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISpellCheckProviderFactory_Impl: Sized {
     fn SupportedLanguages(&self) -> ::windows::core::Result<super::System::Com::IEnumString>;
@@ -1490,6 +1511,7 @@ impl ISpellCheckProviderFactory_Vtbl {
         iid == &<ISpellCheckProviderFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISpellChecker_Impl: Sized {
     fn LanguageTag(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1664,6 +1686,7 @@ impl ISpellChecker_Vtbl {
         iid == &<ISpellChecker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISpellChecker2_Impl: Sized + ISpellChecker_Impl {
     fn Remove(&self, word: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1684,6 +1707,7 @@ impl ISpellChecker2_Vtbl {
         iid == &<ISpellChecker2 as ::windows::core::Interface>::IID || iid == &<ISpellChecker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait ISpellCheckerChangedEventHandler_Impl: Sized {
     fn Invoke(&self, sender: &::core::option::Option<ISpellChecker>) -> ::windows::core::Result<()>;
 }
@@ -1701,6 +1725,7 @@ impl ISpellCheckerChangedEventHandler_Vtbl {
         iid == &<ISpellCheckerChangedEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISpellCheckerFactory_Impl: Sized {
     fn SupportedLanguages(&self) -> ::windows::core::Result<super::System::Com::IEnumString>;
@@ -1756,6 +1781,7 @@ impl ISpellCheckerFactory_Vtbl {
         iid == &<ISpellCheckerFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait ISpellingError_Impl: Sized {
     fn StartIndex(&self) -> ::windows::core::Result<u32>;
     fn Length(&self) -> ::windows::core::Result<u32>;
@@ -1821,6 +1847,7 @@ impl ISpellingError_Vtbl {
         iid == &<ISpellingError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Globalization\"`, `\"implement\"`*"]
 pub trait IUserDictionariesRegistrar_Impl: Sized {
     fn RegisterUserDictionary(&self, dictionarypath: &::windows::core::PCWSTR, languagetag: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn UnregisterUserDictionary(&self, dictionarypath: &::windows::core::PCWSTR, languagetag: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ICompositionFramePresentStatistics_Impl: Sized + IPresentStatistics_Impl {
     fn GetContentTag(&self) -> usize;
@@ -35,6 +36,7 @@ impl ICompositionFramePresentStatistics_Vtbl {
         iid == &<ICompositionFramePresentStatistics as ::windows::core::Interface>::IID || iid == &<IPresentStatistics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IIndependentFlipFramePresentStatistics_Impl: Sized + IPresentStatistics_Impl {
     fn GetOutputAdapterLUID(&self) -> super::super::Foundation::LUID;
@@ -86,6 +88,7 @@ impl IIndependentFlipFramePresentStatistics_Vtbl {
         iid == &<IIndependentFlipFramePresentStatistics as ::windows::core::Interface>::IID || iid == &<IPresentStatistics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"implement\"`*"]
 pub trait IPresentStatistics_Impl: Sized {
     fn GetPresentId(&self) -> u64;
     fn GetKind(&self) -> PresentStatisticsKind;
@@ -113,6 +116,7 @@ impl IPresentStatistics_Vtbl {
         iid == &<IPresentStatistics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"implement\"`*"]
 pub trait IPresentStatusPresentStatistics_Impl: Sized + IPresentStatistics_Impl {
     fn GetCompositionFrameId(&self) -> u64;
     fn GetPresentStatus(&self) -> PresentStatus;
@@ -140,6 +144,7 @@ impl IPresentStatusPresentStatistics_Vtbl {
         iid == &<IPresentStatusPresentStatistics as ::windows::core::Interface>::IID || iid == &<IPresentStatistics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPresentationBuffer_Impl: Sized {
     fn GetAvailableEvent(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -182,6 +187,7 @@ impl IPresentationBuffer_Vtbl {
         iid == &<IPresentationBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"implement\"`*"]
 pub trait IPresentationContent_Impl: Sized {
     fn SetTag(&self, tag: usize);
 }
@@ -199,6 +205,7 @@ impl IPresentationContent_Vtbl {
         iid == &<IPresentationContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"implement\"`*"]
 pub trait IPresentationFactory_Impl: Sized {
     fn IsPresentationSupported(&self) -> u8;
     fn IsPresentationSupportedWithIndependentFlip(&self) -> u8;
@@ -239,6 +246,7 @@ impl IPresentationFactory_Vtbl {
         iid == &<IPresentationFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPresentationManager_Impl: Sized {
     fn AddBufferFromResource(&self, resource: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IPresentationBuffer>;
@@ -382,6 +390,7 @@ impl IPresentationManager_Vtbl {
         iid == &<IPresentationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_CompositionSwapchain\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IPresentationSurface_Impl: Sized + IPresentationContent_Impl {
     fn SetBuffer(&self, presentationbuffer: &::core::option::Option<IPresentationBuffer>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_DXCore\"`, `\"implement\"`*"]
 pub trait IDXCoreAdapter_Impl: Sized {
     fn IsValid(&self) -> bool;
     fn IsAttributeSupported(&self, attributeguid: *const ::windows::core::GUID) -> bool;
@@ -87,6 +88,7 @@ impl IDXCoreAdapter_Vtbl {
         iid == &<IDXCoreAdapter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DXCore\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXCoreAdapterFactory_Impl: Sized {
     fn CreateAdapterList(&self, numattributes: u32, filterattributes: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvadapterlist: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -144,6 +146,7 @@ impl IDXCoreAdapterFactory_Vtbl {
         iid == &<IDXCoreAdapterFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DXCore\"`, `\"implement\"`*"]
 pub trait IDXCoreAdapterList_Impl: Sized {
     fn GetAdapter(&self, index: u32, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetAdapterCount(&self) -> u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 pub trait ID2D1SimplifiedGeometrySink_Impl: Sized {
     fn SetFillMode(&self, fillmode: D2D1_FILL_MODE);
     fn SetSegmentFlags(&self, vertexflags: D2D1_PATH_SEGMENT);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1AnalysisTransform_Impl: Sized {
     fn ProcessAnalysisResults(&self, analysisdata: *const u8, analysisdatacount: u32) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl ID2D1AnalysisTransform_Vtbl {
         iid == &<ID2D1AnalysisTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID2D1Bitmap_Impl: Sized + ID2D1Image_Impl {
     fn GetSize(&self) -> Common::D2D_SIZE_F;
@@ -80,6 +82,7 @@ impl ID2D1Bitmap_Vtbl {
         iid == &<ID2D1Bitmap as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Image as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID2D1Bitmap1_Impl: Sized + ID2D1Bitmap_Impl {
     fn GetColorContext(&self, colorcontext: *mut ::core::option::Option<ID2D1ColorContext>);
@@ -137,6 +140,7 @@ impl ID2D1Bitmap1_Vtbl {
         iid == &<ID2D1Bitmap1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Image as ::windows::core::Interface>::IID || iid == &<ID2D1Bitmap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1BitmapBrush_Impl: Sized + ID2D1Brush_Impl {
     fn SetExtendModeX(&self, extendmodex: D2D1_EXTEND_MODE);
@@ -209,6 +213,7 @@ impl ID2D1BitmapBrush_Vtbl {
         iid == &<ID2D1BitmapBrush as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Brush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1BitmapBrush1_Impl: Sized + ID2D1BitmapBrush_Impl {
     fn SetInterpolationMode1(&self, interpolationmode: D2D1_INTERPOLATION_MODE);
@@ -239,6 +244,7 @@ impl ID2D1BitmapBrush1_Vtbl {
         iid == &<ID2D1BitmapBrush1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Brush as ::windows::core::Interface>::IID || iid == &<ID2D1BitmapBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1BitmapRenderTarget_Impl: Sized + ID2D1RenderTarget_Impl {
     fn GetBitmap(&self) -> ::windows::core::Result<ID2D1Bitmap>;
@@ -265,6 +271,7 @@ impl ID2D1BitmapRenderTarget_Vtbl {
         iid == &<ID2D1BitmapRenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1BlendTransform_Impl: Sized + ID2D1ConcreteTransform_Impl {
     fn SetDescription(&self, description: *const D2D1_BLEND_DESCRIPTION);
@@ -295,6 +302,7 @@ impl ID2D1BlendTransform_Vtbl {
         iid == &<ID2D1BlendTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID || iid == &<ID2D1ConcreteTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1BorderTransform_Impl: Sized + ID2D1ConcreteTransform_Impl {
     fn SetExtendModeX(&self, extendmode: D2D1_EXTEND_MODE);
@@ -339,6 +347,7 @@ impl ID2D1BorderTransform_Vtbl {
         iid == &<ID2D1BorderTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID || iid == &<ID2D1ConcreteTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1BoundsAdjustmentTransform_Impl: Sized + ID2D1TransformNode_Impl {
     fn SetOutputBounds(&self, outputbounds: *const super::super::Foundation::RECT);
@@ -369,6 +378,7 @@ impl ID2D1BoundsAdjustmentTransform_Vtbl {
         iid == &<ID2D1BoundsAdjustmentTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1Brush_Impl: Sized + ID2D1Resource_Impl {
     fn SetOpacity(&self, opacity: f32);
@@ -413,6 +423,7 @@ impl ID2D1Brush_Vtbl {
         iid == &<ID2D1Brush as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1ColorContext_Impl: Sized + ID2D1Resource_Impl {
     fn GetColorSpace(&self) -> D2D1_COLOR_SPACE;
     fn GetProfileSize(&self) -> u32;
@@ -447,6 +458,7 @@ impl ID2D1ColorContext_Vtbl {
         iid == &<ID2D1ColorContext as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID2D1ColorContext1_Impl: Sized + ID2D1ColorContext_Impl {
     fn GetColorContextType(&self) -> D2D1_COLOR_CONTEXT_TYPE;
@@ -490,6 +502,7 @@ impl ID2D1ColorContext1_Vtbl {
         iid == &<ID2D1ColorContext1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1ColorContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1CommandList_Impl: Sized + ID2D1Image_Impl {
     fn Stream(&self, sink: &::core::option::Option<ID2D1CommandSink>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -513,6 +526,7 @@ impl ID2D1CommandList_Vtbl {
         iid == &<ID2D1CommandList as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Image as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink_Impl: Sized {
     fn BeginDraw(&self) -> ::windows::core::Result<()>;
@@ -704,6 +718,7 @@ impl ID2D1CommandSink_Vtbl {
         iid == &<ID2D1CommandSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink1_Impl: Sized + ID2D1CommandSink_Impl {
     fn SetPrimitiveBlend1(&self, primitiveblend: D2D1_PRIMITIVE_BLEND) -> ::windows::core::Result<()>;
@@ -724,6 +739,7 @@ impl ID2D1CommandSink1_Vtbl {
         iid == &<ID2D1CommandSink1 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink2_Impl: Sized + ID2D1CommandSink1_Impl {
     fn DrawInk(&self, ink: &::core::option::Option<ID2D1Ink>, brush: &::core::option::Option<ID2D1Brush>, inkstyle: &::core::option::Option<ID2D1InkStyle>) -> ::windows::core::Result<()>;
@@ -761,6 +777,7 @@ impl ID2D1CommandSink2_Vtbl {
         iid == &<ID2D1CommandSink2 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink3_Impl: Sized + ID2D1CommandSink2_Impl {
     fn DrawSpriteBatch(&self, spritebatch: &::core::option::Option<ID2D1SpriteBatch>, startindex: u32, spritecount: u32, bitmap: &::core::option::Option<ID2D1Bitmap>, interpolationmode: D2D1_BITMAP_INTERPOLATION_MODE, spriteoptions: D2D1_SPRITE_OPTIONS) -> ::windows::core::Result<()>;
@@ -781,6 +798,7 @@ impl ID2D1CommandSink3_Vtbl {
         iid == &<ID2D1CommandSink3 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink1 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink4_Impl: Sized + ID2D1CommandSink3_Impl {
     fn SetPrimitiveBlend2(&self, primitiveblend: D2D1_PRIMITIVE_BLEND) -> ::windows::core::Result<()>;
@@ -801,6 +819,7 @@ impl ID2D1CommandSink4_Vtbl {
         iid == &<ID2D1CommandSink4 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink1 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink2 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1CommandSink5_Impl: Sized + ID2D1CommandSink4_Impl {
     fn BlendImage(&self, image: &::core::option::Option<ID2D1Image>, blendmode: Common::D2D1_BLEND_MODE, targetoffset: *const Common::D2D_POINT_2F, imagerectangle: *const Common::D2D_RECT_F, interpolationmode: D2D1_INTERPOLATION_MODE) -> ::windows::core::Result<()>;
@@ -821,6 +840,7 @@ impl ID2D1CommandSink5_Vtbl {
         iid == &<ID2D1CommandSink5 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink1 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink2 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink3 as ::windows::core::Interface>::IID || iid == &<ID2D1CommandSink4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1ComputeInfo_Impl: Sized + ID2D1RenderInfo_Impl {
     fn SetComputeShaderConstantBuffer(&self, buffer: *const u8, buffercount: u32) -> ::windows::core::Result<()>;
@@ -858,6 +878,7 @@ impl ID2D1ComputeInfo_Vtbl {
         iid == &<ID2D1ComputeInfo as ::windows::core::Interface>::IID || iid == &<ID2D1RenderInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1ComputeTransform_Impl: Sized + ID2D1Transform_Impl {
     fn SetComputeInfo(&self, computeinfo: &::core::option::Option<ID2D1ComputeInfo>) -> ::windows::core::Result<()>;
@@ -888,6 +909,7 @@ impl ID2D1ComputeTransform_Vtbl {
         iid == &<ID2D1ComputeTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID || iid == &<ID2D1Transform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1ConcreteTransform_Impl: Sized + ID2D1TransformNode_Impl {
     fn SetOutputBuffer(&self, bufferprecision: D2D1_BUFFER_PRECISION, channeldepth: D2D1_CHANNEL_DEPTH) -> ::windows::core::Result<()>;
@@ -918,6 +940,7 @@ impl ID2D1ConcreteTransform_Vtbl {
         iid == &<ID2D1ConcreteTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DCRenderTarget_Impl: Sized + ID2D1RenderTarget_Impl {
     fn BindDC(&self, hdc: super::Gdi::HDC, psubrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -938,6 +961,7 @@ impl ID2D1DCRenderTarget_Vtbl {
         iid == &<ID2D1DCRenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device_Impl: Sized + ID2D1Resource_Impl {
     fn CreateDeviceContext(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext>;
@@ -1001,6 +1025,7 @@ impl ID2D1Device_Vtbl {
         iid == &<ID2D1Device as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device1_Impl: Sized + ID2D1Device_Impl {
     fn GetRenderingPriority(&self) -> D2D1_RENDERING_PRIORITY;
@@ -1044,6 +1069,7 @@ impl ID2D1Device1_Vtbl {
         iid == &<ID2D1Device1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device2_Impl: Sized + ID2D1Device1_Impl {
     fn CreateDeviceContext3(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext2>;
@@ -1093,6 +1119,7 @@ impl ID2D1Device2_Vtbl {
         iid == &<ID2D1Device2 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Device as ::windows::core::Interface>::IID || iid == &<ID2D1Device1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device3_Impl: Sized + ID2D1Device2_Impl {
     fn CreateDeviceContext4(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext3>;
@@ -1119,6 +1146,7 @@ impl ID2D1Device3_Vtbl {
         iid == &<ID2D1Device3 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Device as ::windows::core::Interface>::IID || iid == &<ID2D1Device1 as ::windows::core::Interface>::IID || iid == &<ID2D1Device2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device4_Impl: Sized + ID2D1Device3_Impl {
     fn CreateDeviceContext5(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext4>;
@@ -1162,6 +1190,7 @@ impl ID2D1Device4_Vtbl {
         iid == &<ID2D1Device4 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Device as ::windows::core::Interface>::IID || iid == &<ID2D1Device1 as ::windows::core::Interface>::IID || iid == &<ID2D1Device2 as ::windows::core::Interface>::IID || iid == &<ID2D1Device3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device5_Impl: Sized + ID2D1Device4_Impl {
     fn CreateDeviceContext6(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext5>;
@@ -1188,6 +1217,7 @@ impl ID2D1Device5_Vtbl {
         iid == &<ID2D1Device5 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Device as ::windows::core::Interface>::IID || iid == &<ID2D1Device1 as ::windows::core::Interface>::IID || iid == &<ID2D1Device2 as ::windows::core::Interface>::IID || iid == &<ID2D1Device3 as ::windows::core::Interface>::IID || iid == &<ID2D1Device4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Dxgi", feature = "Win32_Graphics_Imaging", feature = "Win32_Storage_Xps_Printing"))]
 pub trait ID2D1Device6_Impl: Sized + ID2D1Device5_Impl {
     fn CreateDeviceContext7(&self, options: D2D1_DEVICE_CONTEXT_OPTIONS) -> ::windows::core::Result<ID2D1DeviceContext6>;
@@ -1214,6 +1244,7 @@ impl ID2D1Device6_Vtbl {
         iid == &<ID2D1Device6 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Device as ::windows::core::Interface>::IID || iid == &<ID2D1Device1 as ::windows::core::Interface>::IID || iid == &<ID2D1Device2 as ::windows::core::Interface>::IID || iid == &<ID2D1Device3 as ::windows::core::Interface>::IID || iid == &<ID2D1Device4 as ::windows::core::Interface>::IID || iid == &<ID2D1Device5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext_Impl: Sized + ID2D1RenderTarget_Impl {
     fn CreateBitmap2(&self, size: &Common::D2D_SIZE_U, sourcedata: *const ::core::ffi::c_void, pitch: u32, bitmapproperties: *const D2D1_BITMAP_PROPERTIES1) -> ::windows::core::Result<ID2D1Bitmap1>;
@@ -1565,6 +1596,7 @@ impl ID2D1DeviceContext_Vtbl {
         iid == &<ID2D1DeviceContext as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext1_Impl: Sized + ID2D1DeviceContext_Impl {
     fn CreateFilledGeometryRealization(&self, geometry: &::core::option::Option<ID2D1Geometry>, flatteningtolerance: f32) -> ::windows::core::Result<ID2D1GeometryRealization>;
@@ -1614,6 +1646,7 @@ impl ID2D1DeviceContext1_Vtbl {
         iid == &<ID2D1DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext2_Impl: Sized + ID2D1DeviceContext1_Impl {
     fn CreateInk(&self, startpoint: *const D2D1_INK_POINT) -> ::windows::core::Result<ID2D1Ink>;
@@ -1755,6 +1788,7 @@ impl ID2D1DeviceContext2_Vtbl {
         iid == &<ID2D1DeviceContext2 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext3_Impl: Sized + ID2D1DeviceContext2_Impl {
     fn CreateSpriteBatch(&self) -> ::windows::core::Result<ID2D1SpriteBatch>;
@@ -1791,6 +1825,7 @@ impl ID2D1DeviceContext3_Vtbl {
         iid == &<ID2D1DeviceContext3 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1DeviceContext4_Impl: Sized + ID2D1DeviceContext3_Impl {
     fn CreateSvgGlyphStyle(&self) -> ::windows::core::Result<ID2D1SvgGlyphStyle>;
@@ -1864,6 +1899,7 @@ impl ID2D1DeviceContext4_Vtbl {
         iid == &<ID2D1DeviceContext4 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext2 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1DeviceContext5_Impl: Sized + ID2D1DeviceContext4_Impl {
     fn CreateSvgDocument(&self, inputxmlstream: &::core::option::Option<super::super::System::Com::IStream>, viewportsize: &Common::D2D_SIZE_F) -> ::windows::core::Result<ID2D1SvgDocument>;
@@ -1926,6 +1962,7 @@ impl ID2D1DeviceContext5_Vtbl {
         iid == &<ID2D1DeviceContext5 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext2 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext3 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1DeviceContext6_Impl: Sized + ID2D1DeviceContext5_Impl {
     fn BlendImage(&self, image: &::core::option::Option<ID2D1Image>, blendmode: Common::D2D1_BLEND_MODE, targetoffset: *const Common::D2D_POINT_2F, imagerectangle: *const Common::D2D_RECT_F, interpolationmode: D2D1_INTERPOLATION_MODE);
@@ -1946,6 +1983,7 @@ impl ID2D1DeviceContext6_Vtbl {
         iid == &<ID2D1DeviceContext6 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext2 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext3 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext4 as ::windows::core::Interface>::IID || iid == &<ID2D1DeviceContext5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1DrawInfo_Impl: Sized + ID2D1RenderInfo_Impl {
     fn SetPixelShaderConstantBuffer(&self, buffer: *const u8, buffercount: u32) -> ::windows::core::Result<()>;
@@ -1997,6 +2035,7 @@ impl ID2D1DrawInfo_Vtbl {
         iid == &<ID2D1DrawInfo as ::windows::core::Interface>::IID || iid == &<ID2D1RenderInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1DrawTransform_Impl: Sized + ID2D1Transform_Impl {
     fn SetDrawInfo(&self, drawinfo: &::core::option::Option<ID2D1DrawInfo>) -> ::windows::core::Result<()>;
@@ -2017,6 +2056,7 @@ impl ID2D1DrawTransform_Vtbl {
         iid == &<ID2D1DrawTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID || iid == &<ID2D1Transform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1DrawingStateBlock_Impl: Sized + ID2D1Resource_Impl {
     fn GetDescription(&self, statedescription: *mut D2D1_DRAWING_STATE_DESCRIPTION);
@@ -2061,6 +2101,7 @@ impl ID2D1DrawingStateBlock_Vtbl {
         iid == &<ID2D1DrawingStateBlock as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_DirectWrite"))]
 pub trait ID2D1DrawingStateBlock1_Impl: Sized + ID2D1DrawingStateBlock_Impl {
     fn GetDescription2(&self, statedescription: *mut D2D1_DRAWING_STATE_DESCRIPTION1);
@@ -2091,6 +2132,7 @@ impl ID2D1DrawingStateBlock1_Vtbl {
         iid == &<ID2D1DrawingStateBlock1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1DrawingStateBlock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1Effect_Impl: Sized + ID2D1Properties_Impl {
     fn SetInput(&self, index: u32, input: &::core::option::Option<ID2D1Image>, invalidate: super::super::Foundation::BOOL);
@@ -2142,6 +2184,7 @@ impl ID2D1Effect_Vtbl {
         iid == &<ID2D1Effect as ::windows::core::Interface>::IID || iid == &<ID2D1Properties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1EffectContext_Impl: Sized {
     fn GetDpi(&self, dpix: *mut f32, dpiy: *mut f32);
@@ -2389,6 +2432,7 @@ impl ID2D1EffectContext_Vtbl {
         iid == &<ID2D1EffectContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1EffectContext1_Impl: Sized + ID2D1EffectContext_Impl {
     fn CreateLookupTable3D(&self, precision: D2D1_BUFFER_PRECISION, extents: *const u32, data: *const u8, datacount: u32, strides: *const u32) -> ::windows::core::Result<ID2D1LookupTable3D>;
@@ -2415,6 +2459,7 @@ impl ID2D1EffectContext1_Vtbl {
         iid == &<ID2D1EffectContext1 as ::windows::core::Interface>::IID || iid == &<ID2D1EffectContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1EffectContext2_Impl: Sized + ID2D1EffectContext1_Impl {
     fn CreateColorContextFromDxgiColorSpace(&self, colorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE) -> ::windows::core::Result<ID2D1ColorContext1>;
@@ -2457,6 +2502,7 @@ impl ID2D1EffectContext2_Vtbl {
         iid == &<ID2D1EffectContext2 as ::windows::core::Interface>::IID || iid == &<ID2D1EffectContext as ::windows::core::Interface>::IID || iid == &<ID2D1EffectContext1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1EffectImpl_Impl: Sized {
     fn Initialize(&self, effectcontext: &::core::option::Option<ID2D1EffectContext>, transformgraph: &::core::option::Option<ID2D1TransformGraph>) -> ::windows::core::Result<()>;
     fn PrepareForRender(&self, changetype: D2D1_CHANGE_TYPE) -> ::windows::core::Result<()>;
@@ -2491,6 +2537,7 @@ impl ID2D1EffectImpl_Vtbl {
         iid == &<ID2D1EffectImpl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1EllipseGeometry_Impl: Sized + ID2D1Geometry_Impl {
     fn GetEllipse(&self, ellipse: *mut D2D1_ELLIPSE);
@@ -2511,6 +2558,7 @@ impl ID2D1EllipseGeometry_Vtbl {
         iid == &<ID2D1EllipseGeometry as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Geometry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1Factory_Impl: Sized {
     fn ReloadSystemMetrics(&self) -> ::windows::core::Result<()>;
@@ -2697,6 +2745,7 @@ impl ID2D1Factory_Vtbl {
         iid == &<ID2D1Factory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory1_Impl: Sized + ID2D1Factory_Impl {
     fn CreateDevice(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device>;
@@ -2819,6 +2868,7 @@ impl ID2D1Factory1_Vtbl {
         iid == &<ID2D1Factory1 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory2_Impl: Sized + ID2D1Factory1_Impl {
     fn CreateDevice2(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device1>;
@@ -2845,6 +2895,7 @@ impl ID2D1Factory2_Vtbl {
         iid == &<ID2D1Factory2 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory as ::windows::core::Interface>::IID || iid == &<ID2D1Factory1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory3_Impl: Sized + ID2D1Factory2_Impl {
     fn CreateDevice3(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device2>;
@@ -2871,6 +2922,7 @@ impl ID2D1Factory3_Vtbl {
         iid == &<ID2D1Factory3 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory as ::windows::core::Interface>::IID || iid == &<ID2D1Factory1 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory4_Impl: Sized + ID2D1Factory3_Impl {
     fn CreateDevice4(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device3>;
@@ -2897,6 +2949,7 @@ impl ID2D1Factory4_Vtbl {
         iid == &<ID2D1Factory4 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory as ::windows::core::Interface>::IID || iid == &<ID2D1Factory1 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory2 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory5_Impl: Sized + ID2D1Factory4_Impl {
     fn CreateDevice5(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device4>;
@@ -2923,6 +2976,7 @@ impl ID2D1Factory5_Vtbl {
         iid == &<ID2D1Factory5 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory as ::windows::core::Interface>::IID || iid == &<ID2D1Factory1 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory2 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory3 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory6_Impl: Sized + ID2D1Factory5_Impl {
     fn CreateDevice6(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device5>;
@@ -2949,6 +3003,7 @@ impl ID2D1Factory6_Vtbl {
         iid == &<ID2D1Factory6 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory as ::windows::core::Interface>::IID || iid == &<ID2D1Factory1 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory2 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory3 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory4 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging", feature = "Win32_System_Com"))]
 pub trait ID2D1Factory7_Impl: Sized + ID2D1Factory6_Impl {
     fn CreateDevice7(&self, dxgidevice: &::core::option::Option<super::Dxgi::IDXGIDevice>) -> ::windows::core::Result<ID2D1Device6>;
@@ -2975,6 +3030,7 @@ impl ID2D1Factory7_Vtbl {
         iid == &<ID2D1Factory7 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory as ::windows::core::Interface>::IID || iid == &<ID2D1Factory1 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory2 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory3 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory4 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory5 as ::windows::core::Interface>::IID || iid == &<ID2D1Factory6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ID2D1GdiInteropRenderTarget_Impl: Sized {
     fn GetDC(&self, mode: D2D1_DC_INITIALIZE_MODE) -> ::windows::core::Result<super::Gdi::HDC>;
@@ -3011,6 +3067,7 @@ impl ID2D1GdiInteropRenderTarget_Vtbl {
         iid == &<ID2D1GdiInteropRenderTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GdiMetafile_Impl: Sized + ID2D1Resource_Impl {
     fn Stream(&self, sink: &::core::option::Option<ID2D1GdiMetafileSink>) -> ::windows::core::Result<()>;
@@ -3047,6 +3104,7 @@ impl ID2D1GdiMetafile_Vtbl {
         iid == &<ID2D1GdiMetafile as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GdiMetafile1_Impl: Sized + ID2D1GdiMetafile_Impl {
     fn GetDpi(&self, dpix: *mut f32, dpiy: *mut f32) -> ::windows::core::Result<()>;
@@ -3083,6 +3141,7 @@ impl ID2D1GdiMetafile1_Vtbl {
         iid == &<ID2D1GdiMetafile1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1GdiMetafile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1GdiMetafileSink_Impl: Sized {
     fn ProcessRecord(&self, recordtype: u32, recorddata: *const ::core::ffi::c_void, recorddatasize: u32) -> ::windows::core::Result<()>;
 }
@@ -3100,6 +3159,7 @@ impl ID2D1GdiMetafileSink_Vtbl {
         iid == &<ID2D1GdiMetafileSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1GdiMetafileSink1_Impl: Sized + ID2D1GdiMetafileSink_Impl {
     fn ProcessRecord2(&self, recordtype: u32, recorddata: *const ::core::ffi::c_void, recorddatasize: u32, flags: u32) -> ::windows::core::Result<()>;
 }
@@ -3117,6 +3177,7 @@ impl ID2D1GdiMetafileSink1_Vtbl {
         iid == &<ID2D1GdiMetafileSink1 as ::windows::core::Interface>::IID || iid == &<ID2D1GdiMetafileSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1Geometry_Impl: Sized + ID2D1Resource_Impl {
     fn GetBounds(&self, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2) -> ::windows::core::Result<Common::D2D_RECT_F>;
@@ -3266,6 +3327,7 @@ impl ID2D1Geometry_Vtbl {
         iid == &<ID2D1Geometry as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1GeometryGroup_Impl: Sized + ID2D1Geometry_Impl {
     fn GetFillMode(&self) -> Common::D2D1_FILL_MODE;
@@ -3303,6 +3365,7 @@ impl ID2D1GeometryGroup_Vtbl {
         iid == &<ID2D1GeometryGroup as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Geometry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1GeometryRealization_Impl: Sized + ID2D1Resource_Impl {}
 impl ::windows::core::RuntimeName for ID2D1GeometryRealization {}
 impl ID2D1GeometryRealization_Vtbl {
@@ -3313,6 +3376,7 @@ impl ID2D1GeometryRealization_Vtbl {
         iid == &<ID2D1GeometryRealization as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GeometrySink_Impl: Sized + Common::ID2D1SimplifiedGeometrySink_Impl {
     fn AddLine(&self, point: &Common::D2D_POINT_2F);
@@ -3364,6 +3428,7 @@ impl ID2D1GeometrySink_Vtbl {
         iid == &<ID2D1GeometrySink as ::windows::core::Interface>::IID || iid == &<Common::ID2D1SimplifiedGeometrySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GradientMesh_Impl: Sized + ID2D1Resource_Impl {
     fn GetPatchCount(&self) -> u32;
@@ -3394,6 +3459,7 @@ impl ID2D1GradientMesh_Vtbl {
         iid == &<ID2D1GradientMesh as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GradientStopCollection_Impl: Sized + ID2D1Resource_Impl {
     fn GetGradientStopCount(&self) -> u32;
@@ -3438,6 +3504,7 @@ impl ID2D1GradientStopCollection_Vtbl {
         iid == &<ID2D1GradientStopCollection as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1GradientStopCollection1_Impl: Sized + ID2D1GradientStopCollection_Impl {
     fn GetGradientStops1(&self, gradientstops: *mut D2D1_GRADIENT_STOP, gradientstopscount: u32);
@@ -3489,6 +3556,7 @@ impl ID2D1GradientStopCollection1_Vtbl {
         iid == &<ID2D1GradientStopCollection1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1GradientStopCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1HwndRenderTarget_Impl: Sized + ID2D1RenderTarget_Impl {
     fn CheckWindowState(&self) -> D2D1_WINDOW_STATE;
@@ -3526,6 +3594,7 @@ impl ID2D1HwndRenderTarget_Vtbl {
         iid == &<ID2D1HwndRenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1Image_Impl: Sized + ID2D1Resource_Impl {}
 impl ::windows::core::RuntimeName for ID2D1Image {}
 impl ID2D1Image_Vtbl {
@@ -3536,6 +3605,7 @@ impl ID2D1Image_Vtbl {
         iid == &<ID2D1Image as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1ImageBrush_Impl: Sized + ID2D1Brush_Impl {
     fn SetImage(&self, image: &::core::option::Option<ID2D1Image>);
@@ -3622,6 +3692,7 @@ impl ID2D1ImageBrush_Vtbl {
         iid == &<ID2D1ImageBrush as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Brush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1ImageSource_Impl: Sized + ID2D1Image_Impl {
     fn OfferResources(&self) -> ::windows::core::Result<()>;
@@ -3658,6 +3729,7 @@ impl ID2D1ImageSource_Vtbl {
         iid == &<ID2D1ImageSource as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Image as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1ImageSourceFromWic_Impl: Sized + ID2D1ImageSource_Impl {
     fn EnsureCached(&self, rectangletofill: *const Common::D2D_RECT_U) -> ::windows::core::Result<()>;
@@ -3695,6 +3767,7 @@ impl ID2D1ImageSourceFromWic_Vtbl {
         iid == &<ID2D1ImageSourceFromWic as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Image as ::windows::core::Interface>::IID || iid == &<ID2D1ImageSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1Ink_Impl: Sized + ID2D1Resource_Impl {
     fn SetStartPoint(&self, startpoint: *const D2D1_INK_POINT);
@@ -3787,6 +3860,7 @@ impl ID2D1Ink_Vtbl {
         iid == &<ID2D1Ink as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Numerics")]
 pub trait ID2D1InkStyle_Impl: Sized + ID2D1Resource_Impl {
     fn SetNibTransform(&self, transform: *const super::super::super::Foundation::Numerics::Matrix3x2);
@@ -3831,6 +3905,7 @@ impl ID2D1InkStyle_Vtbl {
         iid == &<ID2D1InkStyle as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1Layer_Impl: Sized + ID2D1Resource_Impl {
     fn GetSize(&self) -> Common::D2D_SIZE_F;
@@ -3851,6 +3926,7 @@ impl ID2D1Layer_Vtbl {
         iid == &<ID2D1Layer as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1LinearGradientBrush_Impl: Sized + ID2D1Brush_Impl {
     fn SetStartPoint(&self, startpoint: &Common::D2D_POINT_2F);
@@ -3902,6 +3978,7 @@ impl ID2D1LinearGradientBrush_Vtbl {
         iid == &<ID2D1LinearGradientBrush as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Brush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1LookupTable3D_Impl: Sized + ID2D1Resource_Impl {}
 impl ::windows::core::RuntimeName for ID2D1LookupTable3D {}
 impl ID2D1LookupTable3D_Vtbl {
@@ -3912,6 +3989,7 @@ impl ID2D1LookupTable3D_Vtbl {
         iid == &<ID2D1LookupTable3D as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1Mesh_Impl: Sized + ID2D1Resource_Impl {
     fn Open(&self) -> ::windows::core::Result<ID2D1TessellationSink>;
 }
@@ -3935,6 +4013,7 @@ impl ID2D1Mesh_Vtbl {
         iid == &<ID2D1Mesh as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1Multithread_Impl: Sized {
     fn GetMultithreadProtected(&self) -> super::super::Foundation::BOOL;
@@ -3972,6 +4051,7 @@ impl ID2D1Multithread_Vtbl {
         iid == &<ID2D1Multithread as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1OffsetTransform_Impl: Sized + ID2D1TransformNode_Impl {
     fn SetOffset(&self, offset: &super::super::Foundation::POINT);
@@ -4002,6 +4082,7 @@ impl ID2D1OffsetTransform_Vtbl {
         iid == &<ID2D1OffsetTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1PathGeometry_Impl: Sized + ID2D1Geometry_Impl {
     fn Open(&self) -> ::windows::core::Result<ID2D1GeometrySink>;
@@ -4064,6 +4145,7 @@ impl ID2D1PathGeometry_Vtbl {
         iid == &<ID2D1PathGeometry as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Geometry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1PathGeometry1_Impl: Sized + ID2D1PathGeometry_Impl {
     fn ComputePointAndSegmentAtLength(&self, length: f32, startsegment: u32, worldtransform: *const super::super::super::Foundation::Numerics::Matrix3x2, flatteningtolerance: f32) -> ::windows::core::Result<D2D1_POINT_DESCRIPTION>;
@@ -4093,6 +4175,7 @@ impl ID2D1PathGeometry1_Vtbl {
         iid == &<ID2D1PathGeometry1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Geometry as ::windows::core::Interface>::IID || iid == &<ID2D1PathGeometry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 pub trait ID2D1PrintControl_Impl: Sized {
     fn AddPage(&self, commandlist: &::core::option::Option<ID2D1CommandList>, pagesize: &Common::D2D_SIZE_F, pageprintticketstream: &::core::option::Option<super::super::System::Com::IStream>, tag1: *mut u64, tag2: *mut u64) -> ::windows::core::Result<()>;
@@ -4123,6 +4206,7 @@ impl ID2D1PrintControl_Vtbl {
         iid == &<ID2D1PrintControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1Properties_Impl: Sized {
     fn GetPropertyCount(&self) -> u32;
     fn GetPropertyName(&self, index: u32, name: ::windows::core::PWSTR, namecount: u32) -> ::windows::core::Result<()>;
@@ -4213,6 +4297,7 @@ impl ID2D1Properties_Vtbl {
         iid == &<ID2D1Properties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1RadialGradientBrush_Impl: Sized + ID2D1Brush_Impl {
     fn SetCenter(&self, center: &Common::D2D_POINT_2F);
@@ -4292,6 +4377,7 @@ impl ID2D1RadialGradientBrush_Vtbl {
         iid == &<ID2D1RadialGradientBrush as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Brush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1RectangleGeometry_Impl: Sized + ID2D1Geometry_Impl {
     fn GetRect(&self, rect: *mut Common::D2D_RECT_F);
@@ -4312,6 +4398,7 @@ impl ID2D1RectangleGeometry_Vtbl {
         iid == &<ID2D1RectangleGeometry as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Geometry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1RenderInfo_Impl: Sized {
     fn SetInputDescription(&self, inputindex: u32, inputdescription: &D2D1_INPUT_DESCRIPTION) -> ::windows::core::Result<()>;
@@ -4356,6 +4443,7 @@ impl ID2D1RenderInfo_Vtbl {
         iid == &<ID2D1RenderInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_DirectWrite", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Imaging"))]
 pub trait ID2D1RenderTarget_Impl: Sized + ID2D1Resource_Impl {
     fn CreateBitmap(&self, size: &Common::D2D_SIZE_U, srcdata: *const ::core::ffi::c_void, pitch: u32, bitmapproperties: *const D2D1_BITMAP_PROPERTIES) -> ::windows::core::Result<ID2D1Bitmap>;
@@ -4803,6 +4891,7 @@ impl ID2D1RenderTarget_Vtbl {
         iid == &<ID2D1RenderTarget as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1Resource_Impl: Sized {
     fn GetFactory(&self, factory: *mut ::core::option::Option<ID2D1Factory>);
 }
@@ -4820,6 +4909,7 @@ impl ID2D1Resource_Vtbl {
         iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1ResourceTexture_Impl: Sized {
     fn Update(&self, minimumextents: *const u32, maximimumextents: *const u32, strides: *const u32, dimensions: u32, data: *const u8, datacount: u32) -> ::windows::core::Result<()>;
 }
@@ -4837,6 +4927,7 @@ impl ID2D1ResourceTexture_Vtbl {
         iid == &<ID2D1ResourceTexture as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1RoundedRectangleGeometry_Impl: Sized + ID2D1Geometry_Impl {
     fn GetRoundedRect(&self, roundedrect: *mut D2D1_ROUNDED_RECT);
@@ -4857,6 +4948,7 @@ impl ID2D1RoundedRectangleGeometry_Vtbl {
         iid == &<ID2D1RoundedRectangleGeometry as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Geometry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1SolidColorBrush_Impl: Sized + ID2D1Brush_Impl {
     fn SetColor(&self, color: *const Common::D2D1_COLOR_F);
@@ -4887,6 +4979,7 @@ impl ID2D1SolidColorBrush_Vtbl {
         iid == &<ID2D1SolidColorBrush as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Brush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1SourceTransform_Impl: Sized + ID2D1Transform_Impl {
     fn SetRenderInfo(&self, renderinfo: &::core::option::Option<ID2D1RenderInfo>) -> ::windows::core::Result<()>;
@@ -4917,6 +5010,7 @@ impl ID2D1SourceTransform_Vtbl {
         iid == &<ID2D1SourceTransform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID || iid == &<ID2D1Transform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1SpriteBatch_Impl: Sized + ID2D1Resource_Impl {
     fn AddSprites(&self, spritecount: u32, destinationrectangles: *const Common::D2D_RECT_F, sourcerectangles: *const Common::D2D_RECT_U, colors: *const Common::D2D1_COLOR_F, transforms: *const super::super::super::Foundation::Numerics::Matrix3x2, destinationrectanglesstride: u32, sourcerectanglesstride: u32, colorsstride: u32, transformsstride: u32) -> ::windows::core::Result<()>;
@@ -4969,6 +5063,7 @@ impl ID2D1SpriteBatch_Vtbl {
         iid == &<ID2D1SpriteBatch as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1StrokeStyle_Impl: Sized + ID2D1Resource_Impl {
     fn GetStartCap(&self) -> D2D1_CAP_STYLE;
     fn GetEndCap(&self) -> D2D1_CAP_STYLE;
@@ -5045,6 +5140,7 @@ impl ID2D1StrokeStyle_Vtbl {
         iid == &<ID2D1StrokeStyle as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1StrokeStyle1_Impl: Sized + ID2D1StrokeStyle_Impl {
     fn GetStrokeTransformType(&self) -> D2D1_STROKE_TRANSFORM_TYPE;
 }
@@ -5062,6 +5158,7 @@ impl ID2D1StrokeStyle1_Vtbl {
         iid == &<ID2D1StrokeStyle1 as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1StrokeStyle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1SvgAttribute_Impl: Sized + ID2D1Resource_Impl {
     fn GetElement(&self, element: *mut ::core::option::Option<ID2D1SvgElement>);
     fn Clone(&self) -> ::windows::core::Result<ID2D1SvgAttribute>;
@@ -5095,6 +5192,7 @@ impl ID2D1SvgAttribute_Vtbl {
         iid == &<ID2D1SvgAttribute as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_System_Com"))]
 pub trait ID2D1SvgDocument_Impl: Sized + ID2D1Resource_Impl {
     fn SetViewportSize(&self, viewportsize: &Common::D2D_SIZE_F) -> ::windows::core::Result<()>;
@@ -5218,6 +5316,7 @@ impl ID2D1SvgDocument_Vtbl {
         iid == &<ID2D1SvgDocument as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1SvgElement_Impl: Sized + ID2D1Resource_Impl {
     fn GetDocument(&self, document: *mut ::core::option::Option<ID2D1SvgDocument>);
@@ -5456,6 +5555,7 @@ impl ID2D1SvgElement_Vtbl {
         iid == &<ID2D1SvgElement as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1SvgGlyphStyle_Impl: Sized + ID2D1Resource_Impl {
     fn SetFill(&self, brush: &::core::option::Option<ID2D1Brush>) -> ::windows::core::Result<()>;
     fn GetFill(&self, brush: *mut ::core::option::Option<ID2D1Brush>);
@@ -5504,6 +5604,7 @@ impl ID2D1SvgGlyphStyle_Vtbl {
         iid == &<ID2D1SvgGlyphStyle as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1SvgPaint_Impl: Sized + ID2D1SvgAttribute_Impl {
     fn SetPaintType(&self, painttype: D2D1_SVG_PAINT_TYPE) -> ::windows::core::Result<()>;
@@ -5569,6 +5670,7 @@ impl ID2D1SvgPaint_Vtbl {
         iid == &<ID2D1SvgPaint as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1SvgAttribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1SvgPathData_Impl: Sized + ID2D1SvgAttribute_Impl {
     fn RemoveSegmentDataAtEnd(&self, datacount: u32) -> ::windows::core::Result<()>;
@@ -5654,6 +5756,7 @@ impl ID2D1SvgPathData_Vtbl {
         iid == &<ID2D1SvgPathData as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1SvgAttribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1SvgPointCollection_Impl: Sized + ID2D1SvgAttribute_Impl {
     fn RemovePointsAtEnd(&self, pointscount: u32) -> ::windows::core::Result<()>;
@@ -5698,6 +5801,7 @@ impl ID2D1SvgPointCollection_Vtbl {
         iid == &<ID2D1SvgPointCollection as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1SvgAttribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1SvgStrokeDashArray_Impl: Sized + ID2D1SvgAttribute_Impl {
     fn RemoveDashesAtEnd(&self, dashescount: u32) -> ::windows::core::Result<()>;
     fn UpdateDashes(&self, dashes: *const D2D1_SVG_LENGTH, dashescount: u32, startindex: u32) -> ::windows::core::Result<()>;
@@ -5753,6 +5857,7 @@ impl ID2D1SvgStrokeDashArray_Vtbl {
         iid == &<ID2D1SvgStrokeDashArray as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1SvgAttribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait ID2D1TessellationSink_Impl: Sized {
     fn AddTriangles(&self, triangles: *const D2D1_TRIANGLE, trianglescount: u32);
@@ -5783,6 +5888,7 @@ impl ID2D1TessellationSink_Vtbl {
         iid == &<ID2D1TessellationSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID2D1Transform_Impl: Sized + ID2D1TransformNode_Impl {
     fn MapOutputRectToInputRects(&self, outputrect: *const super::super::Foundation::RECT, inputrects: *mut super::super::Foundation::RECT, inputrectscount: u32) -> ::windows::core::Result<()>;
@@ -5826,6 +5932,7 @@ impl ID2D1Transform_Vtbl {
         iid == &<ID2D1Transform as ::windows::core::Interface>::IID || iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1TransformGraph_Impl: Sized {
     fn GetInputCount(&self) -> u32;
     fn SetSingleTransformNode(&self, node: &::core::option::Option<ID2D1TransformNode>) -> ::windows::core::Result<()>;
@@ -5902,6 +6009,7 @@ impl ID2D1TransformGraph_Vtbl {
         iid == &<ID2D1TransformGraph as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1TransformNode_Impl: Sized {
     fn GetInputCount(&self) -> u32;
 }
@@ -5919,6 +6027,7 @@ impl ID2D1TransformNode_Vtbl {
         iid == &<ID2D1TransformNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait ID2D1TransformedGeometry_Impl: Sized + ID2D1Geometry_Impl {
     fn GetSourceGeometry(&self, sourcegeometry: *mut ::core::option::Option<ID2D1Geometry>);
@@ -5949,6 +6058,7 @@ impl ID2D1TransformedGeometry_Vtbl {
         iid == &<ID2D1TransformedGeometry as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Geometry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1TransformedImageSource_Impl: Sized + ID2D1Image_Impl {
     fn GetSource(&self, imagesource: *mut ::core::option::Option<ID2D1ImageSource>);
     fn GetProperties(&self, properties: *mut D2D1_TRANSFORMED_IMAGE_SOURCE_PROPERTIES);
@@ -5976,6 +6086,7 @@ impl ID2D1TransformedImageSource_Vtbl {
         iid == &<ID2D1TransformedImageSource as ::windows::core::Interface>::IID || iid == &<ID2D1Resource as ::windows::core::Interface>::IID || iid == &<ID2D1Image as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 pub trait ID2D1VertexBuffer_Impl: Sized {
     fn Map(&self, data: *mut *mut u8, buffersize: u32) -> ::windows::core::Result<()>;
     fn Unmap(&self) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcAssembler_Impl: Sized {
     fn AssembleToContainer(&self, pshader: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<IDxcOperationResult>;
 }
@@ -21,6 +22,7 @@ impl IDxcAssembler_Vtbl {
         iid == &<IDxcAssembler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcBlob_Impl: Sized {
     fn GetBufferPointer(&self) -> *mut ::core::ffi::c_void;
     fn GetBufferSize(&self) -> usize;
@@ -48,6 +50,7 @@ impl IDxcBlob_Vtbl {
         iid == &<IDxcBlob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDxcBlobEncoding_Impl: Sized + IDxcBlob_Impl {
     fn GetEncoding(&self, pknown: *mut super::super::super::Foundation::BOOL, pcodepage: *mut DXC_CP) -> ::windows::core::Result<()>;
@@ -68,6 +71,7 @@ impl IDxcBlobEncoding_Vtbl {
         iid == &<IDxcBlobEncoding as ::windows::core::Interface>::IID || iid == &<IDxcBlob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDxcBlobUtf16_Impl: Sized + IDxcBlobEncoding_Impl {
     fn GetStringPointer(&self) -> ::windows::core::PWSTR;
@@ -98,6 +102,7 @@ impl IDxcBlobUtf16_Vtbl {
         iid == &<IDxcBlobUtf16 as ::windows::core::Interface>::IID || iid == &<IDxcBlob as ::windows::core::Interface>::IID || iid == &<IDxcBlobEncoding as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDxcBlobUtf8_Impl: Sized + IDxcBlobEncoding_Impl {
     fn GetStringPointer(&self) -> ::windows::core::PSTR;
@@ -128,6 +133,7 @@ impl IDxcBlobUtf8_Vtbl {
         iid == &<IDxcBlobUtf8 as ::windows::core::Interface>::IID || iid == &<IDxcBlob as ::windows::core::Interface>::IID || iid == &<IDxcBlobEncoding as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcCompiler_Impl: Sized {
     fn Compile(&self, psource: &::core::option::Option<IDxcBlob>, psourcename: &::windows::core::PCWSTR, pentrypoint: &::windows::core::PCWSTR, ptargetprofile: &::windows::core::PCWSTR, parguments: *const ::windows::core::PCWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: &::core::option::Option<IDxcIncludeHandler>) -> ::windows::core::Result<IDxcOperationResult>;
     fn Preprocess(&self, psource: &::core::option::Option<IDxcBlob>, psourcename: &::windows::core::PCWSTR, parguments: *const ::windows::core::PCWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: &::core::option::Option<IDxcIncludeHandler>) -> ::windows::core::Result<IDxcOperationResult>;
@@ -180,6 +186,7 @@ impl IDxcCompiler_Vtbl {
         iid == &<IDxcCompiler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcCompiler2_Impl: Sized + IDxcCompiler_Impl {
     fn CompileWithDebug(&self, psource: &::core::option::Option<IDxcBlob>, psourcename: &::windows::core::PCWSTR, pentrypoint: &::windows::core::PCWSTR, ptargetprofile: &::windows::core::PCWSTR, parguments: *const ::windows::core::PCWSTR, argcount: u32, pdefines: *const DxcDefine, definecount: u32, pincludehandler: &::core::option::Option<IDxcIncludeHandler>, ppresult: *mut ::core::option::Option<IDxcOperationResult>, ppdebugblobname: *mut ::windows::core::PWSTR, ppdebugblob: *mut ::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
 }
@@ -211,6 +218,7 @@ impl IDxcCompiler2_Vtbl {
         iid == &<IDxcCompiler2 as ::windows::core::Interface>::IID || iid == &<IDxcCompiler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcCompiler3_Impl: Sized {
     fn Compile(&self, psource: *const DxcBuffer, parguments: *const ::windows::core::PCWSTR, argcount: u32, pincludehandler: &::core::option::Option<IDxcIncludeHandler>, riid: *const ::windows::core::GUID, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Disassemble(&self, pobject: *const DxcBuffer, riid: *const ::windows::core::GUID, ppresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -238,6 +246,7 @@ impl IDxcCompiler3_Vtbl {
         iid == &<IDxcCompiler3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcCompilerArgs_Impl: Sized {
     fn GetArguments(&self) -> *mut ::windows::core::PWSTR;
     fn GetCount(&self) -> u32;
@@ -286,6 +295,7 @@ impl IDxcCompilerArgs_Vtbl {
         iid == &<IDxcCompilerArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcContainerBuilder_Impl: Sized {
     fn Load(&self, pdxilcontainerheader: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
     fn AddPart(&self, fourcc: u32, psource: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
@@ -333,6 +343,7 @@ impl IDxcContainerBuilder_Vtbl {
         iid == &<IDxcContainerBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcContainerReflection_Impl: Sized {
     fn Load(&self, pcontainer: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
     fn GetPartCount(&self) -> ::windows::core::Result<u32>;
@@ -412,6 +423,7 @@ impl IDxcContainerReflection_Vtbl {
         iid == &<IDxcContainerReflection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcExtraOutputs_Impl: Sized {
     fn GetOutputCount(&self) -> u32;
     fn GetOutput(&self, uindex: u32, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void, ppoutputtype: *mut ::core::option::Option<IDxcBlobUtf16>, ppoutputname: *mut ::core::option::Option<IDxcBlobUtf16>) -> ::windows::core::Result<()>;
@@ -439,6 +451,7 @@ impl IDxcExtraOutputs_Vtbl {
         iid == &<IDxcExtraOutputs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcIncludeHandler_Impl: Sized {
     fn LoadSource(&self, pfilename: &::windows::core::PCWSTR, ppincludesource: *mut ::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
 }
@@ -456,6 +469,7 @@ impl IDxcIncludeHandler_Vtbl {
         iid == &<IDxcIncludeHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDxcLibrary_Impl: Sized {
     fn SetMalloc(&self, pmalloc: &::core::option::Option<super::super::super::System::Com::IMalloc>) -> ::windows::core::Result<()>;
@@ -596,6 +610,7 @@ impl IDxcLibrary_Vtbl {
         iid == &<IDxcLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcLinker_Impl: Sized {
     fn RegisterLibrary(&self, plibname: &::windows::core::PCWSTR, plib: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
     fn Link(&self, pentryname: &::windows::core::PCWSTR, ptargetprofile: &::windows::core::PCWSTR, plibnames: *const ::windows::core::PCWSTR, libcount: u32, parguments: *const ::windows::core::PCWSTR, argcount: u32) -> ::windows::core::Result<IDxcOperationResult>;
@@ -629,6 +644,7 @@ impl IDxcLinker_Vtbl {
         iid == &<IDxcLinker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcOperationResult_Impl: Sized {
     fn GetStatus(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
     fn GetResult(&self, ppresult: *mut ::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
@@ -669,6 +685,7 @@ impl IDxcOperationResult_Vtbl {
         iid == &<IDxcOperationResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcOptimizer_Impl: Sized {
     fn GetAvailablePassCount(&self) -> ::windows::core::Result<u32>;
     fn GetAvailablePass(&self, index: u32) -> ::windows::core::Result<IDxcOptimizerPass>;
@@ -715,6 +732,7 @@ impl IDxcOptimizer_Vtbl {
         iid == &<IDxcOptimizer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcOptimizerPass_Impl: Sized {
     fn GetOptionName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -793,6 +811,7 @@ impl IDxcOptimizerPass_Vtbl {
         iid == &<IDxcOptimizerPass as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDxcPdbUtils_Impl: Sized {
     fn Load(&self, ppdbordxil: &::core::option::Option<IDxcBlob>) -> ::windows::core::Result<()>;
@@ -1085,6 +1104,7 @@ impl IDxcPdbUtils_Vtbl {
         iid == &<IDxcPdbUtils as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDxcResult_Impl: Sized + IDxcOperationResult_Impl {
     fn HasOutput(&self, dxcoutkind: DXC_OUT_KIND) -> super::super::super::Foundation::BOOL;
@@ -1136,6 +1156,7 @@ impl IDxcResult_Vtbl {
         iid == &<IDxcResult as ::windows::core::Interface>::IID || iid == &<IDxcOperationResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDxcUtils_Impl: Sized {
     fn CreateBlobFromBlob(&self, pblob: &::core::option::Option<IDxcBlob>, offset: u32, length: u32) -> ::windows::core::Result<IDxcBlob>;
@@ -1303,6 +1324,7 @@ impl IDxcUtils_Vtbl {
         iid == &<IDxcUtils as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcValidator_Impl: Sized {
     fn Validate(&self, pshader: &::core::option::Option<IDxcBlob>, flags: u32) -> ::windows::core::Result<IDxcOperationResult>;
 }
@@ -1326,6 +1348,7 @@ impl IDxcValidator_Vtbl {
         iid == &<IDxcValidator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcValidator2_Impl: Sized + IDxcValidator_Impl {
     fn ValidateWithDebug(&self, pshader: &::core::option::Option<IDxcBlob>, flags: u32, poptdebugbitcode: *const DxcBuffer) -> ::windows::core::Result<IDxcOperationResult>;
 }
@@ -1349,6 +1372,7 @@ impl IDxcValidator2_Vtbl {
         iid == &<IDxcValidator2 as ::windows::core::Interface>::IID || iid == &<IDxcValidator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcVersionInfo_Impl: Sized {
     fn GetVersion(&self, pmajor: *mut u32, pminor: *mut u32) -> ::windows::core::Result<()>;
     fn GetFlags(&self) -> ::windows::core::Result<u32>;
@@ -1382,6 +1406,7 @@ impl IDxcVersionInfo_Vtbl {
         iid == &<IDxcVersionInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcVersionInfo2_Impl: Sized + IDxcVersionInfo_Impl {
     fn GetCommitInfo(&self, pcommitcount: *mut u32, pcommithash: *mut *mut i8) -> ::windows::core::Result<()>;
 }
@@ -1399,6 +1424,7 @@ impl IDxcVersionInfo2_Vtbl {
         iid == &<IDxcVersionInfo2 as ::windows::core::Interface>::IID || iid == &<IDxcVersionInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D_Dxc\"`, `\"implement\"`*"]
 pub trait IDxcVersionInfo3_Impl: Sized {
     fn GetCustomVersionString(&self) -> ::windows::core::Result<*mut i8>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 pub trait ID3DBlob_Impl: Sized {
     fn GetBufferPointer(&self) -> *mut ::core::ffi::c_void;
     fn GetBufferSize(&self) -> usize;
@@ -25,6 +26,7 @@ impl ID3DBlob_Vtbl {
         iid == &<ID3DBlob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 pub trait ID3DDestructionNotifier_Impl: Sized {
     fn RegisterDestructionCallback(&self, callbackfn: PFN_DESTRUCTION_CALLBACK, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<u32>;
     fn UnregisterDestructionCallback(&self, callbackid: u32) -> ::windows::core::Result<()>;
@@ -58,6 +60,7 @@ impl ID3DDestructionNotifier_Vtbl {
         iid == &<ID3DDestructionNotifier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 pub trait ID3DInclude_Impl: Sized {
     fn Open(&self, includetype: D3D_INCLUDE_TYPE, pfilename: &::windows::core::PCSTR, pparentdata: *const ::core::ffi::c_void, ppdata: *mut *mut ::core::ffi::c_void, pbytes: *mut u32) -> ::windows::core::Result<()>;
     fn Close(&self, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10Asynchronous_Impl: Sized + ID3D10DeviceChild_Impl {
     fn Begin(&self);
     fn End(&self);
@@ -39,6 +40,7 @@ impl ID3D10Asynchronous_Vtbl {
         iid == &<ID3D10Asynchronous as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10BlendState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_BLEND_DESC);
@@ -59,6 +61,7 @@ impl ID3D10BlendState_Vtbl {
         iid == &<ID3D10BlendState as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10BlendState1_Impl: Sized + ID3D10BlendState_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D10_BLEND_DESC1);
@@ -79,6 +82,7 @@ impl ID3D10BlendState1_Vtbl {
         iid == &<ID3D10BlendState1 as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10BlendState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10Buffer_Impl: Sized + ID3D10Resource_Impl {
     fn Map(&self, maptype: D3D10_MAP, mapflags: u32, ppdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Unmap(&self);
@@ -113,6 +117,7 @@ impl ID3D10Buffer_Vtbl {
         iid == &<ID3D10Buffer as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10Counter_Impl: Sized + ID3D10Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_COUNTER_DESC);
 }
@@ -130,6 +135,7 @@ impl ID3D10Counter_Vtbl {
         iid == &<ID3D10Counter as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10Asynchronous as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 pub trait ID3D10Debug_Impl: Sized {
     fn SetFeatureMask(&self, mask: u32) -> ::windows::core::Result<()>;
@@ -201,6 +207,7 @@ impl ID3D10Debug_Vtbl {
         iid == &<ID3D10Debug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10DepthStencilState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_DEPTH_STENCIL_DESC);
@@ -221,6 +228,7 @@ impl ID3D10DepthStencilState_Vtbl {
         iid == &<ID3D10DepthStencilState as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10DepthStencilView_Impl: Sized + ID3D10View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_DEPTH_STENCIL_VIEW_DESC);
@@ -241,6 +249,7 @@ impl ID3D10DepthStencilView_Vtbl {
         iid == &<ID3D10DepthStencilView as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10Device_Impl: Sized {
     fn VSSetConstantBuffers(&self, startslot: u32, numbuffers: u32, ppconstantbuffers: *const ::core::option::Option<ID3D10Buffer>);
@@ -952,6 +961,7 @@ impl ID3D10Device_Vtbl {
         iid == &<ID3D10Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10Device1_Impl: Sized + ID3D10Device_Impl {
     fn CreateShaderResourceView1(&self, presource: &::core::option::Option<ID3D10Resource>, pdesc: *const D3D10_SHADER_RESOURCE_VIEW_DESC1, ppsrview: *mut ::core::option::Option<ID3D10ShaderResourceView1>) -> ::windows::core::Result<()>;
@@ -989,6 +999,7 @@ impl ID3D10Device1_Vtbl {
         iid == &<ID3D10Device1 as ::windows::core::Interface>::IID || iid == &<ID3D10Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10DeviceChild_Impl: Sized {
     fn GetDevice(&self, ppdevice: *mut ::core::option::Option<ID3D10Device>);
     fn GetPrivateData(&self, guid: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1030,6 +1041,7 @@ impl ID3D10DeviceChild_Vtbl {
         iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10Effect_Impl: Sized {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
@@ -1149,6 +1161,7 @@ impl ID3D10Effect_Vtbl {
         iid == &<ID3D10Effect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectBlendVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetBlendState(&self, index: u32) -> ::windows::core::Result<ID3D10BlendState>;
@@ -1191,6 +1204,7 @@ impl ID3D10EffectBlendVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectConstantBuffer_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetConstantBuffer(&self, pconstantbuffer: &::core::option::Option<ID3D10Buffer>) -> ::windows::core::Result<()>;
@@ -1257,6 +1271,7 @@ impl ID3D10EffectConstantBuffer {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectDepthStencilVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetDepthStencilState(&self, index: u32) -> ::windows::core::Result<ID3D10DepthStencilState>;
@@ -1305,6 +1320,7 @@ impl ID3D10EffectDepthStencilVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectDepthStencilViewVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetDepthStencil(&self, presource: &::core::option::Option<ID3D10DepthStencilView>) -> ::windows::core::Result<()>;
@@ -1365,6 +1381,7 @@ impl ID3D10EffectDepthStencilViewVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectMatrixVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetMatrix(&self, pdata: *mut f32) -> ::windows::core::Result<()>;
@@ -1447,6 +1464,7 @@ impl ID3D10EffectMatrixVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectPass_Impl: Sized {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
@@ -1541,6 +1559,7 @@ impl ID3D10EffectPass {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10EffectPool_Impl: Sized {
     fn AsEffect(&self) -> ::core::option::Option<ID3D10Effect>;
 }
@@ -1558,6 +1577,7 @@ impl ID3D10EffectPool_Vtbl {
         iid == &<ID3D10EffectPool as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectRasterizerVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetRasterizerState(&self, index: u32) -> ::windows::core::Result<ID3D10RasterizerState>;
@@ -1606,6 +1626,7 @@ impl ID3D10EffectRasterizerVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectRenderTargetViewVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetRenderTarget(&self, presource: &::core::option::Option<ID3D10RenderTargetView>) -> ::windows::core::Result<()>;
@@ -1666,6 +1687,7 @@ impl ID3D10EffectRenderTargetViewVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectSamplerVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetSampler(&self, index: u32) -> ::windows::core::Result<ID3D10SamplerState>;
@@ -1714,6 +1736,7 @@ impl ID3D10EffectSamplerVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectScalarVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetFloat(&self, value: f32) -> ::windows::core::Result<()>;
@@ -1842,6 +1865,7 @@ impl ID3D10EffectScalarVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectShaderResourceVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetResource(&self, presource: &::core::option::Option<ID3D10ShaderResourceView>) -> ::windows::core::Result<()>;
@@ -1902,6 +1926,7 @@ impl ID3D10EffectShaderResourceVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 pub trait ID3D10EffectShaderVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetShaderDesc(&self, shaderindex: u32) -> ::windows::core::Result<D3D10_EFFECT_SHADER_DESC>;
@@ -2006,6 +2031,7 @@ impl ID3D10EffectShaderVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectStringVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn GetString(&self) -> ::windows::core::Result<::windows::core::PSTR>;
@@ -2048,6 +2074,7 @@ impl ID3D10EffectStringVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectTechnique_Impl: Sized {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
@@ -2128,6 +2155,7 @@ impl ID3D10EffectTechnique {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 pub trait ID3D10EffectType_Impl: Sized {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
@@ -2202,6 +2230,7 @@ impl ID3D10EffectType {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectVariable_Impl: Sized {
     fn IsValid(&self) -> super::super::Foundation::BOOL;
@@ -2408,6 +2437,7 @@ impl ID3D10EffectVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10EffectVectorVariable_Impl: Sized + ID3D10EffectVariable_Impl {
     fn SetBoolVector(&self, pdata: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2518,6 +2548,7 @@ impl ID3D10EffectVectorVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10GeometryShader_Impl: Sized + ID3D10DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D10GeometryShader {}
 impl ID3D10GeometryShader_Vtbl {
@@ -2528,6 +2559,7 @@ impl ID3D10GeometryShader_Vtbl {
         iid == &<ID3D10GeometryShader as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10InfoQueue_Impl: Sized {
     fn SetMessageCountLimit(&self, messagecountlimit: u64) -> ::windows::core::Result<()>;
@@ -2789,6 +2821,7 @@ impl ID3D10InfoQueue_Vtbl {
         iid == &<ID3D10InfoQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10InputLayout_Impl: Sized + ID3D10DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D10InputLayout {}
 impl ID3D10InputLayout_Vtbl {
@@ -2799,6 +2832,7 @@ impl ID3D10InputLayout_Vtbl {
         iid == &<ID3D10InputLayout as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10Multithread_Impl: Sized {
     fn Enter(&self);
@@ -2843,6 +2877,7 @@ impl ID3D10Multithread_Vtbl {
         iid == &<ID3D10Multithread as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10PixelShader_Impl: Sized + ID3D10DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D10PixelShader {}
 impl ID3D10PixelShader_Vtbl {
@@ -2853,6 +2888,7 @@ impl ID3D10PixelShader_Vtbl {
         iid == &<ID3D10PixelShader as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10Predicate_Impl: Sized + ID3D10Query_Impl {}
 impl ::windows::core::RuntimeName for ID3D10Predicate {}
 impl ID3D10Predicate_Vtbl {
@@ -2863,6 +2899,7 @@ impl ID3D10Predicate_Vtbl {
         iid == &<ID3D10Predicate as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10Asynchronous as ::windows::core::Interface>::IID || iid == &<ID3D10Query as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10Query_Impl: Sized + ID3D10Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_QUERY_DESC);
 }
@@ -2880,6 +2917,7 @@ impl ID3D10Query_Vtbl {
         iid == &<ID3D10Query as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10Asynchronous as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10RasterizerState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_RASTERIZER_DESC);
@@ -2900,6 +2938,7 @@ impl ID3D10RasterizerState_Vtbl {
         iid == &<ID3D10RasterizerState as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10RenderTargetView_Impl: Sized + ID3D10View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_RENDER_TARGET_VIEW_DESC);
@@ -2920,6 +2959,7 @@ impl ID3D10RenderTargetView_Vtbl {
         iid == &<ID3D10RenderTargetView as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10Resource_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetType(&self, rtype: *mut D3D10_RESOURCE_DIMENSION);
     fn SetEvictionPriority(&self, evictionpriority: u32);
@@ -2954,6 +2994,7 @@ impl ID3D10Resource_Vtbl {
         iid == &<ID3D10Resource as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10SamplerState_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SAMPLER_DESC);
 }
@@ -2971,6 +3012,7 @@ impl ID3D10SamplerState_Vtbl {
         iid == &<ID3D10SamplerState as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10ShaderReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D10_SHADER_DESC>;
@@ -3053,6 +3095,7 @@ impl ID3D10ShaderReflection_Vtbl {
         iid == &<ID3D10ShaderReflection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 pub trait ID3D10ShaderReflection1_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D10_SHADER_DESC>;
@@ -3246,6 +3289,7 @@ impl ID3D10ShaderReflection1_Vtbl {
         iid == &<ID3D10ShaderReflection1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D10_SHADER_BUFFER_DESC>;
@@ -3294,6 +3338,7 @@ impl ID3D10ShaderReflectionConstantBuffer {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D10ShaderReflectionType_Impl: Sized {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_TYPE_DESC) -> ::windows::core::Result<()>;
@@ -3347,6 +3392,7 @@ impl ID3D10ShaderReflectionType {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10ShaderReflectionVariable_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D10_SHADER_VARIABLE_DESC>;
     fn GetType(&self) -> ::core::option::Option<ID3D10ShaderReflectionType>;
@@ -3384,6 +3430,7 @@ impl ID3D10ShaderReflectionVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10ShaderResourceView_Impl: Sized + ID3D10View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D10_SHADER_RESOURCE_VIEW_DESC);
@@ -3404,6 +3451,7 @@ impl ID3D10ShaderResourceView_Vtbl {
         iid == &<ID3D10ShaderResourceView as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D10ShaderResourceView1_Impl: Sized + ID3D10ShaderResourceView_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D10_SHADER_RESOURCE_VIEW_DESC1);
@@ -3424,6 +3472,7 @@ impl ID3D10ShaderResourceView1_Vtbl {
         iid == &<ID3D10ShaderResourceView1 as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10View as ::windows::core::Interface>::IID || iid == &<ID3D10ShaderResourceView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10StateBlock_Impl: Sized {
     fn Capture(&self) -> ::windows::core::Result<()>;
     fn Apply(&self) -> ::windows::core::Result<()>;
@@ -3471,6 +3520,7 @@ impl ID3D10StateBlock_Vtbl {
         iid == &<ID3D10StateBlock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D10SwitchToRef_Impl: Sized {
     fn SetUseRef(&self, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL;
@@ -3501,6 +3551,7 @@ impl ID3D10SwitchToRef_Vtbl {
         iid == &<ID3D10SwitchToRef as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10Texture1D_Impl: Sized + ID3D10Resource_Impl {
     fn Map(&self, subresource: u32, maptype: D3D10_MAP, mapflags: u32, ppdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3538,6 +3589,7 @@ impl ID3D10Texture1D_Vtbl {
         iid == &<ID3D10Texture1D as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10Texture2D_Impl: Sized + ID3D10Resource_Impl {
     fn Map(&self, subresource: u32, maptype: D3D10_MAP, mapflags: u32) -> ::windows::core::Result<D3D10_MAPPED_TEXTURE2D>;
@@ -3581,6 +3633,7 @@ impl ID3D10Texture2D_Vtbl {
         iid == &<ID3D10Texture2D as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D10Texture3D_Impl: Sized + ID3D10Resource_Impl {
     fn Map(&self, subresource: u32, maptype: D3D10_MAP, mapflags: u32) -> ::windows::core::Result<D3D10_MAPPED_TEXTURE3D>;
@@ -3624,6 +3677,7 @@ impl ID3D10Texture3D_Vtbl {
         iid == &<ID3D10Texture3D as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D10Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10VertexShader_Impl: Sized + ID3D10DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D10VertexShader {}
 impl ID3D10VertexShader_Vtbl {
@@ -3634,6 +3688,7 @@ impl ID3D10VertexShader_Vtbl {
         iid == &<ID3D10VertexShader as ::windows::core::Interface>::IID || iid == &<ID3D10DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D10\"`, `\"implement\"`*"]
 pub trait ID3D10View_Impl: Sized + ID3D10DeviceChild_Impl {
     fn GetResource(&self, ppresource: *mut ::core::option::Option<ID3D10Resource>);
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Asynchronous_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDataSize(&self) -> u32;
 }
@@ -15,6 +16,7 @@ impl ID3D11Asynchronous_Vtbl {
         iid == &<ID3D11Asynchronous as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11AuthenticatedChannel_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetCertificateSize(&self) -> ::windows::core::Result<u32>;
@@ -58,6 +60,7 @@ impl ID3D11AuthenticatedChannel_Vtbl {
         iid == &<ID3D11AuthenticatedChannel as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11BlendState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_BLEND_DESC);
@@ -78,6 +81,7 @@ impl ID3D11BlendState_Vtbl {
         iid == &<ID3D11BlendState as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11BlendState1_Impl: Sized + ID3D11BlendState_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_BLEND_DESC1);
@@ -98,6 +102,7 @@ impl ID3D11BlendState1_Vtbl {
         iid == &<ID3D11BlendState1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11BlendState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Buffer_Impl: Sized + ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_BUFFER_DESC);
 }
@@ -115,6 +120,7 @@ impl ID3D11Buffer_Vtbl {
         iid == &<ID3D11Buffer as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11ClassInstance_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetClassLinkage(&self, pplinkage: *mut ::core::option::Option<ID3D11ClassLinkage>);
@@ -159,6 +165,7 @@ impl ID3D11ClassInstance_Vtbl {
         iid == &<ID3D11ClassInstance as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11ClassLinkage_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetClassInstance(&self, pclassinstancename: &::windows::core::PCSTR, instanceindex: u32) -> ::windows::core::Result<ID3D11ClassInstance>;
     fn CreateClassInstance(&self, pclasstypename: &::windows::core::PCSTR, constantbufferoffset: u32, constantvectoroffset: u32, textureoffset: u32, sampleroffset: u32) -> ::windows::core::Result<ID3D11ClassInstance>;
@@ -198,6 +205,7 @@ impl ID3D11ClassLinkage_Vtbl {
         iid == &<ID3D11ClassLinkage as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11CommandList_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetContextFlags(&self) -> u32;
 }
@@ -215,6 +223,7 @@ impl ID3D11CommandList_Vtbl {
         iid == &<ID3D11CommandList as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11ComputeShader_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D11ComputeShader {}
 impl ID3D11ComputeShader_Vtbl {
@@ -225,6 +234,7 @@ impl ID3D11ComputeShader_Vtbl {
         iid == &<ID3D11ComputeShader as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Counter_Impl: Sized + ID3D11Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_COUNTER_DESC);
 }
@@ -242,6 +252,7 @@ impl ID3D11Counter_Vtbl {
         iid == &<ID3D11Counter as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Asynchronous as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11CryptoSession_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetCryptoType(&self, pcryptotype: *mut ::windows::core::GUID);
@@ -299,6 +310,7 @@ impl ID3D11CryptoSession_Vtbl {
         iid == &<ID3D11CryptoSession as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 pub trait ID3D11Debug_Impl: Sized {
     fn SetFeatureMask(&self, mask: u32) -> ::windows::core::Result<()>;
@@ -384,6 +396,7 @@ impl ID3D11Debug_Vtbl {
         iid == &<ID3D11Debug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11DepthStencilState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_DEPTH_STENCIL_DESC);
@@ -404,6 +417,7 @@ impl ID3D11DepthStencilState_Vtbl {
         iid == &<ID3D11DepthStencilState as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11DepthStencilView_Impl: Sized + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_DEPTH_STENCIL_VIEW_DESC);
@@ -424,6 +438,7 @@ impl ID3D11DepthStencilView_Vtbl {
         iid == &<ID3D11DepthStencilView as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device_Impl: Sized {
     fn CreateBuffer(&self, pdesc: *const D3D11_BUFFER_DESC, pinitialdata: *const D3D11_SUBRESOURCE_DATA, ppbuffer: *mut ::core::option::Option<ID3D11Buffer>) -> ::windows::core::Result<()>;
@@ -738,6 +753,7 @@ impl ID3D11Device_Vtbl {
         iid == &<ID3D11Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device1_Impl: Sized + ID3D11Device_Impl {
     fn GetImmediateContext1(&self, ppimmediatecontext: *mut ::core::option::Option<ID3D11DeviceContext1>);
@@ -803,6 +819,7 @@ impl ID3D11Device1_Vtbl {
         iid == &<ID3D11Device1 as ::windows::core::Interface>::IID || iid == &<ID3D11Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device2_Impl: Sized + ID3D11Device1_Impl {
     fn GetImmediateContext2(&self, ppimmediatecontext: *mut ::core::option::Option<ID3D11DeviceContext2>);
@@ -853,6 +870,7 @@ impl ID3D11Device2_Vtbl {
         iid == &<ID3D11Device2 as ::windows::core::Interface>::IID || iid == &<ID3D11Device as ::windows::core::Interface>::IID || iid == &<ID3D11Device1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device3_Impl: Sized + ID3D11Device2_Impl {
     fn CreateTexture2D1(&self, pdesc1: *const D3D11_TEXTURE2D_DESC1, pinitialdata: *const D3D11_SUBRESOURCE_DATA, pptexture2d: *mut ::core::option::Option<ID3D11Texture2D1>) -> ::windows::core::Result<()>;
@@ -946,6 +964,7 @@ impl ID3D11Device3_Vtbl {
         iid == &<ID3D11Device3 as ::windows::core::Interface>::IID || iid == &<ID3D11Device as ::windows::core::Interface>::IID || iid == &<ID3D11Device1 as ::windows::core::Interface>::IID || iid == &<ID3D11Device2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device4_Impl: Sized + ID3D11Device3_Impl {
     fn RegisterDeviceRemovedEvent(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<u32>;
@@ -982,6 +1001,7 @@ impl ID3D11Device4_Vtbl {
         iid == &<ID3D11Device4 as ::windows::core::Interface>::IID || iid == &<ID3D11Device as ::windows::core::Interface>::IID || iid == &<ID3D11Device1 as ::windows::core::Interface>::IID || iid == &<ID3D11Device2 as ::windows::core::Interface>::IID || iid == &<ID3D11Device3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11Device5_Impl: Sized + ID3D11Device4_Impl {
     fn OpenSharedFence(&self, hfence: super::super::Foundation::HANDLE, returnedinterface: *const ::windows::core::GUID, ppfence: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1012,6 +1032,7 @@ impl ID3D11Device5_Vtbl {
         iid == &<ID3D11Device5 as ::windows::core::Interface>::IID || iid == &<ID3D11Device as ::windows::core::Interface>::IID || iid == &<ID3D11Device1 as ::windows::core::Interface>::IID || iid == &<ID3D11Device2 as ::windows::core::Interface>::IID || iid == &<ID3D11Device3 as ::windows::core::Interface>::IID || iid == &<ID3D11Device4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11DeviceChild_Impl: Sized {
     fn GetDevice(&self, ppdevice: *mut ::core::option::Option<ID3D11Device>);
     fn GetPrivateData(&self, guid: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1053,6 +1074,7 @@ impl ID3D11DeviceChild_Vtbl {
         iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext_Impl: Sized + ID3D11DeviceChild_Impl {
     fn VSSetConstantBuffers(&self, startslot: u32, numbuffers: u32, ppconstantbuffers: *const ::core::option::Option<ID3D11Buffer>);
@@ -1825,6 +1847,7 @@ impl ID3D11DeviceContext_Vtbl {
         iid == &<ID3D11DeviceContext as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext1_Impl: Sized + ID3D11DeviceContext_Impl {
     fn CopySubresourceRegion1(&self, pdstresource: &::core::option::Option<ID3D11Resource>, dstsubresource: u32, dstx: u32, dsty: u32, dstz: u32, psrcresource: &::core::option::Option<ID3D11Resource>, srcsubresource: u32, psrcbox: *const D3D11_BOX, copyflags: u32);
@@ -1974,6 +1997,7 @@ impl ID3D11DeviceContext1_Vtbl {
         iid == &<ID3D11DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext2_Impl: Sized + ID3D11DeviceContext1_Impl {
     fn UpdateTileMappings(&self, ptiledresource: &::core::option::Option<ID3D11Resource>, numtiledresourceregions: u32, ptiledresourceregionstartcoordinates: *const D3D11_TILED_RESOURCE_COORDINATE, ptiledresourceregionsizes: *const D3D11_TILE_REGION_SIZE, ptilepool: &::core::option::Option<ID3D11Buffer>, numranges: u32, prangeflags: *const u32, ptilepoolstartoffsets: *const u32, prangetilecounts: *const u32, flags: u32) -> ::windows::core::Result<()>;
@@ -2061,6 +2085,7 @@ impl ID3D11DeviceContext2_Vtbl {
         iid == &<ID3D11DeviceContext2 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext3_Impl: Sized + ID3D11DeviceContext2_Impl {
     fn Flush1(&self, contexttype: D3D11_CONTEXT_TYPE, hevent: super::super::Foundation::HANDLE);
@@ -2098,6 +2123,7 @@ impl ID3D11DeviceContext3_Vtbl {
         iid == &<ID3D11DeviceContext3 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11DeviceContext4_Impl: Sized + ID3D11DeviceContext3_Impl {
     fn Signal(&self, pfence: &::core::option::Option<ID3D11Fence>, value: u64) -> ::windows::core::Result<()>;
@@ -2128,6 +2154,7 @@ impl ID3D11DeviceContext4_Vtbl {
         iid == &<ID3D11DeviceContext4 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext2 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceContext3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11DomainShader_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D11DomainShader {}
 impl ID3D11DomainShader_Vtbl {
@@ -2138,6 +2165,7 @@ impl ID3D11DomainShader_Vtbl {
         iid == &<ID3D11DomainShader as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 pub trait ID3D11Fence_Impl: Sized + ID3D11DeviceChild_Impl {
     fn CreateSharedHandle(&self, pattributes: *const super::super::Security::SECURITY_ATTRIBUTES, dwaccess: u32, lpname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -2181,6 +2209,7 @@ impl ID3D11Fence_Vtbl {
         iid == &<ID3D11Fence as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11FunctionLinkingGraph_Impl: Sized {
     fn CreateModuleInstance(&self, ppmoduleinstance: *mut ::core::option::Option<ID3D11ModuleInstance>, pperrorbuffer: *mut ::core::option::Option<super::Direct3D::ID3DBlob>) -> ::windows::core::Result<()>;
@@ -2277,6 +2306,7 @@ impl ID3D11FunctionLinkingGraph_Vtbl {
         iid == &<ID3D11FunctionLinkingGraph as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11FunctionParameterReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_PARAMETER_DESC>;
@@ -2313,6 +2343,7 @@ impl ID3D11FunctionParameterReflection {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 pub trait ID3D11FunctionReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_FUNCTION_DESC>;
@@ -2405,6 +2436,7 @@ impl ID3D11FunctionReflection {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11GeometryShader_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D11GeometryShader {}
 impl ID3D11GeometryShader_Vtbl {
@@ -2415,6 +2447,7 @@ impl ID3D11GeometryShader_Vtbl {
         iid == &<ID3D11GeometryShader as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11HullShader_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D11HullShader {}
 impl ID3D11HullShader_Vtbl {
@@ -2425,6 +2458,7 @@ impl ID3D11HullShader_Vtbl {
         iid == &<ID3D11HullShader as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11InfoQueue_Impl: Sized {
     fn SetMessageCountLimit(&self, messagecountlimit: u64) -> ::windows::core::Result<()>;
@@ -2686,6 +2720,7 @@ impl ID3D11InfoQueue_Vtbl {
         iid == &<ID3D11InfoQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11InputLayout_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D11InputLayout {}
 impl ID3D11InputLayout_Vtbl {
@@ -2696,6 +2731,7 @@ impl ID3D11InputLayout_Vtbl {
         iid == &<ID3D11InputLayout as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11LibraryReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_LIBRARY_DESC>;
     fn GetFunctionByIndex(&self, functionindex: i32) -> ::core::option::Option<ID3D11FunctionReflection>;
@@ -2729,6 +2765,7 @@ impl ID3D11LibraryReflection_Vtbl {
         iid == &<ID3D11LibraryReflection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11Linker_Impl: Sized {
     fn Link(&self, pentry: &::core::option::Option<ID3D11ModuleInstance>, pentryname: &::windows::core::PCSTR, ptargetname: &::windows::core::PCSTR, uflags: u32, ppshaderblob: *mut ::core::option::Option<super::Direct3D::ID3DBlob>, pperrorbuffer: *mut ::core::option::Option<super::Direct3D::ID3DBlob>) -> ::windows::core::Result<()>;
@@ -2766,6 +2803,7 @@ impl ID3D11Linker_Vtbl {
         iid == &<ID3D11Linker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11LinkingNode_Impl: Sized {}
 impl ::windows::core::RuntimeName for ID3D11LinkingNode {}
 impl ID3D11LinkingNode_Vtbl {
@@ -2776,6 +2814,7 @@ impl ID3D11LinkingNode_Vtbl {
         iid == &<ID3D11LinkingNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Module_Impl: Sized {
     fn CreateInstance(&self, pnamespace: &::windows::core::PCSTR) -> ::windows::core::Result<ID3D11ModuleInstance>;
 }
@@ -2799,6 +2838,7 @@ impl ID3D11Module_Vtbl {
         iid == &<ID3D11Module as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11ModuleInstance_Impl: Sized {
     fn BindConstantBuffer(&self, usrcslot: u32, udstslot: u32, cbdstoffset: u32) -> ::windows::core::Result<()>;
     fn BindConstantBufferByName(&self, pname: &::windows::core::PCSTR, udstslot: u32, cbdstoffset: u32) -> ::windows::core::Result<()>;
@@ -2882,6 +2922,7 @@ impl ID3D11ModuleInstance_Vtbl {
         iid == &<ID3D11ModuleInstance as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11Multithread_Impl: Sized {
     fn Enter(&self);
@@ -2926,6 +2967,7 @@ impl ID3D11Multithread_Vtbl {
         iid == &<ID3D11Multithread as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11PixelShader_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D11PixelShader {}
 impl ID3D11PixelShader_Vtbl {
@@ -2936,6 +2978,7 @@ impl ID3D11PixelShader_Vtbl {
         iid == &<ID3D11PixelShader as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Predicate_Impl: Sized + ID3D11Query_Impl {}
 impl ::windows::core::RuntimeName for ID3D11Predicate {}
 impl ID3D11Predicate_Vtbl {
@@ -2946,6 +2989,7 @@ impl ID3D11Predicate_Vtbl {
         iid == &<ID3D11Predicate as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Asynchronous as ::windows::core::Interface>::IID || iid == &<ID3D11Query as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Query_Impl: Sized + ID3D11Asynchronous_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_QUERY_DESC);
 }
@@ -2963,6 +3007,7 @@ impl ID3D11Query_Vtbl {
         iid == &<ID3D11Query as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Asynchronous as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Query1_Impl: Sized + ID3D11Query_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_QUERY_DESC1);
 }
@@ -2980,6 +3025,7 @@ impl ID3D11Query1_Vtbl {
         iid == &<ID3D11Query1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Asynchronous as ::windows::core::Interface>::IID || iid == &<ID3D11Query as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11RasterizerState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_RASTERIZER_DESC);
@@ -3000,6 +3046,7 @@ impl ID3D11RasterizerState_Vtbl {
         iid == &<ID3D11RasterizerState as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11RasterizerState1_Impl: Sized + ID3D11RasterizerState_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_RASTERIZER_DESC1);
@@ -3020,6 +3067,7 @@ impl ID3D11RasterizerState1_Vtbl {
         iid == &<ID3D11RasterizerState1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11RasterizerState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11RasterizerState2_Impl: Sized + ID3D11RasterizerState1_Impl {
     fn GetDesc2(&self, pdesc: *mut D3D11_RASTERIZER_DESC2);
@@ -3040,6 +3088,7 @@ impl ID3D11RasterizerState2_Vtbl {
         iid == &<ID3D11RasterizerState2 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11RasterizerState as ::windows::core::Interface>::IID || iid == &<ID3D11RasterizerState1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11RefDefaultTrackingOptions_Impl: Sized {
     fn SetTrackingOptions(&self, resourcetypeflags: u32, options: u32) -> ::windows::core::Result<()>;
 }
@@ -3057,6 +3106,7 @@ impl ID3D11RefDefaultTrackingOptions_Vtbl {
         iid == &<ID3D11RefDefaultTrackingOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11RefTrackingOptions_Impl: Sized {
     fn SetTrackingOptions(&self, uoptions: u32) -> ::windows::core::Result<()>;
 }
@@ -3074,6 +3124,7 @@ impl ID3D11RefTrackingOptions_Vtbl {
         iid == &<ID3D11RefTrackingOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11RenderTargetView_Impl: Sized + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_RENDER_TARGET_VIEW_DESC);
@@ -3094,6 +3145,7 @@ impl ID3D11RenderTargetView_Vtbl {
         iid == &<ID3D11RenderTargetView as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11RenderTargetView1_Impl: Sized + ID3D11RenderTargetView_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_RENDER_TARGET_VIEW_DESC1);
@@ -3114,6 +3166,7 @@ impl ID3D11RenderTargetView1_Vtbl {
         iid == &<ID3D11RenderTargetView1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID || iid == &<ID3D11RenderTargetView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11Resource_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetType(&self, presourcedimension: *mut D3D11_RESOURCE_DIMENSION);
     fn SetEvictionPriority(&self, evictionpriority: u32);
@@ -3148,6 +3201,7 @@ impl ID3D11Resource_Vtbl {
         iid == &<ID3D11Resource as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11SamplerState_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SAMPLER_DESC);
 }
@@ -3165,6 +3219,7 @@ impl ID3D11SamplerState_Vtbl {
         iid == &<ID3D11SamplerState as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 pub trait ID3D11ShaderReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_SHADER_DESC>;
@@ -3356,6 +3411,7 @@ impl ID3D11ShaderReflection_Vtbl {
         iid == &<ID3D11ShaderReflection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_BUFFER_DESC) -> ::windows::core::Result<()>;
@@ -3398,6 +3454,7 @@ impl ID3D11ShaderReflectionConstantBuffer {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D11ShaderReflectionType_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_SHADER_TYPE_DESC>;
@@ -3506,6 +3563,7 @@ impl ID3D11ShaderReflectionType {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11ShaderReflectionVariable_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D11_SHADER_VARIABLE_DESC>;
     fn GetType(&self) -> ::core::option::Option<ID3D11ShaderReflectionType>;
@@ -3555,6 +3613,7 @@ impl ID3D11ShaderReflectionVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11ShaderResourceView_Impl: Sized + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_SHADER_RESOURCE_VIEW_DESC);
@@ -3575,6 +3634,7 @@ impl ID3D11ShaderResourceView_Vtbl {
         iid == &<ID3D11ShaderResourceView as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11ShaderResourceView1_Impl: Sized + ID3D11ShaderResourceView_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_SHADER_RESOURCE_VIEW_DESC1);
@@ -3595,6 +3655,7 @@ impl ID3D11ShaderResourceView1_Vtbl {
         iid == &<ID3D11ShaderResourceView1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID || iid == &<ID3D11ShaderResourceView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11ShaderTrace_Impl: Sized {
     fn TraceReady(&self, ptestcount: *mut u64) -> ::windows::core::Result<()>;
@@ -3685,6 +3746,7 @@ impl ID3D11ShaderTrace_Vtbl {
         iid == &<ID3D11ShaderTrace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11ShaderTraceFactory_Impl: Sized {
     fn CreateShaderTrace(&self, pshader: &::core::option::Option<::windows::core::IUnknown>, ptracedesc: *const D3D11_SHADER_TRACE_DESC) -> ::windows::core::Result<ID3D11ShaderTrace>;
 }
@@ -3708,6 +3770,7 @@ impl ID3D11ShaderTraceFactory_Vtbl {
         iid == &<ID3D11ShaderTraceFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D11SwitchToRef_Impl: Sized {
     fn SetUseRef(&self, useref: super::super::Foundation::BOOL) -> super::super::Foundation::BOOL;
@@ -3738,6 +3801,7 @@ impl ID3D11SwitchToRef_Vtbl {
         iid == &<ID3D11SwitchToRef as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture1D_Impl: Sized + ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE1D_DESC);
@@ -3758,6 +3822,7 @@ impl ID3D11Texture1D_Vtbl {
         iid == &<ID3D11Texture1D as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture2D_Impl: Sized + ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE2D_DESC);
@@ -3778,6 +3843,7 @@ impl ID3D11Texture2D_Vtbl {
         iid == &<ID3D11Texture2D as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture2D1_Impl: Sized + ID3D11Texture2D_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_TEXTURE2D_DESC1);
@@ -3798,6 +3864,7 @@ impl ID3D11Texture2D1_Vtbl {
         iid == &<ID3D11Texture2D1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Resource as ::windows::core::Interface>::IID || iid == &<ID3D11Texture2D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture3D_Impl: Sized + ID3D11Resource_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_TEXTURE3D_DESC);
@@ -3818,6 +3885,7 @@ impl ID3D11Texture3D_Vtbl {
         iid == &<ID3D11Texture3D as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11Texture3D1_Impl: Sized + ID3D11Texture3D_Impl {
     fn GetDesc1(&self, pdesc: *mut D3D11_TEXTURE3D_DESC1);
@@ -3838,6 +3906,7 @@ impl ID3D11Texture3D1_Vtbl {
         iid == &<ID3D11Texture3D1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11Resource as ::windows::core::Interface>::IID || iid == &<ID3D11Texture3D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11TracingDevice_Impl: Sized {
     fn SetShaderTrackingOptionsByType(&self, resourcetypeflags: u32, options: u32) -> ::windows::core::Result<()>;
     fn SetShaderTrackingOptions(&self, pshader: &::core::option::Option<::windows::core::IUnknown>, options: u32) -> ::windows::core::Result<()>;
@@ -3865,6 +3934,7 @@ impl ID3D11TracingDevice_Vtbl {
         iid == &<ID3D11TracingDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11UnorderedAccessView_Impl: Sized + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC);
@@ -3885,6 +3955,7 @@ impl ID3D11UnorderedAccessView_Vtbl {
         iid == &<ID3D11UnorderedAccessView as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11UnorderedAccessView1_Impl: Sized + ID3D11UnorderedAccessView_Impl {
     fn GetDesc1(&self, pdesc1: *mut D3D11_UNORDERED_ACCESS_VIEW_DESC1);
@@ -3905,6 +3976,7 @@ impl ID3D11UnorderedAccessView1_Vtbl {
         iid == &<ID3D11UnorderedAccessView1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID || iid == &<ID3D11UnorderedAccessView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11VertexShader_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D11VertexShader {}
 impl ID3D11VertexShader_Vtbl {
@@ -3915,6 +3987,7 @@ impl ID3D11VertexShader_Vtbl {
         iid == &<ID3D11VertexShader as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoContext_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetDecoderBuffer(&self, pdecoder: &::core::option::Option<ID3D11VideoDecoder>, r#type: D3D11_VIDEO_DECODER_BUFFER_TYPE, pbuffersize: *mut u32, ppbuffer: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -4343,6 +4416,7 @@ impl ID3D11VideoContext_Vtbl {
         iid == &<ID3D11VideoContext as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoContext1_Impl: Sized + ID3D11VideoContext_Impl {
     fn SubmitDecoderBuffers1(&self, pdecoder: &::core::option::Option<ID3D11VideoDecoder>, numbuffers: u32, pbufferdesc: *const D3D11_VIDEO_DECODER_BUFFER_DESC1) -> ::windows::core::Result<()>;
@@ -4475,6 +4549,7 @@ impl ID3D11VideoContext1_Vtbl {
         iid == &<ID3D11VideoContext1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11VideoContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoContext2_Impl: Sized + ID3D11VideoContext1_Impl {
     fn VideoProcessorSetOutputHDRMetaData(&self, pvideoprocessor: &::core::option::Option<ID3D11VideoProcessor>, r#type: super::Dxgi::DXGI_HDR_METADATA_TYPE, size: u32, phdrmetadata: *const ::core::ffi::c_void);
@@ -4519,6 +4594,7 @@ impl ID3D11VideoContext2_Vtbl {
         iid == &<ID3D11VideoContext2 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11VideoContext as ::windows::core::Interface>::IID || iid == &<ID3D11VideoContext1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoContext3_Impl: Sized + ID3D11VideoContext2_Impl {
     fn DecoderBeginFrame1(&self, pdecoder: &::core::option::Option<ID3D11VideoDecoder>, pview: &::core::option::Option<ID3D11VideoDecoderOutputView>, contentkeysize: u32, pcontentkey: *const ::core::ffi::c_void, numcomponenthistograms: u32, phistogramoffsets: *const u32, pphistogrambuffers: *const ::core::option::Option<ID3D11Buffer>) -> ::windows::core::Result<()>;
@@ -4549,6 +4625,7 @@ impl ID3D11VideoContext3_Vtbl {
         iid == &<ID3D11VideoContext3 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11VideoContext as ::windows::core::Interface>::IID || iid == &<ID3D11VideoContext1 as ::windows::core::Interface>::IID || iid == &<ID3D11VideoContext2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoDecoder_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetCreationParameters(&self, pvideodesc: *mut D3D11_VIDEO_DECODER_DESC, pconfig: *mut D3D11_VIDEO_DECODER_CONFIG) -> ::windows::core::Result<()>;
@@ -4585,6 +4662,7 @@ impl ID3D11VideoDecoder_Vtbl {
         iid == &<ID3D11VideoDecoder as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11VideoDecoderOutputView_Impl: Sized + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC);
 }
@@ -4602,6 +4680,7 @@ impl ID3D11VideoDecoderOutputView_Vtbl {
         iid == &<ID3D11VideoDecoderOutputView as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoDevice_Impl: Sized {
     fn CreateVideoDecoder(&self, pvideodesc: *const D3D11_VIDEO_DECODER_DESC, pconfig: *const D3D11_VIDEO_DECODER_CONFIG) -> ::windows::core::Result<ID3D11VideoDecoder>;
@@ -4803,6 +4882,7 @@ impl ID3D11VideoDevice_Vtbl {
         iid == &<ID3D11VideoDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoDevice1_Impl: Sized + ID3D11VideoDevice_Impl {
     fn GetCryptoSessionPrivateDataSize(&self, pcryptotype: *const ::windows::core::GUID, pdecoderprofile: *const ::windows::core::GUID, pkeyexchangetype: *const ::windows::core::GUID, pprivateinputsize: *mut u32, pprivateoutputsize: *mut u32) -> ::windows::core::Result<()>;
@@ -4859,6 +4939,7 @@ impl ID3D11VideoDevice1_Vtbl {
         iid == &<ID3D11VideoDevice1 as ::windows::core::Interface>::IID || iid == &<ID3D11VideoDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoDevice2_Impl: Sized + ID3D11VideoDevice1_Impl {
     fn CheckFeatureSupport(&self, feature: D3D11_FEATURE_VIDEO, pfeaturesupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::Result<()>;
@@ -4889,6 +4970,7 @@ impl ID3D11VideoDevice2_Vtbl {
         iid == &<ID3D11VideoDevice2 as ::windows::core::Interface>::IID || iid == &<ID3D11VideoDevice as ::windows::core::Interface>::IID || iid == &<ID3D11VideoDevice1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D11VideoProcessor_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetContentDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_CONTENT_DESC);
@@ -4919,6 +5001,7 @@ impl ID3D11VideoProcessor_Vtbl {
         iid == &<ID3D11VideoProcessor as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoProcessorEnumerator_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetVideoProcessorContentDesc(&self) -> ::windows::core::Result<D3D11_VIDEO_PROCESSOR_CONTENT_DESC>;
@@ -5013,6 +5096,7 @@ impl ID3D11VideoProcessorEnumerator_Vtbl {
         iid == &<ID3D11VideoProcessorEnumerator as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D11VideoProcessorEnumerator1_Impl: Sized + ID3D11VideoProcessorEnumerator_Impl {
     fn CheckVideoProcessorFormatConversion(&self, inputformat: super::Dxgi::Common::DXGI_FORMAT, inputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE, outputformat: super::Dxgi::Common::DXGI_FORMAT, outputcolorspace: super::Dxgi::Common::DXGI_COLOR_SPACE_TYPE) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -5042,6 +5126,7 @@ impl ID3D11VideoProcessorEnumerator1_Vtbl {
         iid == &<ID3D11VideoProcessorEnumerator1 as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11VideoProcessorEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11VideoProcessorInputView_Impl: Sized + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_INPUT_VIEW_DESC);
 }
@@ -5059,6 +5144,7 @@ impl ID3D11VideoProcessorInputView_Vtbl {
         iid == &<ID3D11VideoProcessorInputView as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11VideoProcessorOutputView_Impl: Sized + ID3D11View_Impl {
     fn GetDesc(&self, pdesc: *mut D3D11_VIDEO_PROCESSOR_OUTPUT_VIEW_DESC);
 }
@@ -5076,6 +5162,7 @@ impl ID3D11VideoProcessorOutputView_Vtbl {
         iid == &<ID3D11VideoProcessorOutputView as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D11View as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3D11View_Impl: Sized + ID3D11DeviceChild_Impl {
     fn GetResource(&self, ppresource: *mut ::core::option::Option<ID3D11Resource>);
 }
@@ -5093,6 +5180,7 @@ impl ID3D11View_Vtbl {
         iid == &<ID3D11View as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3DDeviceContextState_Impl: Sized + ID3D11DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3DDeviceContextState {}
 impl ID3DDeviceContextState_Vtbl {
@@ -5103,6 +5191,7 @@ impl ID3DDeviceContextState_Vtbl {
         iid == &<ID3DDeviceContextState as ::windows::core::Interface>::IID || iid == &<ID3D11DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3DUserDefinedAnnotation_Impl: Sized {
     fn BeginEvent(&self, name: &::windows::core::PCWSTR) -> i32;
@@ -5147,6 +5236,7 @@ impl ID3DUserDefinedAnnotation_Vtbl {
         iid == &<ID3DUserDefinedAnnotation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3DX11FFT_Impl: Sized {
     fn SetForwardScale(&self, forwardscale: f32) -> ::windows::core::Result<()>;
     fn GetForwardScale(&self) -> f32;
@@ -5209,6 +5299,7 @@ impl ID3DX11FFT_Vtbl {
         iid == &<ID3DX11FFT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3DX11Scan_Impl: Sized {
     fn SetScanDirection(&self, direction: D3DX11_SCAN_DIRECTION) -> ::windows::core::Result<()>;
     fn Scan(&self, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: &::core::option::Option<ID3D11UnorderedAccessView>, pdst: &::core::option::Option<ID3D11UnorderedAccessView>) -> ::windows::core::Result<()>;
@@ -5243,6 +5334,7 @@ impl ID3DX11Scan_Vtbl {
         iid == &<ID3DX11Scan as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`, `\"implement\"`*"]
 pub trait ID3DX11SegmentedScan_Impl: Sized {
     fn SetScanDirection(&self, direction: D3DX11_SCAN_DIRECTION) -> ::windows::core::Result<()>;
     fn SegScan(&self, elementtype: D3DX11_SCAN_DATA_TYPE, opcode: D3DX11_SCAN_OPCODE, elementscansize: u32, psrc: &::core::option::Option<ID3D11UnorderedAccessView>, psrcelementflags: &::core::option::Option<ID3D11UnorderedAccessView>, pdst: &::core::option::Option<ID3D11UnorderedAccessView>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11on12\"`, `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D11On12Device_Impl: Sized {
     fn CreateWrappedResource(&self, presource12: &::core::option::Option<::windows::core::IUnknown>, pflags11: *const D3D11_RESOURCE_FLAGS, instate: super::Direct3D12::D3D12_RESOURCE_STATES, outstate: super::Direct3D12::D3D12_RESOURCE_STATES, riid: *const ::windows::core::GUID, ppresource11: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -35,6 +36,7 @@ impl ID3D11On12Device_Vtbl {
         iid == &<ID3D11On12Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11on12\"`, `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D11On12Device1_Impl: Sized + ID3D11On12Device_Impl {
     fn GetD3D12Device(&self, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -55,6 +57,7 @@ impl ID3D11On12Device1_Vtbl {
         iid == &<ID3D11On12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D11On12Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D11on12\"`, `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D11On12Device2_Impl: Sized + ID3D11On12Device1_Impl {
     fn UnwrapUnderlyingResource(&self, presource11: &::core::option::Option<super::Direct3D11::ID3D11Resource>, pcommandqueue: &::core::option::Option<super::Direct3D12::ID3D12CommandQueue>, riid: *const ::windows::core::GUID, ppvresource12: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12CommandAllocator_Impl: Sized + ID3D12Pageable_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl ID3D12CommandAllocator_Vtbl {
         iid == &<ID3D12CommandAllocator as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12CommandList_Impl: Sized + ID3D12DeviceChild_Impl {
     fn GetType(&self) -> D3D12_COMMAND_LIST_TYPE;
 }
@@ -32,6 +34,7 @@ impl ID3D12CommandList_Vtbl {
         iid == &<ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12CommandQueue_Impl: Sized + ID3D12Pageable_Impl {
     fn UpdateTileMappings(&self, presource: &::core::option::Option<ID3D12Resource>, numresourceregions: u32, presourceregionstartcoordinates: *const D3D12_TILED_RESOURCE_COORDINATE, presourceregionsizes: *const D3D12_TILE_REGION_SIZE, pheap: &::core::option::Option<ID3D12Heap>, numranges: u32, prangeflags: *const D3D12_TILE_RANGE_FLAGS, pheaprangestartoffsets: *const u32, prangetilecounts: *const u32, flags: D3D12_TILE_MAPPING_FLAGS);
@@ -131,6 +134,7 @@ impl ID3D12CommandQueue_Vtbl {
         iid == &<ID3D12CommandQueue as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12CommandSignature_Impl: Sized + ID3D12Pageable_Impl {}
 impl ::windows::core::RuntimeName for ID3D12CommandSignature {}
 impl ID3D12CommandSignature_Vtbl {
@@ -141,6 +145,7 @@ impl ID3D12CommandSignature_Vtbl {
         iid == &<ID3D12CommandSignature as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12Debug_Impl: Sized {
     fn EnableDebugLayer(&self);
 }
@@ -158,6 +163,7 @@ impl ID3D12Debug_Vtbl {
         iid == &<ID3D12Debug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12Debug1_Impl: Sized {
     fn EnableDebugLayer(&self);
@@ -195,6 +201,7 @@ impl ID3D12Debug1_Vtbl {
         iid == &<ID3D12Debug1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12Debug2_Impl: Sized {
     fn SetGPUBasedValidationFlags(&self, flags: D3D12_GPU_BASED_VALIDATION_FLAGS);
 }
@@ -215,6 +222,7 @@ impl ID3D12Debug2_Vtbl {
         iid == &<ID3D12Debug2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12Debug3_Impl: Sized + ID3D12Debug_Impl {
     fn SetEnableGPUBasedValidation(&self, enable: super::super::Foundation::BOOL);
@@ -252,6 +260,7 @@ impl ID3D12Debug3_Vtbl {
         iid == &<ID3D12Debug3 as ::windows::core::Interface>::IID || iid == &<ID3D12Debug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12Debug4_Impl: Sized + ID3D12Debug3_Impl {
     fn DisableDebugLayer(&self);
@@ -272,6 +281,7 @@ impl ID3D12Debug4_Vtbl {
         iid == &<ID3D12Debug4 as ::windows::core::Interface>::IID || iid == &<ID3D12Debug as ::windows::core::Interface>::IID || iid == &<ID3D12Debug3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12Debug5_Impl: Sized + ID3D12Debug4_Impl {
     fn SetEnableAutoName(&self, enable: super::super::Foundation::BOOL);
@@ -292,6 +302,7 @@ impl ID3D12Debug5_Vtbl {
         iid == &<ID3D12Debug5 as ::windows::core::Interface>::IID || iid == &<ID3D12Debug as ::windows::core::Interface>::IID || iid == &<ID3D12Debug3 as ::windows::core::Interface>::IID || iid == &<ID3D12Debug4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12DebugCommandList_Impl: Sized {
     fn AssertResourceState(&self, presource: &::core::option::Option<ID3D12Resource>, subresource: u32, state: u32) -> super::super::Foundation::BOOL;
@@ -329,6 +340,7 @@ impl ID3D12DebugCommandList_Vtbl {
         iid == &<ID3D12DebugCommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12DebugCommandList1_Impl: Sized {
     fn AssertResourceState(&self, presource: &::core::option::Option<ID3D12Resource>, subresource: u32, state: u32) -> super::super::Foundation::BOOL;
@@ -366,6 +378,7 @@ impl ID3D12DebugCommandList1_Vtbl {
         iid == &<ID3D12DebugCommandList1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12DebugCommandList2_Impl: Sized + ID3D12DebugCommandList_Impl {
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_COMMAND_LIST_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
@@ -396,6 +409,7 @@ impl ID3D12DebugCommandList2_Vtbl {
         iid == &<ID3D12DebugCommandList2 as ::windows::core::Interface>::IID || iid == &<ID3D12DebugCommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12DebugCommandQueue_Impl: Sized {
     fn AssertResourceState(&self, presource: &::core::option::Option<ID3D12Resource>, subresource: u32, state: u32) -> super::super::Foundation::BOOL;
@@ -416,6 +430,7 @@ impl ID3D12DebugCommandQueue_Vtbl {
         iid == &<ID3D12DebugCommandQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DebugDevice_Impl: Sized {
     fn SetFeatureMask(&self, mask: D3D12_DEBUG_FEATURE) -> ::windows::core::Result<()>;
     fn GetFeatureMask(&self) -> D3D12_DEBUG_FEATURE;
@@ -450,6 +465,7 @@ impl ID3D12DebugDevice_Vtbl {
         iid == &<ID3D12DebugDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DebugDevice1_Impl: Sized {
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *mut ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
@@ -484,6 +500,7 @@ impl ID3D12DebugDevice1_Vtbl {
         iid == &<ID3D12DebugDevice1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DebugDevice2_Impl: Sized + ID3D12DebugDevice_Impl {
     fn SetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *const ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
     fn GetDebugParameter(&self, r#type: D3D12_DEBUG_DEVICE_PARAMETER_TYPE, pdata: *mut ::core::ffi::c_void, datasize: u32) -> ::windows::core::Result<()>;
@@ -511,6 +528,7 @@ impl ID3D12DebugDevice2_Vtbl {
         iid == &<ID3D12DebugDevice2 as ::windows::core::Interface>::IID || iid == &<ID3D12DebugDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DescriptorHeap_Impl: Sized + ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_DESCRIPTOR_HEAP_DESC;
     fn GetCPUDescriptorHandleForHeapStart(&self) -> D3D12_CPU_DESCRIPTOR_HANDLE;
@@ -545,6 +563,7 @@ impl ID3D12DescriptorHeap_Vtbl {
         iid == &<ID3D12DescriptorHeap as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device_Impl: Sized + ID3D12Object_Impl {
     fn GetNodeCount(&self) -> u32;
@@ -832,6 +851,7 @@ impl ID3D12Device_Vtbl {
         iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device1_Impl: Sized + ID3D12Device_Impl {
     fn CreatePipelineLibrary(&self, plibraryblob: *const ::core::ffi::c_void, bloblength: usize, riid: *const ::windows::core::GUID, pppipelinelibrary: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -869,6 +889,7 @@ impl ID3D12Device1_Vtbl {
         iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device2_Impl: Sized + ID3D12Device1_Impl {
     fn CreatePipelineState(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const ::windows::core::GUID, pppipelinestate: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -889,6 +910,7 @@ impl ID3D12Device2_Vtbl {
         iid == &<ID3D12Device2 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device3_Impl: Sized + ID3D12Device2_Impl {
     fn OpenExistingHeapFromAddress(&self, paddress: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, ppvheap: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -926,6 +948,7 @@ impl ID3D12Device3_Vtbl {
         iid == &<ID3D12Device3 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Device2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device4_Impl: Sized + ID3D12Device3_Impl {
     fn CreateCommandList1(&self, nodemask: u32, r#type: D3D12_COMMAND_LIST_TYPE, flags: D3D12_COMMAND_LIST_FLAGS, riid: *const ::windows::core::GUID, ppcommandlist: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -984,6 +1007,7 @@ impl ID3D12Device4_Vtbl {
         iid == &<ID3D12Device4 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Device2 as ::windows::core::Interface>::IID || iid == &<ID3D12Device3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device5_Impl: Sized + ID3D12Device4_Impl {
     fn CreateLifetimeTracker(&self, powner: &::core::option::Option<ID3D12LifetimeOwner>, riid: *const ::windows::core::GUID, ppvtracker: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1056,6 +1080,7 @@ impl ID3D12Device5_Vtbl {
         iid == &<ID3D12Device5 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Device2 as ::windows::core::Interface>::IID || iid == &<ID3D12Device3 as ::windows::core::Interface>::IID || iid == &<ID3D12Device4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device6_Impl: Sized + ID3D12Device5_Impl {
     fn SetBackgroundProcessingMode(&self, mode: D3D12_BACKGROUND_PROCESSING_MODE, measurementsaction: D3D12_MEASUREMENTS_ACTION, heventtosignaluponcompletion: super::super::Foundation::HANDLE, pbfurthermeasurementsdesired: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1076,6 +1101,7 @@ impl ID3D12Device6_Vtbl {
         iid == &<ID3D12Device6 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Device2 as ::windows::core::Interface>::IID || iid == &<ID3D12Device3 as ::windows::core::Interface>::IID || iid == &<ID3D12Device4 as ::windows::core::Interface>::IID || iid == &<ID3D12Device5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device7_Impl: Sized + ID3D12Device6_Impl {
     fn AddToStateObject(&self, paddition: *const D3D12_STATE_OBJECT_DESC, pstateobjecttogrowfrom: &::core::option::Option<ID3D12StateObject>, riid: *const ::windows::core::GUID, ppnewstateobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1106,6 +1132,7 @@ impl ID3D12Device7_Vtbl {
         iid == &<ID3D12Device7 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Device2 as ::windows::core::Interface>::IID || iid == &<ID3D12Device3 as ::windows::core::Interface>::IID || iid == &<ID3D12Device4 as ::windows::core::Interface>::IID || iid == &<ID3D12Device5 as ::windows::core::Interface>::IID || iid == &<ID3D12Device6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device8_Impl: Sized + ID3D12Device7_Impl {
     fn GetResourceAllocationInfo2(&self, visiblemask: u32, numresourcedescs: u32, presourcedescs: *const D3D12_RESOURCE_DESC1, presourceallocationinfo1: *mut D3D12_RESOURCE_ALLOCATION_INFO1) -> D3D12_RESOURCE_ALLOCATION_INFO;
@@ -1157,6 +1184,7 @@ impl ID3D12Device8_Vtbl {
         iid == &<ID3D12Device8 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Device2 as ::windows::core::Interface>::IID || iid == &<ID3D12Device3 as ::windows::core::Interface>::IID || iid == &<ID3D12Device4 as ::windows::core::Interface>::IID || iid == &<ID3D12Device5 as ::windows::core::Interface>::IID || iid == &<ID3D12Device6 as ::windows::core::Interface>::IID || iid == &<ID3D12Device7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Security"))]
 pub trait ID3D12Device9_Impl: Sized + ID3D12Device8_Impl {
     fn CreateShaderCacheSession(&self, pdesc: *const D3D12_SHADER_CACHE_SESSION_DESC, riid: *const ::windows::core::GUID, ppvsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1194,6 +1222,7 @@ impl ID3D12Device9_Vtbl {
         iid == &<ID3D12Device9 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12Device as ::windows::core::Interface>::IID || iid == &<ID3D12Device1 as ::windows::core::Interface>::IID || iid == &<ID3D12Device2 as ::windows::core::Interface>::IID || iid == &<ID3D12Device3 as ::windows::core::Interface>::IID || iid == &<ID3D12Device4 as ::windows::core::Interface>::IID || iid == &<ID3D12Device5 as ::windows::core::Interface>::IID || iid == &<ID3D12Device6 as ::windows::core::Interface>::IID || iid == &<ID3D12Device7 as ::windows::core::Interface>::IID || iid == &<ID3D12Device8 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DeviceChild_Impl: Sized + ID3D12Object_Impl {
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1211,6 +1240,7 @@ impl ID3D12DeviceChild_Vtbl {
         iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DeviceRemovedExtendedData_Impl: Sized {
     fn GetAutoBreadcrumbsOutput(&self) -> ::windows::core::Result<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT>;
     fn GetPageFaultAllocationOutput(&self) -> ::windows::core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT>;
@@ -1250,6 +1280,7 @@ impl ID3D12DeviceRemovedExtendedData_Vtbl {
         iid == &<ID3D12DeviceRemovedExtendedData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DeviceRemovedExtendedData1_Impl: Sized + ID3D12DeviceRemovedExtendedData_Impl {
     fn GetAutoBreadcrumbsOutput1(&self) -> ::windows::core::Result<D3D12_DRED_AUTO_BREADCRUMBS_OUTPUT1>;
     fn GetPageFaultAllocationOutput1(&self) -> ::windows::core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT1>;
@@ -1289,6 +1320,7 @@ impl ID3D12DeviceRemovedExtendedData1_Vtbl {
         iid == &<ID3D12DeviceRemovedExtendedData1 as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceRemovedExtendedData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DeviceRemovedExtendedData2_Impl: Sized + ID3D12DeviceRemovedExtendedData1_Impl {
     fn GetPageFaultAllocationOutput2(&self) -> ::windows::core::Result<D3D12_DRED_PAGE_FAULT_OUTPUT2>;
     fn GetDeviceState(&self) -> D3D12_DRED_DEVICE_STATE;
@@ -1322,6 +1354,7 @@ impl ID3D12DeviceRemovedExtendedData2_Vtbl {
         iid == &<ID3D12DeviceRemovedExtendedData2 as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceRemovedExtendedData as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceRemovedExtendedData1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DeviceRemovedExtendedDataSettings_Impl: Sized {
     fn SetAutoBreadcrumbsEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
     fn SetPageFaultEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
@@ -1356,6 +1389,7 @@ impl ID3D12DeviceRemovedExtendedDataSettings_Vtbl {
         iid == &<ID3D12DeviceRemovedExtendedDataSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12DeviceRemovedExtendedDataSettings1_Impl: Sized + ID3D12DeviceRemovedExtendedDataSettings_Impl {
     fn SetBreadcrumbContextEnablement(&self, enablement: D3D12_DRED_ENABLEMENT);
 }
@@ -1376,6 +1410,7 @@ impl ID3D12DeviceRemovedExtendedDataSettings1_Vtbl {
         iid == &<ID3D12DeviceRemovedExtendedDataSettings1 as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceRemovedExtendedDataSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12Fence_Impl: Sized + ID3D12Pageable_Impl {
     fn GetCompletedValue(&self) -> u64;
@@ -1413,6 +1448,7 @@ impl ID3D12Fence_Vtbl {
         iid == &<ID3D12Fence as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12Fence1_Impl: Sized + ID3D12Fence_Impl {
     fn GetCreationFlags(&self) -> D3D12_FENCE_FLAGS;
@@ -1433,6 +1469,7 @@ impl ID3D12Fence1_Vtbl {
         iid == &<ID3D12Fence1 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12Fence as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12FunctionParameterReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_PARAMETER_DESC>;
@@ -1469,6 +1506,7 @@ impl ID3D12FunctionParameterReflection {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 pub trait ID3D12FunctionReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_FUNCTION_DESC>;
@@ -1561,6 +1599,7 @@ impl ID3D12FunctionReflection {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList_Impl: Sized + ID3D12CommandList_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -1934,6 +1973,7 @@ impl ID3D12GraphicsCommandList_Vtbl {
         iid == &<ID3D12GraphicsCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12CommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList1_Impl: Sized + ID3D12GraphicsCommandList_Impl {
     fn AtomicCopyBufferUINT(&self, pdstbuffer: &::core::option::Option<ID3D12Resource>, dstoffset: u64, psrcbuffer: &::core::option::Option<ID3D12Resource>, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64);
@@ -1992,6 +2032,7 @@ impl ID3D12GraphicsCommandList1_Vtbl {
         iid == &<ID3D12GraphicsCommandList1 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList2_Impl: Sized + ID3D12GraphicsCommandList1_Impl {
     fn WriteBufferImmediate(&self, count: u32, pparams: *const D3D12_WRITEBUFFERIMMEDIATE_PARAMETER, pmodes: *const D3D12_WRITEBUFFERIMMEDIATE_MODE);
@@ -2012,6 +2053,7 @@ impl ID3D12GraphicsCommandList2_Vtbl {
         iid == &<ID3D12GraphicsCommandList2 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList3_Impl: Sized + ID3D12GraphicsCommandList2_Impl {
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: &::core::option::Option<ID3D12ProtectedResourceSession>);
@@ -2035,6 +2077,7 @@ impl ID3D12GraphicsCommandList3_Vtbl {
         iid == &<ID3D12GraphicsCommandList3 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList1 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList4_Impl: Sized + ID3D12GraphicsCommandList3_Impl {
     fn BeginRenderPass(&self, numrendertargets: u32, prendertargets: *const D3D12_RENDER_PASS_RENDER_TARGET_DESC, pdepthstencil: *const D3D12_RENDER_PASS_DEPTH_STENCIL_DESC, flags: D3D12_RENDER_PASS_FLAGS);
@@ -2114,6 +2157,7 @@ impl ID3D12GraphicsCommandList4_Vtbl {
         iid == &<ID3D12GraphicsCommandList4 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList1 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList2 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList5_Impl: Sized + ID3D12GraphicsCommandList4_Impl {
     fn RSSetShadingRate(&self, baseshadingrate: D3D12_SHADING_RATE, combiners: *const D3D12_SHADING_RATE_COMBINER);
@@ -2144,6 +2188,7 @@ impl ID3D12GraphicsCommandList5_Vtbl {
         iid == &<ID3D12GraphicsCommandList5 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList1 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList2 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList3 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12GraphicsCommandList6_Impl: Sized + ID3D12GraphicsCommandList5_Impl {
     fn DispatchMesh(&self, threadgroupcountx: u32, threadgroupcounty: u32, threadgroupcountz: u32);
@@ -2164,6 +2209,7 @@ impl ID3D12GraphicsCommandList6_Vtbl {
         iid == &<ID3D12GraphicsCommandList6 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList1 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList2 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList3 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList4 as ::windows::core::Interface>::IID || iid == &<ID3D12GraphicsCommandList5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12Heap_Impl: Sized + ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_HEAP_DESC;
 }
@@ -2181,6 +2227,7 @@ impl ID3D12Heap_Vtbl {
         iid == &<ID3D12Heap as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12Heap1_Impl: Sized + ID3D12Heap_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -2198,6 +2245,7 @@ impl ID3D12Heap1_Vtbl {
         iid == &<ID3D12Heap1 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12Heap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12InfoQueue_Impl: Sized {
     fn SetMessageCountLimit(&self, messagecountlimit: u64) -> ::windows::core::Result<()>;
@@ -2459,6 +2507,7 @@ impl ID3D12InfoQueue_Vtbl {
         iid == &<ID3D12InfoQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12InfoQueue1_Impl: Sized + ID3D12InfoQueue_Impl {
     fn RegisterMessageCallback(&self, callbackfunc: D3D12MessageFunc, callbackfilterflags: D3D12_MESSAGE_CALLBACK_FLAGS, pcontext: *const ::core::ffi::c_void, pcallbackcookie: *mut u32) -> ::windows::core::Result<()>;
@@ -2489,6 +2538,7 @@ impl ID3D12InfoQueue1_Vtbl {
         iid == &<ID3D12InfoQueue1 as ::windows::core::Interface>::IID || iid == &<ID3D12InfoQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12LibraryReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_LIBRARY_DESC>;
     fn GetFunctionByIndex(&self, functionindex: i32) -> ::core::option::Option<ID3D12FunctionReflection>;
@@ -2522,6 +2572,7 @@ impl ID3D12LibraryReflection_Vtbl {
         iid == &<ID3D12LibraryReflection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12LifetimeOwner_Impl: Sized {
     fn LifetimeStateUpdated(&self, newstate: D3D12_LIFETIME_STATE);
 }
@@ -2539,6 +2590,7 @@ impl ID3D12LifetimeOwner_Vtbl {
         iid == &<ID3D12LifetimeOwner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12LifetimeTracker_Impl: Sized + ID3D12DeviceChild_Impl {
     fn DestroyOwnedObject(&self, pobject: &::core::option::Option<ID3D12DeviceChild>) -> ::windows::core::Result<()>;
 }
@@ -2556,6 +2608,7 @@ impl ID3D12LifetimeTracker_Vtbl {
         iid == &<ID3D12LifetimeTracker as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12MetaCommand_Impl: Sized + ID3D12Pageable_Impl {
     fn GetRequiredParameterResourceSize(&self, stage: D3D12_META_COMMAND_PARAMETER_STAGE, parameterindex: u32) -> u64;
 }
@@ -2576,6 +2629,7 @@ impl ID3D12MetaCommand_Vtbl {
         iid == &<ID3D12MetaCommand as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12Object_Impl: Sized {
     fn GetPrivateData(&self, guid: *const ::windows::core::GUID, pdatasize: *mut u32, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn SetPrivateData(&self, guid: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2617,6 +2671,7 @@ impl ID3D12Object_Vtbl {
         iid == &<ID3D12Object as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12Pageable_Impl: Sized + ID3D12DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D12Pageable {}
 impl ID3D12Pageable_Vtbl {
@@ -2627,6 +2682,7 @@ impl ID3D12Pageable_Vtbl {
         iid == &<ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12PipelineLibrary_Impl: Sized + ID3D12DeviceChild_Impl {
     fn StorePipeline(&self, pname: &::windows::core::PCWSTR, ppipeline: &::core::option::Option<ID3D12PipelineState>) -> ::windows::core::Result<()>;
@@ -2678,6 +2734,7 @@ impl ID3D12PipelineLibrary_Vtbl {
         iid == &<ID3D12PipelineLibrary as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12PipelineLibrary1_Impl: Sized + ID3D12PipelineLibrary_Impl {
     fn LoadPipeline(&self, pname: &::windows::core::PCWSTR, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC, riid: *const ::windows::core::GUID, pppipelinestate: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2698,6 +2755,7 @@ impl ID3D12PipelineLibrary1_Vtbl {
         iid == &<ID3D12PipelineLibrary1 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12PipelineLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12PipelineState_Impl: Sized + ID3D12Pageable_Impl {
     fn GetCachedBlob(&self) -> ::windows::core::Result<super::Direct3D::ID3DBlob>;
@@ -2724,6 +2782,7 @@ impl ID3D12PipelineState_Vtbl {
         iid == &<ID3D12PipelineState as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12ProtectedResourceSession_Impl: Sized + ID3D12ProtectedSession_Impl {
     fn GetDesc(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC;
 }
@@ -2741,6 +2800,7 @@ impl ID3D12ProtectedResourceSession_Vtbl {
         iid == &<ID3D12ProtectedResourceSession as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12ProtectedSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12ProtectedResourceSession1_Impl: Sized + ID3D12ProtectedResourceSession_Impl {
     fn GetDesc1(&self) -> D3D12_PROTECTED_RESOURCE_SESSION_DESC1;
 }
@@ -2758,6 +2818,7 @@ impl ID3D12ProtectedResourceSession1_Vtbl {
         iid == &<ID3D12ProtectedResourceSession1 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12ProtectedSession as ::windows::core::Interface>::IID || iid == &<ID3D12ProtectedResourceSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12ProtectedSession_Impl: Sized + ID3D12DeviceChild_Impl {
     fn GetStatusFence(&self, riid: *const ::windows::core::GUID, ppfence: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetSessionStatus(&self) -> D3D12_PROTECTED_SESSION_STATUS;
@@ -2785,6 +2846,7 @@ impl ID3D12ProtectedSession_Vtbl {
         iid == &<ID3D12ProtectedSession as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12QueryHeap_Impl: Sized + ID3D12Pageable_Impl {}
 impl ::windows::core::RuntimeName for ID3D12QueryHeap {}
 impl ID3D12QueryHeap_Vtbl {
@@ -2795,6 +2857,7 @@ impl ID3D12QueryHeap_Vtbl {
         iid == &<ID3D12QueryHeap as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12Resource_Impl: Sized + ID3D12Pageable_Impl {
     fn Map(&self, subresource: u32, preadrange: *const D3D12_RANGE, ppdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2860,6 +2923,7 @@ impl ID3D12Resource_Vtbl {
         iid == &<ID3D12Resource as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12Resource1_Impl: Sized + ID3D12Resource_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2880,6 +2944,7 @@ impl ID3D12Resource1_Vtbl {
         iid == &<ID3D12Resource1 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12Resource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait ID3D12Resource2_Impl: Sized + ID3D12Resource1_Impl {
     fn GetDesc1(&self) -> D3D12_RESOURCE_DESC1;
@@ -2900,6 +2965,7 @@ impl ID3D12Resource2_Vtbl {
         iid == &<ID3D12Resource2 as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12Resource as ::windows::core::Interface>::IID || iid == &<ID3D12Resource1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12RootSignature_Impl: Sized + ID3D12DeviceChild_Impl {}
 impl ::windows::core::RuntimeName for ID3D12RootSignature {}
 impl ID3D12RootSignature_Vtbl {
@@ -2910,6 +2976,7 @@ impl ID3D12RootSignature_Vtbl {
         iid == &<ID3D12RootSignature as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12RootSignatureDeserializer_Impl: Sized {
     fn GetRootSignatureDesc(&self) -> *mut D3D12_ROOT_SIGNATURE_DESC;
 }
@@ -2927,6 +2994,7 @@ impl ID3D12RootSignatureDeserializer_Vtbl {
         iid == &<ID3D12RootSignatureDeserializer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12SDKConfiguration_Impl: Sized {
     fn SetSDKVersion(&self, sdkversion: u32, sdkpath: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
 }
@@ -2944,6 +3012,7 @@ impl ID3D12SDKConfiguration_Vtbl {
         iid == &<ID3D12SDKConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12ShaderCacheSession_Impl: Sized + ID3D12DeviceChild_Impl {
     fn FindValue(&self, pkey: *const ::core::ffi::c_void, keysize: u32, pvalue: *mut ::core::ffi::c_void, pvaluesize: *mut u32) -> ::windows::core::Result<()>;
     fn StoreValue(&self, pkey: *const ::core::ffi::c_void, keysize: u32, pvalue: *const ::core::ffi::c_void, valuesize: u32) -> ::windows::core::Result<()>;
@@ -2985,6 +3054,7 @@ impl ID3D12ShaderCacheSession_Vtbl {
         iid == &<ID3D12ShaderCacheSession as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D"))]
 pub trait ID3D12ShaderReflection_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_SHADER_DESC>;
@@ -3176,6 +3246,7 @@ impl ID3D12ShaderReflection_Vtbl {
         iid == &<ID3D12ShaderReflection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12ShaderReflectionConstantBuffer_Impl: Sized {
     fn GetDesc(&self, pdesc: *mut D3D12_SHADER_BUFFER_DESC) -> ::windows::core::Result<()>;
@@ -3218,6 +3289,7 @@ impl ID3D12ShaderReflectionConstantBuffer {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait ID3D12ShaderReflectionType_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_SHADER_TYPE_DESC>;
@@ -3326,6 +3398,7 @@ impl ID3D12ShaderReflectionType {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12ShaderReflectionVariable_Impl: Sized {
     fn GetDesc(&self) -> ::windows::core::Result<D3D12_SHADER_VARIABLE_DESC>;
     fn GetType(&self) -> ::core::option::Option<ID3D12ShaderReflectionType>;
@@ -3375,6 +3448,7 @@ impl ID3D12ShaderReflectionVariable {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12SharingContract_Impl: Sized {
     fn Present(&self, presource: &::core::option::Option<ID3D12Resource>, subresource: u32, window: super::super::Foundation::HWND);
@@ -3419,6 +3493,7 @@ impl ID3D12SharingContract_Vtbl {
         iid == &<ID3D12SharingContract as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12StateObject_Impl: Sized + ID3D12Pageable_Impl {}
 impl ::windows::core::RuntimeName for ID3D12StateObject {}
 impl ID3D12StateObject_Vtbl {
@@ -3429,6 +3504,7 @@ impl ID3D12StateObject_Vtbl {
         iid == &<ID3D12StateObject as ::windows::core::Interface>::IID || iid == &<ID3D12Object as ::windows::core::Interface>::IID || iid == &<ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12StateObjectProperties_Impl: Sized {
     fn GetShaderIdentifier(&self, pexportname: &::windows::core::PCWSTR) -> *mut ::core::ffi::c_void;
     fn GetShaderStackSize(&self, pexportname: &::windows::core::PCWSTR) -> u64;
@@ -3470,6 +3546,7 @@ impl ID3D12StateObjectProperties_Vtbl {
         iid == &<ID3D12StateObjectProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12SwapChainAssistant_Impl: Sized {
     fn GetLUID(&self) -> super::super::Foundation::LUID;
@@ -3514,6 +3591,7 @@ impl ID3D12SwapChainAssistant_Vtbl {
         iid == &<ID3D12SwapChainAssistant as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ID3D12Tools_Impl: Sized {
     fn EnableShaderInstrumentation(&self, benable: super::super::Foundation::BOOL);
@@ -3544,6 +3622,7 @@ impl ID3D12Tools_Vtbl {
         iid == &<ID3D12Tools as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 pub trait ID3D12VersionedRootSignatureDeserializer_Impl: Sized {
     fn GetRootSignatureDescAtVersion(&self, converttoversion: D3D_ROOT_SIGNATURE_VERSION) -> ::windows::core::Result<*mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC>;
     fn GetUnconvertedRootSignatureDesc(&self) -> *mut D3D12_VERSIONED_ROOT_SIGNATURE_DESC;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirect3D9_Impl: Sized {
     fn RegisterSoftwareDevice(&self, pinitializefunction: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -112,6 +113,7 @@ impl IDirect3D9_Vtbl {
         iid == &<IDirect3D9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirect3D9Ex_Impl: Sized + IDirect3D9_Impl {
     fn GetAdapterModeCountEx(&self, adapter: u32, pfilter: *const D3DDISPLAYMODEFILTER) -> u32;
@@ -163,6 +165,7 @@ impl IDirect3D9Ex_Vtbl {
         iid == &<IDirect3D9Ex as ::windows::core::Interface>::IID || iid == &<IDirect3D9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DBaseTexture9_Impl: Sized + IDirect3DResource9_Impl {
     fn SetLOD(&self, lodnew: u32) -> u32;
     fn GetLOD(&self) -> u32;
@@ -218,6 +221,7 @@ impl IDirect3DBaseTexture9_Vtbl {
         iid == &<IDirect3DBaseTexture9 as ::windows::core::Interface>::IID || iid == &<IDirect3DResource9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirect3DCubeTexture9_Impl: Sized + IDirect3DBaseTexture9_Impl {
     fn GetLevelDesc(&self, level: u32, pdesc: *mut D3DSURFACE_DESC) -> ::windows::core::Result<()>;
@@ -275,6 +279,7 @@ impl IDirect3DCubeTexture9_Vtbl {
         iid == &<IDirect3DCubeTexture9 as ::windows::core::Interface>::IID || iid == &<IDirect3DResource9 as ::windows::core::Interface>::IID || iid == &<IDirect3DBaseTexture9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirect3DDevice9_Impl: Sized {
     fn TestCooperativeLevel(&self) -> ::windows::core::Result<()>;
@@ -1199,6 +1204,7 @@ impl IDirect3DDevice9_Vtbl {
         iid == &<IDirect3DDevice9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirect3DDevice9Ex_Impl: Sized + IDirect3DDevice9_Impl {
     fn SetConvolutionMonoKernel(&self, width: u32, height: u32, rows: *mut f32, columns: *mut f32) -> ::windows::core::Result<()>;
@@ -1320,6 +1326,7 @@ impl IDirect3DDevice9Ex_Vtbl {
         iid == &<IDirect3DDevice9Ex as ::windows::core::Interface>::IID || iid == &<IDirect3DDevice9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DIndexBuffer9_Impl: Sized + IDirect3DResource9_Impl {
     fn Lock(&self, offsettolock: u32, sizetolock: u32, ppbdata: *mut *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::Result<()>;
     fn Unlock(&self) -> ::windows::core::Result<()>;
@@ -1354,6 +1361,7 @@ impl IDirect3DIndexBuffer9_Vtbl {
         iid == &<IDirect3DIndexBuffer9 as ::windows::core::Interface>::IID || iid == &<IDirect3DResource9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DPixelShader9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetFunction(&self, param0: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::Result<()>;
@@ -1387,6 +1395,7 @@ impl IDirect3DPixelShader9_Vtbl {
         iid == &<IDirect3DPixelShader9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DQuery9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetType(&self) -> D3DQUERYTYPE;
@@ -1441,6 +1450,7 @@ impl IDirect3DQuery9_Vtbl {
         iid == &<IDirect3DQuery9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DResource9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn SetPrivateData(&self, refguid: *const ::windows::core::GUID, pdata: *const ::core::ffi::c_void, sizeofdata: u32, flags: u32) -> ::windows::core::Result<()>;
@@ -1516,6 +1526,7 @@ impl IDirect3DResource9_Vtbl {
         iid == &<IDirect3DResource9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DStateBlock9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn Capture(&self) -> ::windows::core::Result<()>;
@@ -1556,6 +1567,7 @@ impl IDirect3DStateBlock9_Vtbl {
         iid == &<IDirect3DStateBlock9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirect3DSurface9_Impl: Sized + IDirect3DResource9_Impl {
     fn GetContainer(&self, riid: *const ::windows::core::GUID, ppcontainer: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1614,6 +1626,7 @@ impl IDirect3DSurface9_Vtbl {
         iid == &<IDirect3DSurface9 as ::windows::core::Interface>::IID || iid == &<IDirect3DResource9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirect3DSwapChain9_Impl: Sized {
     fn Present(&self, psourcerect: *const super::super::Foundation::RECT, pdestrect: *const super::super::Foundation::RECT, hdestwindowoverride: super::super::Foundation::HWND, pdirtyregion: *const super::Gdi::RGNDATA, dwflags: u32) -> ::windows::core::Result<()>;
@@ -1691,6 +1704,7 @@ impl IDirect3DSwapChain9_Vtbl {
         iid == &<IDirect3DSwapChain9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirect3DSwapChain9Ex_Impl: Sized + IDirect3DSwapChain9_Impl {
     fn GetLastPresentCount(&self, plastpresentcount: *mut u32) -> ::windows::core::Result<()>;
@@ -1728,6 +1742,7 @@ impl IDirect3DSwapChain9Ex_Vtbl {
         iid == &<IDirect3DSwapChain9Ex as ::windows::core::Interface>::IID || iid == &<IDirect3DSwapChain9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirect3DTexture9_Impl: Sized + IDirect3DBaseTexture9_Impl {
     fn GetLevelDesc(&self, level: u32, pdesc: *mut D3DSURFACE_DESC) -> ::windows::core::Result<()>;
@@ -1785,6 +1800,7 @@ impl IDirect3DTexture9_Vtbl {
         iid == &<IDirect3DTexture9 as ::windows::core::Interface>::IID || iid == &<IDirect3DResource9 as ::windows::core::Interface>::IID || iid == &<IDirect3DBaseTexture9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DVertexBuffer9_Impl: Sized + IDirect3DResource9_Impl {
     fn Lock(&self, offsettolock: u32, sizetolock: u32, ppbdata: *mut *mut ::core::ffi::c_void, flags: u32) -> ::windows::core::Result<()>;
     fn Unlock(&self) -> ::windows::core::Result<()>;
@@ -1819,6 +1835,7 @@ impl IDirect3DVertexBuffer9_Vtbl {
         iid == &<IDirect3DVertexBuffer9 as ::windows::core::Interface>::IID || iid == &<IDirect3DResource9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DVertexDeclaration9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetDeclaration(&self, pelement: *mut D3DVERTEXELEMENT9, pnumelements: *mut u32) -> ::windows::core::Result<()>;
@@ -1852,6 +1869,7 @@ impl IDirect3DVertexDeclaration9_Vtbl {
         iid == &<IDirect3DVertexDeclaration9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DVertexShader9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn GetFunction(&self, param0: *mut ::core::ffi::c_void, psizeofdata: *mut u32) -> ::windows::core::Result<()>;
@@ -1885,6 +1903,7 @@ impl IDirect3DVertexShader9_Vtbl {
         iid == &<IDirect3DVertexShader9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DVolume9_Impl: Sized {
     fn GetDevice(&self) -> ::windows::core::Result<IDirect3DDevice9>;
     fn SetPrivateData(&self, refguid: *const ::windows::core::GUID, pdata: *const ::core::ffi::c_void, sizeofdata: u32, flags: u32) -> ::windows::core::Result<()>;
@@ -1960,6 +1979,7 @@ impl IDirect3DVolume9_Vtbl {
         iid == &<IDirect3DVolume9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 pub trait IDirect3DVolumeTexture9_Impl: Sized + IDirect3DBaseTexture9_Impl {
     fn GetLevelDesc(&self, level: u32, pdesc: *mut D3DVOLUME_DESC) -> ::windows::core::Result<()>;
     fn GetVolumeLevel(&self, level: u32) -> ::windows::core::Result<IDirect3DVolume9>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9on12/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Direct3D9on12\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirect3DDevice9On12_Impl: Sized {
     fn GetD3D12Device(&self, riid: *const ::windows::core::GUID, ppvdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectComposition/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Foundation_Numerics\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionAffineTransform2DEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetInterpolationMode(&self, interpolationmode: super::Direct2D::Common::D2D1_2DAFFINETRANSFORM_INTERPOLATION_MODE) -> ::windows::core::Result<()>;
@@ -63,6 +64,7 @@ impl IDCompositionAffineTransform2DEffect_Vtbl {
         iid == &<IDCompositionAffineTransform2DEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionAnimation_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn SetAbsoluteBeginTime(&self, begintime: i64) -> ::windows::core::Result<()>;
@@ -118,6 +120,7 @@ impl IDCompositionAnimation_Vtbl {
         iid == &<IDCompositionAnimation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionArithmeticCompositeEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetCoefficients(&self, coefficients: *const super::Direct2D::Common::D2D_VECTOR_4F) -> ::windows::core::Result<()>;
@@ -204,6 +207,7 @@ impl IDCompositionArithmeticCompositeEffect_Vtbl {
         iid == &<IDCompositionArithmeticCompositeEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDCompositionBlendEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetMode(&self, mode: super::Direct2D::Common::D2D1_BLEND_MODE) -> ::windows::core::Result<()>;
@@ -224,6 +228,7 @@ impl IDCompositionBlendEffect_Vtbl {
         iid == &<IDCompositionBlendEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDCompositionBrightnessEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetWhitePoint(&self, whitepoint: *const super::Direct2D::Common::D2D_VECTOR_2F) -> ::windows::core::Result<()>;
@@ -310,6 +315,7 @@ impl IDCompositionBrightnessEffect_Vtbl {
         iid == &<IDCompositionBrightnessEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionClip_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDCompositionClip {}
 impl IDCompositionClip_Vtbl {
@@ -320,6 +326,7 @@ impl IDCompositionClip_Vtbl {
         iid == &<IDCompositionClip as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionColorMatrixEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetMatrix(&self, matrix: *const super::Direct2D::Common::D2D_MATRIX_5X4_F) -> ::windows::core::Result<()>;
@@ -371,6 +378,7 @@ impl IDCompositionColorMatrixEffect_Vtbl {
         iid == &<IDCompositionColorMatrixEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDCompositionCompositeEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetMode(&self, mode: super::Direct2D::Common::D2D1_COMPOSITE_MODE) -> ::windows::core::Result<()>;
@@ -391,6 +399,7 @@ impl IDCompositionCompositeEffect_Vtbl {
         iid == &<IDCompositionCompositeEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDCompositionDelegatedInkTrail_Impl: Sized {
     fn AddTrailPoints(&self, inkpoints: *const DCompositionInkTrailPoint, inkpointscount: u32) -> ::windows::core::Result<u32>;
@@ -447,6 +456,7 @@ impl IDCompositionDelegatedInkTrail_Vtbl {
         iid == &<IDCompositionDelegatedInkTrail as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDCompositionDesktopDevice_Impl: Sized + IDCompositionDevice2_Impl {
     fn CreateTargetForHwnd(&self, hwnd: super::super::Foundation::HWND, topmost: super::super::Foundation::BOOL) -> ::windows::core::Result<IDCompositionTarget>;
@@ -502,6 +512,7 @@ impl IDCompositionDesktopDevice_Vtbl {
         iid == &<IDCompositionDesktopDevice as ::windows::core::Interface>::IID || iid == &<IDCompositionDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDCompositionDevice_Impl: Sized {
     fn Commit(&self) -> ::windows::core::Result<()>;
@@ -818,6 +829,7 @@ impl IDCompositionDevice_Vtbl {
         iid == &<IDCompositionDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDCompositionDevice2_Impl: Sized {
     fn Commit(&self) -> ::windows::core::Result<()>;
@@ -1095,6 +1107,7 @@ impl IDCompositionDevice2_Vtbl {
         iid == &<IDCompositionDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDCompositionDevice3_Impl: Sized + IDCompositionDevice2_Impl {
     fn CreateGaussianBlurEffect(&self) -> ::windows::core::Result<IDCompositionGaussianBlurEffect>;
@@ -1280,6 +1293,7 @@ impl IDCompositionDevice3_Vtbl {
         iid == &<IDCompositionDevice3 as ::windows::core::Interface>::IID || iid == &<IDCompositionDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionDeviceDebug_Impl: Sized {
     fn EnableDebugCounters(&self) -> ::windows::core::Result<()>;
     fn DisableDebugCounters(&self) -> ::windows::core::Result<()>;
@@ -1307,6 +1321,7 @@ impl IDCompositionDeviceDebug_Vtbl {
         iid == &<IDCompositionDeviceDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionEffect_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDCompositionEffect {}
 impl IDCompositionEffect_Vtbl {
@@ -1317,6 +1332,7 @@ impl IDCompositionEffect_Vtbl {
         iid == &<IDCompositionEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionEffectGroup_Impl: Sized + IDCompositionEffect_Impl {
     fn SetOpacity(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetOpacity2(&self, opacity: f32) -> ::windows::core::Result<()>;
@@ -1351,6 +1367,7 @@ impl IDCompositionEffectGroup_Vtbl {
         iid == &<IDCompositionEffectGroup as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionFilterEffect_Impl: Sized + IDCompositionEffect_Impl {
     fn SetInput(&self, index: u32, input: &::core::option::Option<::windows::core::IUnknown>, flags: u32) -> ::windows::core::Result<()>;
 }
@@ -1368,6 +1385,7 @@ impl IDCompositionFilterEffect_Vtbl {
         iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDCompositionGaussianBlurEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetStandardDeviation(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
@@ -1405,6 +1423,7 @@ impl IDCompositionGaussianBlurEffect_Vtbl {
         iid == &<IDCompositionGaussianBlurEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionHueRotationEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetAngle(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetAngle2(&self, amountdegrees: f32) -> ::windows::core::Result<()>;
@@ -1432,6 +1451,7 @@ impl IDCompositionHueRotationEffect_Vtbl {
         iid == &<IDCompositionHueRotationEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionInkTrailDevice_Impl: Sized {
     fn CreateDelegatedInkTrail(&self) -> ::windows::core::Result<IDCompositionDelegatedInkTrail>;
     fn CreateDelegatedInkTrailForSwapChain(&self, swapchain: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IDCompositionDelegatedInkTrail>;
@@ -1471,6 +1491,7 @@ impl IDCompositionInkTrailDevice_Vtbl {
         iid == &<IDCompositionInkTrailDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDCompositionLinearTransferEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetRedYIntercept(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
@@ -1634,6 +1655,7 @@ impl IDCompositionLinearTransferEffect_Vtbl {
         iid == &<IDCompositionLinearTransferEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Foundation_Numerics\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Numerics")]
 pub trait IDCompositionMatrixTransform_Impl: Sized + IDCompositionTransform_Impl {
     fn SetMatrix(&self, matrix: *const super::super::super::Foundation::Numerics::Matrix3x2) -> ::windows::core::Result<()>;
@@ -1671,6 +1693,7 @@ impl IDCompositionMatrixTransform_Vtbl {
         iid == &<IDCompositionMatrixTransform as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Foundation_Numerics\"`, `\"implement\"`*"]
 #[cfg(feature = "Foundation_Numerics")]
 pub trait IDCompositionMatrixTransform3D_Impl: Sized + IDCompositionTransform3D_Impl {
     fn SetMatrix(&self, matrix: *const super::super::super::Foundation::Numerics::Matrix4x4) -> ::windows::core::Result<()>;
@@ -1708,6 +1731,7 @@ impl IDCompositionMatrixTransform3D_Vtbl {
         iid == &<IDCompositionMatrixTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionRectangleClip_Impl: Sized + IDCompositionClip_Impl {
     fn SetLeft(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetLeft2(&self, left: f32) -> ::windows::core::Result<()>;
@@ -1889,6 +1913,7 @@ impl IDCompositionRectangleClip_Vtbl {
         iid == &<IDCompositionRectangleClip as ::windows::core::Interface>::IID || iid == &<IDCompositionClip as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionRotateTransform_Impl: Sized + IDCompositionTransform_Impl {
     fn SetAngle(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetAngle2(&self, angle: f32) -> ::windows::core::Result<()>;
@@ -1944,6 +1969,7 @@ impl IDCompositionRotateTransform_Vtbl {
         iid == &<IDCompositionRotateTransform as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionRotateTransform3D_Impl: Sized + IDCompositionTransform3D_Impl {
     fn SetAngle(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetAngle2(&self, angle: f32) -> ::windows::core::Result<()>;
@@ -2055,6 +2081,7 @@ impl IDCompositionRotateTransform3D_Vtbl {
         iid == &<IDCompositionRotateTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionSaturationEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetSaturation(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetSaturation2(&self, ratio: f32) -> ::windows::core::Result<()>;
@@ -2082,6 +2109,7 @@ impl IDCompositionSaturationEffect_Vtbl {
         iid == &<IDCompositionSaturationEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionScaleTransform_Impl: Sized + IDCompositionTransform_Impl {
     fn SetScaleX(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetScaleX2(&self, scalex: f32) -> ::windows::core::Result<()>;
@@ -2151,6 +2179,7 @@ impl IDCompositionScaleTransform_Vtbl {
         iid == &<IDCompositionScaleTransform as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionScaleTransform3D_Impl: Sized + IDCompositionTransform3D_Impl {
     fn SetScaleX(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetScaleX2(&self, scalex: f32) -> ::windows::core::Result<()>;
@@ -2248,6 +2277,7 @@ impl IDCompositionScaleTransform3D_Vtbl {
         iid == &<IDCompositionScaleTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub trait IDCompositionShadowEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetStandardDeviation(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
@@ -2341,6 +2371,7 @@ impl IDCompositionShadowEffect_Vtbl {
         iid == &<IDCompositionShadowEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionSkewTransform_Impl: Sized + IDCompositionTransform_Impl {
     fn SetAngleX(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetAngleX2(&self, anglex: f32) -> ::windows::core::Result<()>;
@@ -2410,6 +2441,7 @@ impl IDCompositionSkewTransform_Vtbl {
         iid == &<IDCompositionSkewTransform as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDCompositionSurface_Impl: Sized {
     fn BeginDraw(&self, updaterect: *const super::super::Foundation::RECT, iid: *const ::windows::core::GUID, updateobject: *mut *mut ::core::ffi::c_void, updateoffset: *mut super::super::Foundation::POINT) -> ::windows::core::Result<()>;
@@ -2461,6 +2493,7 @@ impl IDCompositionSurface_Vtbl {
         iid == &<IDCompositionSurface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDCompositionSurfaceFactory_Impl: Sized {
     fn CreateSurface(&self, width: u32, height: u32, pixelformat: super::Dxgi::Common::DXGI_FORMAT, alphamode: super::Dxgi::Common::DXGI_ALPHA_MODE) -> ::windows::core::Result<IDCompositionSurface>;
@@ -2503,6 +2536,7 @@ impl IDCompositionSurfaceFactory_Vtbl {
         iid == &<IDCompositionSurfaceFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDCompositionTableTransferEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetRedTable(&self, tablevalues: *const f32, count: u32) -> ::windows::core::Result<()>;
@@ -2638,6 +2672,7 @@ impl IDCompositionTableTransferEffect_Vtbl {
         iid == &<IDCompositionTableTransferEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionTarget_Impl: Sized {
     fn SetRoot(&self, visual: &::core::option::Option<IDCompositionVisual>) -> ::windows::core::Result<()>;
 }
@@ -2655,6 +2690,7 @@ impl IDCompositionTarget_Vtbl {
         iid == &<IDCompositionTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionTransform_Impl: Sized + IDCompositionTransform3D_Impl {}
 impl ::windows::core::RuntimeName for IDCompositionTransform {}
 impl IDCompositionTransform_Vtbl {
@@ -2665,6 +2701,7 @@ impl IDCompositionTransform_Vtbl {
         iid == &<IDCompositionTransform as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionTransform3D_Impl: Sized + IDCompositionEffect_Impl {}
 impl ::windows::core::RuntimeName for IDCompositionTransform3D {}
 impl IDCompositionTransform3D_Vtbl {
@@ -2675,6 +2712,7 @@ impl IDCompositionTransform3D_Vtbl {
         iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionTranslateTransform_Impl: Sized + IDCompositionTransform_Impl {
     fn SetOffsetX(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetOffsetX2(&self, offsetx: f32) -> ::windows::core::Result<()>;
@@ -2716,6 +2754,7 @@ impl IDCompositionTranslateTransform_Vtbl {
         iid == &<IDCompositionTranslateTransform as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 pub trait IDCompositionTranslateTransform3D_Impl: Sized + IDCompositionTransform3D_Impl {
     fn SetOffsetX(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
     fn SetOffsetX2(&self, offsetx: f32) -> ::windows::core::Result<()>;
@@ -2771,6 +2810,7 @@ impl IDCompositionTranslateTransform3D_Vtbl {
         iid == &<IDCompositionTranslateTransform3D as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionTransform3D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionTurbulenceEffect_Impl: Sized + IDCompositionFilterEffect_Impl {
     fn SetOffset(&self, offset: *const super::Direct2D::Common::D2D_VECTOR_2F) -> ::windows::core::Result<()>;
@@ -2836,6 +2876,7 @@ impl IDCompositionTurbulenceEffect_Vtbl {
         iid == &<IDCompositionTurbulenceEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionEffect as ::windows::core::Interface>::IID || iid == &<IDCompositionFilterEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDCompositionVirtualSurface_Impl: Sized + IDCompositionSurface_Impl {
     fn Resize(&self, width: u32, height: u32) -> ::windows::core::Result<()>;
@@ -2866,6 +2907,7 @@ impl IDCompositionVirtualSurface_Vtbl {
         iid == &<IDCompositionVirtualSurface as ::windows::core::Interface>::IID || iid == &<IDCompositionSurface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionVisual_Impl: Sized {
     fn SetOffsetX(&self, animation: &::core::option::Option<IDCompositionAnimation>) -> ::windows::core::Result<()>;
@@ -3001,6 +3043,7 @@ impl IDCompositionVisual_Vtbl {
         iid == &<IDCompositionVisual as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionVisual2_Impl: Sized + IDCompositionVisual_Impl {
     fn SetOpacityMode(&self, mode: DCOMPOSITION_OPACITY_MODE) -> ::windows::core::Result<()>;
@@ -3031,6 +3074,7 @@ impl IDCompositionVisual2_Vtbl {
         iid == &<IDCompositionVisual2 as ::windows::core::Interface>::IID || iid == &<IDCompositionVisual as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionVisual3_Impl: Sized + IDCompositionVisualDebug_Impl {
     fn SetDepthMode(&self, mode: DCOMPOSITION_DEPTH_MODE) -> ::windows::core::Result<()>;
@@ -3103,6 +3147,7 @@ impl IDCompositionVisual3_Vtbl {
         iid == &<IDCompositionVisual3 as ::windows::core::Interface>::IID || iid == &<IDCompositionVisual as ::windows::core::Interface>::IID || iid == &<IDCompositionVisual2 as ::windows::core::Interface>::IID || iid == &<IDCompositionVisualDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectComposition\"`, `\"Foundation_Numerics\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDCompositionVisualDebug_Impl: Sized + IDCompositionVisual2_Impl {
     fn EnableHeatMap(&self, color: *const super::Direct2D::Common::D2D1_COLOR_F) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDDVideoPortContainer_Impl: Sized {
     fn CreateVideoPort(&self, param0: u32, param1: *mut DDVIDEOPORTDESC, param2: *mut ::core::option::Option<IDirectDrawVideoPort>, param3: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -42,6 +43,7 @@ impl IDDVideoPortContainer_Vtbl {
         iid == &<IDDVideoPortContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDraw_Impl: Sized {
     fn Compact(&self) -> ::windows::core::Result<()>;
@@ -210,6 +212,7 @@ impl IDirectDraw_Vtbl {
         iid == &<IDirectDraw as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDraw2_Impl: Sized {
     fn Compact(&self) -> ::windows::core::Result<()>;
@@ -385,6 +388,7 @@ impl IDirectDraw2_Vtbl {
         iid == &<IDirectDraw2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDraw4_Impl: Sized {
     fn Compact(&self) -> ::windows::core::Result<()>;
@@ -594,6 +598,7 @@ impl IDirectDraw4_Vtbl {
         iid == &<IDirectDraw4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDraw7_Impl: Sized {
     fn Compact(&self) -> ::windows::core::Result<()>;
@@ -817,6 +822,7 @@ impl IDirectDraw7_Vtbl {
         iid == &<IDirectDraw7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDrawClipper_Impl: Sized {
     fn GetClipList(&self, param0: *mut super::super::Foundation::RECT, param1: *mut super::Gdi::RGNDATA, param2: *mut u32) -> ::windows::core::Result<()>;
@@ -875,6 +881,7 @@ impl IDirectDrawClipper_Vtbl {
         iid == &<IDirectDrawClipper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 pub trait IDirectDrawColorControl_Impl: Sized {
     fn GetColorControls(&self, param0: *mut DDCOLORCONTROL) -> ::windows::core::Result<()>;
     fn SetColorControls(&self, param0: *mut DDCOLORCONTROL) -> ::windows::core::Result<()>;
@@ -902,6 +909,7 @@ impl IDirectDrawColorControl_Vtbl {
         iid == &<IDirectDrawColorControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 pub trait IDirectDrawGammaControl_Impl: Sized {
     fn GetGammaRamp(&self, param0: u32, param1: *mut DDGAMMARAMP) -> ::windows::core::Result<()>;
     fn SetGammaRamp(&self, param0: u32, param1: *mut DDGAMMARAMP) -> ::windows::core::Result<()>;
@@ -929,6 +937,7 @@ impl IDirectDrawGammaControl_Vtbl {
         iid == &<IDirectDrawGammaControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 pub trait IDirectDrawKernel_Impl: Sized {
     fn GetCaps(&self, param0: *mut DDKERNELCAPS) -> ::windows::core::Result<()>;
     fn GetKernelHandle(&self, param0: *mut usize) -> ::windows::core::Result<()>;
@@ -963,6 +972,7 @@ impl IDirectDrawKernel_Vtbl {
         iid == &<IDirectDrawKernel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDirectDrawPalette_Impl: Sized {
     fn GetCaps(&self, param0: *mut u32) -> ::windows::core::Result<()>;
@@ -1007,6 +1017,7 @@ impl IDirectDrawPalette_Vtbl {
         iid == &<IDirectDrawPalette as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDrawSurface_Impl: Sized {
     fn AddAttachedSurface(&self, param0: &::core::option::Option<IDirectDrawSurface>) -> ::windows::core::Result<()>;
@@ -1266,6 +1277,7 @@ impl IDirectDrawSurface_Vtbl {
         iid == &<IDirectDrawSurface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDrawSurface2_Impl: Sized {
     fn AddAttachedSurface(&self, param0: &::core::option::Option<IDirectDrawSurface2>) -> ::windows::core::Result<()>;
@@ -1546,6 +1558,7 @@ impl IDirectDrawSurface2_Vtbl {
         iid == &<IDirectDrawSurface2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDrawSurface3_Impl: Sized {
     fn AddAttachedSurface(&self, param0: &::core::option::Option<IDirectDrawSurface3>) -> ::windows::core::Result<()>;
@@ -1833,6 +1846,7 @@ impl IDirectDrawSurface3_Vtbl {
         iid == &<IDirectDrawSurface3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDrawSurface4_Impl: Sized {
     fn AddAttachedSurface(&self, param0: &::core::option::Option<IDirectDrawSurface4>) -> ::windows::core::Result<()>;
@@ -2155,6 +2169,7 @@ impl IDirectDrawSurface4_Vtbl {
         iid == &<IDirectDrawSurface4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDirectDrawSurface7_Impl: Sized {
     fn AddAttachedSurface(&self, param0: &::core::option::Option<IDirectDrawSurface7>) -> ::windows::core::Result<()>;
@@ -2505,6 +2520,7 @@ impl IDirectDrawSurface7_Vtbl {
         iid == &<IDirectDrawSurface7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 pub trait IDirectDrawSurfaceKernel_Impl: Sized {
     fn GetKernelHandle(&self, param0: *mut usize) -> ::windows::core::Result<()>;
     fn ReleaseKernelHandle(&self) -> ::windows::core::Result<()>;
@@ -2532,6 +2548,7 @@ impl IDirectDrawSurfaceKernel_Vtbl {
         iid == &<IDirectDrawSurfaceKernel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectDrawVideoPort_Impl: Sized {
     fn Flip(&self, param0: &::core::option::Option<IDirectDrawSurface>, param1: u32) -> ::windows::core::Result<()>;
@@ -2646,6 +2663,7 @@ impl IDirectDrawVideoPort_Vtbl {
         iid == &<IDirectDrawVideoPort as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectDrawVideoPortNotify_Impl: Sized {
     fn AcquireNotification(&self, param0: *mut super::super::Foundation::HANDLE, param1: *mut DDVIDEOPORTNOTIFY) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationAutoScrollBehavior_Impl: Sized {
     fn SetConfiguration(&self, motiontypes: DIRECTMANIPULATION_MOTION_TYPES, scrollmotion: DIRECTMANIPULATION_AUTOSCROLL_CONFIGURATION) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IDirectManipulationAutoScrollBehavior_Vtbl {
         iid == &<IDirectManipulationAutoScrollBehavior as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationCompositor_Impl: Sized {
     fn AddContent(&self, content: &::core::option::Option<IDirectManipulationContent>, device: &::core::option::Option<::windows::core::IUnknown>, parentvisual: &::core::option::Option<::windows::core::IUnknown>, childvisual: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn RemoveContent(&self, content: &::core::option::Option<IDirectManipulationContent>) -> ::windows::core::Result<()>;
@@ -56,6 +58,7 @@ impl IDirectManipulationCompositor_Vtbl {
         iid == &<IDirectManipulationCompositor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationCompositor2_Impl: Sized + IDirectManipulationCompositor_Impl {
     fn AddContentWithCrossProcessChaining(&self, content: &::core::option::Option<IDirectManipulationPrimaryContent>, device: &::core::option::Option<::windows::core::IUnknown>, parentvisual: &::core::option::Option<::windows::core::IUnknown>, childvisual: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -76,6 +79,7 @@ impl IDirectManipulationCompositor2_Vtbl {
         iid == &<IDirectManipulationCompositor2 as ::windows::core::Interface>::IID || iid == &<IDirectManipulationCompositor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectManipulationContent_Impl: Sized {
     fn GetContentRect(&self) -> ::windows::core::Result<super::super::Foundation::RECT>;
@@ -154,6 +158,7 @@ impl IDirectManipulationContent_Vtbl {
         iid == &<IDirectManipulationContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationDeferContactService_Impl: Sized {
     fn DeferContact(&self, pointerid: u32, timeout: u32) -> ::windows::core::Result<()>;
     fn CancelContact(&self, pointerid: u32) -> ::windows::core::Result<()>;
@@ -188,6 +193,7 @@ impl IDirectManipulationDeferContactService_Vtbl {
         iid == &<IDirectManipulationDeferContactService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationDragDropBehavior_Impl: Sized {
     fn SetConfiguration(&self, configuration: DIRECTMANIPULATION_DRAG_DROP_CONFIGURATION) -> ::windows::core::Result<()>;
     fn GetStatus(&self) -> ::windows::core::Result<DIRECTMANIPULATION_DRAG_DROP_STATUS>;
@@ -221,6 +227,7 @@ impl IDirectManipulationDragDropBehavior_Vtbl {
         iid == &<IDirectManipulationDragDropBehavior as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationDragDropEventHandler_Impl: Sized {
     fn OnDragDropStatusChange(&self, viewport: &::core::option::Option<IDirectManipulationViewport2>, current: DIRECTMANIPULATION_DRAG_DROP_STATUS, previous: DIRECTMANIPULATION_DRAG_DROP_STATUS) -> ::windows::core::Result<()>;
 }
@@ -238,6 +245,7 @@ impl IDirectManipulationDragDropEventHandler_Vtbl {
         iid == &<IDirectManipulationDragDropEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationFrameInfoProvider_Impl: Sized {
     fn GetNextFrameInfo(&self, time: *mut u64, processtime: *mut u64, compositiontime: *mut u64) -> ::windows::core::Result<()>;
 }
@@ -255,6 +263,7 @@ impl IDirectManipulationFrameInfoProvider_Vtbl {
         iid == &<IDirectManipulationFrameInfoProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationInteractionEventHandler_Impl: Sized {
     fn OnInteraction(&self, viewport: &::core::option::Option<IDirectManipulationViewport2>, interaction: DIRECTMANIPULATION_INTERACTION_TYPE) -> ::windows::core::Result<()>;
 }
@@ -272,6 +281,7 @@ impl IDirectManipulationInteractionEventHandler_Vtbl {
         iid == &<IDirectManipulationInteractionEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IDirectManipulationManager_Impl: Sized {
     fn Activate(&self, window: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -343,6 +353,7 @@ impl IDirectManipulationManager_Vtbl {
         iid == &<IDirectManipulationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IDirectManipulationManager2_Impl: Sized + IDirectManipulationManager_Impl {
     fn CreateBehavior(&self, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -363,6 +374,7 @@ impl IDirectManipulationManager2_Vtbl {
         iid == &<IDirectManipulationManager2 as ::windows::core::Interface>::IID || iid == &<IDirectManipulationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IDirectManipulationManager3_Impl: Sized + IDirectManipulationManager2_Impl {
     fn GetService(&self, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, object: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -383,6 +395,7 @@ impl IDirectManipulationManager3_Vtbl {
         iid == &<IDirectManipulationManager3 as ::windows::core::Interface>::IID || iid == &<IDirectManipulationManager as ::windows::core::Interface>::IID || iid == &<IDirectManipulationManager2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationPrimaryContent_Impl: Sized {
     fn SetSnapInterval(&self, motion: DIRECTMANIPULATION_MOTION_TYPES, interval: f32, offset: f32) -> ::windows::core::Result<()>;
     fn SetSnapPoints(&self, motion: DIRECTMANIPULATION_MOTION_TYPES, points: *const f32, pointcount: u32) -> ::windows::core::Result<()>;
@@ -459,6 +472,7 @@ impl IDirectManipulationPrimaryContent_Vtbl {
         iid == &<IDirectManipulationPrimaryContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationUpdateHandler_Impl: Sized {
     fn Update(&self) -> ::windows::core::Result<()>;
 }
@@ -476,6 +490,7 @@ impl IDirectManipulationUpdateHandler_Vtbl {
         iid == &<IDirectManipulationUpdateHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectManipulationUpdateManager_Impl: Sized {
     fn RegisterWaitHandleCallback(&self, handle: super::super::Foundation::HANDLE, eventhandler: &::core::option::Option<IDirectManipulationUpdateHandler>) -> ::windows::core::Result<u32>;
@@ -519,6 +534,7 @@ impl IDirectManipulationUpdateManager_Vtbl {
         iid == &<IDirectManipulationUpdateManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectManipulationViewport_Impl: Sized {
     fn Enable(&self) -> ::windows::core::Result<()>;
@@ -749,6 +765,7 @@ impl IDirectManipulationViewport_Vtbl {
         iid == &<IDirectManipulationViewport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectManipulationViewport2_Impl: Sized + IDirectManipulationViewport_Impl {
     fn AddBehavior(&self, behavior: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
@@ -792,6 +809,7 @@ impl IDirectManipulationViewport2_Vtbl {
         iid == &<IDirectManipulationViewport2 as ::windows::core::Interface>::IID || iid == &<IDirectManipulationViewport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectManipulation\"`, `\"implement\"`*"]
 pub trait IDirectManipulationViewportEventHandler_Impl: Sized {
     fn OnViewportStatusChanged(&self, viewport: &::core::option::Option<IDirectManipulationViewport>, current: DIRECTMANIPULATION_STATUS, previous: DIRECTMANIPULATION_STATUS) -> ::windows::core::Result<()>;
     fn OnViewportUpdated(&self, viewport: &::core::option::Option<IDirectManipulationViewport>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteAsyncResult_Impl: Sized {
     fn GetWaitHandle(&self) -> super::super::Foundation::HANDLE;
@@ -28,6 +29,7 @@ impl IDWriteAsyncResult_Vtbl {
         iid == &<IDWriteAsyncResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteBitmapRenderTarget_Impl: Sized {
     fn DrawGlyphRun(&self, baselineoriginx: f32, baselineoriginy: f32, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, renderingparams: &::core::option::Option<IDWriteRenderingParams>, textcolor: super::super::Foundation::COLORREF, blackboxrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -112,6 +114,7 @@ impl IDWriteBitmapRenderTarget_Vtbl {
         iid == &<IDWriteBitmapRenderTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteBitmapRenderTarget1_Impl: Sized + IDWriteBitmapRenderTarget_Impl {
     fn GetTextAntialiasMode(&self) -> DWRITE_TEXT_ANTIALIAS_MODE;
@@ -142,6 +145,7 @@ impl IDWriteBitmapRenderTarget1_Vtbl {
         iid == &<IDWriteBitmapRenderTarget1 as ::windows::core::Interface>::IID || iid == &<IDWriteBitmapRenderTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteColorGlyphRunEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -184,6 +188,7 @@ impl IDWriteColorGlyphRunEnumerator_Vtbl {
         iid == &<IDWriteColorGlyphRunEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteColorGlyphRunEnumerator1_Impl: Sized + IDWriteColorGlyphRunEnumerator_Impl {
     fn GetCurrentRun2(&self) -> ::windows::core::Result<*mut DWRITE_COLOR_GLYPH_RUN1>;
@@ -210,6 +215,7 @@ impl IDWriteColorGlyphRunEnumerator1_Vtbl {
         iid == &<IDWriteColorGlyphRunEnumerator1 as ::windows::core::Interface>::IID || iid == &<IDWriteColorGlyphRunEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory_Impl: Sized {
     fn GetSystemFontCollection(&self, fontcollection: *mut ::core::option::Option<IDWriteFontCollection>, checkforupdates: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -469,6 +475,7 @@ impl IDWriteFactory_Vtbl {
         iid == &<IDWriteFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory1_Impl: Sized + IDWriteFactory_Impl {
     fn GetEudcFontCollection(&self, fontcollection: *mut ::core::option::Option<IDWriteFontCollection>, checkforupdates: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -505,6 +512,7 @@ impl IDWriteFactory1_Vtbl {
         iid == &<IDWriteFactory1 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory2_Impl: Sized + IDWriteFactory1_Impl {
     fn GetSystemFontFallback(&self) -> ::windows::core::Result<IDWriteFontFallback>;
@@ -586,6 +594,7 @@ impl IDWriteFactory2_Vtbl {
         iid == &<IDWriteFactory2 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory as ::windows::core::Interface>::IID || iid == &<IDWriteFactory1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory3_Impl: Sized + IDWriteFactory2_Impl {
     fn CreateGlyphRunAnalysis3(&self, glyphrun: *const DWRITE_GLYPH_RUN, transform: *const DWRITE_MATRIX, renderingmode: DWRITE_RENDERING_MODE1, measuringmode: DWRITE_MEASURING_MODE, gridfitmode: DWRITE_GRID_FIT_MODE, antialiasmode: DWRITE_TEXT_ANTIALIAS_MODE, baselineoriginx: f32, baselineoriginy: f32) -> ::windows::core::Result<IDWriteGlyphRunAnalysis>;
@@ -713,6 +722,7 @@ impl IDWriteFactory3_Vtbl {
         iid == &<IDWriteFactory3 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory as ::windows::core::Interface>::IID || iid == &<IDWriteFactory1 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory4_Impl: Sized + IDWriteFactory3_Impl {
     fn TranslateColorGlyphRun2(&self, baselineorigin: &super::Direct2D::Common::D2D_POINT_2F, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, desiredglyphimageformats: DWRITE_GLYPH_IMAGE_FORMATS, measuringmode: DWRITE_MEASURING_MODE, worldanddpitransform: *const DWRITE_MATRIX, colorpaletteindex: u32) -> ::windows::core::Result<IDWriteColorGlyphRunEnumerator1>;
@@ -768,6 +778,7 @@ impl IDWriteFactory4_Vtbl {
         iid == &<IDWriteFactory4 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory as ::windows::core::Interface>::IID || iid == &<IDWriteFactory1 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory2 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory5_Impl: Sized + IDWriteFactory4_Impl {
     fn CreateFontSetBuilder2(&self) -> ::windows::core::Result<IDWriteFontSetBuilder1>;
@@ -843,6 +854,7 @@ impl IDWriteFactory5_Vtbl {
         iid == &<IDWriteFactory5 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory as ::windows::core::Interface>::IID || iid == &<IDWriteFactory1 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory2 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory3 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory6_Impl: Sized + IDWriteFactory5_Impl {
     fn CreateFontFaceReference3(&self, fontfile: &::core::option::Option<IDWriteFontFile>, faceindex: u32, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<IDWriteFontFaceReference1>;
@@ -950,6 +962,7 @@ impl IDWriteFactory6_Vtbl {
         iid == &<IDWriteFactory6 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory as ::windows::core::Interface>::IID || iid == &<IDWriteFactory1 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory2 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory3 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory4 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteFactory7_Impl: Sized + IDWriteFactory6_Impl {
     fn GetSystemFontSet3(&self, includedownloadablefonts: super::super::Foundation::BOOL) -> ::windows::core::Result<IDWriteFontSet2>;
@@ -992,6 +1005,7 @@ impl IDWriteFactory7_Vtbl {
         iid == &<IDWriteFactory7 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory as ::windows::core::Interface>::IID || iid == &<IDWriteFactory1 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory2 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory3 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory4 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory5 as ::windows::core::Interface>::IID || iid == &<IDWriteFactory6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFont_Impl: Sized {
     fn GetFontFamily(&self) -> ::windows::core::Result<IDWriteFontFamily>;
@@ -1109,6 +1123,7 @@ impl IDWriteFont_Vtbl {
         iid == &<IDWriteFont as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFont1_Impl: Sized + IDWriteFont_Impl {
     fn GetMetrics2(&self, fontmetrics: *mut DWRITE_FONT_METRICS1);
@@ -1153,6 +1168,7 @@ impl IDWriteFont1_Vtbl {
         iid == &<IDWriteFont1 as ::windows::core::Interface>::IID || iid == &<IDWriteFont as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFont2_Impl: Sized + IDWriteFont1_Impl {
     fn IsColorFont(&self) -> super::super::Foundation::BOOL;
@@ -1173,6 +1189,7 @@ impl IDWriteFont2_Vtbl {
         iid == &<IDWriteFont2 as ::windows::core::Interface>::IID || iid == &<IDWriteFont as ::windows::core::Interface>::IID || iid == &<IDWriteFont1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFont3_Impl: Sized + IDWriteFont2_Impl {
     fn CreateFontFace2(&self) -> ::windows::core::Result<IDWriteFontFace3>;
@@ -1236,6 +1253,7 @@ impl IDWriteFont3_Vtbl {
         iid == &<IDWriteFont3 as ::windows::core::Interface>::IID || iid == &<IDWriteFont as ::windows::core::Interface>::IID || iid == &<IDWriteFont1 as ::windows::core::Interface>::IID || iid == &<IDWriteFont2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontCollection_Impl: Sized {
     fn GetFontFamilyCount(&self) -> u32;
@@ -1292,6 +1310,7 @@ impl IDWriteFontCollection_Vtbl {
         iid == &<IDWriteFontCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontCollection1_Impl: Sized + IDWriteFontCollection_Impl {
     fn GetFontSet(&self) -> ::windows::core::Result<IDWriteFontSet>;
@@ -1334,6 +1353,7 @@ impl IDWriteFontCollection1_Vtbl {
         iid == &<IDWriteFontCollection1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontCollection2_Impl: Sized + IDWriteFontCollection1_Impl {
     fn GetFontFamily3(&self, index: u32) -> ::windows::core::Result<IDWriteFontFamily2>;
@@ -1396,6 +1416,7 @@ impl IDWriteFontCollection2_Vtbl {
         iid == &<IDWriteFontCollection2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontCollection as ::windows::core::Interface>::IID || iid == &<IDWriteFontCollection1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontCollection3_Impl: Sized + IDWriteFontCollection2_Impl {
     fn GetExpirationEvent(&self) -> super::super::Foundation::HANDLE;
@@ -1416,6 +1437,7 @@ impl IDWriteFontCollection3_Vtbl {
         iid == &<IDWriteFontCollection3 as ::windows::core::Interface>::IID || iid == &<IDWriteFontCollection as ::windows::core::Interface>::IID || iid == &<IDWriteFontCollection1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontCollection2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontCollectionLoader_Impl: Sized {
     fn CreateEnumeratorFromKey(&self, factory: &::core::option::Option<IDWriteFactory>, collectionkey: *const ::core::ffi::c_void, collectionkeysize: u32) -> ::windows::core::Result<IDWriteFontFileEnumerator>;
 }
@@ -1439,6 +1461,7 @@ impl IDWriteFontCollectionLoader_Vtbl {
         iid == &<IDWriteFontCollectionLoader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontDownloadListener_Impl: Sized {
     fn DownloadCompleted(&self, downloadqueue: &::core::option::Option<IDWriteFontDownloadQueue>, context: &::core::option::Option<::windows::core::IUnknown>, downloadresult: ::windows::core::HRESULT);
 }
@@ -1456,6 +1479,7 @@ impl IDWriteFontDownloadListener_Vtbl {
         iid == &<IDWriteFontDownloadListener as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontDownloadQueue_Impl: Sized {
     fn AddListener(&self, listener: &::core::option::Option<IDWriteFontDownloadListener>) -> ::windows::core::Result<u32>;
@@ -1520,6 +1544,7 @@ impl IDWriteFontDownloadQueue_Vtbl {
         iid == &<IDWriteFontDownloadQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDWriteFontFace_Impl: Sized {
     fn GetType(&self) -> DWRITE_FONT_FACE_TYPE;
@@ -1653,6 +1678,7 @@ impl IDWriteFontFace_Vtbl {
         iid == &<IDWriteFontFace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDWriteFontFace1_Impl: Sized + IDWriteFontFace_Impl {
     fn GetMetrics2(&self, fontmetrics: *mut DWRITE_FONT_METRICS1);
@@ -1765,6 +1791,7 @@ impl IDWriteFontFace1_Vtbl {
         iid == &<IDWriteFontFace1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDWriteFontFace2_Impl: Sized + IDWriteFontFace1_Impl {
     fn IsColorFont(&self) -> super::super::Foundation::BOOL;
@@ -1816,6 +1843,7 @@ impl IDWriteFontFace2_Vtbl {
         iid == &<IDWriteFontFace2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDWriteFontFace3_Impl: Sized + IDWriteFontFace2_Impl {
     fn GetFontFaceReference(&self) -> ::windows::core::Result<IDWriteFontFaceReference>;
@@ -1960,6 +1988,7 @@ impl IDWriteFontFace3_Vtbl {
         iid == &<IDWriteFontFace3 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDWriteFontFace4_Impl: Sized + IDWriteFontFace3_Impl {
     fn GetGlyphImageFormats(&self, glyphid: u16, pixelsperemfirst: u32, pixelsperemlast: u32) -> ::windows::core::Result<DWRITE_GLYPH_IMAGE_FORMATS>;
@@ -2010,6 +2039,7 @@ impl IDWriteFontFace4_Vtbl {
         iid == &<IDWriteFontFace4 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDWriteFontFace5_Impl: Sized + IDWriteFontFace4_Impl {
     fn GetFontAxisValueCount(&self) -> u32;
@@ -2067,6 +2097,7 @@ impl IDWriteFontFace5_Vtbl {
         iid == &<IDWriteFontFace5 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace3 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common"))]
 pub trait IDWriteFontFace6_Impl: Sized + IDWriteFontFace5_Impl {
     fn GetFamilyNames2(&self, fontfamilymodel: DWRITE_FONT_FAMILY_MODEL) -> ::windows::core::Result<IDWriteLocalizedStrings>;
@@ -2109,6 +2140,7 @@ impl IDWriteFontFace6_Vtbl {
         iid == &<IDWriteFontFace6 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace3 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace4 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFace5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontFaceReference_Impl: Sized {
     fn CreateFontFace(&self) -> ::windows::core::Result<IDWriteFontFace3>;
@@ -2247,6 +2279,7 @@ impl IDWriteFontFaceReference_Vtbl {
         iid == &<IDWriteFontFaceReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontFaceReference1_Impl: Sized + IDWriteFontFaceReference_Impl {
     fn CreateFontFace2(&self) -> ::windows::core::Result<IDWriteFontFace5>;
@@ -2290,6 +2323,7 @@ impl IDWriteFontFaceReference1_Vtbl {
         iid == &<IDWriteFontFaceReference1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFaceReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFallback_Impl: Sized {
     fn MapCharacters(&self, analysissource: &::core::option::Option<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, basefontcollection: &::core::option::Option<IDWriteFontCollection>, basefamilyname: &::windows::core::PCWSTR, baseweight: DWRITE_FONT_WEIGHT, basestyle: DWRITE_FONT_STYLE, basestretch: DWRITE_FONT_STRETCH, mappedlength: *mut u32, mappedfont: *mut ::core::option::Option<IDWriteFont>, scale: *mut f32) -> ::windows::core::Result<()>;
 }
@@ -2308,6 +2342,7 @@ impl IDWriteFontFallback_Vtbl {
         iid == &<IDWriteFontFallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFallback1_Impl: Sized + IDWriteFontFallback_Impl {
     fn MapCharacters2(&self, analysissource: &::core::option::Option<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, basefontcollection: &::core::option::Option<IDWriteFontCollection>, basefamilyname: &::windows::core::PCWSTR, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, mappedlength: *mut u32, scale: *mut f32, mappedfontface: *mut ::core::option::Option<IDWriteFontFace5>) -> ::windows::core::Result<()>;
 }
@@ -2325,6 +2360,7 @@ impl IDWriteFontFallback1_Vtbl {
         iid == &<IDWriteFontFallback1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontFallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFallbackBuilder_Impl: Sized {
     fn AddMapping(&self, ranges: *const DWRITE_UNICODE_RANGE, rangescount: u32, targetfamilynames: *const *const u16, targetfamilynamescount: u32, fontcollection: &::core::option::Option<IDWriteFontCollection>, localename: &::windows::core::PCWSTR, basefamilyname: &::windows::core::PCWSTR, scale: f32) -> ::windows::core::Result<()>;
     fn AddMappings(&self, fontfallback: &::core::option::Option<IDWriteFontFallback>) -> ::windows::core::Result<()>;
@@ -2365,6 +2401,7 @@ impl IDWriteFontFallbackBuilder_Vtbl {
         iid == &<IDWriteFontFallbackBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFamily_Impl: Sized + IDWriteFontList_Impl {
     fn GetFamilyNames(&self) -> ::windows::core::Result<IDWriteLocalizedStrings>;
     fn GetFirstMatchingFont(&self, weight: DWRITE_FONT_WEIGHT, stretch: DWRITE_FONT_STRETCH, style: DWRITE_FONT_STYLE) -> ::windows::core::Result<IDWriteFont>;
@@ -2417,6 +2454,7 @@ impl IDWriteFontFamily_Vtbl {
         iid == &<IDWriteFontFamily as ::windows::core::Interface>::IID || iid == &<IDWriteFontList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFamily1_Impl: Sized + IDWriteFontFamily_Impl {
     fn GetFontLocality(&self, listindex: u32) -> DWRITE_LOCALITY;
     fn GetFont2(&self, listindex: u32) -> ::windows::core::Result<IDWriteFont3>;
@@ -2463,6 +2501,7 @@ impl IDWriteFontFamily1_Vtbl {
         iid == &<IDWriteFontFamily1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontList as ::windows::core::Interface>::IID || iid == &<IDWriteFontFamily as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFamily2_Impl: Sized + IDWriteFontFamily1_Impl {
     fn GetMatchingFonts2(&self, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<IDWriteFontList2>;
     fn GetFontSet(&self) -> ::windows::core::Result<IDWriteFontSet1>;
@@ -2502,6 +2541,7 @@ impl IDWriteFontFamily2_Vtbl {
         iid == &<IDWriteFontFamily2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontList as ::windows::core::Interface>::IID || iid == &<IDWriteFontFamily as ::windows::core::Interface>::IID || iid == &<IDWriteFontFamily1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontFile_Impl: Sized {
     fn GetReferenceKey(&self, fontfilereferencekey: *mut *mut ::core::ffi::c_void, fontfilereferencekeysize: *mut u32) -> ::windows::core::Result<()>;
@@ -2545,6 +2585,7 @@ impl IDWriteFontFile_Vtbl {
         iid == &<IDWriteFontFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontFileEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2587,6 +2628,7 @@ impl IDWriteFontFileEnumerator_Vtbl {
         iid == &<IDWriteFontFileEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFileLoader_Impl: Sized {
     fn CreateStreamFromKey(&self, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32) -> ::windows::core::Result<IDWriteFontFileStream>;
 }
@@ -2610,6 +2652,7 @@ impl IDWriteFontFileLoader_Vtbl {
         iid == &<IDWriteFontFileLoader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontFileStream_Impl: Sized {
     fn ReadFileFragment(&self, fragmentstart: *mut *mut ::core::ffi::c_void, fileoffset: u64, fragmentsize: u64, fragmentcontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn ReleaseFileFragment(&self, fragmentcontext: *mut ::core::ffi::c_void);
@@ -2663,6 +2706,7 @@ impl IDWriteFontFileStream_Vtbl {
         iid == &<IDWriteFontFileStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontList_Impl: Sized {
     fn GetFontCollection(&self) -> ::windows::core::Result<IDWriteFontCollection>;
     fn GetFontCount(&self) -> u32;
@@ -2709,6 +2753,7 @@ impl IDWriteFontList_Vtbl {
         iid == &<IDWriteFontList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontList1_Impl: Sized + IDWriteFontList_Impl {
     fn GetFontLocality(&self, listindex: u32) -> DWRITE_LOCALITY;
     fn GetFont2(&self, listindex: u32) -> ::windows::core::Result<IDWriteFont3>;
@@ -2755,6 +2800,7 @@ impl IDWriteFontList1_Vtbl {
         iid == &<IDWriteFontList1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontList2_Impl: Sized + IDWriteFontList1_Impl {
     fn GetFontSet(&self) -> ::windows::core::Result<IDWriteFontSet1>;
 }
@@ -2778,6 +2824,7 @@ impl IDWriteFontList2_Vtbl {
         iid == &<IDWriteFontList2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontList as ::windows::core::Interface>::IID || iid == &<IDWriteFontList1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontResource_Impl: Sized {
     fn GetFontFile(&self) -> ::windows::core::Result<IDWriteFontFile>;
@@ -2902,6 +2949,7 @@ impl IDWriteFontResource_Vtbl {
         iid == &<IDWriteFontResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontSet_Impl: Sized {
     fn GetFontCount(&self) -> u32;
@@ -3024,6 +3072,7 @@ impl IDWriteFontSet_Vtbl {
         iid == &<IDWriteFontSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontSet1_Impl: Sized + IDWriteFontSet_Impl {
     fn GetMatchingFonts3(&self, fontproperty: *const DWRITE_FONT_PROPERTY, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<IDWriteFontSet1>;
@@ -3179,6 +3228,7 @@ impl IDWriteFontSet1_Vtbl {
         iid == &<IDWriteFontSet1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontSet2_Impl: Sized + IDWriteFontSet1_Impl {
     fn GetExpirationEvent(&self) -> super::super::Foundation::HANDLE;
@@ -3199,6 +3249,7 @@ impl IDWriteFontSet2_Vtbl {
         iid == &<IDWriteFontSet2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontSet as ::windows::core::Interface>::IID || iid == &<IDWriteFontSet1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteFontSet3_Impl: Sized + IDWriteFontSet2_Impl {
     fn GetFontSourceType(&self, fontindex: u32) -> DWRITE_FONT_SOURCE_TYPE;
@@ -3236,6 +3287,7 @@ impl IDWriteFontSet3_Vtbl {
         iid == &<IDWriteFontSet3 as ::windows::core::Interface>::IID || iid == &<IDWriteFontSet as ::windows::core::Interface>::IID || iid == &<IDWriteFontSet1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontSet2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontSetBuilder_Impl: Sized {
     fn AddFontFaceReference(&self, fontfacereference: &::core::option::Option<IDWriteFontFaceReference>, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> ::windows::core::Result<()>;
     fn AddFontFaceReference2(&self, fontfacereference: &::core::option::Option<IDWriteFontFaceReference>) -> ::windows::core::Result<()>;
@@ -3283,6 +3335,7 @@ impl IDWriteFontSetBuilder_Vtbl {
         iid == &<IDWriteFontSetBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontSetBuilder1_Impl: Sized + IDWriteFontSetBuilder_Impl {
     fn AddFontFile(&self, fontfile: &::core::option::Option<IDWriteFontFile>) -> ::windows::core::Result<()>;
 }
@@ -3300,6 +3353,7 @@ impl IDWriteFontSetBuilder1_Vtbl {
         iid == &<IDWriteFontSetBuilder1 as ::windows::core::Interface>::IID || iid == &<IDWriteFontSetBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteFontSetBuilder2_Impl: Sized + IDWriteFontSetBuilder1_Impl {
     fn AddFont(&self, fontfile: &::core::option::Option<IDWriteFontFile>, fontfaceindex: u32, fontsimulations: DWRITE_FONT_SIMULATIONS, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, fontaxisranges: *const DWRITE_FONT_AXIS_RANGE, fontaxisrangecount: u32, properties: *const DWRITE_FONT_PROPERTY, propertycount: u32) -> ::windows::core::Result<()>;
     fn AddFontFile2(&self, filepath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -3327,6 +3381,7 @@ impl IDWriteFontSetBuilder2_Vtbl {
         iid == &<IDWriteFontSetBuilder2 as ::windows::core::Interface>::IID || iid == &<IDWriteFontSetBuilder as ::windows::core::Interface>::IID || iid == &<IDWriteFontSetBuilder1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteGdiInterop_Impl: Sized {
     fn CreateFontFromLOGFONT(&self, logfont: *const super::Gdi::LOGFONTW) -> ::windows::core::Result<IDWriteFont>;
@@ -3402,6 +3457,7 @@ impl IDWriteGdiInterop_Vtbl {
         iid == &<IDWriteGdiInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi"))]
 pub trait IDWriteGdiInterop1_Impl: Sized + IDWriteGdiInterop_Impl {
     fn CreateFontFromLOGFONT2(&self, logfont: *const super::Gdi::LOGFONTW, fontcollection: &::core::option::Option<IDWriteFontCollection>) -> ::windows::core::Result<IDWriteFont>;
@@ -3470,6 +3526,7 @@ impl IDWriteGdiInterop1_Vtbl {
         iid == &<IDWriteGdiInterop1 as ::windows::core::Interface>::IID || iid == &<IDWriteGdiInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteGlyphRunAnalysis_Impl: Sized {
     fn GetAlphaTextureBounds(&self, texturetype: DWRITE_TEXTURE_TYPE) -> ::windows::core::Result<super::super::Foundation::RECT>;
@@ -3513,6 +3570,7 @@ impl IDWriteGlyphRunAnalysis_Vtbl {
         iid == &<IDWriteGlyphRunAnalysis as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteInMemoryFontFileLoader_Impl: Sized + IDWriteFontFileLoader_Impl {
     fn CreateInMemoryFontFileReference(&self, factory: &::core::option::Option<IDWriteFactory>, fontdata: *const ::core::ffi::c_void, fontdatasize: u32, ownerobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IDWriteFontFile>;
     fn GetFileCount(&self) -> u32;
@@ -3546,6 +3604,7 @@ impl IDWriteInMemoryFontFileLoader_Vtbl {
         iid == &<IDWriteInMemoryFontFileLoader as ::windows::core::Interface>::IID || iid == &<IDWriteFontFileLoader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteInlineObject_Impl: Sized {
     fn Draw(&self, clientdrawingcontext: *const ::core::ffi::c_void, renderer: &::core::option::Option<IDWriteTextRenderer>, originx: f32, originy: f32, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL, clientdrawingeffect: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -3602,6 +3661,7 @@ impl IDWriteInlineObject_Vtbl {
         iid == &<IDWriteInlineObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteLocalFontFileLoader_Impl: Sized + IDWriteFontFileLoader_Impl {
     fn GetFilePathLengthFromKey(&self, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32) -> ::windows::core::Result<u32>;
@@ -3651,6 +3711,7 @@ impl IDWriteLocalFontFileLoader_Vtbl {
         iid == &<IDWriteLocalFontFileLoader as ::windows::core::Interface>::IID || iid == &<IDWriteFontFileLoader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteLocalizedStrings_Impl: Sized {
     fn GetCount(&self) -> u32;
@@ -3721,6 +3782,7 @@ impl IDWriteLocalizedStrings_Vtbl {
         iid == &<IDWriteLocalizedStrings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteNumberSubstitution_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDWriteNumberSubstitution {}
 impl IDWriteNumberSubstitution_Vtbl {
@@ -3731,6 +3793,7 @@ impl IDWriteNumberSubstitution_Vtbl {
         iid == &<IDWriteNumberSubstitution as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWritePixelSnapping_Impl: Sized {
     fn IsPixelSnappingDisabled(&self, clientdrawingcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3786,6 +3849,7 @@ impl IDWritePixelSnapping_Vtbl {
         iid == &<IDWritePixelSnapping as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteRemoteFontFileLoader_Impl: Sized + IDWriteFontFileLoader_Impl {
     fn CreateRemoteStreamFromKey(&self, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32) -> ::windows::core::Result<IDWriteRemoteFontFileStream>;
     fn GetLocalityFromKey(&self, fontfilereferencekey: *const ::core::ffi::c_void, fontfilereferencekeysize: u32) -> ::windows::core::Result<DWRITE_LOCALITY>;
@@ -3838,6 +3902,7 @@ impl IDWriteRemoteFontFileLoader_Vtbl {
         iid == &<IDWriteRemoteFontFileLoader as ::windows::core::Interface>::IID || iid == &<IDWriteFontFileLoader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteRemoteFontFileStream_Impl: Sized + IDWriteFontFileStream_Impl {
     fn GetLocalFileSize(&self) -> ::windows::core::Result<u64>;
@@ -3888,6 +3953,7 @@ impl IDWriteRemoteFontFileStream_Vtbl {
         iid == &<IDWriteRemoteFontFileStream as ::windows::core::Interface>::IID || iid == &<IDWriteFontFileStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteRenderingParams_Impl: Sized {
     fn GetGamma(&self) -> f32;
     fn GetEnhancedContrast(&self) -> f32;
@@ -3936,6 +4002,7 @@ impl IDWriteRenderingParams_Vtbl {
         iid == &<IDWriteRenderingParams as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteRenderingParams1_Impl: Sized + IDWriteRenderingParams_Impl {
     fn GetGrayscaleEnhancedContrast(&self) -> f32;
 }
@@ -3956,6 +4023,7 @@ impl IDWriteRenderingParams1_Vtbl {
         iid == &<IDWriteRenderingParams1 as ::windows::core::Interface>::IID || iid == &<IDWriteRenderingParams as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteRenderingParams2_Impl: Sized + IDWriteRenderingParams1_Impl {
     fn GetGridFitMode(&self) -> DWRITE_GRID_FIT_MODE;
 }
@@ -3973,6 +4041,7 @@ impl IDWriteRenderingParams2_Vtbl {
         iid == &<IDWriteRenderingParams2 as ::windows::core::Interface>::IID || iid == &<IDWriteRenderingParams as ::windows::core::Interface>::IID || iid == &<IDWriteRenderingParams1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteRenderingParams3_Impl: Sized + IDWriteRenderingParams2_Impl {
     fn GetRenderingMode1(&self) -> DWRITE_RENDERING_MODE1;
 }
@@ -3990,6 +4059,7 @@ impl IDWriteRenderingParams3_Vtbl {
         iid == &<IDWriteRenderingParams3 as ::windows::core::Interface>::IID || iid == &<IDWriteRenderingParams as ::windows::core::Interface>::IID || iid == &<IDWriteRenderingParams1 as ::windows::core::Interface>::IID || iid == &<IDWriteRenderingParams2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteStringList_Impl: Sized {
     fn GetCount(&self) -> u32;
     fn GetLocaleNameLength(&self, listindex: u32) -> ::windows::core::Result<u32>;
@@ -4050,6 +4120,7 @@ impl IDWriteStringList_Vtbl {
         iid == &<IDWriteStringList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteTextAnalysisSink_Impl: Sized {
     fn SetScriptAnalysis(&self, textposition: u32, textlength: u32, scriptanalysis: *const DWRITE_SCRIPT_ANALYSIS) -> ::windows::core::Result<()>;
     fn SetLineBreakpoints(&self, textposition: u32, textlength: u32, linebreakpoints: *const DWRITE_LINE_BREAKPOINT) -> ::windows::core::Result<()>;
@@ -4091,6 +4162,7 @@ impl IDWriteTextAnalysisSink_Vtbl {
         iid == &<IDWriteTextAnalysisSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextAnalysisSink1_Impl: Sized + IDWriteTextAnalysisSink_Impl {
     fn SetGlyphOrientation(&self, textposition: u32, textlength: u32, glyphorientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, adjustedbidilevel: u8, issideways: super::super::Foundation::BOOL, isrighttoleft: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4111,6 +4183,7 @@ impl IDWriteTextAnalysisSink1_Vtbl {
         iid == &<IDWriteTextAnalysisSink1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextAnalysisSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteTextAnalysisSource_Impl: Sized {
     fn GetTextAtPosition(&self, textposition: u32, textstring: *mut *mut u16, textlength: *mut u32) -> ::windows::core::Result<()>;
     fn GetTextBeforePosition(&self, textposition: u32, textstring: *mut *mut u16, textlength: *mut u32) -> ::windows::core::Result<()>;
@@ -4159,6 +4232,7 @@ impl IDWriteTextAnalysisSource_Vtbl {
         iid == &<IDWriteTextAnalysisSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteTextAnalysisSource1_Impl: Sized + IDWriteTextAnalysisSource_Impl {
     fn GetVerticalGlyphOrientation(&self, textposition: u32, textlength: *mut u32, glyphorientation: *mut DWRITE_VERTICAL_GLYPH_ORIENTATION, bidilevel: *mut u8) -> ::windows::core::Result<()>;
 }
@@ -4179,6 +4253,7 @@ impl IDWriteTextAnalysisSource1_Vtbl {
         iid == &<IDWriteTextAnalysisSource1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextAnalysisSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextAnalyzer_Impl: Sized {
     fn AnalyzeScript(&self, analysissource: &::core::option::Option<IDWriteTextAnalysisSource>, textposition: u32, textlength: u32, analysissink: &::core::option::Option<IDWriteTextAnalysisSink>) -> ::windows::core::Result<()>;
@@ -4391,6 +4466,7 @@ impl IDWriteTextAnalyzer_Vtbl {
         iid == &<IDWriteTextAnalyzer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextAnalyzer1_Impl: Sized + IDWriteTextAnalyzer_Impl {
     fn ApplyCharacterSpacing(&self, leadingspacing: f32, trailingspacing: f32, minimumadvancewidth: f32, textlength: u32, glyphcount: u32, clustermap: *const u16, glyphadvances: *const f32, glyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()>;
@@ -4514,6 +4590,7 @@ impl IDWriteTextAnalyzer1_Vtbl {
         iid == &<IDWriteTextAnalyzer1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextAnalyzer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextAnalyzer2_Impl: Sized + IDWriteTextAnalyzer1_Impl {
     fn GetGlyphOrientationTransform2(&self, glyphorientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, issideways: super::super::Foundation::BOOL, originx: f32, originy: f32) -> ::windows::core::Result<DWRITE_MATRIX>;
@@ -4557,6 +4634,7 @@ impl IDWriteTextAnalyzer2_Vtbl {
         iid == &<IDWriteTextAnalyzer2 as ::windows::core::Interface>::IID || iid == &<IDWriteTextAnalyzer as ::windows::core::Interface>::IID || iid == &<IDWriteTextAnalyzer1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteTextFormat_Impl: Sized {
     fn SetTextAlignment(&self, textalignment: DWRITE_TEXT_ALIGNMENT) -> ::windows::core::Result<()>;
     fn SetParagraphAlignment(&self, paragraphalignment: DWRITE_PARAGRAPH_ALIGNMENT) -> ::windows::core::Result<()>;
@@ -4751,6 +4829,7 @@ impl IDWriteTextFormat_Vtbl {
         iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextFormat1_Impl: Sized + IDWriteTextFormat_Impl {
     fn SetVerticalGlyphOrientation(&self, glyphorientation: DWRITE_VERTICAL_GLYPH_ORIENTATION) -> ::windows::core::Result<()>;
@@ -4829,6 +4908,7 @@ impl IDWriteTextFormat1_Vtbl {
         iid == &<IDWriteTextFormat1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextFormat2_Impl: Sized + IDWriteTextFormat1_Impl {
     fn SetLineSpacing2(&self, linespacingoptions: *const DWRITE_LINE_SPACING) -> ::windows::core::Result<()>;
@@ -4865,6 +4945,7 @@ impl IDWriteTextFormat2_Vtbl {
         iid == &<IDWriteTextFormat2 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextFormat3_Impl: Sized + IDWriteTextFormat2_Impl {
     fn SetFontAxisValues(&self, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32) -> ::windows::core::Result<()>;
@@ -4916,6 +4997,7 @@ impl IDWriteTextFormat3_Vtbl {
         iid == &<IDWriteTextFormat3 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextLayout_Impl: Sized + IDWriteTextFormat_Impl {
     fn SetMaxWidth(&self, maxwidth: f32) -> ::windows::core::Result<()>;
@@ -5223,6 +5305,7 @@ impl IDWriteTextLayout_Vtbl {
         iid == &<IDWriteTextLayout as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextLayout1_Impl: Sized + IDWriteTextLayout_Impl {
     fn SetPairKerning(&self, ispairkerningenabled: super::super::Foundation::BOOL, textrange: &DWRITE_TEXT_RANGE) -> ::windows::core::Result<()>;
@@ -5267,6 +5350,7 @@ impl IDWriteTextLayout1_Vtbl {
         iid == &<IDWriteTextLayout1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextLayout2_Impl: Sized + IDWriteTextLayout1_Impl {
     fn GetMetrics2(&self) -> ::windows::core::Result<DWRITE_TEXT_METRICS1>;
@@ -5358,6 +5442,7 @@ impl IDWriteTextLayout2_Vtbl {
         iid == &<IDWriteTextLayout2 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextLayout3_Impl: Sized + IDWriteTextLayout2_Impl {
     fn InvalidateLayout(&self) -> ::windows::core::Result<()>;
@@ -5408,6 +5493,7 @@ impl IDWriteTextLayout3_Vtbl {
         iid == &<IDWriteTextLayout3 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextLayout4_Impl: Sized + IDWriteTextLayout3_Impl {
     fn SetFontAxisValues(&self, fontaxisvalues: *const DWRITE_FONT_AXIS_VALUE, fontaxisvaluecount: u32, textrange: &DWRITE_TEXT_RANGE) -> ::windows::core::Result<()>;
@@ -5459,6 +5545,7 @@ impl IDWriteTextLayout4_Vtbl {
         iid == &<IDWriteTextLayout4 as ::windows::core::Interface>::IID || iid == &<IDWriteTextFormat as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout1 as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout2 as ::windows::core::Interface>::IID || iid == &<IDWriteTextLayout3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextRenderer_Impl: Sized + IDWritePixelSnapping_Impl {
     fn DrawGlyphRun(&self, clientdrawingcontext: *const ::core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, clientdrawingeffect: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -5503,6 +5590,7 @@ impl IDWriteTextRenderer_Vtbl {
         iid == &<IDWriteTextRenderer as ::windows::core::Interface>::IID || iid == &<IDWritePixelSnapping as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDWriteTextRenderer1_Impl: Sized + IDWriteTextRenderer_Impl {
     fn DrawGlyphRun2(&self, clientdrawingcontext: *const ::core::ffi::c_void, baselineoriginx: f32, baselineoriginy: f32, orientationangle: DWRITE_GLYPH_ORIENTATION_ANGLE, measuringmode: DWRITE_MEASURING_MODE, glyphrun: *const DWRITE_GLYPH_RUN, glyphrundescription: *const DWRITE_GLYPH_RUN_DESCRIPTION, clientdrawingeffect: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -5547,6 +5635,7 @@ impl IDWriteTextRenderer1_Vtbl {
         iid == &<IDWriteTextRenderer1 as ::windows::core::Interface>::IID || iid == &<IDWritePixelSnapping as ::windows::core::Interface>::IID || iid == &<IDWriteTextRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"implement\"`*"]
 pub trait IDWriteTypography_Impl: Sized {
     fn AddFontFeature(&self, fontfeature: &DWRITE_FONT_FEATURE) -> ::windows::core::Result<()>;
     fn GetFontFeatureCount(&self) -> u32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIAdapter_Impl: Sized + IDXGIObject_Impl {
     fn EnumOutputs(&self, output: u32) -> ::windows::core::Result<IDXGIOutput>;
@@ -53,6 +54,7 @@ impl IDXGIAdapter_Vtbl {
         iid == &<IDXGIAdapter as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIAdapter1_Impl: Sized + IDXGIAdapter_Impl {
     fn GetDesc1(&self) -> ::windows::core::Result<DXGI_ADAPTER_DESC1>;
@@ -79,6 +81,7 @@ impl IDXGIAdapter1_Vtbl {
         iid == &<IDXGIAdapter1 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIAdapter2_Impl: Sized + IDXGIAdapter1_Impl {
     fn GetDesc2(&self) -> ::windows::core::Result<DXGI_ADAPTER_DESC2>;
@@ -105,6 +108,7 @@ impl IDXGIAdapter2_Vtbl {
         iid == &<IDXGIAdapter2 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIAdapter3_Impl: Sized + IDXGIAdapter2_Impl {
     fn RegisterHardwareContentProtectionTeardownStatusEvent(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<u32>;
@@ -181,6 +185,7 @@ impl IDXGIAdapter3_Vtbl {
         iid == &<IDXGIAdapter3 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter1 as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIAdapter4_Impl: Sized + IDXGIAdapter3_Impl {
     fn GetDesc3(&self) -> ::windows::core::Result<DXGI_ADAPTER_DESC3>;
@@ -207,6 +212,7 @@ impl IDXGIAdapter4_Vtbl {
         iid == &<IDXGIAdapter4 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter1 as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter2 as ::windows::core::Interface>::IID || iid == &<IDXGIAdapter3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 pub trait IDXGIDebug_Impl: Sized {
     fn ReportLiveObjects(&self, apiid: &::windows::core::GUID, flags: DXGI_DEBUG_RLO_FLAGS) -> ::windows::core::Result<()>;
 }
@@ -224,6 +230,7 @@ impl IDXGIDebug_Vtbl {
         iid == &<IDXGIDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIDebug1_Impl: Sized + IDXGIDebug_Impl {
     fn EnableLeakTrackingForThread(&self);
@@ -261,6 +268,7 @@ impl IDXGIDebug1_Vtbl {
         iid == &<IDXGIDebug1 as ::windows::core::Interface>::IID || iid == &<IDXGIDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIDecodeSwapChain_Impl: Sized {
     fn PresentBuffer(&self, buffertopresent: u32, syncinterval: u32, flags: u32) -> ::windows::core::HRESULT;
@@ -352,6 +360,7 @@ impl IDXGIDecodeSwapChain_Vtbl {
         iid == &<IDXGIDecodeSwapChain as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIDevice_Impl: Sized + IDXGIObject_Impl {
     fn GetAdapter(&self) -> ::windows::core::Result<IDXGIAdapter>;
@@ -415,6 +424,7 @@ impl IDXGIDevice_Vtbl {
         iid == &<IDXGIDevice as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIDevice1_Impl: Sized + IDXGIDevice_Impl {
     fn SetMaximumFrameLatency(&self, maxlatency: u32) -> ::windows::core::Result<()>;
@@ -451,6 +461,7 @@ impl IDXGIDevice1_Vtbl {
         iid == &<IDXGIDevice1 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIDevice2_Impl: Sized + IDXGIDevice1_Impl {
     fn OfferResources(&self, numresources: u32, ppresources: *const ::core::option::Option<IDXGIResource>, priority: DXGI_OFFER_RESOURCE_PRIORITY) -> ::windows::core::Result<()>;
@@ -488,6 +499,7 @@ impl IDXGIDevice2_Vtbl {
         iid == &<IDXGIDevice2 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDevice as ::windows::core::Interface>::IID || iid == &<IDXGIDevice1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIDevice3_Impl: Sized + IDXGIDevice2_Impl {
     fn Trim(&self);
@@ -508,6 +520,7 @@ impl IDXGIDevice3_Vtbl {
         iid == &<IDXGIDevice3 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDevice as ::windows::core::Interface>::IID || iid == &<IDXGIDevice1 as ::windows::core::Interface>::IID || iid == &<IDXGIDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIDevice4_Impl: Sized + IDXGIDevice3_Impl {
     fn OfferResources1(&self, numresources: u32, ppresources: *const ::core::option::Option<IDXGIResource>, priority: DXGI_OFFER_RESOURCE_PRIORITY, flags: u32) -> ::windows::core::Result<()>;
@@ -538,6 +551,7 @@ impl IDXGIDevice4_Vtbl {
         iid == &<IDXGIDevice4 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDevice as ::windows::core::Interface>::IID || iid == &<IDXGIDevice1 as ::windows::core::Interface>::IID || iid == &<IDXGIDevice2 as ::windows::core::Interface>::IID || iid == &<IDXGIDevice3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 pub trait IDXGIDeviceSubObject_Impl: Sized + IDXGIObject_Impl {
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppdevice: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -555,6 +569,7 @@ impl IDXGIDeviceSubObject_Vtbl {
         iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIDisplayControl_Impl: Sized {
     fn IsStereoEnabled(&self) -> super::super::Foundation::BOOL;
@@ -585,6 +600,7 @@ impl IDXGIDisplayControl_Vtbl {
         iid == &<IDXGIDisplayControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory_Impl: Sized + IDXGIObject_Impl {
     fn EnumAdapters(&self, adapter: u32) -> ::windows::core::Result<IDXGIAdapter>;
@@ -654,6 +670,7 @@ impl IDXGIFactory_Vtbl {
         iid == &<IDXGIFactory as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory1_Impl: Sized + IDXGIFactory_Impl {
     fn EnumAdapters1(&self, adapter: u32) -> ::windows::core::Result<IDXGIAdapter1>;
@@ -690,6 +707,7 @@ impl IDXGIFactory1_Vtbl {
         iid == &<IDXGIFactory1 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory2_Impl: Sized + IDXGIFactory1_Impl {
     fn IsWindowedStereoEnabled(&self) -> super::super::Foundation::BOOL;
@@ -831,6 +849,7 @@ impl IDXGIFactory2_Vtbl {
         iid == &<IDXGIFactory2 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIFactory as ::windows::core::Interface>::IID || iid == &<IDXGIFactory1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory3_Impl: Sized + IDXGIFactory2_Impl {
     fn GetCreationFlags(&self) -> u32;
@@ -851,6 +870,7 @@ impl IDXGIFactory3_Vtbl {
         iid == &<IDXGIFactory3 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIFactory as ::windows::core::Interface>::IID || iid == &<IDXGIFactory1 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory4_Impl: Sized + IDXGIFactory3_Impl {
     fn EnumAdapterByLuid(&self, adapterluid: &super::super::Foundation::LUID, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -881,6 +901,7 @@ impl IDXGIFactory4_Vtbl {
         iid == &<IDXGIFactory4 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIFactory as ::windows::core::Interface>::IID || iid == &<IDXGIFactory1 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory2 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory5_Impl: Sized + IDXGIFactory4_Impl {
     fn CheckFeatureSupport(&self, feature: DXGI_FEATURE, pfeaturesupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::Result<()>;
@@ -901,6 +922,7 @@ impl IDXGIFactory5_Vtbl {
         iid == &<IDXGIFactory5 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIFactory as ::windows::core::Interface>::IID || iid == &<IDXGIFactory1 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory2 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory3 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory6_Impl: Sized + IDXGIFactory5_Impl {
     fn EnumAdapterByGpuPreference(&self, adapter: u32, gpupreference: DXGI_GPU_PREFERENCE, riid: *const ::windows::core::GUID, ppvadapter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -921,6 +943,7 @@ impl IDXGIFactory6_Vtbl {
         iid == &<IDXGIFactory6 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIFactory as ::windows::core::Interface>::IID || iid == &<IDXGIFactory1 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory2 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory3 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory4 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactory7_Impl: Sized + IDXGIFactory6_Impl {
     fn RegisterAdaptersChangedEvent(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<u32>;
@@ -957,6 +980,7 @@ impl IDXGIFactory7_Vtbl {
         iid == &<IDXGIFactory7 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIFactory as ::windows::core::Interface>::IID || iid == &<IDXGIFactory1 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory2 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory3 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory4 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory5 as ::windows::core::Interface>::IID || iid == &<IDXGIFactory6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIFactoryMedia_Impl: Sized {
     fn CreateSwapChainForCompositionSurfaceHandle(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>, hsurface: super::super::Foundation::HANDLE, pdesc: *const DXGI_SWAP_CHAIN_DESC1, prestricttooutput: &::core::option::Option<IDXGIOutput>) -> ::windows::core::Result<IDXGISwapChain1>;
@@ -999,6 +1023,7 @@ impl IDXGIFactoryMedia_Vtbl {
         iid == &<IDXGIFactoryMedia as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIInfoQueue_Impl: Sized {
     fn SetMessageCountLimit(&self, producer: &::windows::core::GUID, messagecountlimit: u64) -> ::windows::core::Result<()>;
@@ -1274,6 +1299,7 @@ impl IDXGIInfoQueue_Vtbl {
         iid == &<IDXGIInfoQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 pub trait IDXGIKeyedMutex_Impl: Sized + IDXGIDeviceSubObject_Impl {
     fn AcquireSync(&self, key: u64, dwmilliseconds: u32) -> ::windows::core::Result<()>;
     fn ReleaseSync(&self, key: u64) -> ::windows::core::Result<()>;
@@ -1301,6 +1327,7 @@ impl IDXGIKeyedMutex_Vtbl {
         iid == &<IDXGIKeyedMutex as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 pub trait IDXGIObject_Impl: Sized {
     fn SetPrivateData(&self, name: *const ::windows::core::GUID, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn SetPrivateDataInterface(&self, name: *const ::windows::core::GUID, punknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1342,6 +1369,7 @@ impl IDXGIObject_Vtbl {
         iid == &<IDXGIObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput_Impl: Sized + IDXGIObject_Impl {
     fn GetDesc(&self) -> ::windows::core::Result<DXGI_OUTPUT_DESC>;
@@ -1466,6 +1494,7 @@ impl IDXGIOutput_Vtbl {
         iid == &<IDXGIOutput as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput1_Impl: Sized + IDXGIOutput_Impl {
     fn GetDisplayModeList1(&self, enumformat: Common::DXGI_FORMAT, flags: u32, pnummodes: *mut u32, pdesc: *mut DXGI_MODE_DESC1) -> ::windows::core::Result<()>;
@@ -1516,6 +1545,7 @@ impl IDXGIOutput1_Vtbl {
         iid == &<IDXGIOutput1 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIOutput as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput2_Impl: Sized + IDXGIOutput1_Impl {
     fn SupportsOverlays(&self) -> super::super::Foundation::BOOL;
@@ -1536,6 +1566,7 @@ impl IDXGIOutput2_Vtbl {
         iid == &<IDXGIOutput2 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIOutput as ::windows::core::Interface>::IID || iid == &<IDXGIOutput1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput3_Impl: Sized + IDXGIOutput2_Impl {
     fn CheckOverlaySupport(&self, enumformat: Common::DXGI_FORMAT, pconcerneddevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
@@ -1562,6 +1593,7 @@ impl IDXGIOutput3_Vtbl {
         iid == &<IDXGIOutput3 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIOutput as ::windows::core::Interface>::IID || iid == &<IDXGIOutput1 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput4_Impl: Sized + IDXGIOutput3_Impl {
     fn CheckOverlayColorSpaceSupport(&self, format: Common::DXGI_FORMAT, colorspace: Common::DXGI_COLOR_SPACE_TYPE, pconcerneddevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
@@ -1591,6 +1623,7 @@ impl IDXGIOutput4_Vtbl {
         iid == &<IDXGIOutput4 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIOutput as ::windows::core::Interface>::IID || iid == &<IDXGIOutput1 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput2 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput5_Impl: Sized + IDXGIOutput4_Impl {
     fn DuplicateOutput1(&self, pdevice: &::core::option::Option<::windows::core::IUnknown>, flags: u32, supportedformatscount: u32, psupportedformats: *const Common::DXGI_FORMAT) -> ::windows::core::Result<IDXGIOutputDuplication>;
@@ -1617,6 +1650,7 @@ impl IDXGIOutput5_Vtbl {
         iid == &<IDXGIOutput5 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIOutput as ::windows::core::Interface>::IID || iid == &<IDXGIOutput1 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput2 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput3 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGIOutput6_Impl: Sized + IDXGIOutput5_Impl {
     fn GetDesc1(&self) -> ::windows::core::Result<DXGI_OUTPUT_DESC1>;
@@ -1659,6 +1693,7 @@ impl IDXGIOutput6_Vtbl {
         iid == &<IDXGIOutput6 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIOutput as ::windows::core::Interface>::IID || iid == &<IDXGIOutput1 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput2 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput3 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput4 as ::windows::core::Interface>::IID || iid == &<IDXGIOutput5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGIOutputDuplication_Impl: Sized + IDXGIObject_Impl {
     fn GetDesc(&self, pdesc: *mut DXGI_OUTDUPL_DESC);
@@ -1737,6 +1772,7 @@ impl IDXGIOutputDuplication_Vtbl {
         iid == &<IDXGIOutputDuplication as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDXGIResource_Impl: Sized + IDXGIDeviceSubObject_Impl {
     fn GetSharedHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -1799,6 +1835,7 @@ impl IDXGIResource_Vtbl {
         iid == &<IDXGIResource as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 pub trait IDXGIResource1_Impl: Sized + IDXGIResource_Impl {
     fn CreateSubresourceSurface(&self, index: u32) -> ::windows::core::Result<IDXGISurface2>;
@@ -1841,6 +1878,7 @@ impl IDXGIResource1_Vtbl {
         iid == &<IDXGIResource1 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGIResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IDXGISurface_Impl: Sized + IDXGIDeviceSubObject_Impl {
     fn GetDesc(&self) -> ::windows::core::Result<DXGI_SURFACE_DESC>;
@@ -1884,6 +1922,7 @@ impl IDXGISurface_Vtbl {
         iid == &<IDXGISurface as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGISurface1_Impl: Sized + IDXGISurface_Impl {
     fn GetDC(&self, discard: super::super::Foundation::BOOL) -> ::windows::core::Result<super::Gdi::HDC>;
@@ -1920,6 +1959,7 @@ impl IDXGISurface1_Vtbl {
         iid == &<IDXGISurface1 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGISurface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common", feature = "Win32_Graphics_Gdi"))]
 pub trait IDXGISurface2_Impl: Sized + IDXGISurface1_Impl {
     fn GetResource(&self, riid: *const ::windows::core::GUID, ppparentresource: *mut *mut ::core::ffi::c_void, psubresourceindex: *mut u32) -> ::windows::core::Result<()>;
@@ -1940,6 +1980,7 @@ impl IDXGISurface2_Vtbl {
         iid == &<IDXGISurface2 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGISurface as ::windows::core::Interface>::IID || iid == &<IDXGISurface1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGISwapChain_Impl: Sized + IDXGIDeviceSubObject_Impl {
     fn Present(&self, syncinterval: u32, flags: u32) -> ::windows::core::HRESULT;
@@ -2050,6 +2091,7 @@ impl IDXGISwapChain_Vtbl {
         iid == &<IDXGISwapChain as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGISwapChain1_Impl: Sized + IDXGISwapChain_Impl {
     fn GetDesc1(&self) -> ::windows::core::Result<DXGI_SWAP_CHAIN_DESC1>;
@@ -2179,6 +2221,7 @@ impl IDXGISwapChain1_Vtbl {
         iid == &<IDXGISwapChain1 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGISwapChain2_Impl: Sized + IDXGISwapChain1_Impl {
     fn SetSourceSize(&self, width: u32, height: u32) -> ::windows::core::Result<()>;
@@ -2256,6 +2299,7 @@ impl IDXGISwapChain2_Vtbl {
         iid == &<IDXGISwapChain2 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGISwapChain3_Impl: Sized + IDXGISwapChain2_Impl {
     fn GetCurrentBackBufferIndex(&self) -> u32;
@@ -2306,6 +2350,7 @@ impl IDXGISwapChain3_Vtbl {
         iid == &<IDXGISwapChain3 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain1 as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IDXGISwapChain4_Impl: Sized + IDXGISwapChain3_Impl {
     fn SetHDRMetaData(&self, r#type: DXGI_HDR_METADATA_TYPE, size: u32, pmetadata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2326,6 +2371,7 @@ impl IDXGISwapChain4_Vtbl {
         iid == &<IDXGISwapChain4 as ::windows::core::Interface>::IID || iid == &<IDXGIObject as ::windows::core::Interface>::IID || iid == &<IDXGIDeviceSubObject as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain1 as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain2 as ::windows::core::Interface>::IID || iid == &<IDXGISwapChain3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 pub trait IDXGISwapChainMedia_Impl: Sized {
     fn GetFrameStatisticsMedia(&self) -> ::windows::core::Result<DXGI_FRAME_STATISTICS_MEDIA>;
     fn SetPresentDuration(&self, duration: u32) -> ::windows::core::Result<()>;
@@ -2366,6 +2412,7 @@ impl IDXGISwapChainMedia_Vtbl {
         iid == &<IDXGISwapChainMedia as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 pub trait IDXGraphicsAnalysis_Impl: Sized {
     fn BeginCapture(&self);
     fn EndCapture(&self);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/D2D/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Imaging_D2D\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IWICImageEncoder_Impl: Sized {
     fn WriteFrame(&self, pimage: &::core::option::Option<super::super::Direct2D::ID2D1Image>, pframeencode: &::core::option::Option<super::IWICBitmapFrameEncode>, pimageparameters: *const super::WICImageParameters) -> ::windows::core::Result<()>;
@@ -35,6 +36,7 @@ impl IWICImageEncoder_Vtbl {
         iid == &<IWICImageEncoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging_D2D\"`, `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct2D", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IWICImagingFactory2_Impl: Sized + super::IWICImagingFactory_Impl {
     fn CreateImageEncoder(&self, pd2ddevice: &::core::option::Option<super::super::Direct2D::ID2D1Device>) -> ::windows::core::Result<IWICImageEncoder>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmap_Impl: Sized + IWICBitmapSource_Impl {
     fn Lock(&self, prclock: *const WICRect, flags: u32) -> ::windows::core::Result<IWICBitmapLock>;
     fn SetPalette(&self, pipalette: &::core::option::Option<IWICPalette>) -> ::windows::core::Result<()>;
@@ -38,6 +39,7 @@ impl IWICBitmap_Vtbl {
         iid == &<IWICBitmap as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmapClipper_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pisource: &::core::option::Option<IWICBitmapSource>, prc: *const WICRect) -> ::windows::core::Result<()>;
 }
@@ -55,6 +57,7 @@ impl IWICBitmapClipper_Vtbl {
         iid == &<IWICBitmapClipper as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICBitmapCodecInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn GetContainerFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -191,6 +194,7 @@ impl IWICBitmapCodecInfo_Vtbl {
         iid == &<IWICBitmapCodecInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmapCodecProgressNotification_Impl: Sized {
     fn RegisterProgressNotification(&self, pfnprogressnotification: PFNProgressNotification, pvdata: *const ::core::ffi::c_void, dwprogressflags: u32) -> ::windows::core::Result<()>;
 }
@@ -211,6 +215,7 @@ impl IWICBitmapCodecProgressNotification_Vtbl {
         iid == &<IWICBitmapCodecProgressNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWICBitmapDecoder_Impl: Sized {
     fn QueryCapability(&self, pistream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<u32>;
@@ -352,6 +357,7 @@ impl IWICBitmapDecoder_Vtbl {
         iid == &<IWICBitmapDecoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWICBitmapDecoderInfo_Impl: Sized + IWICBitmapCodecInfo_Impl {
     fn GetPatterns(&self, cbsizepatterns: u32, ppatterns: *mut WICBitmapPattern, pcpatterns: *mut u32, pcbpatternsactual: *mut u32) -> ::windows::core::Result<()>;
@@ -401,6 +407,7 @@ impl IWICBitmapDecoderInfo_Vtbl {
         iid == &<IWICBitmapDecoderInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID || iid == &<IWICBitmapCodecInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IWICBitmapEncoder_Impl: Sized {
     fn Initialize(&self, pistream: &::core::option::Option<super::super::System::Com::IStream>, cacheoption: WICBitmapEncoderCacheOption) -> ::windows::core::Result<()>;
@@ -505,6 +512,7 @@ impl IWICBitmapEncoder_Vtbl {
         iid == &<IWICBitmapEncoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICBitmapEncoderInfo_Impl: Sized + IWICBitmapCodecInfo_Impl {
     fn CreateInstance(&self) -> ::windows::core::Result<IWICBitmapEncoder>;
@@ -531,6 +539,7 @@ impl IWICBitmapEncoderInfo_Vtbl {
         iid == &<IWICBitmapEncoderInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID || iid == &<IWICBitmapCodecInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmapFlipRotator_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pisource: &::core::option::Option<IWICBitmapSource>, options: WICBitmapTransformOptions) -> ::windows::core::Result<()>;
 }
@@ -548,6 +557,7 @@ impl IWICBitmapFlipRotator_Vtbl {
         iid == &<IWICBitmapFlipRotator as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmapFrameDecode_Impl: Sized + IWICBitmapSource_Impl {
     fn GetMetadataQueryReader(&self) -> ::windows::core::Result<IWICMetadataQueryReader>;
     fn GetColorContexts(&self, ccount: u32, ppicolorcontexts: *mut ::core::option::Option<IWICColorContext>, pcactualcount: *mut u32) -> ::windows::core::Result<()>;
@@ -594,6 +604,7 @@ impl IWICBitmapFrameDecode_Vtbl {
         iid == &<IWICBitmapFrameDecode as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IWICBitmapFrameEncode_Impl: Sized {
     fn Initialize(&self, piencoderoptions: &::core::option::Option<super::super::System::Com::StructuredStorage::IPropertyBag2>) -> ::windows::core::Result<()>;
@@ -693,6 +704,7 @@ impl IWICBitmapFrameEncode_Vtbl {
         iid == &<IWICBitmapFrameEncode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmapLock_Impl: Sized {
     fn GetSize(&self, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::Result<()>;
     fn GetStride(&self) -> ::windows::core::Result<u32>;
@@ -746,6 +758,7 @@ impl IWICBitmapLock_Vtbl {
         iid == &<IWICBitmapLock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmapScaler_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pisource: &::core::option::Option<IWICBitmapSource>, uiwidth: u32, uiheight: u32, mode: WICBitmapInterpolationMode) -> ::windows::core::Result<()>;
 }
@@ -763,6 +776,7 @@ impl IWICBitmapScaler_Vtbl {
         iid == &<IWICBitmapScaler as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICBitmapSource_Impl: Sized {
     fn GetSize(&self, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::Result<()>;
     fn GetPixelFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -817,6 +831,7 @@ impl IWICBitmapSource_Vtbl {
         iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICBitmapSourceTransform_Impl: Sized {
     fn CopyPixels(&self, prc: *const WICRect, uiwidth: u32, uiheight: u32, pguiddstformat: *const ::windows::core::GUID, dsttransform: WICBitmapTransformOptions, nstride: u32, cbbuffersize: u32, pbbuffer: *mut u8) -> ::windows::core::Result<()>;
@@ -867,6 +882,7 @@ impl IWICBitmapSourceTransform_Vtbl {
         iid == &<IWICBitmapSourceTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICColorContext_Impl: Sized {
     fn InitializeFromFilename(&self, wzfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn InitializeFromMemory(&self, pbbuffer: *const u8, cbbuffersize: u32) -> ::windows::core::Result<()>;
@@ -934,6 +950,7 @@ impl IWICColorContext_Vtbl {
         iid == &<IWICColorContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICColorTransform_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pibitmapsource: &::core::option::Option<IWICBitmapSource>, picontextsource: &::core::option::Option<IWICColorContext>, picontextdest: &::core::option::Option<IWICColorContext>, pixelfmtdest: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -951,6 +968,7 @@ impl IWICColorTransform_Vtbl {
         iid == &<IWICColorTransform as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IWICComponentFactory_Impl: Sized + IWICImagingFactory_Impl {
     fn CreateMetadataReader(&self, guidmetadataformat: *const ::windows::core::GUID, pguidvendor: *const ::windows::core::GUID, dwoptions: u32, pistream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<IWICMetadataReader>;
@@ -1058,6 +1076,7 @@ impl IWICComponentFactory_Vtbl {
         iid == &<IWICComponentFactory as ::windows::core::Interface>::IID || iid == &<IWICImagingFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICComponentInfo_Impl: Sized {
     fn GetComponentType(&self) -> ::windows::core::Result<WICComponentType>;
     fn GetCLSID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1151,6 +1170,7 @@ impl IWICComponentInfo_Vtbl {
         iid == &<IWICComponentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IWICDdsDecoder_Impl: Sized {
     fn GetParameters(&self) -> ::windows::core::Result<WICDdsParameters>;
@@ -1193,6 +1213,7 @@ impl IWICDdsDecoder_Vtbl {
         iid == &<IWICDdsDecoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IWICDdsEncoder_Impl: Sized {
     fn SetParameters(&self, pparameters: *const WICDdsParameters) -> ::windows::core::Result<()>;
@@ -1236,6 +1257,7 @@ impl IWICDdsEncoder_Vtbl {
         iid == &<IWICDdsEncoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IWICDdsFrameDecode_Impl: Sized {
     fn GetSizeInBlocks(&self, pwidthinblocks: *mut u32, pheightinblocks: *mut u32) -> ::windows::core::Result<()>;
@@ -1279,6 +1301,7 @@ impl IWICDdsFrameDecode_Vtbl {
         iid == &<IWICDdsFrameDecode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IWICDevelopRaw_Impl: Sized + IWICBitmapFrameDecode_Impl {
     fn QueryRawCapabilitiesInfo(&self, pinfo: *mut WICRawCapabilitiesInfo) -> ::windows::core::Result<()>;
@@ -1591,6 +1614,7 @@ impl IWICDevelopRaw_Vtbl {
         iid == &<IWICDevelopRaw as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID || iid == &<IWICBitmapFrameDecode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICDevelopRawNotificationCallback_Impl: Sized {
     fn Notify(&self, notificationmask: u32) -> ::windows::core::Result<()>;
 }
@@ -1608,6 +1632,7 @@ impl IWICDevelopRawNotificationCallback_Vtbl {
         iid == &<IWICDevelopRawNotificationCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWICEnumMetadataItem_Impl: Sized {
     fn Next(&self, celt: u32, rgeltschema: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, rgeltid: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, rgeltvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1658,6 +1683,7 @@ impl IWICEnumMetadataItem_Vtbl {
         iid == &<IWICEnumMetadataItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICFastMetadataEncoder_Impl: Sized {
     fn Commit(&self) -> ::windows::core::Result<()>;
     fn GetMetadataQueryWriter(&self) -> ::windows::core::Result<IWICMetadataQueryWriter>;
@@ -1691,6 +1717,7 @@ impl IWICFastMetadataEncoder_Vtbl {
         iid == &<IWICFastMetadataEncoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICFormatConverter_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, pisource: &::core::option::Option<IWICBitmapSource>, dstformat: *const ::windows::core::GUID, dither: WICBitmapDitherType, pipalette: &::core::option::Option<IWICPalette>, alphathresholdpercent: f64, palettetranslate: WICBitmapPaletteType) -> ::windows::core::Result<()>;
@@ -1727,6 +1754,7 @@ impl IWICFormatConverter_Vtbl {
         iid == &<IWICFormatConverter as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICFormatConverterInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn GetPixelFormats(&self, cformats: u32, ppixelformatguids: *mut ::windows::core::GUID, pcactual: *mut u32) -> ::windows::core::Result<()>;
     fn CreateInstance(&self) -> ::windows::core::Result<IWICFormatConverter>;
@@ -1760,6 +1788,7 @@ impl IWICFormatConverterInfo_Vtbl {
         iid == &<IWICFormatConverterInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IWICImagingFactory_Impl: Sized {
     fn CreateDecoderFromFilename(&self, wzfilename: &::windows::core::PCWSTR, pguidvendor: *const ::windows::core::GUID, dwdesiredaccess: u32, metadataoptions: WICDecodeOptions) -> ::windows::core::Result<IWICBitmapDecoder>;
@@ -2101,6 +2130,7 @@ impl IWICImagingFactory_Vtbl {
         iid == &<IWICImagingFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IWICJpegFrameDecode_Impl: Sized {
     fn DoesSupportIndexing(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2223,6 +2253,7 @@ impl IWICJpegFrameDecode_Vtbl {
         iid == &<IWICJpegFrameDecode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
 pub trait IWICJpegFrameEncode_Impl: Sized {
     fn GetAcHuffmanTable(&self, scanindex: u32, tableindex: u32) -> ::windows::core::Result<super::Dxgi::Common::DXGI_JPEG_AC_HUFFMAN_TABLE>;
@@ -2285,6 +2316,7 @@ impl IWICJpegFrameEncode_Vtbl {
         iid == &<IWICJpegFrameEncode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWICMetadataBlockReader_Impl: Sized {
     fn GetContainerFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2353,6 +2385,7 @@ impl IWICMetadataBlockReader_Vtbl {
         iid == &<IWICMetadataBlockReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWICMetadataBlockWriter_Impl: Sized + IWICMetadataBlockReader_Impl {
     fn InitializeFromBlockReader(&self, pimdblockreader: &::core::option::Option<IWICMetadataBlockReader>) -> ::windows::core::Result<()>;
@@ -2410,6 +2443,7 @@ impl IWICMetadataBlockWriter_Vtbl {
         iid == &<IWICMetadataBlockWriter as ::windows::core::Interface>::IID || iid == &<IWICMetadataBlockReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICMetadataHandlerInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn GetMetadataFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2499,6 +2533,7 @@ impl IWICMetadataHandlerInfo_Vtbl {
         iid == &<IWICMetadataHandlerInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWICMetadataQueryReader_Impl: Sized {
     fn GetContainerFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2555,6 +2590,7 @@ impl IWICMetadataQueryReader_Vtbl {
         iid == &<IWICMetadataQueryReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWICMetadataQueryWriter_Impl: Sized + IWICMetadataQueryReader_Impl {
     fn SetMetadataByName(&self, wzname: &::windows::core::PCWSTR, pvarvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -2585,6 +2621,7 @@ impl IWICMetadataQueryWriter_Vtbl {
         iid == &<IWICMetadataQueryWriter as ::windows::core::Interface>::IID || iid == &<IWICMetadataQueryReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWICMetadataReader_Impl: Sized {
     fn GetMetadataFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2667,6 +2704,7 @@ impl IWICMetadataReader_Vtbl {
         iid == &<IWICMetadataReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWICMetadataReaderInfo_Impl: Sized + IWICMetadataHandlerInfo_Impl {
     fn GetPatterns(&self, guidcontainerformat: *const ::windows::core::GUID, cbsize: u32, ppattern: *mut WICMetadataPattern, pccount: *mut u32, pcbactual: *mut u32) -> ::windows::core::Result<()>;
@@ -2716,6 +2754,7 @@ impl IWICMetadataReaderInfo_Vtbl {
         iid == &<IWICMetadataReaderInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID || iid == &<IWICMetadataHandlerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IWICMetadataWriter_Impl: Sized + IWICMetadataReader_Impl {
     fn SetValue(&self, pvarschema: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarid: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -2760,6 +2799,7 @@ impl IWICMetadataWriter_Vtbl {
         iid == &<IWICMetadataWriter as ::windows::core::Interface>::IID || iid == &<IWICMetadataReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICMetadataWriterInfo_Impl: Sized + IWICMetadataHandlerInfo_Impl {
     fn GetHeader(&self, guidcontainerformat: *const ::windows::core::GUID, cbsize: u32, pheader: *mut WICMetadataHeader, pcbactual: *mut u32) -> ::windows::core::Result<()>;
@@ -2796,6 +2836,7 @@ impl IWICMetadataWriterInfo_Vtbl {
         iid == &<IWICMetadataWriterInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID || iid == &<IWICMetadataHandlerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICPalette_Impl: Sized {
     fn InitializePredefined(&self, epalettetype: WICBitmapPaletteType, faddtransparentcolor: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2912,6 +2953,7 @@ impl IWICPalette_Vtbl {
         iid == &<IWICPalette as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWICPersistStream_Impl: Sized + super::super::System::Com::IPersistStream_Impl {
     fn LoadEx(&self, pistream: &::core::option::Option<super::super::System::Com::IStream>, pguidpreferredvendor: *const ::windows::core::GUID, dwpersistoptions: u32) -> ::windows::core::Result<()>;
@@ -2942,6 +2984,7 @@ impl IWICPersistStream_Vtbl {
         iid == &<IWICPersistStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersistStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICPixelFormatInfo_Impl: Sized + IWICComponentInfo_Impl {
     fn GetFormatGUID(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetColorContext(&self) -> ::windows::core::Result<IWICColorContext>;
@@ -3014,6 +3057,7 @@ impl IWICPixelFormatInfo_Vtbl {
         iid == &<IWICPixelFormatInfo as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICPixelFormatInfo2_Impl: Sized + IWICPixelFormatInfo_Impl {
     fn SupportsTransparency(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3056,6 +3100,7 @@ impl IWICPixelFormatInfo2_Vtbl {
         iid == &<IWICPixelFormatInfo2 as ::windows::core::Interface>::IID || iid == &<IWICComponentInfo as ::windows::core::Interface>::IID || iid == &<IWICPixelFormatInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICPlanarBitmapFrameEncode_Impl: Sized {
     fn WritePixels(&self, linecount: u32, pplanes: *const WICBitmapPlane, cplanes: u32) -> ::windows::core::Result<()>;
     fn WriteSource(&self, ppplanes: *const ::core::option::Option<IWICBitmapSource>, cplanes: u32, prcsource: *const WICRect) -> ::windows::core::Result<()>;
@@ -3083,6 +3128,7 @@ impl IWICPlanarBitmapFrameEncode_Vtbl {
         iid == &<IWICPlanarBitmapFrameEncode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICPlanarBitmapSourceTransform_Impl: Sized {
     fn DoesSupportTransform(&self, puiwidth: *mut u32, puiheight: *mut u32, dsttransform: WICBitmapTransformOptions, dstplanaroptions: WICPlanarOptions, pguiddstformats: *const ::windows::core::GUID, pplanedescriptions: *mut WICBitmapPlaneDescription, cplanes: u32, pfissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3113,6 +3159,7 @@ impl IWICPlanarBitmapSourceTransform_Vtbl {
         iid == &<IWICPlanarBitmapSourceTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWICPlanarFormatConverter_Impl: Sized + IWICBitmapSource_Impl {
     fn Initialize(&self, ppplanes: *const ::core::option::Option<IWICBitmapSource>, cplanes: u32, dstformat: *const ::windows::core::GUID, dither: WICBitmapDitherType, pipalette: &::core::option::Option<IWICPalette>, alphathresholdpercent: f64, palettetranslate: WICBitmapPaletteType) -> ::windows::core::Result<()>;
@@ -3149,6 +3196,7 @@ impl IWICPlanarFormatConverter_Vtbl {
         iid == &<IWICPlanarFormatConverter as ::windows::core::Interface>::IID || iid == &<IWICBitmapSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICProgressCallback_Impl: Sized {
     fn Notify(&self, uframenum: u32, operation: WICProgressOperation, dblprogress: f64) -> ::windows::core::Result<()>;
 }
@@ -3166,6 +3214,7 @@ impl IWICProgressCallback_Vtbl {
         iid == &<IWICProgressCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait IWICProgressiveLevelControl_Impl: Sized {
     fn GetLevelCount(&self) -> ::windows::core::Result<u32>;
     fn GetCurrentLevel(&self) -> ::windows::core::Result<u32>;
@@ -3212,6 +3261,7 @@ impl IWICProgressiveLevelControl_Vtbl {
         iid == &<IWICProgressiveLevelControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWICStream_Impl: Sized + super::super::System::Com::IStream_Impl {
     fn InitializeFromIStream(&self, pistream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -3256,6 +3306,7 @@ impl IWICStream_Vtbl {
         iid == &<IWICStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWICStreamProvider_Impl: Sized {
     fn GetStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAsyncGetSendNotificationCookie_Impl: Sized + IPrintAsyncCookie_Impl {
     fn FinishAsyncCallWithData(&self, param0: &::core::option::Option<IPrintAsyncNotifyDataObject>, param1: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl IAsyncGetSendNotificationCookie_Vtbl {
         iid == &<IAsyncGetSendNotificationCookie as ::windows::core::Interface>::IID || iid == &<IPrintAsyncCookie as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IAsyncGetSrvReferralCookie_Impl: Sized {
     fn FinishAsyncCall(&self, param0: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn CancelAsyncCall(&self, param0: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -52,6 +54,7 @@ impl IAsyncGetSrvReferralCookie_Vtbl {
         iid == &<IAsyncGetSrvReferralCookie as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IBidiAsyncNotifyChannel_Impl: Sized + IPrintAsyncNotifyChannel_Impl {
     fn CreateNotificationChannel(&self) -> ::windows::core::Result<()>;
     fn GetPrintName(&self, param0: *const ::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
@@ -100,6 +103,7 @@ impl IBidiAsyncNotifyChannel_Vtbl {
         iid == &<IBidiAsyncNotifyChannel as ::windows::core::Interface>::IID || iid == &<IPrintAsyncNotifyChannel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IBidiRequest_Impl: Sized {
     fn SetSchema(&self, pszschema: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetInputData(&self, dwtype: u32, pdata: *const u8, usize: u32) -> ::windows::core::Result<()>;
@@ -160,6 +164,7 @@ impl IBidiRequest_Vtbl {
         iid == &<IBidiRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBidiRequestContainer_Impl: Sized {
     fn AddRequest(&self, prequest: &::core::option::Option<IBidiRequest>) -> ::windows::core::Result<()>;
@@ -209,6 +214,7 @@ impl IBidiRequestContainer_Vtbl {
         iid == &<IBidiRequestContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IBidiSpl_Impl: Sized {
     fn BindDevice(&self, pszdevicename: &::windows::core::PCWSTR, dwaccess: u32) -> ::windows::core::Result<()>;
     fn UnbindDevice(&self) -> ::windows::core::Result<()>;
@@ -250,6 +256,7 @@ impl IBidiSpl_Vtbl {
         iid == &<IBidiSpl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBidiSpl2_Impl: Sized {
     fn BindDevice(&self, pszdevicename: &::windows::core::PCWSTR, dwaccess: u32) -> ::windows::core::Result<()>;
@@ -306,6 +313,7 @@ impl IBidiSpl2_Vtbl {
         iid == &<IBidiSpl2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IFixedDocument_Impl: Sized {
     fn GetUri(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetPrintTicket(&self) -> ::windows::core::Result<IPartPrintTicket>;
@@ -352,6 +360,7 @@ impl IFixedDocument_Vtbl {
         iid == &<IFixedDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IFixedDocumentSequence_Impl: Sized {
     fn GetUri(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetPrintTicket(&self) -> ::windows::core::Result<IPartPrintTicket>;
@@ -398,6 +407,7 @@ impl IFixedDocumentSequence_Vtbl {
         iid == &<IFixedDocumentSequence as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IFixedPage_Impl: Sized + IPartBase_Impl {
     fn GetPrintTicket(&self) -> ::windows::core::Result<IPartPrintTicket>;
     fn GetPagePart(&self, uri: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -484,6 +494,7 @@ impl IFixedPage_Vtbl {
         iid == &<IFixedPage as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Ole")]
 pub trait IImgCreateErrorInfo_Impl: Sized + super::super::System::Ole::ICreateErrorInfo_Impl {
     fn AttachToErrorInfo(&self, perrorinfo: *mut ImgErrorInfo) -> ::windows::core::Result<()>;
@@ -507,6 +518,7 @@ impl IImgCreateErrorInfo_Vtbl {
         iid == &<IImgCreateErrorInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::ICreateErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IImgErrorInfo_Impl: Sized + super::super::System::Com::IErrorInfo_Impl {
     fn GetDeveloperDescription(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -614,6 +626,7 @@ impl IImgErrorInfo_Vtbl {
         iid == &<IImgErrorInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IInterFilterCommunicator_Impl: Sized {
     fn RequestReader(&self, ppireader: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn RequestWriter(&self, ppiwriter: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -641,6 +654,7 @@ impl IInterFilterCommunicator_Vtbl {
         iid == &<IInterFilterCommunicator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartBase_Impl: Sized {
     fn GetUri(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetStream(&self) -> ::windows::core::Result<IPrintReadStream>;
@@ -700,6 +714,7 @@ impl IPartBase_Vtbl {
         iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartColorProfile_Impl: Sized + IPartBase_Impl {}
 impl ::windows::core::RuntimeName for IPartColorProfile {}
 impl IPartColorProfile_Vtbl {
@@ -710,6 +725,7 @@ impl IPartColorProfile_Vtbl {
         iid == &<IPartColorProfile as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartDiscardControl_Impl: Sized {
     fn GetDiscardProperties(&self, urisentinelpage: *mut ::windows::core::BSTR, uriparttodiscard: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -727,6 +743,7 @@ impl IPartDiscardControl_Vtbl {
         iid == &<IPartDiscardControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartFont_Impl: Sized + IPartBase_Impl {
     fn GetFontProperties(&self, pcontenttype: *mut ::windows::core::BSTR, pfontoptions: *mut EXpsFontOptions) -> ::windows::core::Result<()>;
     fn SetFontContent(&self, pcontenttype: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -761,6 +778,7 @@ impl IPartFont_Vtbl {
         iid == &<IPartFont as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartFont2_Impl: Sized + IPartFont_Impl {
     fn GetFontRestriction(&self) -> ::windows::core::Result<EXpsFontRestriction>;
 }
@@ -784,6 +802,7 @@ impl IPartFont2_Vtbl {
         iid == &<IPartFont2 as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID || iid == &<IPartFont as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartImage_Impl: Sized + IPartBase_Impl {
     fn GetImageProperties(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn SetImageContent(&self, pcontenttype: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -817,6 +836,7 @@ impl IPartImage_Vtbl {
         iid == &<IPartImage as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartPrintTicket_Impl: Sized + IPartBase_Impl {}
 impl ::windows::core::RuntimeName for IPartPrintTicket {}
 impl IPartPrintTicket_Vtbl {
@@ -827,6 +847,7 @@ impl IPartPrintTicket_Vtbl {
         iid == &<IPartPrintTicket as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartResourceDictionary_Impl: Sized + IPartBase_Impl {}
 impl ::windows::core::RuntimeName for IPartResourceDictionary {}
 impl IPartResourceDictionary_Vtbl {
@@ -837,6 +858,7 @@ impl IPartResourceDictionary_Vtbl {
         iid == &<IPartResourceDictionary as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPartThumbnail_Impl: Sized + IPartBase_Impl {
     fn GetThumbnailProperties(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn SetThumbnailContent(&self, pcontenttype: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -870,6 +892,7 @@ impl IPartThumbnail_Vtbl {
         iid == &<IPartThumbnail as ::windows::core::Interface>::IID || iid == &<IPartBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncCookie_Impl: Sized {
     fn FinishAsyncCall(&self, param0: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn CancelAsyncCall(&self, param0: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -897,6 +920,7 @@ impl IPrintAsyncCookie_Vtbl {
         iid == &<IPrintAsyncCookie as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncNewChannelCookie_Impl: Sized + IPrintAsyncCookie_Impl {
     fn FinishAsyncCallWithData(&self, param0: *const ::core::option::Option<IPrintAsyncNotifyChannel>, param1: u32) -> ::windows::core::Result<()>;
 }
@@ -914,6 +938,7 @@ impl IPrintAsyncNewChannelCookie_Vtbl {
         iid == &<IPrintAsyncNewChannelCookie as ::windows::core::Interface>::IID || iid == &<IPrintAsyncCookie as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncNotify_Impl: Sized {
     fn CreatePrintAsyncNotifyChannel(&self, param0: u32, param1: *const ::windows::core::GUID, param2: PrintAsyncNotifyUserFilter, param3: PrintAsyncNotifyConversationStyle, param4: &::core::option::Option<IPrintAsyncNotifyCallback>) -> ::windows::core::Result<IPrintAsyncNotifyChannel>;
     fn CreatePrintAsyncNotifyRegistration(&self, param0: *const ::windows::core::GUID, param1: PrintAsyncNotifyUserFilter, param2: PrintAsyncNotifyConversationStyle, param3: &::core::option::Option<IPrintAsyncNotifyCallback>) -> ::windows::core::Result<IPrintAsyncNotifyRegistration>;
@@ -953,6 +978,7 @@ impl IPrintAsyncNotify_Vtbl {
         iid == &<IPrintAsyncNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncNotifyCallback_Impl: Sized {
     fn OnEventNotify(&self, pchannel: &::core::option::Option<IPrintAsyncNotifyChannel>, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
     fn ChannelClosed(&self, pchannel: &::core::option::Option<IPrintAsyncNotifyChannel>, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
@@ -980,6 +1006,7 @@ impl IPrintAsyncNotifyCallback_Vtbl {
         iid == &<IPrintAsyncNotifyCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncNotifyChannel_Impl: Sized {
     fn SendNotification(&self, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
     fn CloseChannel(&self, pdata: &::core::option::Option<IPrintAsyncNotifyDataObject>) -> ::windows::core::Result<()>;
@@ -1007,6 +1034,7 @@ impl IPrintAsyncNotifyChannel_Vtbl {
         iid == &<IPrintAsyncNotifyChannel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncNotifyDataObject_Impl: Sized {
     fn AcquireData(&self, ppnotificationdata: *mut *mut u8, psize: *mut u32, ppschema: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn ReleaseData(&self) -> ::windows::core::Result<()>;
@@ -1034,6 +1062,7 @@ impl IPrintAsyncNotifyDataObject_Vtbl {
         iid == &<IPrintAsyncNotifyDataObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncNotifyRegistration_Impl: Sized {
     fn RegisterForNotifications(&self) -> ::windows::core::Result<()>;
     fn UnregisterForNotifications(&self) -> ::windows::core::Result<()>;
@@ -1061,6 +1090,7 @@ impl IPrintAsyncNotifyRegistration_Vtbl {
         iid == &<IPrintAsyncNotifyRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintAsyncNotifyServerReferral_Impl: Sized {
     fn GetServerReferral(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn AsyncGetServerReferral(&self, param0: &::core::option::Option<IAsyncGetSrvReferralCookie>) -> ::windows::core::Result<()>;
@@ -1101,6 +1131,7 @@ impl IPrintAsyncNotifyServerReferral_Vtbl {
         iid == &<IPrintAsyncNotifyServerReferral as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintBidiAsyncNotifyRegistration_Impl: Sized + IPrintAsyncNotifyRegistration_Impl {
     fn AsyncGetNewChannel(&self, param0: &::core::option::Option<IPrintAsyncNewChannelCookie>) -> ::windows::core::Result<()>;
 }
@@ -1118,6 +1149,7 @@ impl IPrintBidiAsyncNotifyRegistration_Vtbl {
         iid == &<IPrintBidiAsyncNotifyRegistration as ::windows::core::Interface>::IID || iid == &<IPrintAsyncNotifyRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintClassObjectFactory_Impl: Sized {
     fn GetPrintClassObject(&self, pszprintername: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppnewobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1135,6 +1167,7 @@ impl IPrintClassObjectFactory_Vtbl {
         iid == &<IPrintClassObjectFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IPrintCoreHelper_Impl: Sized {
     fn GetOption(&self, pdevmode: *const super::Gdi::DEVMODEA, cbsize: u32, pszfeaturerequested: &::windows::core::PCSTR) -> ::windows::core::Result<::windows::core::PSTR>;
@@ -1220,6 +1253,7 @@ impl IPrintCoreHelper_Vtbl {
         iid == &<IPrintCoreHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IPrintCoreHelperPS_Impl: Sized + IPrintCoreHelper_Impl {
     fn GetGlobalAttribute(&self, pszattribute: &::windows::core::PCSTR, pdwdatatype: *mut u32, ppbdata: *mut *mut u8, pcbsize: *mut u32) -> ::windows::core::Result<()>;
@@ -1257,6 +1291,7 @@ impl IPrintCoreHelperPS_Vtbl {
         iid == &<IPrintCoreHelperPS as ::windows::core::Interface>::IID || iid == &<IPrintCoreHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IPrintCoreHelperUni_Impl: Sized + IPrintCoreHelper_Impl {
     fn CreateGDLSnapshot(&self, pdevmode: *mut super::Gdi::DEVMODEA, cbsize: u32, dwflags: u32, ppsnapshotstream: *mut ::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -1293,6 +1328,7 @@ impl IPrintCoreHelperUni_Vtbl {
         iid == &<IPrintCoreHelperUni as ::windows::core::Interface>::IID || iid == &<IPrintCoreHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IPrintCoreHelperUni2_Impl: Sized + IPrintCoreHelperUni_Impl {
     fn GetNamedCommand(&self, pdevmode: *const super::Gdi::DEVMODEA, cbsize: u32, pszcommandname: &::windows::core::PCWSTR, ppcommandbytes: *mut *mut u8, pcbcommandsize: *mut u32) -> ::windows::core::Result<()>;
@@ -1313,6 +1349,7 @@ impl IPrintCoreHelperUni2_Vtbl {
         iid == &<IPrintCoreHelperUni2 as ::windows::core::Interface>::IID || iid == &<IPrintCoreHelper as ::windows::core::Interface>::IID || iid == &<IPrintCoreHelperUni as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPrintCoreUI2_Impl: Sized + IPrintOemDriverUI_Impl {
     fn GetOptions(&self, poemuiobj: *const OEMUIOBJ, dwflags: u32, pmszfeaturesrequested: *const i8, cbin: u32, pmszfeatureoptionbuf: ::windows::core::PSTR, cbsize: u32, pcbneeded: *mut u32) -> ::windows::core::Result<()>;
@@ -1405,6 +1442,7 @@ impl IPrintCoreUI2_Vtbl {
         iid == &<IPrintCoreUI2 as ::windows::core::Interface>::IID || iid == &<IPrintOemDriverUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintJob_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn Id(&self) -> ::windows::core::Result<u32>;
@@ -1503,6 +1541,7 @@ impl IPrintJob_Vtbl {
         iid == &<IPrintJob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintJobCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -1558,6 +1597,7 @@ impl IPrintJobCollection_Vtbl {
         iid == &<IPrintJobCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IPrintOemCommon_Impl: Sized {
     fn GetInfo(&self, dwmode: u32, pbuffer: *mut ::core::ffi::c_void, cbsize: u32, pcbneeded: *mut u32) -> ::windows::core::Result<()>;
@@ -1588,6 +1628,7 @@ impl IPrintOemCommon_Vtbl {
         iid == &<IPrintOemCommon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPrintOemDriverUI_Impl: Sized {
     fn DrvGetDriverSetting(&self, pci: *mut ::core::ffi::c_void, feature: &::windows::core::PCSTR, poutput: *mut ::core::ffi::c_void, cbsize: u32, pcbneeded: *mut u32, pdwoptionsreturned: *mut u32) -> ::windows::core::Result<()>;
@@ -1625,6 +1666,7 @@ impl IPrintOemDriverUI_Vtbl {
         iid == &<IPrintOemDriverUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPrintOemUI_Impl: Sized + IPrintOemCommon_Impl {
     fn PublishDriverInterface(&self, piunknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1725,6 +1767,7 @@ impl IPrintOemUI_Vtbl {
         iid == &<IPrintOemUI as ::windows::core::Interface>::IID || iid == &<IPrintOemCommon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPrintOemUI2_Impl: Sized + IPrintOemUI_Impl {
     fn QueryJobAttributes(&self, hprinter: super::super::Foundation::HANDLE, pdevmode: *const super::Gdi::DEVMODEA, dwlevel: u32, lpattributeinfo: *const u8) -> ::windows::core::Result<()>;
@@ -1762,6 +1805,7 @@ impl IPrintOemUI2_Vtbl {
         iid == &<IPrintOemUI2 as ::windows::core::Interface>::IID || iid == &<IPrintOemCommon as ::windows::core::Interface>::IID || iid == &<IPrintOemUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IPrintOemUIMXDC_Impl: Sized {
     fn AdjustImageableArea(&self, hprinter: super::super::Foundation::HANDLE, cbdevmode: u32, pdevmode: *const super::Gdi::DEVMODEA, cboemdm: u32, poemdm: *const ::core::ffi::c_void, prclimageablearea: *mut super::super::Foundation::RECTL) -> ::windows::core::Result<()>;
@@ -1799,6 +1843,7 @@ impl IPrintOemUIMXDC_Vtbl {
         iid == &<IPrintOemUIMXDC as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintPipelineFilter_Impl: Sized {
     fn InitializeFilter(&self, pinegotiation: &::core::option::Option<IInterFilterCommunicator>, pipropertybag: &::core::option::Option<IPrintPipelinePropertyBag>, pipipelinecontrol: &::core::option::Option<IPrintPipelineManagerControl>) -> ::windows::core::Result<()>;
     fn ShutdownOperation(&self) -> ::windows::core::Result<()>;
@@ -1833,6 +1878,7 @@ impl IPrintPipelineFilter_Vtbl {
         iid == &<IPrintPipelineFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IPrintPipelineManagerControl_Impl: Sized {
     fn RequestShutdown(&self, hrreason: ::windows::core::HRESULT, preason: &::core::option::Option<IImgErrorInfo>) -> ::windows::core::Result<()>;
@@ -1863,6 +1909,7 @@ impl IPrintPipelineManagerControl_Vtbl {
         iid == &<IPrintPipelineManagerControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintPipelineProgressReport_Impl: Sized {
     fn ReportProgress(&self, update: EXpsJobConsumption) -> ::windows::core::Result<()>;
 }
@@ -1880,6 +1927,7 @@ impl IPrintPipelineProgressReport_Vtbl {
         iid == &<IPrintPipelineProgressReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintPipelinePropertyBag_Impl: Sized {
     fn AddProperty(&self, pszname: &::windows::core::PCWSTR, pvar: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -1923,6 +1971,7 @@ impl IPrintPipelinePropertyBag_Vtbl {
         iid == &<IPrintPipelinePropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Dxgi")]
 pub trait IPrintPreviewDxgiPackageTarget_Impl: Sized {
     fn SetJobPageCount(&self, counttype: PageCountType, count: u32) -> ::windows::core::Result<()>;
@@ -1960,6 +2009,7 @@ impl IPrintPreviewDxgiPackageTarget_Vtbl {
         iid == &<IPrintPreviewDxgiPackageTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPrintReadStream_Impl: Sized {
     fn Seek(&self, dlibmove: i64, dworigin: u32, plibnewposition: *mut u64) -> ::windows::core::Result<()>;
@@ -1990,6 +2040,7 @@ impl IPrintReadStream_Vtbl {
         iid == &<IPrintReadStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintReadStreamFactory_Impl: Sized {
     fn GetStream(&self) -> ::windows::core::Result<IPrintReadStream>;
 }
@@ -2013,6 +2064,7 @@ impl IPrintReadStreamFactory_Vtbl {
         iid == &<IPrintReadStreamFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaAsyncOperation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Start(&self) -> ::windows::core::Result<()>;
@@ -2043,6 +2095,7 @@ impl IPrintSchemaAsyncOperation_Vtbl {
         iid == &<IPrintSchemaAsyncOperation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaAsyncOperationEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Completed(&self, pticket: &::core::option::Option<IPrintSchemaTicket>, hroperation: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -2063,6 +2116,7 @@ impl IPrintSchemaAsyncOperationEvent_Vtbl {
         iid == &<IPrintSchemaAsyncOperationEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaCapabilities_Impl: Sized + IPrintSchemaElement_Impl {
     fn GetFeatureByKeyName(&self, bstrkeyname: &::windows::core::BSTR) -> ::windows::core::Result<IPrintSchemaFeature>;
@@ -2170,6 +2224,7 @@ impl IPrintSchemaCapabilities_Vtbl {
         iid == &<IPrintSchemaCapabilities as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaCapabilities2_Impl: Sized + IPrintSchemaCapabilities_Impl {
     fn GetParameterDefinition(&self, bstrname: &::windows::core::BSTR, bstrnamespaceuri: &::windows::core::BSTR) -> ::windows::core::Result<IPrintSchemaParameterDefinition>;
@@ -2196,6 +2251,7 @@ impl IPrintSchemaCapabilities2_Vtbl {
         iid == &<IPrintSchemaCapabilities2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaDisplayableElement_Impl: Sized + IPrintSchemaElement_Impl {
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2222,6 +2278,7 @@ impl IPrintSchemaDisplayableElement_Vtbl {
         iid == &<IPrintSchemaDisplayableElement as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaElement_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn XmlNode(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -2277,6 +2334,7 @@ impl IPrintSchemaElement_Vtbl {
         iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaFeature_Impl: Sized + IPrintSchemaDisplayableElement_Impl {
     fn SelectedOption(&self) -> ::windows::core::Result<IPrintSchemaOption>;
@@ -2352,6 +2410,7 @@ impl IPrintSchemaFeature_Vtbl {
         iid == &<IPrintSchemaFeature as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaDisplayableElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaNUpOption_Impl: Sized + IPrintSchemaOption_Impl {
     fn PagesPerSheet(&self) -> ::windows::core::Result<u32>;
@@ -2378,6 +2437,7 @@ impl IPrintSchemaNUpOption_Vtbl {
         iid == &<IPrintSchemaNUpOption as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaDisplayableElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaOption as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaOption_Impl: Sized + IPrintSchemaDisplayableElement_Impl {
     fn Selected(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2433,6 +2493,7 @@ impl IPrintSchemaOption_Vtbl {
         iid == &<IPrintSchemaOption as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaDisplayableElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaOptionCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -2488,6 +2549,7 @@ impl IPrintSchemaOptionCollection_Vtbl {
         iid == &<IPrintSchemaOptionCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaPageImageableSize_Impl: Sized + IPrintSchemaElement_Impl {
     fn ImageableSizeWidthInMicrons(&self) -> ::windows::core::Result<u32>;
@@ -2582,6 +2644,7 @@ impl IPrintSchemaPageImageableSize_Vtbl {
         iid == &<IPrintSchemaPageImageableSize as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaPageMediaSizeOption_Impl: Sized + IPrintSchemaOption_Impl {
     fn WidthInMicrons(&self) -> ::windows::core::Result<u32>;
@@ -2624,6 +2687,7 @@ impl IPrintSchemaPageMediaSizeOption_Vtbl {
         iid == &<IPrintSchemaPageMediaSizeOption as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaDisplayableElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaOption as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaParameterDefinition_Impl: Sized + IPrintSchemaDisplayableElement_Impl {
     fn UserInputRequired(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2705,6 +2769,7 @@ impl IPrintSchemaParameterDefinition_Vtbl {
         iid == &<IPrintSchemaParameterDefinition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaDisplayableElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaParameterInitializer_Impl: Sized + IPrintSchemaElement_Impl {
     fn Value(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -2741,6 +2806,7 @@ impl IPrintSchemaParameterInitializer_Vtbl {
         iid == &<IPrintSchemaParameterInitializer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaTicket_Impl: Sized + IPrintSchemaElement_Impl {
     fn GetFeatureByKeyName(&self, bstrkeyname: &::windows::core::BSTR) -> ::windows::core::Result<IPrintSchemaFeature>;
@@ -2849,6 +2915,7 @@ impl IPrintSchemaTicket_Vtbl {
         iid == &<IPrintSchemaTicket as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintSchemaTicket2_Impl: Sized + IPrintSchemaTicket_Impl {
     fn GetParameterInitializer(&self, bstrname: &::windows::core::BSTR, bstrnamespaceuri: &::windows::core::BSTR) -> ::windows::core::Result<IPrintSchemaParameterInitializer>;
@@ -2875,6 +2942,7 @@ impl IPrintSchemaTicket2_Vtbl {
         iid == &<IPrintSchemaTicket2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrintSchemaElement as ::windows::core::Interface>::IID || iid == &<IPrintSchemaTicket as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IPrintTicketProvider_Impl: Sized {
     fn GetSupportedVersions(&self, hprinter: super::super::Foundation::HANDLE, ppversions: *mut *mut i32, cversions: *mut i32) -> ::windows::core::Result<()>;
@@ -2946,6 +3014,7 @@ impl IPrintTicketProvider_Vtbl {
         iid == &<IPrintTicketProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IPrintTicketProvider2_Impl: Sized + IPrintTicketProvider_Impl {
     fn GetPrintDeviceCapabilities(&self, pprintticket: &::core::option::Option<super::super::Data::Xml::MsXml::IXMLDOMDocument2>) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMDocument2>;
@@ -2988,6 +3057,7 @@ impl IPrintTicketProvider2_Vtbl {
         iid == &<IPrintTicketProvider2 as ::windows::core::Interface>::IID || iid == &<IPrintTicketProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintUnidiAsyncNotifyRegistration_Impl: Sized + IPrintAsyncNotifyRegistration_Impl {
     fn AsyncGetNotification(&self, param0: &::core::option::Option<IAsyncGetSendNotificationCookie>) -> ::windows::core::Result<()>;
 }
@@ -3008,6 +3078,7 @@ impl IPrintUnidiAsyncNotifyRegistration_Vtbl {
         iid == &<IPrintUnidiAsyncNotifyRegistration as ::windows::core::Interface>::IID || iid == &<IPrintAsyncNotifyRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintWriteStream_Impl: Sized {
     fn WriteBytes(&self, pvbuffer: *const ::core::ffi::c_void, cbbuffer: u32) -> ::windows::core::Result<u32>;
     fn Close(&self);
@@ -3041,6 +3112,7 @@ impl IPrintWriteStream_Vtbl {
         iid == &<IPrintWriteStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrintWriteStreamFlush_Impl: Sized {
     fn FlushData(&self) -> ::windows::core::Result<()>;
 }
@@ -3058,6 +3130,7 @@ impl IPrintWriteStreamFlush_Vtbl {
         iid == &<IPrintWriteStreamFlush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrinterBidiSetRequestCallback_Impl: Sized {
     fn Completed(&self, bstrresponse: &::windows::core::BSTR, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -3075,6 +3148,7 @@ impl IPrinterBidiSetRequestCallback_Vtbl {
         iid == &<IPrinterBidiSetRequestCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrinterExtensionAsyncOperation_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
 }
@@ -3092,6 +3166,7 @@ impl IPrinterExtensionAsyncOperation_Vtbl {
         iid == &<IPrinterExtensionAsyncOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterExtensionContext_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn PrinterQueue(&self) -> ::windows::core::Result<IPrinterQueue>;
@@ -3160,6 +3235,7 @@ impl IPrinterExtensionContext_Vtbl {
         iid == &<IPrinterExtensionContext as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterExtensionContextCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -3215,6 +3291,7 @@ impl IPrinterExtensionContextCollection_Vtbl {
         iid == &<IPrinterExtensionContextCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterExtensionEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OnDriverEvent(&self, peventargs: &::core::option::Option<IPrinterExtensionEventArgs>) -> ::windows::core::Result<()>;
@@ -3245,6 +3322,7 @@ impl IPrinterExtensionEvent_Vtbl {
         iid == &<IPrinterExtensionEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterExtensionEventArgs_Impl: Sized + IPrinterExtensionContext_Impl {
     fn BidiNotification(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3352,6 +3430,7 @@ impl IPrinterExtensionEventArgs_Vtbl {
         iid == &<IPrinterExtensionEventArgs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrinterExtensionContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IPrinterExtensionManager_Impl: Sized {
     fn EnableEvents(&self, printerdriverid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn DisableEvents(&self) -> ::windows::core::Result<()>;
@@ -3379,6 +3458,7 @@ impl IPrinterExtensionManager_Vtbl {
         iid == &<IPrinterExtensionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterExtensionRequest_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Cancel(&self, hrstatus: ::windows::core::HRESULT, bstrlogmessage: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3409,6 +3489,7 @@ impl IPrinterExtensionRequest_Vtbl {
         iid == &<IPrinterExtensionRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterPropertyBag_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetBool(&self, bstrname: &::windows::core::BSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3525,6 +3606,7 @@ impl IPrinterPropertyBag_Vtbl {
         iid == &<IPrinterPropertyBag as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterQueue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Handle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -3587,6 +3669,7 @@ impl IPrinterQueue_Vtbl {
         iid == &<IPrinterQueue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterQueue2_Impl: Sized + IPrinterQueue_Impl {
     fn SendBidiSetRequestAsync(&self, bstrbidirequest: &::windows::core::BSTR, pcallback: &::core::option::Option<IPrinterBidiSetRequestCallback>) -> ::windows::core::Result<IPrinterExtensionAsyncOperation>;
@@ -3629,6 +3712,7 @@ impl IPrinterQueue2_Vtbl {
         iid == &<IPrinterQueue2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrinterQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterQueueEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OnBidiResponseReceived(&self, bstrresponse: &::windows::core::BSTR, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -3652,6 +3736,7 @@ impl IPrinterQueueEvent_Vtbl {
         iid == &<IPrinterQueueEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterQueueView_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetViewRange(&self, ulviewoffset: u32, ulviewsize: u32) -> ::windows::core::Result<()>;
@@ -3672,6 +3757,7 @@ impl IPrinterQueueView_Vtbl {
         iid == &<IPrinterQueueView as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterQueueViewEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OnChanged(&self, pcollection: &::core::option::Option<IPrintJobCollection>, ulviewoffset: u32, ulviewsize: u32, ulcountjobsinprintqueue: u32) -> ::windows::core::Result<()>;
@@ -3692,6 +3778,7 @@ impl IPrinterQueueViewEvent_Vtbl {
         iid == &<IPrinterQueueViewEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterScriptContext_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DriverProperties(&self) -> ::windows::core::Result<IPrinterScriptablePropertyBag>;
@@ -3747,6 +3834,7 @@ impl IPrinterScriptContext_Vtbl {
         iid == &<IPrinterScriptContext as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterScriptablePropertyBag_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetBool(&self, bstrname: &::windows::core::BSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3869,6 +3957,7 @@ impl IPrinterScriptablePropertyBag_Vtbl {
         iid == &<IPrinterScriptablePropertyBag as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterScriptablePropertyBag2_Impl: Sized + IPrinterScriptablePropertyBag_Impl {
     fn GetReadStreamAsXML(&self, bstrname: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3895,6 +3984,7 @@ impl IPrinterScriptablePropertyBag2_Vtbl {
         iid == &<IPrinterScriptablePropertyBag2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrinterScriptablePropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterScriptableSequentialStream_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Read(&self, cbread: i32) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -3937,6 +4027,7 @@ impl IPrinterScriptableSequentialStream_Vtbl {
         iid == &<IPrinterScriptableSequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrinterScriptableStream_Impl: Sized + IPrinterScriptableSequentialStream_Impl {
     fn Commit(&self) -> ::windows::core::Result<()>;
@@ -3980,6 +4071,7 @@ impl IPrinterScriptableStream_Vtbl {
         iid == &<IPrinterScriptableStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IPrinterScriptableSequentialStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IXpsDocument_Impl: Sized {
     fn GetThumbnail(&self) -> ::windows::core::Result<IPartThumbnail>;
     fn SetThumbnail(&self, pthumbnail: &::core::option::Option<IPartThumbnail>) -> ::windows::core::Result<()>;
@@ -4013,6 +4105,7 @@ impl IXpsDocument_Vtbl {
         iid == &<IXpsDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IXpsDocumentConsumer_Impl: Sized {
     fn SendXpsUnknown(&self, punknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SendXpsDocument(&self, pixpsdocument: &::core::option::Option<IXpsDocument>) -> ::windows::core::Result<()>;
@@ -4075,6 +4168,7 @@ impl IXpsDocumentConsumer_Vtbl {
         iid == &<IXpsDocumentConsumer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IXpsDocumentProvider_Impl: Sized {
     fn GetXpsPart(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -4098,6 +4192,7 @@ impl IXpsDocumentProvider_Vtbl {
         iid == &<IXpsDocumentProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXpsPartIterator_Impl: Sized {
     fn Reset(&self);
@@ -4142,6 +4237,7 @@ impl IXpsPartIterator_Vtbl {
         iid == &<IXpsPartIterator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_Xps")]
 pub trait IXpsRasterizationFactory_Impl: Sized {
     fn CreateRasterizer(&self, xpspage: &::core::option::Option<super::super::Storage::Xps::IXpsOMPage>, dpi: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE) -> ::windows::core::Result<IXpsRasterizer>;
@@ -4168,6 +4264,7 @@ impl IXpsRasterizationFactory_Vtbl {
         iid == &<IXpsRasterizationFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_Xps")]
 pub trait IXpsRasterizationFactory1_Impl: Sized {
     fn CreateRasterizer(&self, xpspage: &::core::option::Option<super::super::Storage::Xps::IXpsOMPage>, dpi: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, pixelformat: XPSRAS_PIXEL_FORMAT) -> ::windows::core::Result<IXpsRasterizer>;
@@ -4194,6 +4291,7 @@ impl IXpsRasterizationFactory1_Vtbl {
         iid == &<IXpsRasterizationFactory1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_Xps")]
 pub trait IXpsRasterizationFactory2_Impl: Sized {
     fn CreateRasterizer(&self, xpspage: &::core::option::Option<super::super::Storage::Xps::IXpsOMPage>, dpix: f32, dpiy: f32, nontextrenderingmode: XPSRAS_RENDERING_MODE, textrenderingmode: XPSRAS_RENDERING_MODE, pixelformat: XPSRAS_PIXEL_FORMAT, backgroundcolor: XPSRAS_BACKGROUND_COLOR) -> ::windows::core::Result<IXpsRasterizer>;
@@ -4220,6 +4318,7 @@ impl IXpsRasterizationFactory2_Vtbl {
         iid == &<IXpsRasterizationFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Imaging")]
 pub trait IXpsRasterizer_Impl: Sized {
     fn RasterizeRect(&self, x: i32, y: i32, width: i32, height: i32, notificationcallback: &::core::option::Option<IXpsRasterizerNotificationCallback>) -> ::windows::core::Result<super::Imaging::IWICBitmap>;
@@ -4256,6 +4355,7 @@ impl IXpsRasterizer_Vtbl {
         iid == &<IXpsRasterizer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Graphics_Printing\"`, `\"implement\"`*"]
 pub trait IXpsRasterizerNotificationCallback_Impl: Sized {
     fn Continue(&self) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IApoAcousticEchoCancellation_Impl: Sized {}
 impl ::windows::core::RuntimeName for IApoAcousticEchoCancellation {}
 impl IApoAcousticEchoCancellation_Vtbl {
@@ -8,6 +9,7 @@ impl IApoAcousticEchoCancellation_Vtbl {
         iid == &<IApoAcousticEchoCancellation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IApoAuxiliaryInputConfiguration_Impl: Sized {
     fn AddAuxiliaryInput(&self, dwinputid: u32, cbdatasize: u32, pbydata: *const u8, pinputconnection: *const APO_CONNECTION_DESCRIPTOR) -> ::windows::core::Result<()>;
     fn RemoveAuxiliaryInput(&self, dwinputid: u32) -> ::windows::core::Result<()>;
@@ -48,6 +50,7 @@ impl IApoAuxiliaryInputConfiguration_Vtbl {
         iid == &<IApoAuxiliaryInputConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IApoAuxiliaryInputRT_Impl: Sized {
     fn AcceptInput(&self, dwinputid: u32, pinputconnection: *const APO_CONNECTION_PROPERTY);
 }
@@ -65,6 +68,7 @@ impl IApoAuxiliaryInputRT_Vtbl {
         iid == &<IApoAuxiliaryInputRT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioDeviceModulesClient_Impl: Sized {
     fn SetAudioDeviceModulesManager(&self, paudiodevicemodulesmanager: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -85,6 +89,7 @@ impl IAudioDeviceModulesClient_Vtbl {
         iid == &<IAudioDeviceModulesClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioMediaType_Impl: Sized {
     fn IsCompressedFormat(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -147,6 +152,7 @@ impl IAudioMediaType_Vtbl {
         iid == &<IAudioMediaType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioProcessingObject_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetLatency(&self) -> ::windows::core::Result<i64>;
@@ -239,6 +245,7 @@ impl IAudioProcessingObject_Vtbl {
         iid == &<IAudioProcessingObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioProcessingObjectConfiguration_Impl: Sized {
     fn LockForProcess(&self, u32numinputconnections: u32, ppinputconnections: *const *const APO_CONNECTION_DESCRIPTOR, u32numoutputconnections: u32, ppoutputconnections: *const *const APO_CONNECTION_DESCRIPTOR) -> ::windows::core::Result<()>;
     fn UnlockForProcess(&self) -> ::windows::core::Result<()>;
@@ -266,6 +273,7 @@ impl IAudioProcessingObjectConfiguration_Vtbl {
         iid == &<IAudioProcessingObjectConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioProcessingObjectLoggingService_Impl: Sized {
     fn ApoLog(&self, level: APO_LOG_LEVEL, format: &::windows::core::PCWSTR);
 }
@@ -283,6 +291,7 @@ impl IAudioProcessingObjectLoggingService_Vtbl {
         iid == &<IAudioProcessingObjectLoggingService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IAudioProcessingObjectNotifications_Impl: Sized {
     fn GetApoNotificationRegistrationInfo(&self, aponotifications: *mut *mut APO_NOTIFICATION_DESCRIPTOR, count: *mut u32) -> ::windows::core::Result<()>;
@@ -313,6 +322,7 @@ impl IAudioProcessingObjectNotifications_Vtbl {
         iid == &<IAudioProcessingObjectNotifications as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioProcessingObjectRT_Impl: Sized {
     fn APOProcess(&self, u32numinputconnections: u32, ppinputconnections: *const *const APO_CONNECTION_PROPERTY, u32numoutputconnections: u32, ppoutputconnections: *mut *mut APO_CONNECTION_PROPERTY);
     fn CalcInputFrames(&self, u32outputframecount: u32) -> u32;
@@ -347,6 +357,7 @@ impl IAudioProcessingObjectRT_Vtbl {
         iid == &<IAudioProcessingObjectRT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioProcessingObjectRTQueueService_Impl: Sized {
     fn GetRealTimeWorkQueue(&self) -> ::windows::core::Result<u32>;
 }
@@ -370,6 +381,7 @@ impl IAudioProcessingObjectRTQueueService_Vtbl {
         iid == &<IAudioProcessingObjectRTQueueService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioProcessingObjectVBR_Impl: Sized {
     fn CalcMaxInputFrames(&self, u32maxoutputframecount: u32) -> ::windows::core::Result<u32>;
     fn CalcMaxOutputFrames(&self, u32maxinputframecount: u32) -> ::windows::core::Result<u32>;
@@ -409,6 +421,7 @@ impl IAudioProcessingObjectVBR_Vtbl {
         iid == &<IAudioProcessingObjectVBR as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioSystemEffects_Impl: Sized {}
 impl ::windows::core::RuntimeName for IAudioSystemEffects {}
 impl IAudioSystemEffects_Vtbl {
@@ -419,6 +432,7 @@ impl IAudioSystemEffects_Vtbl {
         iid == &<IAudioSystemEffects as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioSystemEffects2_Impl: Sized + IAudioSystemEffects_Impl {
     fn GetEffectsList(&self, ppeffectsids: *mut *mut ::windows::core::GUID, pceffects: *mut u32, event: super::super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -439,6 +453,7 @@ impl IAudioSystemEffects2_Vtbl {
         iid == &<IAudioSystemEffects2 as ::windows::core::Interface>::IID || iid == &<IAudioSystemEffects as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioSystemEffects3_Impl: Sized + IAudioSystemEffects2_Impl {
     fn GetControllableSystemEffectsList(&self, effects: *mut *mut AUDIO_SYSTEMEFFECT, numeffects: *mut u32, event: super::super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -469,6 +484,7 @@ impl IAudioSystemEffects3_Vtbl {
         iid == &<IAudioSystemEffects3 as ::windows::core::Interface>::IID || iid == &<IAudioSystemEffects as ::windows::core::Interface>::IID || iid == &<IAudioSystemEffects2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 pub trait IAudioSystemEffectsCustomFormats_Impl: Sized {
     fn GetFormatCount(&self) -> ::windows::core::Result<u32>;
     fn GetFormat(&self, nformat: u32) -> ::windows::core::Result<IAudioMediaType>;

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 pub trait IDirectMusic_Impl: Sized {
     fn EnumPort(&self, dwindex: u32, pportcaps: *mut DMUS_PORTCAPS) -> ::windows::core::Result<()>;
@@ -77,6 +78,7 @@ impl IDirectMusic_Vtbl {
         iid == &<IDirectMusic as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 pub trait IDirectMusic8_Impl: Sized + IDirectMusic_Impl {
     fn SetExternalMasterClock(&self, pclock: &::core::option::Option<super::super::IReferenceClock>) -> ::windows::core::Result<()>;
@@ -97,6 +99,7 @@ impl IDirectMusic8_Vtbl {
         iid == &<IDirectMusic8 as ::windows::core::Interface>::IID || iid == &<IDirectMusic as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"implement\"`*"]
 pub trait IDirectMusicBuffer_Impl: Sized {
     fn Flush(&self) -> ::windows::core::Result<()>;
     fn TotalTime(&self, prttime: *mut i64) -> ::windows::core::Result<()>;
@@ -201,6 +204,7 @@ impl IDirectMusicBuffer_Vtbl {
         iid == &<IDirectMusicBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"implement\"`*"]
 pub trait IDirectMusicCollection_Impl: Sized {
     fn GetInstrument(&self, dwpatch: u32) -> ::windows::core::Result<IDirectMusicInstrument>;
     fn EnumInstrument(&self, dwindex: u32, pdwpatch: *mut u32, pwszname: &::windows::core::PCWSTR, dwnamelen: u32) -> ::windows::core::Result<()>;
@@ -234,6 +238,7 @@ impl IDirectMusicCollection_Vtbl {
         iid == &<IDirectMusicCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"implement\"`*"]
 pub trait IDirectMusicDownload_Impl: Sized {
     fn GetBuffer(&self, ppvbuffer: *mut *mut ::core::ffi::c_void, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -251,6 +256,7 @@ impl IDirectMusicDownload_Vtbl {
         iid == &<IDirectMusicDownload as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"implement\"`*"]
 pub trait IDirectMusicDownloadedInstrument_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDirectMusicDownloadedInstrument {}
 impl IDirectMusicDownloadedInstrument_Vtbl {
@@ -261,6 +267,7 @@ impl IDirectMusicDownloadedInstrument_Vtbl {
         iid == &<IDirectMusicDownloadedInstrument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"implement\"`*"]
 pub trait IDirectMusicInstrument_Impl: Sized {
     fn GetPatch(&self, pdwpatch: *mut u32) -> ::windows::core::Result<()>;
     fn SetPatch(&self, dwpatch: u32) -> ::windows::core::Result<()>;
@@ -288,6 +295,7 @@ impl IDirectMusicInstrument_Vtbl {
         iid == &<IDirectMusicInstrument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_System_IO\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound", feature = "Win32_System_IO"))]
 pub trait IDirectMusicPort_Impl: Sized {
     fn PlayBuffer(&self, pbuffer: &::core::option::Option<IDirectMusicBuffer>) -> ::windows::core::Result<()>;
@@ -429,6 +437,7 @@ impl IDirectMusicPort_Vtbl {
         iid == &<IDirectMusicPort as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"implement\"`*"]
 pub trait IDirectMusicPortDownload_Impl: Sized {
     fn GetBuffer(&self, dwdlid: u32) -> ::windows::core::Result<IDirectMusicDownload>;
     fn AllocateBuffer(&self, dwsize: u32) -> ::windows::core::Result<IDirectMusicDownload>;
@@ -496,6 +505,7 @@ impl IDirectMusicPortDownload_Vtbl {
         iid == &<IDirectMusicPortDownload as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectMusicSynth_Impl: Sized {
     fn Open(&self, pportparams: *mut DMUS_PORTPARAMS8) -> ::windows::core::Result<()>;
@@ -637,6 +647,7 @@ impl IDirectMusicSynth_Vtbl {
         iid == &<IDirectMusicSynth as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectMusicSynth8_Impl: Sized + IDirectMusicSynth_Impl {
     fn PlayVoice(&self, rt: i64, dwvoiceid: u32, dwchannelgroup: u32, dwchannel: u32, dwdlid: u32, prpitch: i32, vrvolume: i32, stvoicestart: u64, stloopstart: u64, stloopend: u64) -> ::windows::core::Result<()>;
@@ -688,6 +699,7 @@ impl IDirectMusicSynth8_Vtbl {
         iid == &<IDirectMusicSynth8 as ::windows::core::Interface>::IID || iid == &<IDirectMusicSynth as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 pub trait IDirectMusicSynthSink_Impl: Sized {
     fn Init(&self, psynth: &::core::option::Option<IDirectMusicSynth>) -> ::windows::core::Result<()>;
@@ -766,6 +778,7 @@ impl IDirectMusicSynthSink_Vtbl {
         iid == &<IDirectMusicSynthSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`, `\"implement\"`*"]
 pub trait IDirectMusicThru_Impl: Sized {
     fn ThruChannel(&self, dwsourcechannelgroup: u32, dwsourcechannel: u32, dwdestinationchannelgroup: u32, dwdestinationchannel: u32, pdestinationport: &::core::option::Option<IDirectMusicPort>) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectSound_Impl: Sized {
     fn CreateSoundBuffer(&self, pcdsbufferdesc: *const DSBUFFERDESC, ppdsbuffer: *mut ::core::option::Option<IDirectSoundBuffer>, punkouter: ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -88,6 +89,7 @@ impl IDirectSound_Vtbl {
         iid == &<IDirectSound as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait IDirectSound3DBuffer_Impl: Sized {
     fn GetAllParameters(&self) -> ::windows::core::Result<DS3DBUFFER>;
@@ -278,6 +280,7 @@ impl IDirectSound3DBuffer_Vtbl {
         iid == &<IDirectSound3DBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Graphics_Direct3D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub trait IDirectSound3DListener_Impl: Sized {
     fn GetAllParameters(&self) -> ::windows::core::Result<DS3DLISTENER>;
@@ -435,6 +438,7 @@ impl IDirectSound3DListener_Vtbl {
         iid == &<IDirectSound3DListener as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectSound8_Impl: Sized + IDirectSound_Impl {
     fn VerifyCertification(&self) -> ::windows::core::Result<u32>;
@@ -461,6 +465,7 @@ impl IDirectSound8_Vtbl {
         iid == &<IDirectSound8 as ::windows::core::Interface>::IID || iid == &<IDirectSound as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundBuffer_Impl: Sized {
     fn GetCaps(&self) -> ::windows::core::Result<DSBCAPS>;
     fn GetCurrentPosition(&self, pdwcurrentplaycursor: *mut u32, pdwcurrentwritecursor: *mut u32) -> ::windows::core::Result<()>;
@@ -630,6 +635,7 @@ impl IDirectSoundBuffer_Vtbl {
         iid == &<IDirectSoundBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundBuffer8_Impl: Sized + IDirectSoundBuffer_Impl {
     fn SetFX(&self, dweffectscount: u32, pdsfxdesc: *const DSEFFECTDESC, pdwresultcodes: *mut u32) -> ::windows::core::Result<()>;
     fn AcquireResources(&self, dwflags: u32, dweffectscount: u32, pdwresultcodes: *mut u32) -> ::windows::core::Result<()>;
@@ -664,6 +670,7 @@ impl IDirectSoundBuffer8_Vtbl {
         iid == &<IDirectSoundBuffer8 as ::windows::core::Interface>::IID || iid == &<IDirectSoundBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundCapture_Impl: Sized {
     fn CreateCaptureBuffer(&self, pcdscbufferdesc: *const DSCBUFFERDESC, ppdscbuffer: *mut ::core::option::Option<IDirectSoundCaptureBuffer>, punkouter: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetCaps(&self) -> ::windows::core::Result<DSCCAPS>;
@@ -704,6 +711,7 @@ impl IDirectSoundCapture_Vtbl {
         iid == &<IDirectSoundCapture as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundCaptureBuffer_Impl: Sized {
     fn GetCaps(&self) -> ::windows::core::Result<DSCBCAPS>;
     fn GetCurrentPosition(&self, pdwcaptureposition: *mut u32, pdwreadposition: *mut u32) -> ::windows::core::Result<()>;
@@ -792,6 +800,7 @@ impl IDirectSoundCaptureBuffer_Vtbl {
         iid == &<IDirectSoundCaptureBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundCaptureBuffer8_Impl: Sized + IDirectSoundCaptureBuffer_Impl {
     fn GetObjectInPath(&self, rguidobject: *const ::windows::core::GUID, dwindex: u32, rguidinterface: *const ::windows::core::GUID, ppobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetFXStatus(&self, dweffectscount: u32, pdwfxstatus: *mut u32) -> ::windows::core::Result<()>;
@@ -819,6 +828,7 @@ impl IDirectSoundCaptureBuffer8_Vtbl {
         iid == &<IDirectSoundCaptureBuffer8 as ::windows::core::Interface>::IID || iid == &<IDirectSoundCaptureBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectSoundCaptureFXAec_Impl: Sized {
     fn SetAllParameters(&self, pdscfxaec: *const DSCFXAec) -> ::windows::core::Result<()>;
@@ -875,6 +885,7 @@ impl IDirectSoundCaptureFXAec_Vtbl {
         iid == &<IDirectSoundCaptureFXAec as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectSoundCaptureFXNoiseSuppress_Impl: Sized {
     fn SetAllParameters(&self, pcdscfxnoisesuppress: *const DSCFXNoiseSuppress) -> ::windows::core::Result<()>;
@@ -918,6 +929,7 @@ impl IDirectSoundCaptureFXNoiseSuppress_Vtbl {
         iid == &<IDirectSoundCaptureFXNoiseSuppress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXChorus_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxchorus: *const DSFXChorus) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXChorus>;
@@ -951,6 +963,7 @@ impl IDirectSoundFXChorus_Vtbl {
         iid == &<IDirectSoundFXChorus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXCompressor_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxcompressor: *const DSFXCompressor) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXCompressor>;
@@ -984,6 +997,7 @@ impl IDirectSoundFXCompressor_Vtbl {
         iid == &<IDirectSoundFXCompressor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXDistortion_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxdistortion: *const DSFXDistortion) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXDistortion>;
@@ -1017,6 +1031,7 @@ impl IDirectSoundFXDistortion_Vtbl {
         iid == &<IDirectSoundFXDistortion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXEcho_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxecho: *const DSFXEcho) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXEcho>;
@@ -1050,6 +1065,7 @@ impl IDirectSoundFXEcho_Vtbl {
         iid == &<IDirectSoundFXEcho as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXFlanger_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxflanger: *const DSFXFlanger) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXFlanger>;
@@ -1083,6 +1099,7 @@ impl IDirectSoundFXFlanger_Vtbl {
         iid == &<IDirectSoundFXFlanger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXGargle_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxgargle: *const DSFXGargle) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXGargle>;
@@ -1116,6 +1133,7 @@ impl IDirectSoundFXGargle_Vtbl {
         iid == &<IDirectSoundFXGargle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXI3DL2Reverb_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxi3dl2reverb: *const DSFXI3DL2Reverb) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXI3DL2Reverb>;
@@ -1189,6 +1207,7 @@ impl IDirectSoundFXI3DL2Reverb_Vtbl {
         iid == &<IDirectSoundFXI3DL2Reverb as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXParamEq_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxparameq: *const DSFXParamEq) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXParamEq>;
@@ -1222,6 +1241,7 @@ impl IDirectSoundFXParamEq_Vtbl {
         iid == &<IDirectSoundFXParamEq as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 pub trait IDirectSoundFXWavesReverb_Impl: Sized {
     fn SetAllParameters(&self, pcdsfxwavesreverb: *const DSFXWavesReverb) -> ::windows::core::Result<()>;
     fn GetAllParameters(&self) -> ::windows::core::Result<DSFXWavesReverb>;
@@ -1255,6 +1275,7 @@ impl IDirectSoundFXWavesReverb_Vtbl {
         iid == &<IDirectSoundFXWavesReverb as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectSoundFullDuplex_Impl: Sized {
     fn Initialize(&self, pcaptureguid: *const ::windows::core::GUID, prenderguid: *const ::windows::core::GUID, lpdscbufferdesc: *const DSCBUFFERDESC, lpdsbufferdesc: *const DSBUFFERDESC, hwnd: super::super::super::Foundation::HWND, dwlevel: u32, lplpdirectsoundcapturebuffer8: *mut ::core::option::Option<IDirectSoundCaptureBuffer8>, lplpdirectsoundbuffer8: *mut ::core::option::Option<IDirectSoundBuffer8>) -> ::windows::core::Result<()>;
@@ -1275,6 +1296,7 @@ impl IDirectSoundFullDuplex_Vtbl {
         iid == &<IDirectSoundFullDuplex as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_DirectSound\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectSoundNotify_Impl: Sized {
     fn SetNotificationPositions(&self, dwpositionnotifies: u32, pcpositionnotifies: *const DSBPOSITIONNOTIFY) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"implement\"`*"]
 pub trait IAudioEndpointFormatControl_Impl: Sized {
     fn ResetToDefault(&self, resetflags: u32) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IAudioEndpointFormatControl_Vtbl {
         iid == &<IAudioEndpointFormatControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_Apo"))]
 pub trait IAudioEndpointLastBufferControl_Impl: Sized {
     fn IsLastBufferControlSupported(&self) -> super::super::super::Foundation::BOOL;
@@ -45,6 +47,7 @@ impl IAudioEndpointLastBufferControl_Vtbl {
         iid == &<IAudioEndpointLastBufferControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"implement\"`*"]
 pub trait IAudioEndpointOffloadStreamMeter_Impl: Sized {
     fn GetMeterChannelCount(&self) -> ::windows::core::Result<u32>;
     fn GetMeteringData(&self, u32channelcount: u32) -> ::windows::core::Result<f32>;
@@ -84,6 +87,7 @@ impl IAudioEndpointOffloadStreamMeter_Vtbl {
         iid == &<IAudioEndpointOffloadStreamMeter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"implement\"`*"]
 pub trait IAudioEndpointOffloadStreamMute_Impl: Sized {
     fn SetMute(&self, bmuted: u8) -> ::windows::core::Result<()>;
     fn GetMute(&self) -> ::windows::core::Result<u8>;
@@ -117,6 +121,7 @@ impl IAudioEndpointOffloadStreamMute_Vtbl {
         iid == &<IAudioEndpointOffloadStreamMute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 pub trait IAudioEndpointOffloadStreamVolume_Impl: Sized {
     fn GetVolumeChannelCount(&self) -> ::windows::core::Result<u32>;
@@ -166,6 +171,7 @@ impl IAudioEndpointOffloadStreamVolume_Vtbl {
         iid == &<IAudioEndpointOffloadStreamVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioEndpointVolume_Impl: Sized {
     fn RegisterControlChangeNotify(&self, pnotify: &::core::option::Option<IAudioEndpointVolumeCallback>) -> ::windows::core::Result<()>;
@@ -350,6 +356,7 @@ impl IAudioEndpointVolume_Vtbl {
         iid == &<IAudioEndpointVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioEndpointVolumeCallback_Impl: Sized {
     fn OnNotify(&self, pnotify: *mut super::AUDIO_VOLUME_NOTIFICATION_DATA) -> ::windows::core::Result<()>;
@@ -370,6 +377,7 @@ impl IAudioEndpointVolumeCallback_Vtbl {
         iid == &<IAudioEndpointVolumeCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioEndpointVolumeEx_Impl: Sized + IAudioEndpointVolume_Impl {
     fn GetVolumeRangeChannel(&self, ichannel: u32, pflvolumemindb: *mut f32, pflvolumemaxdb: *mut f32, pflvolumeincrementdb: *mut f32) -> ::windows::core::Result<()>;
@@ -390,6 +398,7 @@ impl IAudioEndpointVolumeEx_Vtbl {
         iid == &<IAudioEndpointVolumeEx as ::windows::core::Interface>::IID || iid == &<IAudioEndpointVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioLfxControl_Impl: Sized {
     fn SetLocalEffectsState(&self, benabled: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -426,6 +435,7 @@ impl IAudioLfxControl_Vtbl {
         iid == &<IAudioLfxControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"implement\"`*"]
 pub trait IAudioMeterInformation_Impl: Sized {
     fn GetPeakValue(&self) -> ::windows::core::Result<f32>;
     fn GetMeteringChannelCount(&self) -> ::windows::core::Result<u32>;
@@ -485,6 +495,7 @@ impl IAudioMeterInformation_Vtbl {
         iid == &<IAudioMeterInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_Endpoints\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IHardwareAudioEngineBase_Impl: Sized {
     fn GetAvailableOffloadConnectorCount(&self, _pwstrdeviceid: &::windows::core::PCWSTR, _uconnectorid: u32) -> ::windows::core::Result<u32>;

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/XAudio2/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAPO_Impl: Sized {
     fn GetRegistrationProperties(&self) -> ::windows::core::Result<*mut XAPO_REGISTRATION_PROPERTIES>;
@@ -90,6 +91,7 @@ impl IXAPO_Vtbl {
         iid == &<IXAPO as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"implement\"`*"]
 pub trait IXAPOHrtfParameters_Impl: Sized {
     fn SetSourcePosition(&self, position: *const HrtfPosition) -> ::windows::core::Result<()>;
     fn SetSourceOrientation(&self, orientation: *const HrtfOrientation) -> ::windows::core::Result<()>;
@@ -131,6 +133,7 @@ impl IXAPOHrtfParameters_Vtbl {
         iid == &<IXAPOHrtfParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"implement\"`*"]
 pub trait IXAPOParameters_Impl: Sized {
     fn SetParameters(&self, pparameters: *const ::core::ffi::c_void, parameterbytesize: u32);
     fn GetParameters(&self, pparameters: *mut ::core::ffi::c_void, parameterbytesize: u32);
@@ -158,6 +161,7 @@ impl IXAPOParameters_Vtbl {
         iid == &<IXAPOParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAudio2_Impl: Sized {
     fn RegisterForCallbacks(&self, pcallback: &::core::option::Option<IXAudio2EngineCallback>) -> ::windows::core::Result<()>;
@@ -244,6 +248,7 @@ impl IXAudio2_Vtbl {
         iid == &<IXAudio2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"implement\"`*"]
 pub trait IXAudio2EngineCallback_Impl: Sized {
     fn OnProcessingPassStart(&self);
     fn OnProcessingPassEnd(&self);
@@ -281,6 +286,7 @@ impl IXAudio2EngineCallback {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"implement\"`*"]
 pub trait IXAudio2Extension_Impl: Sized {
     fn GetProcessingQuantum(&self, quantumnumerator: *mut u32, quantumdenominator: *mut u32);
     fn GetProcessor(&self, processor: *mut u32);
@@ -308,6 +314,7 @@ impl IXAudio2Extension_Vtbl {
         iid == &<IXAudio2Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAudio2MasteringVoice_Impl: Sized + IXAudio2Voice_Impl {
     fn GetChannelMask(&self) -> ::windows::core::Result<u32>;
@@ -344,6 +351,7 @@ impl IXAudio2MasteringVoice {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAudio2SourceVoice_Impl: Sized + IXAudio2Voice_Impl {
     fn Start(&self, flags: u32, operationset: u32) -> ::windows::core::Result<()>;
@@ -440,6 +448,7 @@ impl IXAudio2SourceVoice {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAudio2SubmixVoice_Impl: Sized + IXAudio2Voice_Impl {}
 #[cfg(feature = "Win32_Foundation")]
@@ -463,6 +472,7 @@ impl IXAudio2SubmixVoice {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXAudio2Voice_Impl: Sized {
     fn GetVoiceDetails(&self, pvoicedetails: *mut XAUDIO2_VOICE_DETAILS);
@@ -621,6 +631,7 @@ impl IXAudio2Voice {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio_XAudio2\"`, `\"implement\"`*"]
 pub trait IXAudio2VoiceCallback_Impl: Sized {
     fn OnVoiceProcessingPassStart(&self, bytesrequired: u32);
     fn OnVoiceProcessingPassEnd(&self);

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IActivateAudioInterfaceAsyncOperation_Impl: Sized {
     fn GetActivateResult(&self, activateresult: *mut ::windows::core::HRESULT, activatedinterface: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IActivateAudioInterfaceAsyncOperation_Vtbl {
         iid == &<IActivateAudioInterfaceAsyncOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IActivateAudioInterfaceCompletionHandler_Impl: Sized {
     fn ActivateCompleted(&self, activateoperation: &::core::option::Option<IActivateAudioInterfaceAsyncOperation>) -> ::windows::core::Result<()>;
 }
@@ -32,6 +34,7 @@ impl IActivateAudioInterfaceCompletionHandler_Vtbl {
         iid == &<IActivateAudioInterfaceCompletionHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioAmbisonicsControl_Impl: Sized {
     fn SetData(&self, pambisonicsparams: *const AMBISONICS_PARAMS, cbambisonicsparams: u32) -> ::windows::core::Result<()>;
@@ -82,6 +85,7 @@ impl IAudioAmbisonicsControl_Vtbl {
         iid == &<IAudioAmbisonicsControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioAutoGainControl_Impl: Sized {
     fn GetEnabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -118,6 +122,7 @@ impl IAudioAutoGainControl_Vtbl {
         iid == &<IAudioAutoGainControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioBass_Impl: Sized + IPerChannelDbLevel_Impl {}
 impl ::windows::core::RuntimeName for IAudioBass {}
 impl IAudioBass_Vtbl {
@@ -128,6 +133,7 @@ impl IAudioBass_Vtbl {
         iid == &<IAudioBass as ::windows::core::Interface>::IID || iid == &<IPerChannelDbLevel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioCaptureClient_Impl: Sized {
     fn GetBuffer(&self, ppdata: *mut *mut u8, pnumframestoread: *mut u32, pdwflags: *mut u32, pu64deviceposition: *mut u64, pu64qpcposition: *mut u64) -> ::windows::core::Result<()>;
     fn ReleaseBuffer(&self, numframesread: u32) -> ::windows::core::Result<()>;
@@ -168,6 +174,7 @@ impl IAudioCaptureClient_Vtbl {
         iid == &<IAudioCaptureClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioChannelConfig_Impl: Sized {
     fn SetChannelConfig(&self, dwconfig: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetChannelConfig(&self) -> ::windows::core::Result<u32>;
@@ -201,6 +208,7 @@ impl IAudioChannelConfig_Vtbl {
         iid == &<IAudioChannelConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioClient_Impl: Sized {
     fn Initialize(&self, sharemode: AUDCLNT_SHAREMODE, streamflags: u32, hnsbufferduration: i64, hnsperiodicity: i64, pformat: *const WAVEFORMATEX, audiosessionguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -325,6 +333,7 @@ impl IAudioClient_Vtbl {
         iid == &<IAudioClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioClient2_Impl: Sized + IAudioClient_Impl {
     fn IsOffloadCapable(&self, category: AUDIO_STREAM_CATEGORY) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -368,6 +377,7 @@ impl IAudioClient2_Vtbl {
         iid == &<IAudioClient2 as ::windows::core::Interface>::IID || iid == &<IAudioClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioClient3_Impl: Sized + IAudioClient2_Impl {
     fn GetSharedModeEnginePeriod(&self, pformat: *const WAVEFORMATEX, pdefaultperiodinframes: *mut u32, pfundamentalperiodinframes: *mut u32, pminperiodinframes: *mut u32, pmaxperiodinframes: *mut u32) -> ::windows::core::Result<()>;
@@ -405,6 +415,7 @@ impl IAudioClient3_Vtbl {
         iid == &<IAudioClient3 as ::windows::core::Interface>::IID || iid == &<IAudioClient as ::windows::core::Interface>::IID || iid == &<IAudioClient2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioClientDuckingControl_Impl: Sized {
     fn SetDuckingOptionsForCurrentStream(&self, options: AUDIO_DUCKING_OPTIONS) -> ::windows::core::Result<()>;
 }
@@ -425,6 +436,7 @@ impl IAudioClientDuckingControl_Vtbl {
         iid == &<IAudioClientDuckingControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioClock_Impl: Sized {
     fn GetFrequency(&self) -> ::windows::core::Result<u64>;
     fn GetPosition(&self, pu64position: *mut u64, pu64qpcposition: *mut u64) -> ::windows::core::Result<()>;
@@ -471,6 +483,7 @@ impl IAudioClock_Vtbl {
         iid == &<IAudioClock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioClock2_Impl: Sized {
     fn GetDevicePosition(&self, deviceposition: *mut u64, qpcposition: *mut u64) -> ::windows::core::Result<()>;
 }
@@ -488,6 +501,7 @@ impl IAudioClock2_Vtbl {
         iid == &<IAudioClock2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioClockAdjustment_Impl: Sized {
     fn SetSampleRate(&self, flsamplerate: f32) -> ::windows::core::Result<()>;
 }
@@ -505,6 +519,7 @@ impl IAudioClockAdjustment_Vtbl {
         iid == &<IAudioClockAdjustment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioEffectsChangedNotificationClient_Impl: Sized {
     fn OnAudioEffectsChanged(&self) -> ::windows::core::Result<()>;
 }
@@ -522,6 +537,7 @@ impl IAudioEffectsChangedNotificationClient_Vtbl {
         iid == &<IAudioEffectsChangedNotificationClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioEffectsManager_Impl: Sized {
     fn RegisterAudioEffectsChangedNotificationCallback(&self, client: &::core::option::Option<IAudioEffectsChangedNotificationClient>) -> ::windows::core::Result<()>;
@@ -566,6 +582,7 @@ impl IAudioEffectsManager_Vtbl {
         iid == &<IAudioEffectsManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioFormatEnumerator_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetFormat(&self, index: u32) -> ::windows::core::Result<*mut WAVEFORMATEX>;
@@ -605,6 +622,7 @@ impl IAudioFormatEnumerator_Vtbl {
         iid == &<IAudioFormatEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioInputSelector_Impl: Sized {
     fn GetSelection(&self) -> ::windows::core::Result<u32>;
     fn SetSelection(&self, nidselect: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -638,6 +656,7 @@ impl IAudioInputSelector_Vtbl {
         iid == &<IAudioInputSelector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioLoudness_Impl: Sized {
     fn GetEnabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -674,6 +693,7 @@ impl IAudioLoudness_Vtbl {
         iid == &<IAudioLoudness as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioMidrange_Impl: Sized + IPerChannelDbLevel_Impl {}
 impl ::windows::core::RuntimeName for IAudioMidrange {}
 impl IAudioMidrange_Vtbl {
@@ -684,6 +704,7 @@ impl IAudioMidrange_Vtbl {
         iid == &<IAudioMidrange as ::windows::core::Interface>::IID || iid == &<IPerChannelDbLevel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioMute_Impl: Sized {
     fn SetMute(&self, bmuted: super::super::Foundation::BOOL, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -720,6 +741,7 @@ impl IAudioMute_Vtbl {
         iid == &<IAudioMute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioOutputSelector_Impl: Sized {
     fn GetSelection(&self) -> ::windows::core::Result<u32>;
     fn SetSelection(&self, nidselect: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -753,6 +775,7 @@ impl IAudioOutputSelector_Vtbl {
         iid == &<IAudioOutputSelector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioPeakMeter_Impl: Sized {
     fn GetChannelCount(&self) -> ::windows::core::Result<u32>;
     fn GetLevel(&self, nchannel: u32) -> ::windows::core::Result<f32>;
@@ -792,6 +815,7 @@ impl IAudioPeakMeter_Vtbl {
         iid == &<IAudioPeakMeter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioRenderClient_Impl: Sized {
     fn GetBuffer(&self, numframesrequested: u32) -> ::windows::core::Result<*mut u8>;
     fn ReleaseBuffer(&self, numframeswritten: u32, dwflags: u32) -> ::windows::core::Result<()>;
@@ -825,6 +849,7 @@ impl IAudioRenderClient_Vtbl {
         iid == &<IAudioRenderClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioSessionControl_Impl: Sized {
     fn GetState(&self) -> ::windows::core::Result<AudioSessionState>;
     fn GetDisplayName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -925,6 +950,7 @@ impl IAudioSessionControl_Vtbl {
         iid == &<IAudioSessionControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioSessionControl2_Impl: Sized + IAudioSessionControl_Impl {
     fn GetSessionIdentifier(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -994,6 +1020,7 @@ impl IAudioSessionControl2_Vtbl {
         iid == &<IAudioSessionControl2 as ::windows::core::Interface>::IID || iid == &<IAudioSessionControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioSessionEnumerator_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<i32>;
     fn GetSession(&self, sessioncount: i32) -> ::windows::core::Result<IAudioSessionControl>;
@@ -1033,6 +1060,7 @@ impl IAudioSessionEnumerator_Vtbl {
         iid == &<IAudioSessionEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioSessionEvents_Impl: Sized {
     fn OnDisplayNameChanged(&self, newdisplayname: &::windows::core::PCWSTR, eventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1098,6 +1126,7 @@ impl IAudioSessionEvents_Vtbl {
         iid == &<IAudioSessionEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioSessionManager_Impl: Sized {
     fn GetAudioSessionControl(&self, audiosessionguid: *const ::windows::core::GUID, streamflags: u32) -> ::windows::core::Result<IAudioSessionControl>;
     fn GetSimpleAudioVolume(&self, audiosessionguid: *const ::windows::core::GUID, streamflags: u32) -> ::windows::core::Result<ISimpleAudioVolume>;
@@ -1137,6 +1166,7 @@ impl IAudioSessionManager_Vtbl {
         iid == &<IAudioSessionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioSessionManager2_Impl: Sized + IAudioSessionManager_Impl {
     fn GetSessionEnumerator(&self) -> ::windows::core::Result<IAudioSessionEnumerator>;
     fn RegisterSessionNotification(&self, sessionnotification: &::core::option::Option<IAudioSessionNotification>) -> ::windows::core::Result<()>;
@@ -1191,6 +1221,7 @@ impl IAudioSessionManager2_Vtbl {
         iid == &<IAudioSessionManager2 as ::windows::core::Interface>::IID || iid == &<IAudioSessionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioSessionNotification_Impl: Sized {
     fn OnSessionCreated(&self, newsession: &::core::option::Option<IAudioSessionControl>) -> ::windows::core::Result<()>;
 }
@@ -1208,6 +1239,7 @@ impl IAudioSessionNotification_Vtbl {
         iid == &<IAudioSessionNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioStateMonitor_Impl: Sized {
     fn RegisterCallback(&self, callback: PAudioStateMonitorCallback, context: *const ::core::ffi::c_void) -> ::windows::core::Result<i64>;
     fn UnregisterCallback(&self, registration: i64);
@@ -1248,6 +1280,7 @@ impl IAudioStateMonitor_Vtbl {
         iid == &<IAudioStateMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioStreamVolume_Impl: Sized {
     fn GetChannelCount(&self) -> ::windows::core::Result<u32>;
     fn SetChannelVolume(&self, dwindex: u32, flevel: f32) -> ::windows::core::Result<()>;
@@ -1308,6 +1341,7 @@ impl IAudioStreamVolume_Vtbl {
         iid == &<IAudioStreamVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IAudioSystemEffectsPropertyChangeNotificationClient_Impl: Sized {
     fn OnPropertyChanged(&self, r#type: AUDIO_SYSTEMEFFECTS_PROPERTYSTORE_TYPE, key: &super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<()>;
@@ -1328,6 +1362,7 @@ impl IAudioSystemEffectsPropertyChangeNotificationClient_Vtbl {
         iid == &<IAudioSystemEffectsPropertyChangeNotificationClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IAudioSystemEffectsPropertyStore_Impl: Sized {
     fn OpenDefaultPropertyStore(&self, stgmaccess: u32) -> ::windows::core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
@@ -1411,6 +1446,7 @@ impl IAudioSystemEffectsPropertyStore_Vtbl {
         iid == &<IAudioSystemEffectsPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioTreble_Impl: Sized + IPerChannelDbLevel_Impl {}
 impl ::windows::core::RuntimeName for IAudioTreble {}
 impl IAudioTreble_Vtbl {
@@ -1421,6 +1457,7 @@ impl IAudioTreble_Vtbl {
         iid == &<IAudioTreble as ::windows::core::Interface>::IID || iid == &<IPerChannelDbLevel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioVolumeDuckNotification_Impl: Sized {
     fn OnVolumeDuckNotification(&self, sessionid: &::windows::core::PCWSTR, countcommunicationsessions: u32) -> ::windows::core::Result<()>;
     fn OnVolumeUnduckNotification(&self, sessionid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1448,6 +1485,7 @@ impl IAudioVolumeDuckNotification_Vtbl {
         iid == &<IAudioVolumeDuckNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IAudioVolumeLevel_Impl: Sized + IPerChannelDbLevel_Impl {}
 impl ::windows::core::RuntimeName for IAudioVolumeLevel {}
 impl IAudioVolumeLevel_Vtbl {
@@ -1458,6 +1496,7 @@ impl IAudioVolumeLevel_Vtbl {
         iid == &<IAudioVolumeLevel as ::windows::core::Interface>::IID || iid == &<IPerChannelDbLevel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IChannelAudioVolume_Impl: Sized {
     fn GetChannelCount(&self) -> ::windows::core::Result<u32>;
     fn SetChannelVolume(&self, dwindex: u32, flevel: f32, eventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1518,6 +1557,7 @@ impl IChannelAudioVolume_Vtbl {
         iid == &<IChannelAudioVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IConnector_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<ConnectorType>;
@@ -1626,6 +1666,7 @@ impl IConnector_Vtbl {
         iid == &<IConnector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IControlChangeNotify_Impl: Sized {
     fn OnNotify(&self, dwsenderprocessid: u32, pguideventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -1643,6 +1684,7 @@ impl IControlChangeNotify_Vtbl {
         iid == &<IControlChangeNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IControlInterface_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetIID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1682,6 +1724,7 @@ impl IControlInterface_Vtbl {
         iid == &<IControlInterface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IDeviceSpecificProperty_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<u16>;
     fn GetValue(&self, pvvalue: *mut ::core::ffi::c_void, pcbvalue: *mut u32) -> ::windows::core::Result<()>;
@@ -1729,6 +1772,7 @@ impl IDeviceSpecificProperty_Vtbl {
         iid == &<IDeviceSpecificProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDeviceTopology_Impl: Sized {
     fn GetConnectorCount(&self) -> ::windows::core::Result<u32>;
@@ -1836,6 +1880,7 @@ impl IDeviceTopology_Vtbl {
         iid == &<IDeviceTopology as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IMMDevice_Impl: Sized {
     fn Activate(&self, iid: *const ::windows::core::GUID, dwclsctx: super::super::System::Com::CLSCTX, pactivationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1898,6 +1943,7 @@ impl IMMDevice_Vtbl {
         iid == &<IMMDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMMDeviceActivator_Impl: Sized {
     fn Activate(&self, iid: *const ::windows::core::GUID, pdevice: &::core::option::Option<IMMDevice>, pactivationparams: *const super::super::System::Com::StructuredStorage::PROPVARIANT, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1918,6 +1964,7 @@ impl IMMDeviceActivator_Vtbl {
         iid == &<IMMDeviceActivator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IMMDeviceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn Item(&self, ndevice: u32) -> ::windows::core::Result<IMMDevice>;
@@ -1957,6 +2004,7 @@ impl IMMDeviceCollection_Vtbl {
         iid == &<IMMDeviceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IMMDeviceEnumerator_Impl: Sized {
     fn EnumAudioEndpoints(&self, dataflow: EDataFlow, dwstatemask: u32) -> ::windows::core::Result<IMMDeviceCollection>;
     fn GetDefaultAudioEndpoint(&self, dataflow: EDataFlow, role: ERole) -> ::windows::core::Result<IMMDevice>;
@@ -2023,6 +2071,7 @@ impl IMMDeviceEnumerator_Vtbl {
         iid == &<IMMDeviceEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IMMEndpoint_Impl: Sized {
     fn GetDataFlow(&self) -> ::windows::core::Result<EDataFlow>;
 }
@@ -2046,6 +2095,7 @@ impl IMMEndpoint_Vtbl {
         iid == &<IMMEndpoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMMNotificationClient_Impl: Sized {
     fn OnDeviceStateChanged(&self, pwstrdeviceid: &::windows::core::PCWSTR, dwnewstate: u32) -> ::windows::core::Result<()>;
@@ -2097,6 +2147,7 @@ impl IMMNotificationClient_Vtbl {
         iid == &<IMMNotificationClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMessageFilter_Impl: Sized {
     fn HandleInComingCall(&self, dwcalltype: u32, htaskcaller: super::HTASK, dwtickcount: u32, lpinterfaceinfo: *const super::super::System::Com::INTERFACEINFO) -> u32;
@@ -2134,6 +2185,7 @@ impl IMessageFilter_Vtbl {
         iid == &<IMessageFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IPart_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetLocalId(&self) -> ::windows::core::Result<u32>;
@@ -2298,6 +2350,7 @@ impl IPart_Vtbl {
         iid == &<IPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IPartsList_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetPart(&self, nindex: u32) -> ::windows::core::Result<IPart>;
@@ -2337,6 +2390,7 @@ impl IPartsList_Vtbl {
         iid == &<IPartsList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait IPerChannelDbLevel_Impl: Sized {
     fn GetChannelCount(&self) -> ::windows::core::Result<u32>;
     fn GetLevelRange(&self, nchannel: u32, pfminleveldb: *mut f32, pfmaxleveldb: *mut f32, pfstepping: *mut f32) -> ::windows::core::Result<()>;
@@ -2404,6 +2458,7 @@ impl IPerChannelDbLevel_Vtbl {
         iid == &<IPerChannelDbLevel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISimpleAudioVolume_Impl: Sized {
     fn SetMasterVolume(&self, flevel: f32, eventcontext: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -2460,6 +2515,7 @@ impl ISimpleAudioVolume_Vtbl {
         iid == &<ISimpleAudioVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ISpatialAudioClient_Impl: Sized {
     fn GetStaticObjectPosition(&self, r#type: AudioObjectType, x: *mut f32, y: *mut f32, z: *mut f32) -> ::windows::core::Result<()>;
@@ -2556,6 +2612,7 @@ impl ISpatialAudioClient_Vtbl {
         iid == &<ISpatialAudioClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ISpatialAudioClient2_Impl: Sized + ISpatialAudioClient_Impl {
     fn IsOffloadCapable(&self, category: AUDIO_STREAM_CATEGORY) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2598,6 +2655,7 @@ impl ISpatialAudioClient2_Vtbl {
         iid == &<ISpatialAudioClient2 as ::windows::core::Interface>::IID || iid == &<ISpatialAudioClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioMetadataClient_Impl: Sized {
     fn ActivateSpatialAudioMetadataItems(&self, maxitemcount: u16, framecount: u16, metadataitemsbuffer: *mut ::core::option::Option<ISpatialAudioMetadataItemsBuffer>, metadataitems: *mut ::core::option::Option<ISpatialAudioMetadataItems>) -> ::windows::core::Result<()>;
     fn GetSpatialAudioMetadataItemsBufferLength(&self, maxitemcount: u16) -> ::windows::core::Result<u32>;
@@ -2670,6 +2728,7 @@ impl ISpatialAudioMetadataClient_Vtbl {
         iid == &<ISpatialAudioMetadataClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioMetadataCopier_Impl: Sized {
     fn Open(&self, metadataitems: &::core::option::Option<ISpatialAudioMetadataItems>) -> ::windows::core::Result<()>;
     fn CopyMetadataForFrames(&self, copyframecount: u16, copymode: SpatialAudioMetadataCopyMode, dstmetadataitems: &::core::option::Option<ISpatialAudioMetadataItems>) -> ::windows::core::Result<u16>;
@@ -2710,6 +2769,7 @@ impl ISpatialAudioMetadataCopier_Vtbl {
         iid == &<ISpatialAudioMetadataCopier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioMetadataItems_Impl: Sized {
     fn GetFrameCount(&self) -> ::windows::core::Result<u16>;
     fn GetItemCount(&self) -> ::windows::core::Result<u16>;
@@ -2788,6 +2848,7 @@ impl ISpatialAudioMetadataItems_Vtbl {
         iid == &<ISpatialAudioMetadataItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioMetadataItemsBuffer_Impl: Sized {
     fn AttachToBuffer(&self, buffer: *mut u8, bufferlength: u32) -> ::windows::core::Result<()>;
     fn AttachToPopulatedBuffer(&self, buffer: *mut u8, bufferlength: u32) -> ::windows::core::Result<()>;
@@ -2822,6 +2883,7 @@ impl ISpatialAudioMetadataItemsBuffer_Vtbl {
         iid == &<ISpatialAudioMetadataItemsBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioMetadataReader_Impl: Sized {
     fn Open(&self, metadataitems: &::core::option::Option<ISpatialAudioMetadataItems>) -> ::windows::core::Result<()>;
     fn ReadNextItem(&self, commandcount: *mut u8, frameoffset: *mut u16) -> ::windows::core::Result<()>;
@@ -2863,6 +2925,7 @@ impl ISpatialAudioMetadataReader_Vtbl {
         iid == &<ISpatialAudioMetadataReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioMetadataWriter_Impl: Sized {
     fn Open(&self, metadataitems: &::core::option::Option<ISpatialAudioMetadataItems>) -> ::windows::core::Result<()>;
     fn WriteNextItem(&self, frameoffset: u16) -> ::windows::core::Result<()>;
@@ -2904,6 +2967,7 @@ impl ISpatialAudioMetadataWriter_Vtbl {
         iid == &<ISpatialAudioMetadataWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpatialAudioObject_Impl: Sized + ISpatialAudioObjectBase_Impl {
     fn SetPosition(&self, x: f32, y: f32, z: f32) -> ::windows::core::Result<()>;
@@ -2934,6 +2998,7 @@ impl ISpatialAudioObject_Vtbl {
         iid == &<ISpatialAudioObject as ::windows::core::Interface>::IID || iid == &<ISpatialAudioObjectBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpatialAudioObjectBase_Impl: Sized {
     fn GetBuffer(&self, buffer: *mut *mut u8, bufferlength: *mut u32) -> ::windows::core::Result<()>;
@@ -2990,6 +3055,7 @@ impl ISpatialAudioObjectBase_Vtbl {
         iid == &<ISpatialAudioObjectBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpatialAudioObjectForHrtf_Impl: Sized + ISpatialAudioObjectBase_Impl {
     fn SetPosition(&self, x: f32, y: f32, z: f32) -> ::windows::core::Result<()>;
@@ -3048,6 +3114,7 @@ impl ISpatialAudioObjectForHrtf_Vtbl {
         iid == &<ISpatialAudioObjectForHrtf as ::windows::core::Interface>::IID || iid == &<ISpatialAudioObjectBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpatialAudioObjectForMetadataCommands_Impl: Sized + ISpatialAudioObjectBase_Impl {
     fn WriteNextMetadataCommand(&self, commandid: u8, valuebuffer: *const ::core::ffi::c_void, valuebufferlength: u32) -> ::windows::core::Result<()>;
@@ -3071,6 +3138,7 @@ impl ISpatialAudioObjectForMetadataCommands_Vtbl {
         iid == &<ISpatialAudioObjectForMetadataCommands as ::windows::core::Interface>::IID || iid == &<ISpatialAudioObjectBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpatialAudioObjectForMetadataItems_Impl: Sized + ISpatialAudioObjectBase_Impl {
     fn GetSpatialAudioMetadataItems(&self) -> ::windows::core::Result<ISpatialAudioMetadataItems>;
@@ -3100,6 +3168,7 @@ impl ISpatialAudioObjectForMetadataItems_Vtbl {
         iid == &<ISpatialAudioObjectForMetadataItems as ::windows::core::Interface>::IID || iid == &<ISpatialAudioObjectBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioObjectRenderStream_Impl: Sized + ISpatialAudioObjectRenderStreamBase_Impl {
     fn ActivateSpatialAudioObject(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObject>;
 }
@@ -3126,6 +3195,7 @@ impl ISpatialAudioObjectRenderStream_Vtbl {
         iid == &<ISpatialAudioObjectRenderStream as ::windows::core::Interface>::IID || iid == &<ISpatialAudioObjectRenderStreamBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioObjectRenderStreamBase_Impl: Sized {
     fn GetAvailableDynamicObjectCount(&self) -> ::windows::core::Result<u32>;
     fn GetService(&self, riid: *const ::windows::core::GUID, service: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3194,6 +3264,7 @@ impl ISpatialAudioObjectRenderStreamBase_Vtbl {
         iid == &<ISpatialAudioObjectRenderStreamBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioObjectRenderStreamForHrtf_Impl: Sized + ISpatialAudioObjectRenderStreamBase_Impl {
     fn ActivateSpatialAudioObjectForHrtf(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObjectForHrtf>;
 }
@@ -3220,6 +3291,7 @@ impl ISpatialAudioObjectRenderStreamForHrtf_Vtbl {
         iid == &<ISpatialAudioObjectRenderStreamForHrtf as ::windows::core::Interface>::IID || iid == &<ISpatialAudioObjectRenderStreamBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioObjectRenderStreamForMetadata_Impl: Sized + ISpatialAudioObjectRenderStreamBase_Impl {
     fn ActivateSpatialAudioObjectForMetadataCommands(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObjectForMetadataCommands>;
     fn ActivateSpatialAudioObjectForMetadataItems(&self, r#type: AudioObjectType) -> ::windows::core::Result<ISpatialAudioObjectForMetadataItems>;
@@ -3259,6 +3331,7 @@ impl ISpatialAudioObjectRenderStreamForMetadata_Vtbl {
         iid == &<ISpatialAudioObjectRenderStreamForMetadata as ::windows::core::Interface>::IID || iid == &<ISpatialAudioObjectRenderStreamBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISpatialAudioObjectRenderStreamNotify_Impl: Sized {
     fn OnAvailableDynamicObjectCountChange(&self, sender: &::core::option::Option<ISpatialAudioObjectRenderStreamBase>, hnscompliancedeadlinetime: i64, availabledynamicobjectcountchange: u32) -> ::windows::core::Result<()>;
 }
@@ -3279,6 +3352,7 @@ impl ISpatialAudioObjectRenderStreamNotify_Vtbl {
         iid == &<ISpatialAudioObjectRenderStreamNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 pub trait ISubunit_Impl: Sized {}
 impl ::windows::core::RuntimeName for ISubunit {}
 impl ISubunit_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IComponentAuthenticate_Impl: Sized {
     fn SACAuth(&self, dwprotocolid: u32, dwpass: u32, pbdatain: *const u8, dwdatainlen: u32, ppbdataout: *mut *mut u8, pdwdataoutlen: *mut u32) -> ::windows::core::Result<()>;
     fn SACGetProtocols(&self, ppdwprotocols: *mut *mut u32, pdwprotocolcount: *mut u32) -> ::windows::core::Result<()>;
@@ -25,6 +26,7 @@ impl IComponentAuthenticate_Vtbl {
         iid == &<IComponentAuthenticate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IMDSPDevice_Impl: Sized {
     fn GetName(&self, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::Result<()>;
@@ -148,6 +150,7 @@ impl IMDSPDevice_Vtbl {
         iid == &<IMDSPDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Ole"))]
 pub trait IMDSPDevice2_Impl: Sized + IMDSPDevice_Impl {
     fn GetStorage(&self, pszstoragename: &::windows::core::PCWSTR) -> ::windows::core::Result<IMDSPStorage>;
@@ -198,6 +201,7 @@ impl IMDSPDevice2_Vtbl {
         iid == &<IMDSPDevice2 as ::windows::core::Interface>::IID || iid == &<IMDSPDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IMDSPDevice3_Impl: Sized + IMDSPDevice2_Impl {
     fn GetProperty(&self, pwszpropname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
@@ -267,6 +271,7 @@ impl IMDSPDevice3_Vtbl {
         iid == &<IMDSPDevice3 as ::windows::core::Interface>::IID || iid == &<IMDSPDevice as ::windows::core::Interface>::IID || iid == &<IMDSPDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IMDSPDeviceControl_Impl: Sized {
     fn GetDCStatus(&self) -> ::windows::core::Result<u32>;
@@ -351,6 +356,7 @@ impl IMDSPDeviceControl_Vtbl {
         iid == &<IMDSPDeviceControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPDirectTransfer_Impl: Sized {
     fn TransferToDevice(&self, pwszsourcefilepath: &::windows::core::PCWSTR, psourceoperation: &::core::option::Option<IWMDMOperation>, fuflags: u32, pwszdestinationname: &::windows::core::PCWSTR, psourcemetadata: &::core::option::Option<IWMDMMetaData>, ptransferprogress: &::core::option::Option<IWMDMProgress>) -> ::windows::core::Result<IMDSPStorage>;
 }
@@ -374,6 +380,7 @@ impl IMDSPDirectTransfer_Vtbl {
         iid == &<IMDSPDirectTransfer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPEnumDevice_Impl: Sized {
     fn Next(&self, celt: u32, ppdevice: *mut ::core::option::Option<IMDSPDevice>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<u32>;
@@ -427,6 +434,7 @@ impl IMDSPEnumDevice_Vtbl {
         iid == &<IMDSPEnumDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPEnumStorage_Impl: Sized {
     fn Next(&self, celt: u32, ppstorage: *mut ::core::option::Option<IMDSPStorage>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<u32>;
@@ -480,6 +488,7 @@ impl IMDSPEnumStorage_Vtbl {
         iid == &<IMDSPEnumStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPObject_Impl: Sized {
     fn Open(&self, fumode: u32) -> ::windows::core::Result<()>;
     fn Read(&self, pdata: *mut u8, pdwsize: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
@@ -549,6 +558,7 @@ impl IMDSPObject_Vtbl {
         iid == &<IMDSPObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPObject2_Impl: Sized + IMDSPObject_Impl {
     fn ReadOnClearChannel(&self, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
     fn WriteOnClearChannel(&self, pdata: *const u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
@@ -576,6 +586,7 @@ impl IMDSPObject2_Vtbl {
         iid == &<IMDSPObject2 as ::windows::core::Interface>::IID || iid == &<IMDSPObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPObjectInfo_Impl: Sized {
     fn GetPlayLength(&self) -> ::windows::core::Result<u32>;
     fn SetPlayLength(&self, dwlength: u32) -> ::windows::core::Result<()>;
@@ -668,6 +679,7 @@ impl IMDSPObjectInfo_Vtbl {
         iid == &<IMDSPObjectInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPRevoked_Impl: Sized {
     fn GetRevocationURL(&self, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -685,6 +697,7 @@ impl IMDSPRevoked_Vtbl {
         iid == &<IMDSPRevoked as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IMDSPStorage_Impl: Sized {
     fn SetAttributes(&self, dwattributes: u32, pformat: *const super::Audio::WAVEFORMATEX) -> ::windows::core::Result<()>;
@@ -795,6 +808,7 @@ impl IMDSPStorage_Vtbl {
         iid == &<IMDSPStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation"))]
 pub trait IMDSPStorage2_Impl: Sized + IMDSPStorage_Impl {
     fn GetStorage(&self, pszstoragename: &::windows::core::PCWSTR) -> ::windows::core::Result<IMDSPStorage>;
@@ -851,6 +865,7 @@ impl IMDSPStorage2_Vtbl {
         iid == &<IMDSPStorage2 as ::windows::core::Interface>::IID || iid == &<IMDSPStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation"))]
 pub trait IMDSPStorage3_Impl: Sized + IMDSPStorage2_Impl {
     fn GetMetadata(&self, pmetadata: &::core::option::Option<IWMDMMetaData>) -> ::windows::core::Result<()>;
@@ -881,6 +896,7 @@ impl IMDSPStorage3_Vtbl {
         iid == &<IMDSPStorage3 as ::windows::core::Interface>::IID || iid == &<IMDSPStorage as ::windows::core::Interface>::IID || iid == &<IMDSPStorage2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation"))]
 pub trait IMDSPStorage4_Impl: Sized + IMDSPStorage3_Impl {
     fn SetReferences(&self, dwrefs: u32, ppispstorage: *const ::core::option::Option<IMDSPStorage>) -> ::windows::core::Result<()>;
@@ -957,6 +973,7 @@ impl IMDSPStorage4_Vtbl {
         iid == &<IMDSPStorage4 as ::windows::core::Interface>::IID || iid == &<IMDSPStorage as ::windows::core::Interface>::IID || iid == &<IMDSPStorage2 as ::windows::core::Interface>::IID || iid == &<IMDSPStorage3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDSPStorageGlobals_Impl: Sized {
     fn GetCapabilities(&self) -> ::windows::core::Result<u32>;
     fn GetSerialNumber(&self, pserialnum: *mut WMDMID, abmac: *mut u8) -> ::windows::core::Result<()>;
@@ -1057,6 +1074,7 @@ impl IMDSPStorageGlobals_Vtbl {
         iid == &<IMDSPStorageGlobals as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDServiceProvider_Impl: Sized {
     fn GetDeviceCount(&self) -> ::windows::core::Result<u32>;
     fn EnumDevices(&self) -> ::windows::core::Result<IMDSPEnumDevice>;
@@ -1096,6 +1114,7 @@ impl IMDServiceProvider_Vtbl {
         iid == &<IMDServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDServiceProvider2_Impl: Sized + IMDServiceProvider_Impl {
     fn CreateDevice(&self, pwszdevicepath: &::windows::core::PCWSTR, pdwcount: *mut u32, pppdevicearray: *mut *mut ::core::option::Option<IMDSPDevice>) -> ::windows::core::Result<()>;
 }
@@ -1113,6 +1132,7 @@ impl IMDServiceProvider2_Vtbl {
         iid == &<IMDServiceProvider2 as ::windows::core::Interface>::IID || iid == &<IMDServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IMDServiceProvider3_Impl: Sized + IMDServiceProvider2_Impl {
     fn SetDeviceEnumPreference(&self, dwenumpref: u32) -> ::windows::core::Result<()>;
 }
@@ -1130,6 +1150,7 @@ impl IMDServiceProvider3_Vtbl {
         iid == &<IMDServiceProvider3 as ::windows::core::Interface>::IID || iid == &<IMDServiceProvider as ::windows::core::Interface>::IID || iid == &<IMDServiceProvider2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureAuthenticate_Impl: Sized {
     fn GetSecureQuery(&self) -> ::windows::core::Result<ISCPSecureQuery>;
 }
@@ -1153,6 +1174,7 @@ impl ISCPSecureAuthenticate_Vtbl {
         iid == &<ISCPSecureAuthenticate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureAuthenticate2_Impl: Sized + ISCPSecureAuthenticate_Impl {
     fn GetSCPSession(&self) -> ::windows::core::Result<ISCPSession>;
 }
@@ -1176,6 +1198,7 @@ impl ISCPSecureAuthenticate2_Vtbl {
         iid == &<ISCPSecureAuthenticate2 as ::windows::core::Interface>::IID || iid == &<ISCPSecureAuthenticate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureExchange_Impl: Sized {
     fn TransferContainerData(&self, pdata: *const u8, dwsize: u32, pfureadyflags: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
     fn ObjectData(&self, pdata: *mut u8, pdwsize: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
@@ -1210,6 +1233,7 @@ impl ISCPSecureExchange_Vtbl {
         iid == &<ISCPSecureExchange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureExchange2_Impl: Sized + ISCPSecureExchange_Impl {
     fn TransferContainerData2(&self, pdata: *const u8, dwsize: u32, pprogresscallback: &::core::option::Option<IWMDMProgress3>, pfureadyflags: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
 }
@@ -1227,6 +1251,7 @@ impl ISCPSecureExchange2_Vtbl {
         iid == &<ISCPSecureExchange2 as ::windows::core::Interface>::IID || iid == &<ISCPSecureExchange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureExchange3_Impl: Sized + ISCPSecureExchange2_Impl {
     fn TransferContainerDataOnClearChannel(&self, pdevice: &::core::option::Option<IMDSPDevice>, pdata: *const u8, dwsize: u32, pprogresscallback: &::core::option::Option<IWMDMProgress3>) -> ::windows::core::Result<u32>;
     fn GetObjectDataOnClearChannel(&self, pdevice: &::core::option::Option<IMDSPDevice>, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
@@ -1267,6 +1292,7 @@ impl ISCPSecureExchange3_Vtbl {
         iid == &<ISCPSecureExchange3 as ::windows::core::Interface>::IID || iid == &<ISCPSecureExchange as ::windows::core::Interface>::IID || iid == &<ISCPSecureExchange2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureQuery_Impl: Sized {
     fn GetDataDemands(&self, pfuflags: *mut u32, pdwminrightsdata: *mut u32, pdwminexaminedata: *mut u32, pdwmindecidedata: *mut u32, abmac: *mut u8) -> ::windows::core::Result<()>;
     fn ExamineData(&self, fuflags: u32, pwszextension: &::windows::core::PCWSTR, pdata: *const u8, dwsize: u32, abmac: *mut u8) -> ::windows::core::Result<()>;
@@ -1308,6 +1334,7 @@ impl ISCPSecureQuery_Vtbl {
         iid == &<ISCPSecureQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureQuery2_Impl: Sized + ISCPSecureQuery_Impl {
     fn MakeDecision2(&self, fuflags: u32, pdata: *const u8, dwsize: u32, dwappsec: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstorageglobals: &::core::option::Option<IMDSPStorageGlobals>, pappcertapp: *const u8, dwappcertapplen: u32, pappcertsp: *const u8, dwappcertsplen: u32, pszrevocationurl: *mut ::windows::core::PWSTR, pdwrevocationurllen: *mut u32, pdwrevocationbitflag: *mut u32, pqwfilesize: *mut u64, punknown: &::core::option::Option<::windows::core::IUnknown>, ppexchange: *mut ::core::option::Option<ISCPSecureExchange>, abmac: *mut u8) -> ::windows::core::Result<()>;
 }
@@ -1345,6 +1372,7 @@ impl ISCPSecureQuery2_Vtbl {
         iid == &<ISCPSecureQuery2 as ::windows::core::Interface>::IID || iid == &<ISCPSecureQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSecureQuery3_Impl: Sized + ISCPSecureQuery2_Impl {
     fn GetRightsOnClearChannel(&self, pdata: *const u8, dwsize: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstgglobals: &::core::option::Option<IMDSPStorageGlobals>, pprogresscallback: &::core::option::Option<IWMDMProgress3>, pprights: *mut *mut WMDMRIGHTS, pnrightscount: *mut u32) -> ::windows::core::Result<()>;
     fn MakeDecisionOnClearChannel(&self, fuflags: u32, pdata: *const u8, dwsize: u32, dwappsec: u32, pbspsessionkey: *const u8, dwsessionkeylen: u32, pstorageglobals: &::core::option::Option<IMDSPStorageGlobals>, pprogresscallback: &::core::option::Option<IWMDMProgress3>, pappcertapp: *const u8, dwappcertapplen: u32, pappcertsp: *const u8, dwappcertsplen: u32, pszrevocationurl: *mut ::windows::core::PWSTR, pdwrevocationurllen: *mut u32, pdwrevocationbitflag: *mut u32, pqwfilesize: *mut u64, punknown: &::core::option::Option<::windows::core::IUnknown>, ppexchange: *mut ::core::option::Option<ISCPSecureExchange>) -> ::windows::core::Result<()>;
@@ -1392,6 +1420,7 @@ impl ISCPSecureQuery3_Vtbl {
         iid == &<ISCPSecureQuery3 as ::windows::core::Interface>::IID || iid == &<ISCPSecureQuery as ::windows::core::Interface>::IID || iid == &<ISCPSecureQuery2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait ISCPSession_Impl: Sized {
     fn BeginSession(&self, pidevice: &::core::option::Option<IMDSPDevice>, pctx: *const u8, dwsizectx: u32) -> ::windows::core::Result<()>;
     fn EndSession(&self, pctx: *const u8, dwsizectx: u32) -> ::windows::core::Result<()>;
@@ -1432,6 +1461,7 @@ impl ISCPSession_Vtbl {
         iid == &<ISCPSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IWMDMDevice_Impl: Sized {
     fn GetName(&self, pwszname: ::windows::core::PWSTR, nmaxchars: u32) -> ::windows::core::Result<()>;
@@ -1555,6 +1585,7 @@ impl IWMDMDevice_Vtbl {
         iid == &<IWMDMDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Ole"))]
 pub trait IWMDMDevice2_Impl: Sized + IWMDMDevice_Impl {
     fn GetStorage(&self, pszstoragename: &::windows::core::PCWSTR) -> ::windows::core::Result<IWMDMStorage>;
@@ -1605,6 +1636,7 @@ impl IWMDMDevice2_Vtbl {
         iid == &<IWMDMDevice2 as ::windows::core::Interface>::IID || iid == &<IWMDMDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IWMDMDevice3_Impl: Sized + IWMDMDevice2_Impl {
     fn GetProperty(&self, pwszpropname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
@@ -1674,6 +1706,7 @@ impl IWMDMDevice3_Vtbl {
         iid == &<IWMDMDevice3 as ::windows::core::Interface>::IID || iid == &<IWMDMDevice as ::windows::core::Interface>::IID || iid == &<IWMDMDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IWMDMDeviceControl_Impl: Sized {
     fn GetStatus(&self) -> ::windows::core::Result<u32>;
@@ -1758,6 +1791,7 @@ impl IWMDMDeviceControl_Vtbl {
         iid == &<IWMDMDeviceControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMDeviceSession_Impl: Sized {
     fn BeginSession(&self, r#type: WMDM_SESSION_TYPE, pctx: *const u8, dwsizectx: u32) -> ::windows::core::Result<()>;
     fn EndSession(&self, r#type: WMDM_SESSION_TYPE, pctx: *const u8, dwsizectx: u32) -> ::windows::core::Result<()>;
@@ -1785,6 +1819,7 @@ impl IWMDMDeviceSession_Vtbl {
         iid == &<IWMDMDeviceSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMEnumDevice_Impl: Sized {
     fn Next(&self, celt: u32, ppdevice: *mut ::core::option::Option<IWMDMDevice>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<u32>;
@@ -1838,6 +1873,7 @@ impl IWMDMEnumDevice_Vtbl {
         iid == &<IWMDMEnumDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMEnumStorage_Impl: Sized {
     fn Next(&self, celt: u32, ppstorage: *mut ::core::option::Option<IWMDMStorage>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<u32>;
@@ -1891,6 +1927,7 @@ impl IWMDMEnumStorage_Vtbl {
         iid == &<IWMDMEnumStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMDMLogger_Impl: Sized {
     fn IsEnabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -1976,6 +2013,7 @@ impl IWMDMLogger_Vtbl {
         iid == &<IWMDMLogger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMMetaData_Impl: Sized {
     fn AddItem(&self, r#type: WMDM_TAG_DATATYPE, pwsztagname: &::windows::core::PCWSTR, pvalue: *const u8, ilength: u32) -> ::windows::core::Result<()>;
     fn QueryByName(&self, pwsztagname: &::windows::core::PCWSTR, ptype: *mut WMDM_TAG_DATATYPE, pvalue: *mut *mut u8, pcblength: *mut u32) -> ::windows::core::Result<()>;
@@ -2023,6 +2061,7 @@ impl IWMDMMetaData_Vtbl {
         iid == &<IWMDMMetaData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMNotification_Impl: Sized {
     fn WMDMMessage(&self, dwmessagetype: u32, pwszcanonicalname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -2040,6 +2079,7 @@ impl IWMDMNotification_Vtbl {
         iid == &<IWMDMNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMObjectInfo_Impl: Sized {
     fn GetPlayLength(&self) -> ::windows::core::Result<u32>;
     fn SetPlayLength(&self, dwlength: u32) -> ::windows::core::Result<()>;
@@ -2132,6 +2172,7 @@ impl IWMDMObjectInfo_Vtbl {
         iid == &<IWMDMObjectInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IWMDMOperation_Impl: Sized {
     fn BeginRead(&self) -> ::windows::core::Result<()>;
@@ -2218,6 +2259,7 @@ impl IWMDMOperation_Vtbl {
         iid == &<IWMDMOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation"))]
 pub trait IWMDMOperation2_Impl: Sized + IWMDMOperation_Impl {
     fn SetObjectAttributes2(&self, dwattributes: u32, dwattributesex: u32, pformat: *const super::Audio::WAVEFORMATEX, pvideoformat: *const super::MediaFoundation::VIDEOINFOHEADER) -> ::windows::core::Result<()>;
@@ -2248,6 +2290,7 @@ impl IWMDMOperation2_Vtbl {
         iid == &<IWMDMOperation2 as ::windows::core::Interface>::IID || iid == &<IWMDMOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IWMDMOperation3_Impl: Sized + IWMDMOperation_Impl {
     fn TransferObjectDataOnClearChannel(&self, pdata: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
@@ -2271,6 +2314,7 @@ impl IWMDMOperation3_Vtbl {
         iid == &<IWMDMOperation3 as ::windows::core::Interface>::IID || iid == &<IWMDMOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMProgress_Impl: Sized {
     fn Begin(&self, dwestimatedticks: u32) -> ::windows::core::Result<()>;
     fn Progress(&self, dwtranspiredticks: u32) -> ::windows::core::Result<()>;
@@ -2305,6 +2349,7 @@ impl IWMDMProgress_Vtbl {
         iid == &<IWMDMProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMProgress2_Impl: Sized + IWMDMProgress_Impl {
     fn End2(&self, hrcompletioncode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -2322,6 +2367,7 @@ impl IWMDMProgress2_Vtbl {
         iid == &<IWMDMProgress2 as ::windows::core::Interface>::IID || iid == &<IWMDMProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMProgress3_Impl: Sized + IWMDMProgress2_Impl {
     fn Begin3(&self, eventid: &::windows::core::GUID, dwestimatedticks: u32, pcontext: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
     fn Progress3(&self, eventid: &::windows::core::GUID, dwtranspiredticks: u32, pcontext: *mut OPAQUECOMMAND) -> ::windows::core::Result<()>;
@@ -2356,6 +2402,7 @@ impl IWMDMProgress3_Vtbl {
         iid == &<IWMDMProgress3 as ::windows::core::Interface>::IID || iid == &<IWMDMProgress as ::windows::core::Interface>::IID || iid == &<IWMDMProgress2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMRevoked_Impl: Sized {
     fn GetRevocationURL(&self, ppwszrevocationurl: *mut ::windows::core::PWSTR, pdwbufferlen: *mut u32, pdwrevokedbitflag: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -2373,6 +2420,7 @@ impl IWMDMRevoked_Vtbl {
         iid == &<IWMDMRevoked as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IWMDMStorage_Impl: Sized {
     fn SetAttributes(&self, dwattributes: u32, pformat: *const super::Audio::WAVEFORMATEX) -> ::windows::core::Result<()>;
@@ -2470,6 +2518,7 @@ impl IWMDMStorage_Vtbl {
         iid == &<IWMDMStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation"))]
 pub trait IWMDMStorage2_Impl: Sized + IWMDMStorage_Impl {
     fn GetStorage(&self, pszstoragename: &::windows::core::PCWSTR) -> ::windows::core::Result<IWMDMStorage>;
@@ -2513,6 +2562,7 @@ impl IWMDMStorage2_Vtbl {
         iid == &<IWMDMStorage2 as ::windows::core::Interface>::IID || iid == &<IWMDMStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation"))]
 pub trait IWMDMStorage3_Impl: Sized + IWMDMStorage2_Impl {
     fn GetMetadata(&self) -> ::windows::core::Result<IWMDMMetaData>;
@@ -2569,6 +2619,7 @@ impl IWMDMStorage3_Vtbl {
         iid == &<IWMDMStorage3 as ::windows::core::Interface>::IID || iid == &<IWMDMStorage as ::windows::core::Interface>::IID || iid == &<IWMDMStorage2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_Audio\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_Audio", feature = "Win32_Media_MediaFoundation"))]
 pub trait IWMDMStorage4_Impl: Sized + IWMDMStorage3_Impl {
     fn SetReferences(&self, dwrefs: u32, ppiwmdmstorage: *const ::core::option::Option<IWMDMStorage>) -> ::windows::core::Result<()>;
@@ -2645,6 +2696,7 @@ impl IWMDMStorage4_Vtbl {
         iid == &<IWMDMStorage4 as ::windows::core::Interface>::IID || iid == &<IWMDMStorage as ::windows::core::Interface>::IID || iid == &<IWMDMStorage2 as ::windows::core::Interface>::IID || iid == &<IWMDMStorage3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMStorageControl_Impl: Sized {
     fn Insert(&self, fumode: u32, pwszfile: &::windows::core::PCWSTR, poperation: &::core::option::Option<IWMDMOperation>, pprogress: &::core::option::Option<IWMDMProgress>) -> ::windows::core::Result<IWMDMStorage>;
     fn Delete(&self, fumode: u32, pprogress: &::core::option::Option<IWMDMProgress>) -> ::windows::core::Result<()>;
@@ -2699,6 +2751,7 @@ impl IWMDMStorageControl_Vtbl {
         iid == &<IWMDMStorageControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMStorageControl2_Impl: Sized + IWMDMStorageControl_Impl {
     fn Insert2(&self, fumode: u32, pwszfilesource: &::windows::core::PCWSTR, pwszfiledest: &::windows::core::PCWSTR, poperation: &::core::option::Option<IWMDMOperation>, pprogress: &::core::option::Option<IWMDMProgress>, punknown: &::core::option::Option<::windows::core::IUnknown>, ppnewobject: *mut ::core::option::Option<IWMDMStorage>) -> ::windows::core::Result<()>;
 }
@@ -2716,6 +2769,7 @@ impl IWMDMStorageControl2_Vtbl {
         iid == &<IWMDMStorageControl2 as ::windows::core::Interface>::IID || iid == &<IWMDMStorageControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMStorageControl3_Impl: Sized + IWMDMStorageControl2_Impl {
     fn Insert3(&self, fumode: u32, futype: u32, pwszfilesource: &::windows::core::PCWSTR, pwszfiledest: &::windows::core::PCWSTR, poperation: &::core::option::Option<IWMDMOperation>, pprogress: &::core::option::Option<IWMDMProgress>, pmetadata: &::core::option::Option<IWMDMMetaData>, punknown: &::core::option::Option<::windows::core::IUnknown>, ppnewobject: *mut ::core::option::Option<IWMDMStorage>) -> ::windows::core::Result<()>;
 }
@@ -2733,6 +2787,7 @@ impl IWMDMStorageControl3_Vtbl {
         iid == &<IWMDMStorageControl3 as ::windows::core::Interface>::IID || iid == &<IWMDMStorageControl as ::windows::core::Interface>::IID || iid == &<IWMDMStorageControl2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDMStorageGlobals_Impl: Sized {
     fn GetCapabilities(&self) -> ::windows::core::Result<u32>;
     fn GetSerialNumber(&self, pserialnum: *mut WMDMID, abmac: *mut u8) -> ::windows::core::Result<()>;
@@ -2807,6 +2862,7 @@ impl IWMDMStorageGlobals_Vtbl {
         iid == &<IWMDMStorageGlobals as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDeviceManager_Impl: Sized {
     fn GetRevision(&self) -> ::windows::core::Result<u32>;
     fn GetDeviceCount(&self) -> ::windows::core::Result<u32>;
@@ -2859,6 +2915,7 @@ impl IWMDeviceManager_Vtbl {
         iid == &<IWMDeviceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDeviceManager2_Impl: Sized + IWMDeviceManager_Impl {
     fn GetDeviceFromCanonicalName(&self, pwszcanonicalname: &::windows::core::PCWSTR) -> ::windows::core::Result<IWMDMDevice>;
     fn EnumDevices2(&self) -> ::windows::core::Result<IWMDMEnumDevice>;
@@ -2905,6 +2962,7 @@ impl IWMDeviceManager2_Vtbl {
         iid == &<IWMDeviceManager2 as ::windows::core::Interface>::IID || iid == &<IWMDeviceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DeviceManager\"`, `\"implement\"`*"]
 pub trait IWMDeviceManager3_Impl: Sized + IWMDeviceManager2_Impl {
     fn SetDeviceEnumPreference(&self, dwenumpref: u32) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_DirectShow_Xml\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
 pub trait IXMLGraphBuilder_Impl: Sized {
     fn BuildFromXML(&self, pgraph: &::core::option::Option<super::IGraphBuilder>, pxml: &::core::option::Option<super::super::super::Data::Xml::MsXml::IXMLElement>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMAnalogVideoDecoder_Impl: Sized {
     fn AvailableTVFormats(&self) -> ::windows::core::Result<i32>;
     fn SetTVFormat(&self, lanalogvideostandard: i32) -> ::windows::core::Result<()>;
@@ -110,6 +111,7 @@ impl IAMAnalogVideoDecoder_Vtbl {
         iid == &<IAMAnalogVideoDecoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMAnalogVideoEncoder_Impl: Sized {
     fn AvailableTVFormats(&self) -> ::windows::core::Result<i32>;
     fn SetTVFormat(&self, lanalogvideostandard: i32) -> ::windows::core::Result<()>;
@@ -196,6 +198,7 @@ impl IAMAnalogVideoEncoder_Vtbl {
         iid == &<IAMAnalogVideoEncoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMAsyncReaderTimestampScaling_Impl: Sized {
     fn GetTimestampMode(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -232,6 +235,7 @@ impl IAMAsyncReaderTimestampScaling_Vtbl {
         iid == &<IAMAsyncReaderTimestampScaling as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMAudioInputMixer_Impl: Sized {
     fn SetEnable(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -414,6 +418,7 @@ impl IAMAudioInputMixer_Vtbl {
         iid == &<IAMAudioInputMixer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMAudioRendererStats_Impl: Sized {
     fn GetStatParam(&self, dwparam: u32, pdwparam1: *mut u32, pdwparam2: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -431,6 +436,7 @@ impl IAMAudioRendererStats_Vtbl {
         iid == &<IAMAudioRendererStats as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMBufferNegotiation_Impl: Sized {
     fn SuggestAllocatorProperties(&self, pprop: *const ALLOCATOR_PROPERTIES) -> ::windows::core::Result<()>;
     fn GetAllocatorProperties(&self) -> ::windows::core::Result<ALLOCATOR_PROPERTIES>;
@@ -464,6 +470,7 @@ impl IAMBufferNegotiation_Vtbl {
         iid == &<IAMBufferNegotiation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMCameraControl_Impl: Sized {
     fn GetRange(&self, property: i32, pmin: *mut i32, pmax: *mut i32, psteppingdelta: *mut i32, pdefault: *mut i32, pcapsflags: *mut i32) -> ::windows::core::Result<()>;
     fn Set(&self, property: i32, lvalue: i32, flags: i32) -> ::windows::core::Result<()>;
@@ -498,6 +505,7 @@ impl IAMCameraControl_Vtbl {
         iid == &<IAMCameraControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMCertifiedOutputProtection_Impl: Sized {
     fn KeyExchange(&self, prandom: *mut ::windows::core::GUID, varlencertgh: *mut *mut u8, pdwlengthcertgh: *mut u32) -> ::windows::core::Result<()>;
     fn SessionSequenceStart(&self, psig: *mut AMCOPPSignature) -> ::windows::core::Result<()>;
@@ -545,6 +553,7 @@ impl IAMCertifiedOutputProtection_Vtbl {
         iid == &<IAMCertifiedOutputProtection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMChannelInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ChannelName(&self, pbstrchannelname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -603,6 +612,7 @@ impl IAMChannelInfo_Vtbl {
         iid == &<IAMChannelInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMClockAdjust_Impl: Sized {
     fn SetClockDelta(&self, rtdelta: i64) -> ::windows::core::Result<()>;
 }
@@ -620,6 +630,7 @@ impl IAMClockAdjust_Vtbl {
         iid == &<IAMClockAdjust as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMClockSlave_Impl: Sized {
     fn SetErrorTolerance(&self, dwtolerance: u32) -> ::windows::core::Result<()>;
     fn GetErrorTolerance(&self) -> ::windows::core::Result<u32>;
@@ -653,6 +664,7 @@ impl IAMClockSlave_Vtbl {
         iid == &<IAMClockSlave as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -708,6 +720,7 @@ impl IAMCollection_Vtbl {
         iid == &<IAMCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMCopyCaptureFileProgress_Impl: Sized {
     fn Progress(&self, iprogress: i32) -> ::windows::core::Result<()>;
 }
@@ -725,6 +738,7 @@ impl IAMCopyCaptureFileProgress_Vtbl {
         iid == &<IAMCopyCaptureFileProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMCrossbar_Impl: Sized {
     fn get_PinCounts(&self, outputpincount: *mut i32, inputpincount: *mut i32) -> ::windows::core::Result<()>;
@@ -782,6 +796,7 @@ impl IAMCrossbar_Vtbl {
         iid == &<IAMCrossbar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMDecoderCaps_Impl: Sized {
     fn GetDecoderCaps(&self, dwcapindex: u32) -> ::windows::core::Result<u32>;
 }
@@ -805,6 +820,7 @@ impl IAMDecoderCaps_Vtbl {
         iid == &<IAMDecoderCaps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMDevMemoryAllocator_Impl: Sized {
     fn GetInfo(&self, pdwcbtotalfree: *mut u32, pdwcblargestfree: *mut u32, pdwcbtotalmemory: *mut u32, pdwcbminimumchunk: *mut u32) -> ::windows::core::Result<()>;
     fn CheckMemory(&self, pbuffer: *const u8) -> ::windows::core::Result<()>;
@@ -853,6 +869,7 @@ impl IAMDevMemoryAllocator_Vtbl {
         iid == &<IAMDevMemoryAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMDevMemoryControl_Impl: Sized {
     fn QueryWriteSync(&self) -> ::windows::core::Result<()>;
     fn WriteSync(&self) -> ::windows::core::Result<()>;
@@ -893,6 +910,7 @@ impl IAMDevMemoryControl_Vtbl {
         iid == &<IAMDevMemoryControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMDeviceRemoval_Impl: Sized {
     fn DeviceInfo(&self, pclsidinterfaceclass: *mut ::windows::core::GUID, pwszsymboliclink: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn Reassociate(&self) -> ::windows::core::Result<()>;
@@ -927,6 +945,7 @@ impl IAMDeviceRemoval_Vtbl {
         iid == &<IAMDeviceRemoval as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio_DirectSound\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio_DirectSound"))]
 pub trait IAMDirectSound_Impl: Sized {
     fn GetDirectSoundInterface(&self) -> ::windows::core::Result<super::Audio::DirectSound::IDirectSound>;
@@ -1017,6 +1036,7 @@ impl IAMDirectSound_Vtbl {
         iid == &<IAMDirectSound as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMDroppedFrames_Impl: Sized {
     fn GetNumDropped(&self) -> ::windows::core::Result<i32>;
     fn GetNumNotDropped(&self) -> ::windows::core::Result<i32>;
@@ -1076,6 +1096,7 @@ impl IAMDroppedFrames_Vtbl {
         iid == &<IAMDroppedFrames as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMExtDevice_Impl: Sized {
     fn GetCapability(&self, capability: i32, pvalue: *mut i32, pdblvalue: *mut f64) -> ::windows::core::Result<()>;
     fn ExternalDeviceID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1175,6 +1196,7 @@ impl IAMExtDevice_Vtbl {
         iid == &<IAMExtDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMExtTransport_Impl: Sized {
     fn GetCapability(&self, capability: i32, pvalue: *mut i32, pdblvalue: *mut f64) -> ::windows::core::Result<()>;
     fn SetMediaState(&self, state: i32) -> ::windows::core::Result<()>;
@@ -1450,6 +1472,7 @@ impl IAMExtTransport_Vtbl {
         iid == &<IAMExtTransport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMExtendedErrorInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn HasError(&self, phaserror: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -1487,6 +1510,7 @@ impl IAMExtendedErrorInfo_Vtbl {
         iid == &<IAMExtendedErrorInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMExtendedSeeking_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ExSeekCapabilities(&self, pexcapabilities: *mut i32) -> ::windows::core::Result<()>;
@@ -1552,6 +1576,7 @@ impl IAMExtendedSeeking_Vtbl {
         iid == &<IAMExtendedSeeking as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMFilterGraphCallback_Impl: Sized {
     fn UnableToRender(&self, ppin: &::core::option::Option<IPin>) -> ::windows::core::Result<()>;
 }
@@ -1569,6 +1594,7 @@ impl IAMFilterGraphCallback_Vtbl {
         iid == &<IAMFilterGraphCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMFilterMiscFlags_Impl: Sized {
     fn GetMiscFlags(&self) -> u32;
 }
@@ -1586,6 +1612,7 @@ impl IAMFilterMiscFlags_Vtbl {
         iid == &<IAMFilterMiscFlags as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAMGraphBuilderCallback_Impl: Sized {
     fn SelectedFilter(&self, pmon: &::core::option::Option<super::super::System::Com::IMoniker>) -> ::windows::core::Result<()>;
@@ -1616,6 +1643,7 @@ impl IAMGraphBuilderCallback_Vtbl {
         iid == &<IAMGraphBuilderCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMGraphStreams_Impl: Sized {
     fn FindUpstreamInterface(&self, ppin: &::core::option::Option<IPin>, riid: *const ::windows::core::GUID, ppvinterface: *mut *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::Result<()>;
@@ -1653,6 +1681,7 @@ impl IAMGraphStreams_Vtbl {
         iid == &<IAMGraphStreams as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMLatency_Impl: Sized {
     fn GetLatency(&self) -> ::windows::core::Result<i64>;
 }
@@ -1676,6 +1705,7 @@ impl IAMLatency_Vtbl {
         iid == &<IAMLatency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IAMLine21Decoder_Impl: Sized {
     fn GetDecoderLevel(&self, lplevel: *mut AM_LINE21_CCLEVEL) -> ::windows::core::Result<()>;
@@ -1783,6 +1813,7 @@ impl IAMLine21Decoder_Vtbl {
         iid == &<IAMLine21Decoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMMediaContent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AuthorName(&self, pbstrauthorname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1890,6 +1921,7 @@ impl IAMMediaContent_Vtbl {
         iid == &<IAMMediaContent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMMediaContent2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_MediaParameter(&self, entrynum: i32, bstrname: &::windows::core::BSTR, pbstrvalue: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1927,6 +1959,7 @@ impl IAMMediaContent2_Vtbl {
         iid == &<IAMMediaContent2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAMMediaStream_Impl: Sized + IMediaStream_Impl {
     fn Initialize(&self, psourceobject: &::core::option::Option<::windows::core::IUnknown>, dwflags: u32, purposeid: *const ::windows::core::GUID, streamtype: STREAM_TYPE) -> ::windows::core::Result<()>;
@@ -1978,6 +2011,7 @@ impl IAMMediaStream_Vtbl {
         iid == &<IAMMediaStream as ::windows::core::Interface>::IID || iid == &<IMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IAMMediaTypeSample_Impl: Sized + IStreamSample_Impl {
     fn SetPointer(&self, pbuffer: *const u8, lsize: i32) -> ::windows::core::Result<()>;
@@ -2125,6 +2159,7 @@ impl IAMMediaTypeSample_Vtbl {
         iid == &<IAMMediaTypeSample as ::windows::core::Interface>::IID || iid == &<IStreamSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IAMMediaTypeStream_Impl: Sized + IMediaStream_Impl {
     fn GetFormat(&self, pmediatype: *mut super::MediaFoundation::AM_MEDIA_TYPE, dwflags: u32) -> ::windows::core::Result<()>;
@@ -2188,6 +2223,7 @@ impl IAMMediaTypeStream_Vtbl {
         iid == &<IAMMediaTypeStream as ::windows::core::Interface>::IID || iid == &<IMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAMMultiMediaStream_Impl: Sized + IMultiMediaStream_Impl {
     fn Initialize(&self, streamtype: STREAM_TYPE, dwflags: AMMSF_MMS_INIT_FLAGS, pfiltergraph: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
@@ -2271,6 +2307,7 @@ impl IAMMultiMediaStream_Vtbl {
         iid == &<IAMMultiMediaStream as ::windows::core::Interface>::IID || iid == &<IMultiMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMNetShowConfig_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn BufferingTime(&self, pbufferingtime: *mut f64) -> ::windows::core::Result<()>;
@@ -2441,6 +2478,7 @@ impl IAMNetShowConfig_Vtbl {
         iid == &<IAMNetShowConfig as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMNetShowExProps_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SourceProtocol(&self, psourceprotocol: *mut i32) -> ::windows::core::Result<()>;
@@ -2520,6 +2558,7 @@ impl IAMNetShowExProps_Vtbl {
         iid == &<IAMNetShowExProps as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMNetShowPreroll_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetPreroll(&self, fpreroll: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -2550,6 +2589,7 @@ impl IAMNetShowPreroll_Vtbl {
         iid == &<IAMNetShowPreroll as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMNetworkStatus_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ReceivedPackets(&self, preceivedpackets: *mut i32) -> ::windows::core::Result<()>;
@@ -2615,6 +2655,7 @@ impl IAMNetworkStatus_Vtbl {
         iid == &<IAMNetworkStatus as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMOpenProgress_Impl: Sized {
     fn QueryProgress(&self, plltotal: *mut i64, pllcurrent: *mut i64) -> ::windows::core::Result<()>;
     fn AbortOperation(&self) -> ::windows::core::Result<()>;
@@ -2642,6 +2683,7 @@ impl IAMOpenProgress_Vtbl {
         iid == &<IAMOpenProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMOverlayFX_Impl: Sized {
     fn QueryOverlayFXCaps(&self) -> ::windows::core::Result<u32>;
     fn SetOverlayFX(&self, dwoverlayfx: u32) -> ::windows::core::Result<()>;
@@ -2688,6 +2730,7 @@ impl IAMOverlayFX_Vtbl {
         iid == &<IAMOverlayFX as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMParse_Impl: Sized {
     fn GetParseTime(&self) -> ::windows::core::Result<i64>;
     fn SetParseTime(&self, rtcurrent: i64) -> ::windows::core::Result<()>;
@@ -2728,6 +2771,7 @@ impl IAMParse_Vtbl {
         iid == &<IAMParse as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMPhysicalPinInfo_Impl: Sized {
     fn GetPhysicalType(&self, ptype: *mut i32, ppsztype: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
@@ -2745,6 +2789,7 @@ impl IAMPhysicalPinInfo_Vtbl {
         iid == &<IAMPhysicalPinInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMPlayList_Impl: Sized {
     fn GetFlags(&self) -> ::windows::core::Result<u32>;
     fn GetItemCount(&self) -> ::windows::core::Result<u32>;
@@ -2811,6 +2856,7 @@ impl IAMPlayList_Vtbl {
         iid == &<IAMPlayList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMPlayListItem_Impl: Sized {
     fn GetFlags(&self) -> ::windows::core::Result<u32>;
     fn GetSourceCount(&self) -> ::windows::core::Result<u32>;
@@ -2967,6 +3013,7 @@ impl IAMPlayListItem_Vtbl {
         iid == &<IAMPlayListItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMPluginControl_Impl: Sized {
     fn GetPreferredClsid(&self, subtype: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3044,6 +3091,7 @@ impl IAMPluginControl_Vtbl {
         iid == &<IAMPluginControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMPushSource_Impl: Sized + IAMLatency_Impl {
     fn GetPushSourceFlags(&self) -> ::windows::core::Result<u32>;
     fn SetPushSourceFlags(&self, flags: u32) -> ::windows::core::Result<()>;
@@ -3117,6 +3165,7 @@ impl IAMPushSource_Vtbl {
         iid == &<IAMPushSource as ::windows::core::Interface>::IID || iid == &<IAMLatency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMRebuild_Impl: Sized {
     fn RebuildNow(&self) -> ::windows::core::Result<()>;
 }
@@ -3134,6 +3183,7 @@ impl IAMRebuild_Vtbl {
         iid == &<IAMRebuild as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMResourceControl_Impl: Sized {
     fn Reserve(&self, dwflags: u32, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -3151,6 +3201,7 @@ impl IAMResourceControl_Vtbl {
         iid == &<IAMResourceControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAMStats_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -3221,6 +3272,7 @@ impl IAMStats_Vtbl {
         iid == &<IAMStats as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IAMStreamConfig_Impl: Sized {
     fn SetFormat(&self, pmt: *mut super::MediaFoundation::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
@@ -3271,6 +3323,7 @@ impl IAMStreamConfig_Vtbl {
         iid == &<IAMStreamConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMStreamControl_Impl: Sized {
     fn StartAt(&self, ptstart: *const i64, dwcookie: u32) -> ::windows::core::Result<()>;
@@ -3314,6 +3367,7 @@ impl IAMStreamControl_Vtbl {
         iid == &<IAMStreamControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IAMStreamSelect_Impl: Sized {
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -3357,6 +3411,7 @@ impl IAMStreamSelect_Vtbl {
         iid == &<IAMStreamSelect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMTVAudio_Impl: Sized {
     fn GetHardwareSupportedTVAudioModes(&self) -> ::windows::core::Result<i32>;
     fn GetAvailableTVAudioModes(&self) -> ::windows::core::Result<i32>;
@@ -3430,6 +3485,7 @@ impl IAMTVAudio_Vtbl {
         iid == &<IAMTVAudio as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMTVAudioNotification_Impl: Sized {
     fn OnEvent(&self, event: AMTVAudioEventType) -> ::windows::core::Result<()>;
 }
@@ -3447,6 +3503,7 @@ impl IAMTVAudioNotification_Vtbl {
         iid == &<IAMTVAudioNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMTVTuner_Impl: Sized + IAMTuner_Impl {
     fn AvailableTVFormats(&self) -> ::windows::core::Result<i32>;
@@ -3588,6 +3645,7 @@ impl IAMTVTuner_Vtbl {
         iid == &<IAMTVTuner as ::windows::core::Interface>::IID || iid == &<IAMTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMTimecodeDisplay_Impl: Sized {
     fn GetTCDisplayEnable(&self) -> ::windows::core::Result<i32>;
     fn SetTCDisplayEnable(&self, state: i32) -> ::windows::core::Result<()>;
@@ -3641,6 +3699,7 @@ impl IAMTimecodeDisplay_Vtbl {
         iid == &<IAMTimecodeDisplay as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMTimecodeGenerator_Impl: Sized {
     fn GetTCGMode(&self, param: i32) -> ::windows::core::Result<i32>;
     fn SetTCGMode(&self, param: i32, value: i32) -> ::windows::core::Result<()>;
@@ -3714,6 +3773,7 @@ impl IAMTimecodeGenerator_Vtbl {
         iid == &<IAMTimecodeGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMTimecodeReader_Impl: Sized {
     fn GetTCRMode(&self, param: i32) -> ::windows::core::Result<i32>;
     fn SetTCRMode(&self, param: i32, value: i32) -> ::windows::core::Result<()>;
@@ -3780,6 +3840,7 @@ impl IAMTimecodeReader_Vtbl {
         iid == &<IAMTimecodeReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMTuner_Impl: Sized {
     fn put_Channel(&self, lchannel: i32, lvideosubchannel: i32, laudiosubchannel: i32) -> ::windows::core::Result<()>;
@@ -3931,6 +3992,7 @@ impl IAMTuner_Vtbl {
         iid == &<IAMTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMTunerNotification_Impl: Sized {
     fn OnEvent(&self, event: AMTunerEventType) -> ::windows::core::Result<()>;
 }
@@ -3948,6 +4010,7 @@ impl IAMTunerNotification_Vtbl {
         iid == &<IAMTunerNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMVfwCaptureDialogs_Impl: Sized {
     fn HasDialog(&self, idialog: i32) -> ::windows::core::Result<()>;
@@ -3985,6 +4048,7 @@ impl IAMVfwCaptureDialogs_Vtbl {
         iid == &<IAMVfwCaptureDialogs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMVfwCompressDialogs_Impl: Sized {
     fn ShowDialog(&self, idialog: i32, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -4029,6 +4093,7 @@ impl IAMVfwCompressDialogs_Vtbl {
         iid == &<IAMVfwCompressDialogs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IAMVideoAccelerator_Impl: Sized {
     fn GetVideoAcceleratorGUIDs(&self, pdwnumguidssupported: *mut u32, pguidssupported: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -4129,6 +4194,7 @@ impl IAMVideoAccelerator_Vtbl {
         iid == &<IAMVideoAccelerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 pub trait IAMVideoAcceleratorNotify_Impl: Sized {
     fn GetUncompSurfacesInfo(&self, pguid: *const ::windows::core::GUID, puncompbufferinfo: *mut AMVAUncompBufferInfo) -> ::windows::core::Result<()>;
@@ -4166,6 +4232,7 @@ impl IAMVideoAcceleratorNotify_Vtbl {
         iid == &<IAMVideoAcceleratorNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMVideoCompression_Impl: Sized {
     fn SetKeyFrameRate(&self, keyframerate: i32) -> ::windows::core::Result<()>;
     fn KeyFrameRate(&self) -> ::windows::core::Result<i32>;
@@ -4280,6 +4347,7 @@ impl IAMVideoCompression_Vtbl {
         iid == &<IAMVideoCompression as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAMVideoControl_Impl: Sized {
     fn GetCaps(&self, ppin: &::core::option::Option<IPin>) -> ::windows::core::Result<i32>;
@@ -4362,6 +4430,7 @@ impl IAMVideoControl_Vtbl {
         iid == &<IAMVideoControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMVideoDecimationProperties_Impl: Sized {
     fn QueryDecimationUsage(&self) -> ::windows::core::Result<DECIMATION_USAGE>;
     fn SetDecimationUsage(&self, usage: DECIMATION_USAGE) -> ::windows::core::Result<()>;
@@ -4395,6 +4464,7 @@ impl IAMVideoDecimationProperties_Vtbl {
         iid == &<IAMVideoDecimationProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMVideoProcAmp_Impl: Sized {
     fn GetRange(&self, property: i32, pmin: *mut i32, pmax: *mut i32, psteppingdelta: *mut i32, pdefault: *mut i32, pcapsflags: *mut i32) -> ::windows::core::Result<()>;
     fn Set(&self, property: i32, lvalue: i32, flags: i32) -> ::windows::core::Result<()>;
@@ -4429,6 +4499,7 @@ impl IAMVideoProcAmp_Vtbl {
         iid == &<IAMVideoProcAmp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMWMBufferPass_Impl: Sized {
     fn SetNotify(&self, pcallback: &::core::option::Option<IAMWMBufferPassCallback>) -> ::windows::core::Result<()>;
 }
@@ -4446,6 +4517,7 @@ impl IAMWMBufferPass_Vtbl {
         iid == &<IAMWMBufferPass as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_WindowsMediaFormat")]
 pub trait IAMWMBufferPassCallback_Impl: Sized {
     fn Notify(&self, pnssbuffer3: &::core::option::Option<super::WindowsMediaFormat::INSSBuffer3>, ppin: &::core::option::Option<IPin>, prtstart: *const i64, prtend: *const i64) -> ::windows::core::Result<()>;
@@ -4466,6 +4538,7 @@ impl IAMWMBufferPassCallback_Vtbl {
         iid == &<IAMWMBufferPassCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IAMWstDecoder_Impl: Sized {
     fn GetDecoderLevel(&self, lplevel: *mut AM_WST_LEVEL) -> ::windows::core::Result<()>;
@@ -4608,6 +4681,7 @@ impl IAMWstDecoder_Vtbl {
         iid == &<IAMWstDecoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAMovieSetup_Impl: Sized {
     fn Register(&self) -> ::windows::core::Result<()>;
     fn Unregister(&self) -> ::windows::core::Result<()>;
@@ -4635,6 +4709,7 @@ impl IAMovieSetup_Vtbl {
         iid == &<IAMovieSetup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IATSCChannelTuneRequest_Impl: Sized + IChannelTuneRequest_Impl {
     fn MinorChannel(&self) -> ::windows::core::Result<i32>;
@@ -4671,6 +4746,7 @@ impl IATSCChannelTuneRequest_Vtbl {
         iid == &<IATSCChannelTuneRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuneRequest as ::windows::core::Interface>::IID || iid == &<IChannelTuneRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IATSCComponentType_Impl: Sized + IMPEG2ComponentType_Impl {
     fn Flags(&self) -> ::windows::core::Result<i32>;
@@ -4707,6 +4783,7 @@ impl IATSCComponentType_Vtbl {
         iid == &<IATSCComponentType as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IComponentType as ::windows::core::Interface>::IID || iid == &<ILanguageComponentType as ::windows::core::Interface>::IID || iid == &<IMPEG2ComponentType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IATSCLocator_Impl: Sized + IDigitalLocator_Impl {
     fn PhysicalChannel(&self) -> ::windows::core::Result<i32>;
@@ -4763,6 +4840,7 @@ impl IATSCLocator_Vtbl {
         iid == &<IATSCLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IATSCLocator2_Impl: Sized + IATSCLocator_Impl {
     fn ProgramNumber(&self) -> ::windows::core::Result<i32>;
@@ -4799,6 +4877,7 @@ impl IATSCLocator2_Vtbl {
         iid == &<IATSCLocator2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID || iid == &<IATSCLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IATSCTuningSpace_Impl: Sized + IAnalogTVTuningSpace_Impl {
     fn MinMinorChannel(&self) -> ::windows::core::Result<i32>;
@@ -4895,6 +4974,7 @@ impl IATSCTuningSpace_Vtbl {
         iid == &<IATSCTuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID || iid == &<IAnalogTVTuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IATSC_EIT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -5059,6 +5139,7 @@ impl IATSC_EIT_Vtbl {
         iid == &<IATSC_EIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IATSC_ETT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -5125,6 +5206,7 @@ impl IATSC_ETT_Vtbl {
         iid == &<IATSC_ETT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IATSC_MGT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -5283,6 +5365,7 @@ impl IATSC_MGT_Vtbl {
         iid == &<IATSC_MGT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IATSC_STT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetProtocolVersion(&self) -> ::windows::core::Result<u8>;
@@ -5388,6 +5471,7 @@ impl IATSC_STT_Vtbl {
         iid == &<IATSC_STT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IATSC_VCT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -5718,6 +5802,7 @@ impl IATSC_VCT_Vtbl {
         iid == &<IATSC_VCT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAnalogAudioComponentType_Impl: Sized + IComponentType_Impl {
     fn AnalogAudioMode(&self) -> ::windows::core::Result<TVAudioMode>;
@@ -5754,6 +5839,7 @@ impl IAnalogAudioComponentType_Vtbl {
         iid == &<IAnalogAudioComponentType as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IComponentType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAnalogLocator_Impl: Sized + ILocator_Impl {
     fn VideoStandard(&self) -> ::windows::core::Result<AnalogVideoStandard>;
@@ -5790,6 +5876,7 @@ impl IAnalogLocator_Vtbl {
         iid == &<IAnalogLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAnalogRadioTuningSpace_Impl: Sized + ITuningSpace_Impl {
     fn MinFrequency(&self) -> ::windows::core::Result<i32>;
@@ -5866,6 +5953,7 @@ impl IAnalogRadioTuningSpace_Vtbl {
         iid == &<IAnalogRadioTuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAnalogRadioTuningSpace2_Impl: Sized + IAnalogRadioTuningSpace_Impl {
     fn CountryCode(&self) -> ::windows::core::Result<i32>;
@@ -5902,6 +5990,7 @@ impl IAnalogRadioTuningSpace2_Vtbl {
         iid == &<IAnalogRadioTuningSpace2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID || iid == &<IAnalogRadioTuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAnalogTVTuningSpace_Impl: Sized + ITuningSpace_Impl {
     fn MinChannel(&self) -> ::windows::core::Result<i32>;
@@ -5998,6 +6087,7 @@ impl IAnalogTVTuningSpace_Vtbl {
         iid == &<IAnalogTVTuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAsyncReader_Impl: Sized {
     fn RequestAllocator(&self, ppreferred: &::core::option::Option<IMemAllocator>, pprops: *const ALLOCATOR_PROPERTIES) -> ::windows::core::Result<IMemAllocator>;
     fn Request(&self, psample: &::core::option::Option<IMediaSample>, dwuser: usize) -> ::windows::core::Result<()>;
@@ -6073,6 +6163,7 @@ impl IAsyncReader_Vtbl {
         iid == &<IAsyncReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAtscContentAdvisoryDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -6184,6 +6275,7 @@ impl IAtscContentAdvisoryDescriptor_Vtbl {
         iid == &<IAtscContentAdvisoryDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAtscPsipParser_Impl: Sized {
     fn Initialize(&self, punkmpeg2data: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -6337,6 +6429,7 @@ impl IAtscPsipParser_Vtbl {
         iid == &<IAtscPsipParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAttributeGet_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<i32>;
     fn GetAttribIndexed(&self, lindex: i32, pguidattribute: *mut ::windows::core::GUID, pbattribute: *mut u8, pdwattributelength: *mut u32) -> ::windows::core::Result<()>;
@@ -6377,6 +6470,7 @@ impl IAttributeGet_Vtbl {
         iid == &<IAttributeGet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IAttributeSet_Impl: Sized {
     fn SetAttrib(&self, guidattribute: &::windows::core::GUID, pbattribute: *const u8, dwattributelength: u32) -> ::windows::core::Result<()>;
 }
@@ -6394,6 +6488,7 @@ impl IAttributeSet_Vtbl {
         iid == &<IAttributeSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IAudioData_Impl: Sized + IMemoryData_Impl {
     fn GetFormat(&self) -> ::windows::core::Result<super::Audio::WAVEFORMATEX>;
@@ -6430,6 +6525,7 @@ impl IAudioData_Vtbl {
         iid == &<IAudioData as ::windows::core::Interface>::IID || iid == &<IMemoryData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IAudioMediaStream_Impl: Sized + IMediaStream_Impl {
     fn GetFormat(&self) -> ::windows::core::Result<super::Audio::WAVEFORMATEX>;
@@ -6479,6 +6575,7 @@ impl IAudioMediaStream_Vtbl {
         iid == &<IAudioMediaStream as ::windows::core::Interface>::IID || iid == &<IMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioStreamSample_Impl: Sized + IStreamSample_Impl {
     fn GetAudioData(&self) -> ::windows::core::Result<IAudioData>;
@@ -6505,6 +6602,7 @@ impl IAudioStreamSample_Vtbl {
         iid == &<IAudioStreamSample as ::windows::core::Interface>::IID || iid == &<IStreamSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAuxInTuningSpace_Impl: Sized + ITuningSpace_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -6518,6 +6616,7 @@ impl IAuxInTuningSpace_Vtbl {
         iid == &<IAuxInTuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAuxInTuningSpace2_Impl: Sized + IAuxInTuningSpace_Impl {
     fn CountryCode(&self) -> ::windows::core::Result<i32>;
@@ -6554,6 +6653,7 @@ impl IAuxInTuningSpace2_Vtbl {
         iid == &<IAuxInTuningSpace2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID || iid == &<IAuxInTuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBDAComparable_Impl: Sized {
     fn CompareExact(&self, compareto: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<i32>;
@@ -6648,6 +6748,7 @@ impl IBDAComparable_Vtbl {
         iid == &<IBDAComparable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBDACreateTuneRequestEx_Impl: Sized {
     fn CreateTuneRequestEx(&self, tunerequestiid: *const ::windows::core::GUID) -> ::windows::core::Result<ITuneRequest>;
@@ -6674,6 +6775,7 @@ impl IBDACreateTuneRequestEx_Vtbl {
         iid == &<IBDACreateTuneRequestEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_AUX_Impl: Sized {
     fn QueryCapabilities(&self) -> ::windows::core::Result<u32>;
     fn EnumCapability(&self, dwindex: u32, dwinputid: *mut u32, pconnectortype: *mut ::windows::core::GUID, conntypenum: *mut u32, numvideostds: *mut u32, analogstds: *mut u64) -> ::windows::core::Result<()>;
@@ -6707,6 +6809,7 @@ impl IBDA_AUX_Vtbl {
         iid == &<IBDA_AUX as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_AutoDemodulate_Impl: Sized {
     fn put_AutoDemodulate(&self) -> ::windows::core::Result<()>;
 }
@@ -6724,6 +6827,7 @@ impl IBDA_AutoDemodulate_Vtbl {
         iid == &<IBDA_AutoDemodulate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_AutoDemodulateEx_Impl: Sized + IBDA_AutoDemodulate_Impl {
     fn get_SupportedDeviceNodeTypes(&self, ulcdevicenodetypesmax: u32, pulcdevicenodetypes: *mut u32, pguiddevicenodetypes: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn get_SupportedVideoFormats(&self, pulamtunermodetype: *mut u32, pulanalogvideostandard: *mut u32) -> ::windows::core::Result<()>;
@@ -6758,6 +6862,7 @@ impl IBDA_AutoDemodulateEx_Vtbl {
         iid == &<IBDA_AutoDemodulateEx as ::windows::core::Interface>::IID || iid == &<IBDA_AutoDemodulate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBDA_ConditionalAccess_Impl: Sized {
     fn get_SmartCardStatus(&self, pcardstatus: *mut SmartCardStatusType, pcardassociation: *mut SmartCardAssociationType, pbstrcarderror: *mut ::windows::core::BSTR, pfooblocked: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -6856,6 +6961,7 @@ impl IBDA_ConditionalAccess_Vtbl {
         iid == &<IBDA_ConditionalAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_ConditionalAccessEx_Impl: Sized {
     fn CheckEntitlementToken(&self, uldialogrequest: u32, bstrlanguage: &::windows::core::BSTR, requesttype: BDA_CONDITIONALACCESS_REQUESTTYPE, ulcbentitlementtokenlen: u32, pbentitlementtoken: *const u8) -> ::windows::core::Result<u32>;
     fn SetCaptureToken(&self, ulcbcapturetokenlen: u32, pbcapturetoken: *const u8) -> ::windows::core::Result<()>;
@@ -6922,6 +7028,7 @@ impl IBDA_ConditionalAccessEx_Vtbl {
         iid == &<IBDA_ConditionalAccessEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_DRIDRMService_Impl: Sized {
     fn SetDRM(&self, bstrnewdrm: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn GetDRMStatus(&self, pbstrdrmuuidlist: *mut ::windows::core::BSTR, drmuuid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -6956,6 +7063,7 @@ impl IBDA_DRIDRMService_Vtbl {
         iid == &<IBDA_DRIDRMService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_DRIWMDRMSession_Impl: Sized {
     fn AcknowledgeLicense(&self, hrlicenseack: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn ProcessLicenseChallenge(&self, dwcblicensemessage: u32, pblicensemessage: *const u8, pdwcblicenseresponse: *mut u32, ppblicenseresponse: *mut *mut u8) -> ::windows::core::Result<()>;
@@ -7018,6 +7126,7 @@ impl IBDA_DRIWMDRMSession_Vtbl {
         iid == &<IBDA_DRIWMDRMSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBDA_DRM_Impl: Sized {
     fn GetDRMPairingStatus(&self, pdwstatus: *mut u32, pherror: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -7048,6 +7157,7 @@ impl IBDA_DRM_Vtbl {
         iid == &<IBDA_DRM as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_DRMService_Impl: Sized {
     fn SetDRM(&self, puuidnewdrm: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetDRMStatus(&self, pbstrdrmuuidlist: *mut ::windows::core::BSTR, drmuuid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -7075,6 +7185,7 @@ impl IBDA_DRMService_Vtbl {
         iid == &<IBDA_DRMService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_DeviceControl_Impl: Sized {
     fn StartChanges(&self) -> ::windows::core::Result<()>;
     fn CheckChanges(&self) -> ::windows::core::Result<()>;
@@ -7116,6 +7227,7 @@ impl IBDA_DeviceControl_Vtbl {
         iid == &<IBDA_DeviceControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IBDA_DiagnosticProperties_Impl: Sized + super::super::System::Com::StructuredStorage::IPropertyBag_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
@@ -7129,6 +7241,7 @@ impl IBDA_DiagnosticProperties_Vtbl {
         iid == &<IBDA_DiagnosticProperties as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::StructuredStorage::IPropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_DigitalDemodulator_Impl: Sized {
     fn SetModulationType(&self, pmodulationtype: *const ModulationType) -> ::windows::core::Result<()>;
     fn ModulationType(&self, pmodulationtype: *mut ModulationType) -> ::windows::core::Result<()>;
@@ -7240,6 +7353,7 @@ impl IBDA_DigitalDemodulator_Vtbl {
         iid == &<IBDA_DigitalDemodulator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_DigitalDemodulator2_Impl: Sized + IBDA_DigitalDemodulator_Impl {
     fn SetGuardInterval(&self, pguardinterval: *const GuardInterval) -> ::windows::core::Result<()>;
     fn GuardInterval(&self, pguardinterval: *mut GuardInterval) -> ::windows::core::Result<()>;
@@ -7309,6 +7423,7 @@ impl IBDA_DigitalDemodulator2_Vtbl {
         iid == &<IBDA_DigitalDemodulator2 as ::windows::core::Interface>::IID || iid == &<IBDA_DigitalDemodulator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_DigitalDemodulator3_Impl: Sized + IBDA_DigitalDemodulator2_Impl {
     fn SetSignalTimeouts(&self, psignaltimeouts: *const BDA_SIGNAL_TIMEOUTS) -> ::windows::core::Result<()>;
     fn SignalTimeouts(&self, psignaltimeouts: *mut BDA_SIGNAL_TIMEOUTS) -> ::windows::core::Result<()>;
@@ -7350,6 +7465,7 @@ impl IBDA_DigitalDemodulator3_Vtbl {
         iid == &<IBDA_DigitalDemodulator3 as ::windows::core::Interface>::IID || iid == &<IBDA_DigitalDemodulator as ::windows::core::Interface>::IID || iid == &<IBDA_DigitalDemodulator2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBDA_DiseqCommand_Impl: Sized {
     fn SetEnableDiseqCommands(&self, benable: super::super::Foundation::BOOLEAN) -> ::windows::core::Result<()>;
@@ -7408,6 +7524,7 @@ impl IBDA_DiseqCommand_Vtbl {
         iid == &<IBDA_DiseqCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_EasMessage_Impl: Sized {
     fn get_EasMessage(&self, uleventid: u32, ppeasobject: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -7425,6 +7542,7 @@ impl IBDA_EasMessage_Vtbl {
         iid == &<IBDA_EasMessage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBDA_Encoder_Impl: Sized {
     fn QueryCapabilities(&self, numaudiofmts: *mut u32, numvideofmts: *mut u32) -> ::windows::core::Result<()>;
@@ -7497,6 +7615,7 @@ impl IBDA_Encoder_Vtbl {
         iid == &<IBDA_Encoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_EthernetFilter_Impl: Sized {
     fn GetMulticastListSize(&self, pulcbaddresses: *mut u32) -> ::windows::core::Result<()>;
     fn PutMulticastList(&self, ulcbaddresses: u32, paddresslist: *const u8) -> ::windows::core::Result<()>;
@@ -7551,6 +7670,7 @@ impl IBDA_EthernetFilter_Vtbl {
         iid == &<IBDA_EthernetFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_EventingService_Impl: Sized {
     fn CompleteEvent(&self, uleventid: u32, uleventresult: u32) -> ::windows::core::Result<()>;
 }
@@ -7568,6 +7688,7 @@ impl IBDA_EventingService_Vtbl {
         iid == &<IBDA_EventingService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBDA_FDC_Impl: Sized {
     fn GetStatus(&self, currentbitrate: *mut u32, carrierlock: *mut super::super::Foundation::BOOL, currentfrequency: *mut u32, currentspectruminversion: *mut super::super::Foundation::BOOL, currentpidlist: *mut ::windows::core::BSTR, currenttidlist: *mut ::windows::core::BSTR, overflow: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -7645,6 +7766,7 @@ impl IBDA_FDC_Vtbl {
         iid == &<IBDA_FDC as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_FrequencyFilter_Impl: Sized {
     fn SetAutotune(&self, ultransponder: u32) -> ::windows::core::Result<()>;
     fn Autotune(&self, pultransponder: *mut u32) -> ::windows::core::Result<()>;
@@ -7742,6 +7864,7 @@ impl IBDA_FrequencyFilter_Vtbl {
         iid == &<IBDA_FrequencyFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_GuideDataDeliveryService_Impl: Sized {
     fn GetGuideDataType(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetGuideData(&self, pulcbbufferlen: *mut u32, pbbuffer: *mut u8, pulguidedatapercentageprogress: *mut u32) -> ::windows::core::Result<()>;
@@ -7815,6 +7938,7 @@ impl IBDA_GuideDataDeliveryService_Vtbl {
         iid == &<IBDA_GuideDataDeliveryService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_IPSinkControl_Impl: Sized {
     fn GetMulticastList(&self, pulcbsize: *mut u32, pbbuffer: *mut *mut u8) -> ::windows::core::Result<()>;
     fn GetAdapterIPAddress(&self, pulcbsize: *mut u32, pbbuffer: *mut *mut u8) -> ::windows::core::Result<()>;
@@ -7842,6 +7966,7 @@ impl IBDA_IPSinkControl_Vtbl {
         iid == &<IBDA_IPSinkControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_IPSinkInfo_Impl: Sized {
     fn get_MulticastList(&self, pulcbaddresses: *mut u32, ppbaddresslist: *mut *mut u8) -> ::windows::core::Result<()>;
     fn AdapterIPAddress(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7888,6 +8013,7 @@ impl IBDA_IPSinkInfo_Vtbl {
         iid == &<IBDA_IPSinkInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_IPV4Filter_Impl: Sized {
     fn GetMulticastListSize(&self, pulcbaddresses: *mut u32) -> ::windows::core::Result<()>;
     fn PutMulticastList(&self, ulcbaddresses: u32, paddresslist: *const u8) -> ::windows::core::Result<()>;
@@ -7942,6 +8068,7 @@ impl IBDA_IPV4Filter_Vtbl {
         iid == &<IBDA_IPV4Filter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_IPV6Filter_Impl: Sized {
     fn GetMulticastListSize(&self, pulcbaddresses: *mut u32) -> ::windows::core::Result<()>;
     fn PutMulticastList(&self, ulcbaddresses: u32, paddresslist: *const u8) -> ::windows::core::Result<()>;
@@ -7996,6 +8123,7 @@ impl IBDA_IPV6Filter_Vtbl {
         iid == &<IBDA_IPV6Filter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_ISDBConditionalAccess_Impl: Sized {
     fn SetIsdbCasRequest(&self, ulrequestid: u32, ulcbrequestbufferlen: u32, pbrequestbuffer: *const u8) -> ::windows::core::Result<()>;
 }
@@ -8013,6 +8141,7 @@ impl IBDA_ISDBConditionalAccess_Vtbl {
         iid == &<IBDA_ISDBConditionalAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_LNBInfo_Impl: Sized {
     fn SetLocalOscilatorFrequencyLowBand(&self, ulloflow: u32) -> ::windows::core::Result<()>;
     fn LocalOscilatorFrequencyLowBand(&self, pulloflow: *mut u32) -> ::windows::core::Result<()>;
@@ -8068,6 +8197,7 @@ impl IBDA_LNBInfo_Vtbl {
         iid == &<IBDA_LNBInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_MUX_Impl: Sized {
     fn SetPidList(&self, ulpidlistcount: u32, pbpidlistbuffer: *const BDA_MUX_PIDLISTITEM) -> ::windows::core::Result<()>;
     fn GetPidList(&self, pulpidlistcount: *mut u32, pbpidlistbuffer: *mut BDA_MUX_PIDLISTITEM) -> ::windows::core::Result<()>;
@@ -8095,6 +8225,7 @@ impl IBDA_MUX_Vtbl {
         iid == &<IBDA_MUX as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_NameValueService_Impl: Sized {
     fn GetValueNameByIndex(&self, ulindex: u32) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetValue(&self, bstrname: &::windows::core::BSTR, bstrlanguage: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -8141,6 +8272,7 @@ impl IBDA_NameValueService_Vtbl {
         iid == &<IBDA_NameValueService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_NetworkProvider_Impl: Sized {
     fn PutSignalSource(&self, ulsignalsource: u32) -> ::windows::core::Result<()>;
     fn GetSignalSource(&self, pulsignalsource: *mut u32) -> ::windows::core::Result<()>;
@@ -8203,6 +8335,7 @@ impl IBDA_NetworkProvider_Vtbl {
         iid == &<IBDA_NetworkProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_NullTransform_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -8226,6 +8359,7 @@ impl IBDA_NullTransform_Vtbl {
         iid == &<IBDA_NullTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_PinControl_Impl: Sized {
     fn GetPinID(&self, pulpinid: *mut u32) -> ::windows::core::Result<()>;
     fn GetPinType(&self, pulpintype: *mut u32) -> ::windows::core::Result<()>;
@@ -8260,6 +8394,7 @@ impl IBDA_PinControl_Vtbl {
         iid == &<IBDA_PinControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_SignalProperties_Impl: Sized {
     fn PutNetworkType(&self, guidnetworktype: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetNetworkType(&self, pguidnetworktype: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -8315,6 +8450,7 @@ impl IBDA_SignalProperties_Vtbl {
         iid == &<IBDA_SignalProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBDA_SignalStatistics_Impl: Sized {
     fn SetSignalStrength(&self, ldbstrength: i32) -> ::windows::core::Result<()>;
@@ -8401,6 +8537,7 @@ impl IBDA_SignalStatistics_Vtbl {
         iid == &<IBDA_SignalStatistics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_TIF_REGISTRATION_Impl: Sized {
     fn RegisterTIFEx(&self, ptifinputpin: &::core::option::Option<IPin>, ppvregistrationcontext: *mut u32, ppmpeg2datacontrol: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn UnregisterTIF(&self, pvregistrationcontext: u32) -> ::windows::core::Result<()>;
@@ -8428,6 +8565,7 @@ impl IBDA_TIF_REGISTRATION_Vtbl {
         iid == &<IBDA_TIF_REGISTRATION as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IBDA_Topology_Impl: Sized {
     fn GetNodeTypes(&self, pulcnodetypes: *mut u32, ulcnodetypesmax: u32, rgulnodetypes: *mut u32) -> ::windows::core::Result<()>;
@@ -8521,6 +8659,7 @@ impl IBDA_Topology_Vtbl {
         iid == &<IBDA_Topology as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_TransportStreamInfo_Impl: Sized {
     fn PatTableTickCount(&self) -> ::windows::core::Result<u32>;
 }
@@ -8544,6 +8683,7 @@ impl IBDA_TransportStreamInfo_Vtbl {
         iid == &<IBDA_TransportStreamInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_TransportStreamSelector_Impl: Sized {
     fn SetTSID(&self, ustsid: u16) -> ::windows::core::Result<()>;
     fn GetTSInformation(&self, pultsinformationbufferlen: *mut u32, pbtsinformationbuffer: *mut u8) -> ::windows::core::Result<()>;
@@ -8571,6 +8711,7 @@ impl IBDA_TransportStreamSelector_Vtbl {
         iid == &<IBDA_TransportStreamSelector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_UserActivityService_Impl: Sized {
     fn SetCurrentTunerUseReason(&self, dwusereason: u32) -> ::windows::core::Result<()>;
     fn GetUserActivityInterval(&self) -> ::windows::core::Result<u32>;
@@ -8611,6 +8752,7 @@ impl IBDA_UserActivityService_Vtbl {
         iid == &<IBDA_UserActivityService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_VoidTransform_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -8634,6 +8776,7 @@ impl IBDA_VoidTransform_Vtbl {
         iid == &<IBDA_VoidTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_WMDRMSession_Impl: Sized {
     fn GetStatus(&self, maxcapturetoken: *mut u32, maxstreamingpid: *mut u32, maxlicense: *mut u32, minsecuritylevel: *mut u32, revinfosequencenumber: *mut u32, revinfoissuedtime: *mut u64, revinfottl: *mut u32, revlistversion: *mut u32, ulstate: *mut u32) -> ::windows::core::Result<()>;
     fn SetRevInfo(&self, ulrevinfolen: u32, pbrevinfo: *const u8) -> ::windows::core::Result<()>;
@@ -8703,6 +8846,7 @@ impl IBDA_WMDRMSession_Vtbl {
         iid == &<IBDA_WMDRMSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBDA_WMDRMTuner_Impl: Sized {
     fn PurchaseEntitlement(&self, uldialogrequest: u32, bstrlanguage: &::windows::core::BSTR, ulpurchasetokenlen: u32, pbpurchasetoken: *const u8, puldescramblestatus: *mut u32, pulcapturetokenlen: *mut u32, pbcapturetoken: *mut u8) -> ::windows::core::Result<()>;
     fn CancelCaptureToken(&self, ulcapturetokenlen: u32, pbcapturetoken: *const u8) -> ::windows::core::Result<()>;
@@ -8764,6 +8908,7 @@ impl IBDA_WMDRMTuner_Vtbl {
         iid == &<IBDA_WMDRMTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBPCSatelliteTuner_Impl: Sized + IAMTuner_Impl {
     fn get_DefaultSubChannelTypes(&self, pldefaultvideotype: *mut i32, pldefaultaudiotype: *mut i32) -> ::windows::core::Result<()>;
@@ -8801,6 +8946,7 @@ impl IBPCSatelliteTuner_Vtbl {
         iid == &<IBPCSatelliteTuner as ::windows::core::Interface>::IID || iid == &<IAMTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBaseFilter_Impl: Sized + IMediaFilter_Impl {
     fn EnumPins(&self) -> ::windows::core::Result<IEnumPins>;
@@ -8876,6 +9022,7 @@ impl IBaseFilter_Vtbl {
         iid == &<IBaseFilter as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<IMediaFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBaseVideoMixer_Impl: Sized {
     fn SetLeadPin(&self, ipin: i32) -> ::windows::core::Result<()>;
     fn GetLeadPin(&self) -> ::windows::core::Result<i32>;
@@ -8962,6 +9109,7 @@ impl IBaseVideoMixer_Vtbl {
         iid == &<IBaseVideoMixer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBasicAudio_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetVolume(&self, lvolume: i32) -> ::windows::core::Result<()>;
@@ -9018,6 +9166,7 @@ impl IBasicAudio_Vtbl {
         iid == &<IBasicAudio as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBasicVideo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AvgTimePerFrame(&self) -> ::windows::core::Result<f64>;
@@ -9336,6 +9485,7 @@ impl IBasicVideo_Vtbl {
         iid == &<IBasicVideo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBasicVideo2_Impl: Sized + IBasicVideo_Impl {
     fn GetPreferredAspectRatio(&self, plaspectx: *mut i32, plaspecty: *mut i32) -> ::windows::core::Result<()>;
@@ -9356,6 +9506,7 @@ impl IBasicVideo2_Vtbl {
         iid == &<IBasicVideo2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IBasicVideo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBroadcastEvent_Impl: Sized {
     fn Fire(&self, eventid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -9373,6 +9524,7 @@ impl IBroadcastEvent_Vtbl {
         iid == &<IBroadcastEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBroadcastEventEx_Impl: Sized + IBroadcastEvent_Impl {
     fn FireEx(&self, eventid: &::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32) -> ::windows::core::Result<()>;
 }
@@ -9390,6 +9542,7 @@ impl IBroadcastEventEx_Vtbl {
         iid == &<IBroadcastEventEx as ::windows::core::Interface>::IID || iid == &<IBroadcastEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IBufferingTime_Impl: Sized {
     fn GetBufferingTime(&self, pdwmilliseconds: *mut u32) -> ::windows::core::Result<()>;
     fn SetBufferingTime(&self, dwmilliseconds: u32) -> ::windows::core::Result<()>;
@@ -9417,6 +9570,7 @@ impl IBufferingTime_Vtbl {
         iid == &<IBufferingTime as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICAT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -9520,6 +9674,7 @@ impl ICAT_Vtbl {
         iid == &<ICAT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ICCSubStreamFiltering_Impl: Sized {
     fn SubstreamTypes(&self) -> ::windows::core::Result<i32>;
     fn SetSubstreamTypes(&self, types: i32) -> ::windows::core::Result<()>;
@@ -9553,6 +9708,7 @@ impl ICCSubStreamFiltering_Vtbl {
         iid == &<ICCSubStreamFiltering as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ICameraControl_Impl: Sized {
     fn get_Exposure(&self, pvalue: *mut i32, pflags: *mut i32) -> ::windows::core::Result<()>;
     fn put_Exposure(&self, value: i32, flags: i32) -> ::windows::core::Result<()>;
@@ -9923,6 +10079,7 @@ impl ICameraControl_Vtbl {
         iid == &<ICameraControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ICaptionServiceDescriptor_Impl: Sized {
     fn GetNumberOfServices(&self) -> ::windows::core::Result<u8>;
     fn GetLanguageCode(&self, bindex: u8, langcode: *mut u8) -> ::windows::core::Result<()>;
@@ -10008,6 +10165,7 @@ impl ICaptionServiceDescriptor_Vtbl {
         iid == &<ICaptionServiceDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ICaptureGraphBuilder_Impl: Sized {
     fn SetFiltergraph(&self, pfg: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
@@ -10086,6 +10244,7 @@ impl ICaptureGraphBuilder_Vtbl {
         iid == &<ICaptureGraphBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ICaptureGraphBuilder2_Impl: Sized {
     fn SetFiltergraph(&self, pfg: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
@@ -10177,6 +10336,7 @@ impl ICaptureGraphBuilder2_Vtbl {
         iid == &<ICaptureGraphBuilder2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IChannelIDTuneRequest_Impl: Sized + ITuneRequest_Impl {
     fn ChannelID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -10213,6 +10373,7 @@ impl IChannelIDTuneRequest_Vtbl {
         iid == &<IChannelIDTuneRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuneRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IChannelTuneRequest_Impl: Sized + ITuneRequest_Impl {
     fn Channel(&self) -> ::windows::core::Result<i32>;
@@ -10249,6 +10410,7 @@ impl IChannelTuneRequest_Vtbl {
         iid == &<IChannelTuneRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuneRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComponent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<IComponentType>;
@@ -10358,6 +10520,7 @@ impl IComponent_Vtbl {
         iid == &<IComponent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComponentType_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Category(&self) -> ::windows::core::Result<ComponentCategory>;
@@ -10547,6 +10710,7 @@ impl IComponentType_Vtbl {
         iid == &<IComponentType as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComponentTypes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -10655,6 +10819,7 @@ impl IComponentTypes_Vtbl {
         iid == &<IComponentTypes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComponents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -10763,6 +10928,7 @@ impl IComponents_Vtbl {
         iid == &<IComponents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComponentsOld_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -10864,6 +11030,7 @@ impl IComponentsOld_Vtbl {
         iid == &<IComponentsOld as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_WindowsMediaFormat"))]
 pub trait IConfigAsfWriter_Impl: Sized {
     fn ConfigureFilterUsingProfileId(&self, dwprofileid: u32) -> ::windows::core::Result<()>;
@@ -10960,6 +11127,7 @@ impl IConfigAsfWriter_Vtbl {
         iid == &<IConfigAsfWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_WindowsMediaFormat"))]
 pub trait IConfigAsfWriter2_Impl: Sized + IConfigAsfWriter_Impl {
     fn StreamNumFromPin(&self, ppin: &::core::option::Option<IPin>) -> ::windows::core::Result<u16>;
@@ -11010,6 +11178,7 @@ impl IConfigAsfWriter2_Vtbl {
         iid == &<IConfigAsfWriter2 as ::windows::core::Interface>::IID || iid == &<IConfigAsfWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IConfigAviMux_Impl: Sized {
     fn SetMasterStream(&self, istream: i32) -> ::windows::core::Result<()>;
@@ -11066,6 +11235,7 @@ impl IConfigAviMux_Vtbl {
         iid == &<IConfigAviMux as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IConfigInterleaving_Impl: Sized {
     fn SetMode(&self, mode: InterleavingMode) -> ::windows::core::Result<()>;
     fn Mode(&self) -> ::windows::core::Result<InterleavingMode>;
@@ -11113,6 +11283,7 @@ impl IConfigInterleaving_Vtbl {
         iid == &<IConfigInterleaving as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ICreateDevEnum_Impl: Sized {
     fn CreateClassEnumerator(&self, clsiddeviceclass: *const ::windows::core::GUID, ppenummoniker: *mut ::core::option::Option<super::super::System::Com::IEnumMoniker>, dwflags: u32) -> ::windows::core::Result<()>;
@@ -11133,6 +11304,7 @@ impl ICreateDevEnum_Vtbl {
         iid == &<ICreateDevEnum as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Registry")]
 pub trait ICreatePropBagOnRegKey_Impl: Sized {
     fn Create(&self, hkey: super::super::System::Registry::HKEY, subkey: &::windows::core::PCWSTR, uloptions: u32, samdesired: u32, iid: *const ::windows::core::GUID, ppbag: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -11153,6 +11325,7 @@ impl ICreatePropBagOnRegKey_Vtbl {
         iid == &<ICreatePropBagOnRegKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IDDrawExclModeVideo_Impl: Sized {
     fn SetDDrawObject(&self, pddrawobject: &::core::option::Option<super::super::Graphics::DirectDraw::IDirectDraw>) -> ::windows::core::Result<()>;
@@ -11218,6 +11391,7 @@ impl IDDrawExclModeVideo_Vtbl {
         iid == &<IDDrawExclModeVideo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDDrawExclModeVideoCallback_Impl: Sized {
     fn OnUpdateOverlay(&self, bbefore: super::super::Foundation::BOOL, dwflags: u32, boldvisible: super::super::Foundation::BOOL, prcoldsrc: *const super::super::Foundation::RECT, prcolddest: *const super::super::Foundation::RECT, bnewvisible: super::super::Foundation::BOOL, prcnewsrc: *const super::super::Foundation::RECT, prcnewdest: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -11255,6 +11429,7 @@ impl IDDrawExclModeVideoCallback_Vtbl {
         iid == &<IDDrawExclModeVideoCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDMOWrapperFilter_Impl: Sized {
     fn Init(&self, clsiddmo: *const ::windows::core::GUID, catdmo: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -11272,6 +11447,7 @@ impl IDMOWrapperFilter_Vtbl {
         iid == &<IDMOWrapperFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDShowPlugin_Impl: Sized {
     fn URL(&self, purl: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn UserAgent(&self, puseragent: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -11299,6 +11475,7 @@ impl IDShowPlugin_Vtbl {
         iid == &<IDShowPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDTFilter_Impl: Sized {
     fn EvalRatObjOK(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
@@ -11395,6 +11572,7 @@ impl IDTFilter_Vtbl {
         iid == &<IDTFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDTFilter2_Impl: Sized + IDTFilter_Impl {
     fn ChallengeUrl(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -11444,6 +11622,7 @@ impl IDTFilter2_Vtbl {
         iid == &<IDTFilter2 as ::windows::core::Interface>::IID || iid == &<IDTFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDTFilter3_Impl: Sized + IDTFilter2_Impl {
     fn GetProtectionType(&self) -> ::windows::core::Result<ProtType>;
@@ -11493,6 +11672,7 @@ impl IDTFilter3_Vtbl {
         iid == &<IDTFilter3 as ::windows::core::Interface>::IID || iid == &<IDTFilter as ::windows::core::Interface>::IID || iid == &<IDTFilter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDTFilterConfig_Impl: Sized {
     fn GetSecureChannelObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -11516,6 +11696,7 @@ impl IDTFilterConfig_Vtbl {
         iid == &<IDTFilterConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDTFilterEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -11529,6 +11710,7 @@ impl IDTFilterEvents_Vtbl {
         iid == &<IDTFilterEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDTFilterLicenseRenewal_Impl: Sized {
     fn GetLicenseRenewalData(&self, ppwszfilename: *mut ::windows::core::PWSTR, ppwszexpiredkid: *mut ::windows::core::PWSTR, ppwsztunerid: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
@@ -11546,6 +11728,7 @@ impl IDTFilterLicenseRenewal_Vtbl {
         iid == &<IDTFilterLicenseRenewal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBCLocator_Impl: Sized + IDigitalLocator_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -11559,6 +11742,7 @@ impl IDVBCLocator_Vtbl {
         iid == &<IDVBCLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBSLocator_Impl: Sized + IDigitalLocator_Impl {
     fn SignalPolarisation(&self) -> ::windows::core::Result<Polarisation>;
@@ -11675,6 +11859,7 @@ impl IDVBSLocator_Vtbl {
         iid == &<IDVBSLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBSLocator2_Impl: Sized + IDVBSLocator_Impl {
     fn DiseqLNBSource(&self) -> ::windows::core::Result<LNB_Source>;
@@ -11831,6 +12016,7 @@ impl IDVBSLocator2_Vtbl {
         iid == &<IDVBSLocator2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID || iid == &<IDVBSLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBSTuningSpace_Impl: Sized + IDVBTuningSpace2_Impl {
     fn LowOscillator(&self) -> ::windows::core::Result<i32>;
@@ -11947,6 +12133,7 @@ impl IDVBSTuningSpace_Vtbl {
         iid == &<IDVBSTuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID || iid == &<IDVBTuningSpace as ::windows::core::Interface>::IID || iid == &<IDVBTuningSpace2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBTLocator_Impl: Sized + IDigitalLocator_Impl {
     fn Bandwidth(&self) -> ::windows::core::Result<i32>;
@@ -12103,6 +12290,7 @@ impl IDVBTLocator_Vtbl {
         iid == &<IDVBTLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBTLocator2_Impl: Sized + IDVBTLocator_Impl {
     fn PhysicalLayerPipeId(&self) -> ::windows::core::Result<i32>;
@@ -12139,6 +12327,7 @@ impl IDVBTLocator2_Vtbl {
         iid == &<IDVBTLocator2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID || iid == &<IDVBTLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBTuneRequest_Impl: Sized + ITuneRequest_Impl {
     fn ONID(&self) -> ::windows::core::Result<i32>;
@@ -12215,6 +12404,7 @@ impl IDVBTuneRequest_Vtbl {
         iid == &<IDVBTuneRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuneRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBTuningSpace_Impl: Sized + ITuningSpace_Impl {
     fn SystemType(&self) -> ::windows::core::Result<DVBSystemType>;
@@ -12251,6 +12441,7 @@ impl IDVBTuningSpace_Vtbl {
         iid == &<IDVBTuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDVBTuningSpace2_Impl: Sized + IDVBTuningSpace_Impl {
     fn NetworkID(&self) -> ::windows::core::Result<i32>;
@@ -12287,6 +12478,7 @@ impl IDVBTuningSpace2_Vtbl {
         iid == &<IDVBTuningSpace2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID || iid == &<IDVBTuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVB_BAT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -12469,6 +12661,7 @@ impl IDVB_BAT_Vtbl {
         iid == &<IDVB_BAT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVB_DIT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>) -> ::windows::core::Result<()>;
@@ -12505,6 +12698,7 @@ impl IDVB_DIT_Vtbl {
         iid == &<IDVB_DIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVB_EIT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -12764,6 +12958,7 @@ impl IDVB_EIT_Vtbl {
         iid == &<IDVB_EIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVB_EIT2_Impl: Sized + IDVB_EIT_Impl {
     fn GetSegmentInfo(&self, pbtid: *mut u8, pbsegment: *mut u8) -> ::windows::core::Result<()>;
@@ -12800,6 +12995,7 @@ impl IDVB_EIT2_Vtbl {
         iid == &<IDVB_EIT2 as ::windows::core::Interface>::IID || iid == &<IDVB_EIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVB_NIT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -13001,6 +13197,7 @@ impl IDVB_NIT_Vtbl {
         iid == &<IDVB_NIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDVB_RST_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>) -> ::windows::core::Result<()>;
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u32>;
@@ -13099,6 +13296,7 @@ impl IDVB_RST_Vtbl {
         iid == &<IDVB_RST as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVB_SDT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -13319,6 +13517,7 @@ impl IDVB_SDT_Vtbl {
         iid == &<IDVB_SDT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVB_SIT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -13494,6 +13693,7 @@ impl IDVB_SIT_Vtbl {
         iid == &<IDVB_SIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDVB_ST_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>) -> ::windows::core::Result<()>;
     fn GetDataLength(&self) -> ::windows::core::Result<u16>;
@@ -13540,6 +13740,7 @@ impl IDVB_ST_Vtbl {
         iid == &<IDVB_ST as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDVB_TDT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>) -> ::windows::core::Result<()>;
     fn GetUTCTime(&self) -> ::windows::core::Result<MPEG_DATE_AND_TIME>;
@@ -13573,6 +13774,7 @@ impl IDVB_TDT_Vtbl {
         iid == &<IDVB_TDT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDVB_TOT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>) -> ::windows::core::Result<()>;
     fn GetUTCTime(&self) -> ::windows::core::Result<MPEG_DATE_AND_TIME>;
@@ -13639,6 +13841,7 @@ impl IDVB_TOT_Vtbl {
         iid == &<IDVB_TOT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDVEnc_Impl: Sized {
     fn get_IFormatResolution(&self, videoformat: *mut i32, dvformat: *mut i32, resolution: *mut i32, fdvinfo: u8, sdvinfo: *mut DVINFO) -> ::windows::core::Result<()>;
     fn put_IFormatResolution(&self, videoformat: i32, dvformat: i32, resolution: i32, fdvinfo: u8, sdvinfo: *const DVINFO) -> ::windows::core::Result<()>;
@@ -13666,6 +13869,7 @@ impl IDVEnc_Vtbl {
         iid == &<IDVEnc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDVRGB219_Impl: Sized {
     fn SetRGB219(&self, bstate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -13686,6 +13890,7 @@ impl IDVRGB219_Vtbl {
         iid == &<IDVRGB219 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDVSplitter_Impl: Sized {
     fn DiscardAlternateVideoFrames(&self, ndiscard: i32) -> ::windows::core::Result<()>;
 }
@@ -13706,6 +13911,7 @@ impl IDVSplitter_Vtbl {
         iid == &<IDVSplitter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDecimateVideoImage_Impl: Sized {
     fn SetDecimationImageSize(&self, lwidth: i32, lheight: i32) -> ::windows::core::Result<()>;
     fn ResetDecimationImageSize(&self) -> ::windows::core::Result<()>;
@@ -13733,6 +13939,7 @@ impl IDecimateVideoImage_Vtbl {
         iid == &<IDecimateVideoImage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDeferredCommand_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn Confidence(&self) -> ::windows::core::Result<i32>;
@@ -13786,6 +13993,7 @@ impl IDeferredCommand_Vtbl {
         iid == &<IDeferredCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDigitalCableLocator_Impl: Sized + IATSCLocator2_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -13799,6 +14007,7 @@ impl IDigitalCableLocator_Vtbl {
         iid == &<IDigitalCableLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID || iid == &<IATSCLocator as ::windows::core::Interface>::IID || iid == &<IATSCLocator2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDigitalCableTuneRequest_Impl: Sized + IATSCChannelTuneRequest_Impl {
     fn MajorChannel(&self) -> ::windows::core::Result<i32>;
@@ -13855,6 +14064,7 @@ impl IDigitalCableTuneRequest_Vtbl {
         iid == &<IDigitalCableTuneRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuneRequest as ::windows::core::Interface>::IID || iid == &<IChannelTuneRequest as ::windows::core::Interface>::IID || iid == &<IATSCChannelTuneRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDigitalCableTuningSpace_Impl: Sized + IATSCTuningSpace_Impl {
     fn MinMajorChannel(&self) -> ::windows::core::Result<i32>;
@@ -13951,6 +14161,7 @@ impl IDigitalCableTuningSpace_Vtbl {
         iid == &<IDigitalCableTuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuningSpace as ::windows::core::Interface>::IID || iid == &<IAnalogTVTuningSpace as ::windows::core::Interface>::IID || iid == &<IATSCTuningSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDigitalLocator_Impl: Sized + ILocator_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -13964,6 +14175,7 @@ impl IDigitalLocator_Vtbl {
         iid == &<IDigitalLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IDirectDrawMediaSample_Impl: Sized {
     fn GetSurfaceAndReleaseLock(&self, ppdirectdrawsurface: *mut ::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface>, prect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -13994,6 +14206,7 @@ impl IDirectDrawMediaSample_Vtbl {
         iid == &<IDirectDrawMediaSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 pub trait IDirectDrawMediaSampleAllocator_Impl: Sized {
     fn GetDirectDraw(&self) -> ::windows::core::Result<super::super::Graphics::DirectDraw::IDirectDraw>;
@@ -14020,6 +14233,7 @@ impl IDirectDrawMediaSampleAllocator_Vtbl {
         iid == &<IDirectDrawMediaSampleAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IDirectDrawMediaStream_Impl: Sized + IMediaStream_Impl {
     fn GetFormat(&self, pddsdcurrent: *mut super::super::Graphics::DirectDraw::DDSURFACEDESC, ppdirectdrawpalette: *mut ::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawPalette>, pddsddesired: *mut super::super::Graphics::DirectDraw::DDSURFACEDESC, pdwflags: *mut u32) -> ::windows::core::Result<()>;
@@ -14096,6 +14310,7 @@ impl IDirectDrawMediaStream_Vtbl {
         iid == &<IDirectDrawMediaStream as ::windows::core::Interface>::IID || iid == &<IMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IDirectDrawStreamSample_Impl: Sized + IStreamSample_Impl {
     fn GetSurface(&self, ppdirectdrawsurface: *mut ::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface>, prect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -14126,6 +14341,7 @@ impl IDirectDrawStreamSample_Vtbl {
         iid == &<IDirectDrawStreamSample as ::windows::core::Interface>::IID || iid == &<IStreamSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 pub trait IDirectDrawVideo_Impl: Sized {
     fn GetSwitches(&self) -> ::windows::core::Result<u32>;
@@ -14302,6 +14518,7 @@ impl IDirectDrawVideo_Vtbl {
         iid == &<IDirectDrawVideo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDistributorNotify_Impl: Sized {
     fn Stop(&self) -> ::windows::core::Result<()>;
     fn Pause(&self) -> ::windows::core::Result<()>;
@@ -14350,6 +14567,7 @@ impl IDistributorNotify_Vtbl {
         iid == &<IDistributorNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IDrawVideoImage_Impl: Sized {
     fn DrawVideoImageBegin(&self) -> ::windows::core::Result<()>;
@@ -14387,6 +14605,7 @@ impl IDrawVideoImage_Vtbl {
         iid == &<IDrawVideoImage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbCableDeliverySystemDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -14491,6 +14710,7 @@ impl IDvbCableDeliverySystemDescriptor_Vtbl {
         iid == &<IDvbCableDeliverySystemDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbComponentDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -14589,6 +14809,7 @@ impl IDvbComponentDescriptor_Vtbl {
         iid == &<IDvbComponentDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbContentDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -14655,6 +14876,7 @@ impl IDvbContentDescriptor_Vtbl {
         iid == &<IDvbContentDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbContentIdentifierDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -14714,6 +14936,7 @@ impl IDvbContentIdentifierDescriptor_Vtbl {
         iid == &<IDvbContentIdentifierDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbDataBroadcastDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -14832,6 +15055,7 @@ impl IDvbDataBroadcastDescriptor_Vtbl {
         iid == &<IDvbDataBroadcastDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbDataBroadcastIDDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -14891,6 +15115,7 @@ impl IDvbDataBroadcastIDDescriptor_Vtbl {
         iid == &<IDvbDataBroadcastIDDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbDefaultAuthorityDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -14937,6 +15162,7 @@ impl IDvbDefaultAuthorityDescriptor_Vtbl {
         iid == &<IDvbDefaultAuthorityDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbExtendedEventDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15069,6 +15295,7 @@ impl IDvbExtendedEventDescriptor_Vtbl {
         iid == &<IDvbExtendedEventDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbFrequencyListDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15147,6 +15374,7 @@ impl IDvbFrequencyListDescriptor_Vtbl {
         iid == &<IDvbFrequencyListDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbHDSimulcastLogicalChannelDescriptor_Impl: Sized + IDvbLogicalChannelDescriptor2_Impl {}
 impl ::windows::core::RuntimeName for IDvbHDSimulcastLogicalChannelDescriptor {}
 impl IDvbHDSimulcastLogicalChannelDescriptor_Vtbl {
@@ -15157,6 +15385,7 @@ impl IDvbHDSimulcastLogicalChannelDescriptor_Vtbl {
         iid == &<IDvbHDSimulcastLogicalChannelDescriptor as ::windows::core::Interface>::IID || iid == &<IDvbLogicalChannelDescriptor as ::windows::core::Interface>::IID || iid == &<IDvbLogicalChannelDescriptor2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbLinkageDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15268,6 +15497,7 @@ impl IDvbLinkageDescriptor_Vtbl {
         iid == &<IDvbLinkageDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbLogicalChannel2Descriptor_Impl: Sized + IDvbLogicalChannelDescriptor2_Impl {
     fn GetCountOfLists(&self) -> ::windows::core::Result<u8>;
     fn GetListId(&self, blistindex: u8) -> ::windows::core::Result<u8>;
@@ -15379,6 +15609,7 @@ impl IDvbLogicalChannel2Descriptor_Vtbl {
         iid == &<IDvbLogicalChannel2Descriptor as ::windows::core::Interface>::IID || iid == &<IDvbLogicalChannelDescriptor as ::windows::core::Interface>::IID || iid == &<IDvbLogicalChannelDescriptor2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbLogicalChannelDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15457,6 +15688,7 @@ impl IDvbLogicalChannelDescriptor_Vtbl {
         iid == &<IDvbLogicalChannelDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbLogicalChannelDescriptor2_Impl: Sized + IDvbLogicalChannelDescriptor_Impl {
     fn GetRecordLogicalChannelAndVisibility(&self, brecordindex: u8) -> ::windows::core::Result<u16>;
 }
@@ -15483,6 +15715,7 @@ impl IDvbLogicalChannelDescriptor2_Vtbl {
         iid == &<IDvbLogicalChannelDescriptor2 as ::windows::core::Interface>::IID || iid == &<IDvbLogicalChannelDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbMultilingualServiceNameDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15574,6 +15807,7 @@ impl IDvbMultilingualServiceNameDescriptor_Vtbl {
         iid == &<IDvbMultilingualServiceNameDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbNetworkNameDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15639,6 +15873,7 @@ impl IDvbNetworkNameDescriptor_Vtbl {
         iid == &<IDvbNetworkNameDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbParentalRatingDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15698,6 +15933,7 @@ impl IDvbParentalRatingDescriptor_Vtbl {
         iid == &<IDvbParentalRatingDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbPrivateDataSpecifierDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15750,6 +15986,7 @@ impl IDvbPrivateDataSpecifierDescriptor_Vtbl {
         iid == &<IDvbPrivateDataSpecifierDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbSatelliteDeliverySystemDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -15880,6 +16117,7 @@ impl IDvbSatelliteDeliverySystemDescriptor_Vtbl {
         iid == &<IDvbSatelliteDeliverySystemDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDvbServiceAttributeDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
@@ -15974,6 +16212,7 @@ impl IDvbServiceAttributeDescriptor_Vtbl {
         iid == &<IDvbServiceAttributeDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbServiceDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -16091,6 +16330,7 @@ impl IDvbServiceDescriptor_Vtbl {
         iid == &<IDvbServiceDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbServiceDescriptor2_Impl: Sized + IDvbServiceDescriptor_Impl {
     fn GetServiceProviderNameW2(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetServiceNameW(&self, convmode: DVB_STRCONV_MODE) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -16130,6 +16370,7 @@ impl IDvbServiceDescriptor2_Vtbl {
         iid == &<IDvbServiceDescriptor2 as ::windows::core::Interface>::IID || iid == &<IDvbServiceDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbServiceListDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -16208,6 +16449,7 @@ impl IDvbServiceListDescriptor_Vtbl {
         iid == &<IDvbServiceListDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbShortEventDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -16280,6 +16522,7 @@ impl IDvbShortEventDescriptor_Vtbl {
         iid == &<IDvbShortEventDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbSiParser_Impl: Sized {
     fn Initialize(&self, punkmpeg2data: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetPAT(&self) -> ::windows::core::Result<IPAT>;
@@ -16482,6 +16725,7 @@ impl IDvbSiParser_Vtbl {
         iid == &<IDvbSiParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbSiParser2_Impl: Sized + IDvbSiParser_Impl {
     fn GetEIT2(&self, tableid: u8, pwserviceid: *const u16, pbsegment: *const u8) -> ::windows::core::Result<IDVB_EIT2>;
 }
@@ -16505,6 +16749,7 @@ impl IDvbSiParser2_Vtbl {
         iid == &<IDvbSiParser2 as ::windows::core::Interface>::IID || iid == &<IDvbSiParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbSubtitlingDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -16609,6 +16854,7 @@ impl IDvbSubtitlingDescriptor_Vtbl {
         iid == &<IDvbSubtitlingDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbTeletextDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -16713,6 +16959,7 @@ impl IDvbTeletextDescriptor_Vtbl {
         iid == &<IDvbTeletextDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbTerrestrial2DeliverySystemDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -16895,6 +17142,7 @@ impl IDvbTerrestrial2DeliverySystemDescriptor_Vtbl {
         iid == &<IDvbTerrestrial2DeliverySystemDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvbTerrestrialDeliverySystemDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -17051,6 +17299,7 @@ impl IDvbTerrestrialDeliverySystemDescriptor_Vtbl {
         iid == &<IDvbTerrestrialDeliverySystemDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvdCmd_Impl: Sized {
     fn WaitForStart(&self) -> ::windows::core::Result<()>;
     fn WaitForEnd(&self) -> ::windows::core::Result<()>;
@@ -17078,6 +17327,7 @@ impl IDvdCmd_Vtbl {
         iid == &<IDvdCmd as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDvdControl_Impl: Sized {
     fn TitlePlay(&self, ultitle: u32) -> ::windows::core::Result<()>;
@@ -17339,6 +17589,7 @@ impl IDvdControl_Vtbl {
         iid == &<IDvdControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDvdControl2_Impl: Sized {
     fn PlayTitle(&self, ultitle: u32, dwflags: u32) -> ::windows::core::Result<IDvdCmd>;
@@ -17743,6 +17994,7 @@ impl IDvdControl2_Vtbl {
         iid == &<IDvdControl2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDvdGraphBuilder_Impl: Sized {
     fn GetFiltergraph(&self) -> ::windows::core::Result<IGraphBuilder>;
@@ -17792,6 +18044,7 @@ impl IDvdGraphBuilder_Vtbl {
         iid == &<IDvdGraphBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDvdInfo_Impl: Sized {
     fn GetCurrentDomain(&self, pdomain: *mut DVD_DOMAIN) -> ::windows::core::Result<()>;
@@ -18053,6 +18306,7 @@ impl IDvdInfo_Vtbl {
         iid == &<IDvdInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDvdInfo2_Impl: Sized {
     fn GetCurrentDomain(&self) -> ::windows::core::Result<DVD_DOMAIN>;
@@ -18486,6 +18740,7 @@ impl IDvdInfo2_Vtbl {
         iid == &<IDvdInfo2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IDvdState_Impl: Sized {
     fn GetDiscID(&self) -> ::windows::core::Result<u64>;
     fn GetParentalLevel(&self) -> ::windows::core::Result<u32>;
@@ -18525,6 +18780,7 @@ impl IDvdState_Vtbl {
         iid == &<IDvdState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IESCloseMmiEvent_Impl: Sized + IESEvent_Impl {
     fn GetDialogNumber(&self) -> ::windows::core::Result<u32>;
@@ -18551,6 +18807,7 @@ impl IESCloseMmiEvent_Vtbl {
         iid == &<IESCloseMmiEvent as ::windows::core::Interface>::IID || iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IESEvent_Impl: Sized {
     fn GetEventId(&self) -> ::windows::core::Result<u32>;
@@ -18626,6 +18883,7 @@ impl IESEvent_Vtbl {
         iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IESEventFactory_Impl: Sized {
     fn CreateESEvent(&self, pserviceprovider: &::core::option::Option<::windows::core::IUnknown>, dweventid: u32, guideventtype: &::windows::core::GUID, dweventdatalength: u32, peventdata: *const u8, bstrbaseurl: &::windows::core::BSTR, pinitcontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IESEvent>;
 }
@@ -18649,6 +18907,7 @@ impl IESEventFactory_Vtbl {
         iid == &<IESEventFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IESEventService_Impl: Sized {
     fn FireESEvent(&self, pesevent: &::core::option::Option<IESEvent>) -> ::windows::core::Result<()>;
 }
@@ -18666,6 +18925,7 @@ impl IESEventService_Vtbl {
         iid == &<IESEventService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IESEventServiceConfiguration_Impl: Sized {
     fn SetParent(&self, peventservice: &::core::option::Option<IESEventService>) -> ::windows::core::Result<()>;
     fn RemoveParent(&self) -> ::windows::core::Result<()>;
@@ -18721,6 +18981,7 @@ impl IESEventServiceConfiguration_Vtbl {
         iid == &<IESEventServiceConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IESEvents_Impl: Sized {
     fn OnESEventReceived(&self, guideventtype: &::windows::core::GUID, pesevent: &::core::option::Option<IESEvent>) -> ::windows::core::Result<()>;
 }
@@ -18738,6 +18999,7 @@ impl IESEvents_Vtbl {
         iid == &<IESEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IESFileExpiryDateEvent_Impl: Sized + IESEvent_Impl {
     fn GetTunerId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -18832,6 +19094,7 @@ impl IESFileExpiryDateEvent_Vtbl {
         iid == &<IESFileExpiryDateEvent as ::windows::core::Interface>::IID || iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IESIsdbCasResponseEvent_Impl: Sized + IESEvent_Impl {
     fn GetRequestId(&self) -> ::windows::core::Result<u32>;
@@ -18900,6 +19163,7 @@ impl IESIsdbCasResponseEvent_Vtbl {
         iid == &<IESIsdbCasResponseEvent as ::windows::core::Interface>::IID || iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IESLicenseRenewalResultEvent_Impl: Sized + IESEvent_Impl {
     fn GetCallersId(&self) -> ::windows::core::Result<u32>;
@@ -19059,6 +19323,7 @@ impl IESLicenseRenewalResultEvent_Vtbl {
         iid == &<IESLicenseRenewalResultEvent as ::windows::core::Interface>::IID || iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IESOpenMmiEvent_Impl: Sized + IESEvent_Impl {
     fn GetDialogNumber(&self, pdialogrequest: *mut u32, pdialognumber: *mut u32) -> ::windows::core::Result<()>;
@@ -19115,6 +19380,7 @@ impl IESOpenMmiEvent_Vtbl {
         iid == &<IESOpenMmiEvent as ::windows::core::Interface>::IID || iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IESRequestTunerEvent_Impl: Sized + IESEvent_Impl {
     fn GetPriority(&self) -> ::windows::core::Result<u8>;
@@ -19183,6 +19449,7 @@ impl IESRequestTunerEvent_Vtbl {
         iid == &<IESRequestTunerEvent as ::windows::core::Interface>::IID || iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IESValueUpdatedEvent_Impl: Sized + IESEvent_Impl {
     fn GetValueNames(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -19209,6 +19476,7 @@ impl IESValueUpdatedEvent_Vtbl {
         iid == &<IESValueUpdatedEvent as ::windows::core::Interface>::IID || iid == &<IESEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IETFilter_Impl: Sized {
     fn EvalRatObjOK(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
@@ -19272,6 +19540,7 @@ impl IETFilter_Vtbl {
         iid == &<IETFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IETFilterConfig_Impl: Sized {
     fn InitLicense(&self, licenseid: i32) -> ::windows::core::Result<()>;
     fn GetSecureChannelObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -19305,6 +19574,7 @@ impl IETFilterConfig_Vtbl {
         iid == &<IETFilterConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IETFilterEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -19318,6 +19588,7 @@ impl IETFilterEvents_Vtbl {
         iid == &<IETFilterEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEncoderAPI_Impl: Sized {
     fn IsSupported(&self, api: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -19395,6 +19666,7 @@ impl IEncoderAPI_Vtbl {
         iid == &<IEncoderAPI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumComponentTypes_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IComponentType>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -19445,6 +19717,7 @@ impl IEnumComponentTypes_Vtbl {
         iid == &<IEnumComponentTypes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumComponents_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IComponent>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -19495,6 +19768,7 @@ impl IEnumComponents_Vtbl {
         iid == &<IEnumComponents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumFilters_Impl: Sized {
     fn Next(&self, cfilters: u32, ppfilter: *mut ::core::option::Option<IBaseFilter>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -19545,6 +19819,7 @@ impl IEnumFilters_Vtbl {
         iid == &<IEnumFilters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IEnumGuideDataProperties_Impl: Sized {
     fn Next(&self, celt: u32, ppprop: *mut ::core::option::Option<IGuideDataProperty>, pcelt: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -19592,6 +19867,7 @@ impl IEnumGuideDataProperties_Vtbl {
         iid == &<IEnumGuideDataProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumMSVidGraphSegment_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IMSVidGraphSegment>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -19642,6 +19918,7 @@ impl IEnumMSVidGraphSegment_Vtbl {
         iid == &<IEnumMSVidGraphSegment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IEnumMediaTypes_Impl: Sized {
     fn Next(&self, cmediatypes: u32, ppmediatypes: *mut *mut super::MediaFoundation::AM_MEDIA_TYPE, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -19692,6 +19969,7 @@ impl IEnumMediaTypes_Vtbl {
         iid == &<IEnumMediaTypes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IEnumPIDMap_Impl: Sized {
     fn Next(&self, crequest: u32, ppidmap: *mut PID_MAP, pcreceived: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, crecords: u32) -> ::windows::core::Result<()>;
@@ -19739,6 +20017,7 @@ impl IEnumPIDMap_Vtbl {
         iid == &<IEnumPIDMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IEnumPins_Impl: Sized {
     fn Next(&self, cpins: u32, pppins: *mut ::core::option::Option<IPin>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cpins: u32) -> ::windows::core::Result<()>;
@@ -19786,6 +20065,7 @@ impl IEnumPins_Vtbl {
         iid == &<IEnumPins as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IEnumRegFilters_Impl: Sized {
     fn Next(&self, cfilters: u32, apregfilter: *mut *mut REGFILTER, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cfilters: u32) -> ::windows::core::Result<()>;
@@ -19833,6 +20113,7 @@ impl IEnumRegFilters_Vtbl {
         iid == &<IEnumRegFilters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IEnumStreamBufferRecordingAttrib_Impl: Sized {
     fn Next(&self, crequest: u32, pstreambufferattribute: *mut STREAMBUFFER_ATTRIBUTE, pcreceived: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, crecords: u32) -> ::windows::core::Result<()>;
@@ -19880,6 +20161,7 @@ impl IEnumStreamBufferRecordingAttrib_Vtbl {
         iid == &<IEnumStreamBufferRecordingAttrib as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IEnumStreamIdMap_Impl: Sized {
     fn Next(&self, crequest: u32, pstreamidmap: *mut STREAM_ID_MAP, pcreceived: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, crecords: u32) -> ::windows::core::Result<()>;
@@ -19927,6 +20209,7 @@ impl IEnumStreamIdMap_Vtbl {
         iid == &<IEnumStreamIdMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumTuneRequests_Impl: Sized {
     fn Next(&self, celt: u32, ppprop: *mut ::core::option::Option<ITuneRequest>, pcelt: *mut u32) -> ::windows::core::Result<()>;
@@ -19977,6 +20260,7 @@ impl IEnumTuneRequests_Vtbl {
         iid == &<IEnumTuneRequests as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumTuningSpaces_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<ITuningSpace>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -20027,6 +20311,7 @@ impl IEnumTuningSpaces_Vtbl {
         iid == &<IEnumTuningSpaces as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEvalRat_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_BlockedRatingAttributes(&self, ensystem: EnTvRat_System, enlevel: EnTvRat_GenericLevel) -> ::windows::core::Result<i32>;
@@ -20097,6 +20382,7 @@ impl IEvalRat_Vtbl {
         iid == &<IEvalRat as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IFileSinkFilter_Impl: Sized {
     fn SetFileName(&self, pszfilename: &::windows::core::PCWSTR, pmt: *const super::MediaFoundation::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
@@ -20127,6 +20413,7 @@ impl IFileSinkFilter_Vtbl {
         iid == &<IFileSinkFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IFileSinkFilter2_Impl: Sized + IFileSinkFilter_Impl {
     fn SetMode(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -20163,6 +20450,7 @@ impl IFileSinkFilter2_Vtbl {
         iid == &<IFileSinkFilter2 as ::windows::core::Interface>::IID || iid == &<IFileSinkFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IFileSourceFilter_Impl: Sized {
     fn Load(&self, pszfilename: &::windows::core::PCWSTR, pmt: *const super::MediaFoundation::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
@@ -20193,6 +20481,7 @@ impl IFileSourceFilter_Vtbl {
         iid == &<IFileSourceFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IFilterChain_Impl: Sized {
     fn StartChain(&self, pstartfilter: &::core::option::Option<IBaseFilter>, pendfilter: &::core::option::Option<IBaseFilter>) -> ::windows::core::Result<()>;
@@ -20237,6 +20526,7 @@ impl IFilterChain_Vtbl {
         iid == &<IFilterChain as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com"))]
 pub trait IFilterGraph_Impl: Sized {
     fn AddFilter(&self, pfilter: &::core::option::Option<IBaseFilter>, pname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -20321,6 +20611,7 @@ impl IFilterGraph_Vtbl {
         iid == &<IFilterGraph as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com"))]
 pub trait IFilterGraph2_Impl: Sized + IGraphBuilder_Impl {
     fn AddSourceFilterForMoniker(&self, pmoniker: &::core::option::Option<super::super::System::Com::IMoniker>, pctx: &::core::option::Option<super::super::System::Com::IBindCtx>, lpcwstrfiltername: &::windows::core::PCWSTR) -> ::windows::core::Result<IBaseFilter>;
@@ -20364,6 +20655,7 @@ impl IFilterGraph2_Vtbl {
         iid == &<IFilterGraph2 as ::windows::core::Interface>::IID || iid == &<IFilterGraph as ::windows::core::Interface>::IID || iid == &<IGraphBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com"))]
 pub trait IFilterGraph3_Impl: Sized + IFilterGraph2_Impl {
     fn SetSyncSourceEx(&self, pclockformostoffiltergraph: &::core::option::Option<super::IReferenceClock>, pclockforfilter: &::core::option::Option<super::IReferenceClock>, pfilter: &::core::option::Option<IBaseFilter>) -> ::windows::core::Result<()>;
@@ -20384,6 +20676,7 @@ impl IFilterGraph3_Vtbl {
         iid == &<IFilterGraph3 as ::windows::core::Interface>::IID || iid == &<IFilterGraph as ::windows::core::Interface>::IID || iid == &<IGraphBuilder as ::windows::core::Interface>::IID || iid == &<IFilterGraph2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFilterInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FindPin(&self, strpinid: &::windows::core::BSTR) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -20498,6 +20791,7 @@ impl IFilterInfo_Vtbl {
         iid == &<IFilterInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFilterMapper_Impl: Sized {
     fn RegisterFilter(&self, clsid: &::windows::core::GUID, name: &::windows::core::PCWSTR, dwmerit: u32) -> ::windows::core::Result<()>;
@@ -20576,6 +20870,7 @@ impl IFilterMapper_Vtbl {
         iid == &<IFilterMapper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFilterMapper2_Impl: Sized {
     fn CreateCategory(&self, clsidcategory: *const ::windows::core::GUID, dwcategorymerit: u32, description: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -20637,6 +20932,7 @@ impl IFilterMapper2_Vtbl {
         iid == &<IFilterMapper2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFilterMapper3_Impl: Sized + IFilterMapper2_Impl {
     fn GetICreateDevEnum(&self) -> ::windows::core::Result<ICreateDevEnum>;
@@ -20663,6 +20959,7 @@ impl IFilterMapper3_Vtbl {
         iid == &<IFilterMapper3 as ::windows::core::Interface>::IID || iid == &<IFilterMapper2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IFrequencyMap_Impl: Sized {
     fn get_FrequencyMapping(&self, ulcount: *mut u32, ppullist: *mut *mut u32) -> ::windows::core::Result<()>;
     fn put_FrequencyMapping(&self, ulcount: u32, plist: *const u32) -> ::windows::core::Result<()>;
@@ -20724,6 +21021,7 @@ impl IFrequencyMap_Vtbl {
         iid == &<IFrequencyMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFullScreenVideo_Impl: Sized {
     fn CountModes(&self) -> ::windows::core::Result<i32>;
@@ -20895,6 +21193,7 @@ impl IFullScreenVideo_Vtbl {
         iid == &<IFullScreenVideo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IFullScreenVideoEx_Impl: Sized + IFullScreenVideo_Impl {
     fn SetAcceleratorTable(&self, hwnd: super::super::Foundation::HWND, haccel: super::super::UI::WindowsAndMessaging::HACCEL) -> ::windows::core::Result<()>;
@@ -20945,6 +21244,7 @@ impl IFullScreenVideoEx_Vtbl {
         iid == &<IFullScreenVideoEx as ::windows::core::Interface>::IID || iid == &<IFullScreenVideo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IGenericDescriptor_Impl: Sized {
     fn Initialize(&self, pbdesc: *const u8, bcount: i32) -> ::windows::core::Result<()>;
     fn GetTag(&self) -> ::windows::core::Result<u8>;
@@ -21004,6 +21304,7 @@ impl IGenericDescriptor_Vtbl {
         iid == &<IGenericDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IGenericDescriptor2_Impl: Sized + IGenericDescriptor_Impl {
     fn Initialize2(&self, pbdesc: *const u8, wcount: u16) -> ::windows::core::Result<()>;
     fn GetLength2(&self) -> ::windows::core::Result<u16>;
@@ -21037,6 +21338,7 @@ impl IGenericDescriptor2_Vtbl {
         iid == &<IGenericDescriptor2 as ::windows::core::Interface>::IID || iid == &<IGenericDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Registry")]
 pub trait IGetCapabilitiesKey_Impl: Sized {
     fn GetCapabilitiesKey(&self) -> ::windows::core::Result<super::super::System::Registry::HKEY>;
@@ -21063,6 +21365,7 @@ impl IGetCapabilitiesKey_Vtbl {
         iid == &<IGetCapabilitiesKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IGpnvsCommonBase_Impl: Sized {
     fn GetValueUpdateName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -21086,6 +21389,7 @@ impl IGpnvsCommonBase_Vtbl {
         iid == &<IGpnvsCommonBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com"))]
 pub trait IGraphBuilder_Impl: Sized + IFilterGraph_Impl {
     fn Connect(&self, ppinout: &::core::option::Option<IPin>, ppinin: &::core::option::Option<IPin>) -> ::windows::core::Result<()>;
@@ -21157,6 +21461,7 @@ impl IGraphBuilder_Vtbl {
         iid == &<IGraphBuilder as ::windows::core::Interface>::IID || iid == &<IFilterGraph as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com"))]
 pub trait IGraphConfig_Impl: Sized {
     fn Reconnect(&self, poutputpin: &::core::option::Option<IPin>, pinputpin: &::core::option::Option<IPin>, pmtfirstconnection: *const super::MediaFoundation::AM_MEDIA_TYPE, pusingfilter: &::core::option::Option<IBaseFilter>, habortevent: super::super::Foundation::HANDLE, dwflags: u32) -> ::windows::core::Result<()>;
@@ -21249,6 +21554,7 @@ impl IGraphConfig_Vtbl {
         iid == &<IGraphConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IGraphConfigCallback_Impl: Sized {
     fn Reconfigure(&self, pvcontext: *mut ::core::ffi::c_void, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -21266,6 +21572,7 @@ impl IGraphConfigCallback_Vtbl {
         iid == &<IGraphConfigCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IGraphVersion_Impl: Sized {
     fn QueryVersion(&self) -> ::windows::core::Result<i32>;
 }
@@ -21289,6 +21596,7 @@ impl IGraphVersion_Vtbl {
         iid == &<IGraphVersion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGuideData_Impl: Sized {
     fn GetServices(&self) -> ::windows::core::Result<IEnumTuneRequests>;
@@ -21383,6 +21691,7 @@ impl IGuideData_Vtbl {
         iid == &<IGuideData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGuideDataEvent_Impl: Sized {
     fn GuideDataAcquired(&self) -> ::windows::core::Result<()>;
@@ -21448,6 +21757,7 @@ impl IGuideDataEvent_Vtbl {
         iid == &<IGuideDataEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IGuideDataLoader_Impl: Sized {
     fn Init(&self, pguidestore: &::core::option::Option<IGuideData>) -> ::windows::core::Result<()>;
     fn Terminate(&self) -> ::windows::core::Result<()>;
@@ -21475,6 +21785,7 @@ impl IGuideDataLoader_Vtbl {
         iid == &<IGuideDataLoader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGuideDataProperty_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -21530,6 +21841,7 @@ impl IGuideDataProperty_Vtbl {
         iid == &<IGuideDataProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIPDVDec_Impl: Sized {
     fn IPDisplay(&self) -> ::windows::core::Result<i32>;
     fn SetIPDisplay(&self, displaypix: i32) -> ::windows::core::Result<()>;
@@ -21563,6 +21875,7 @@ impl IIPDVDec_Vtbl {
         iid == &<IIPDVDec as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IISDBSLocator_Impl: Sized + IDVBSLocator_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -21576,6 +21889,7 @@ impl IISDBSLocator_Vtbl {
         iid == &<IISDBSLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<IDigitalLocator as ::windows::core::Interface>::IID || iid == &<IDVBSLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IISDB_BIT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -21740,6 +22054,7 @@ impl IISDB_BIT_Vtbl {
         iid == &<IISDB_BIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IISDB_CDT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>, bsectionnumber: u8) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -21897,6 +22212,7 @@ impl IISDB_CDT_Vtbl {
         iid == &<IISDB_CDT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IISDB_EMM_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -21977,6 +22293,7 @@ impl IISDB_EMM_Vtbl {
         iid == &<IISDB_EMM as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IISDB_LDT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -22121,6 +22438,7 @@ impl IISDB_LDT_Vtbl {
         iid == &<IISDB_LDT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IISDB_NBIT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -22317,6 +22635,7 @@ impl IISDB_NBIT_Vtbl {
         iid == &<IISDB_NBIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IISDB_SDT_Impl: Sized + IDVB_SDT_Impl {
     fn GetRecordEITUserDefinedFlags(&self, dwrecordindex: u32) -> ::windows::core::Result<u8>;
@@ -22343,6 +22662,7 @@ impl IISDB_SDT_Vtbl {
         iid == &<IISDB_SDT as ::windows::core::Interface>::IID || iid == &<IDVB_SDT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IISDB_SDTT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -22604,6 +22924,7 @@ impl IISDB_SDTT_Vtbl {
         iid == &<IISDB_SDTT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IIsdbAudioComponentDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
@@ -22790,6 +23111,7 @@ impl IIsdbAudioComponentDescriptor_Vtbl {
         iid == &<IIsdbAudioComponentDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbCAContractInformationDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -22920,6 +23242,7 @@ impl IIsdbCAContractInformationDescriptor_Vtbl {
         iid == &<IIsdbCAContractInformationDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbCADescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23005,6 +23328,7 @@ impl IIsdbCADescriptor_Vtbl {
         iid == &<IIsdbCADescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbCAServiceDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23090,6 +23414,7 @@ impl IIsdbCAServiceDescriptor_Vtbl {
         iid == &<IIsdbCAServiceDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbComponentGroupDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23246,6 +23571,7 @@ impl IIsdbComponentGroupDescriptor_Vtbl {
         iid == &<IIsdbComponentGroupDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbDataContentDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23383,6 +23709,7 @@ impl IIsdbDataContentDescriptor_Vtbl {
         iid == &<IIsdbDataContentDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbDigitalCopyControlDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23449,6 +23776,7 @@ impl IIsdbDigitalCopyControlDescriptor_Vtbl {
         iid == &<IIsdbDigitalCopyControlDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IIsdbDownloadContentDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
@@ -23674,6 +24002,7 @@ impl IIsdbDownloadContentDescriptor_Vtbl {
         iid == &<IIsdbDownloadContentDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbEmergencyInformationDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23772,6 +24101,7 @@ impl IIsdbEmergencyInformationDescriptor_Vtbl {
         iid == &<IIsdbEmergencyInformationDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbEventGroupDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23864,6 +24194,7 @@ impl IIsdbEventGroupDescriptor_Vtbl {
         iid == &<IIsdbEventGroupDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbHierarchicalTransmissionDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -23955,6 +24286,7 @@ impl IIsdbHierarchicalTransmissionDescriptor_Vtbl {
         iid == &<IIsdbHierarchicalTransmissionDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbLogoTransmissionDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -24059,6 +24391,7 @@ impl IIsdbLogoTransmissionDescriptor_Vtbl {
         iid == &<IIsdbLogoTransmissionDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbSIParameterDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -24170,6 +24503,7 @@ impl IIsdbSIParameterDescriptor_Vtbl {
         iid == &<IIsdbSIParameterDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IIsdbSeriesDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
@@ -24297,6 +24631,7 @@ impl IIsdbSeriesDescriptor_Vtbl {
         iid == &<IIsdbSeriesDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbSiParser2_Impl: Sized + IDvbSiParser2_Impl {
     fn GetSDT2(&self, tableid: u8, pwtransportstreamid: *const u16) -> ::windows::core::Result<IISDB_SDT>;
     fn GetBIT(&self, tableid: u8, pworiginalnetworkid: *const u16) -> ::windows::core::Result<IISDB_BIT>;
@@ -24401,6 +24736,7 @@ impl IIsdbSiParser2_Vtbl {
         iid == &<IIsdbSiParser2 as ::windows::core::Interface>::IID || iid == &<IDvbSiParser as ::windows::core::Interface>::IID || iid == &<IDvbSiParser2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbTSInformationDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -24518,6 +24854,7 @@ impl IIsdbTSInformationDescriptor_Vtbl {
         iid == &<IIsdbTSInformationDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IIsdbTerrestrialDeliverySystemDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u8>;
@@ -24622,6 +24959,7 @@ impl IIsdbTerrestrialDeliverySystemDescriptor_Vtbl {
         iid == &<IIsdbTerrestrialDeliverySystemDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IKsNodeControl_Impl: Sized {
     fn SetNodeId(&self, dwnodeid: u32) -> ::windows::core::Result<()>;
     fn SetKsControl(&self, pkscontrol: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -24649,6 +24987,7 @@ impl IKsNodeControl_Vtbl {
         iid == &<IKsNodeControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_KernelStreaming")]
 pub trait IKsTopologyInfo_Impl: Sized {
     fn NumCategories(&self) -> ::windows::core::Result<u32>;
@@ -24757,6 +25096,7 @@ impl IKsTopologyInfo_Vtbl {
         iid == &<IKsTopologyInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ILanguageComponentType_Impl: Sized + IComponentType_Impl {
     fn LangID(&self) -> ::windows::core::Result<i32>;
@@ -24793,6 +25133,7 @@ impl ILanguageComponentType_Vtbl {
         iid == &<ILanguageComponentType as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IComponentType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ILocator_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CarrierFrequency(&self) -> ::windows::core::Result<i32>;
@@ -24962,6 +25303,7 @@ impl ILocator_Vtbl {
         iid == &<ILocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMPEG2Component_Impl: Sized + IComponent_Impl {
     fn PID(&self) -> ::windows::core::Result<i32>;
@@ -25038,6 +25380,7 @@ impl IMPEG2Component_Vtbl {
         iid == &<IMPEG2Component as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IComponent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMPEG2ComponentType_Impl: Sized + ILanguageComponentType_Impl {
     fn StreamType(&self) -> ::windows::core::Result<MPEG2StreamType>;
@@ -25074,6 +25417,7 @@ impl IMPEG2ComponentType_Vtbl {
         iid == &<IMPEG2ComponentType as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IComponentType as ::windows::core::Interface>::IID || iid == &<ILanguageComponentType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMPEG2PIDMap_Impl: Sized {
     fn MapPID(&self, culpid: u32, pulpid: *const u32, mediasamplecontent: MEDIA_SAMPLE_CONTENT) -> ::windows::core::Result<()>;
     fn UnmapPID(&self, culpid: u32, pulpid: *const u32) -> ::windows::core::Result<()>;
@@ -25114,6 +25458,7 @@ impl IMPEG2PIDMap_Vtbl {
         iid == &<IMPEG2PIDMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMPEG2StreamIdMap_Impl: Sized {
     fn MapStreamId(&self, ulstreamid: u32, mediasamplecontent: u32, ulsubstreamfiltervalue: u32, idataoffset: i32) -> ::windows::core::Result<()>;
     fn UnmapStreamId(&self, culstreamid: u32, pulstreamid: *const u32) -> ::windows::core::Result<()>;
@@ -25154,6 +25499,7 @@ impl IMPEG2StreamIdMap_Vtbl {
         iid == &<IMPEG2StreamIdMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMPEG2TuneRequest_Impl: Sized + ITuneRequest_Impl {
     fn TSID(&self) -> ::windows::core::Result<i32>;
@@ -25210,6 +25556,7 @@ impl IMPEG2TuneRequest_Vtbl {
         iid == &<IMPEG2TuneRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITuneRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMPEG2TuneRequestFactory_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateTuneRequest(&self, tuningspace: &::core::option::Option<ITuningSpace>) -> ::windows::core::Result<IMPEG2TuneRequest>;
@@ -25239,6 +25586,7 @@ impl IMPEG2TuneRequestFactory_Vtbl {
         iid == &<IMPEG2TuneRequestFactory as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMPEG2TuneRequestSupport_Impl: Sized {}
 impl ::windows::core::RuntimeName for IMPEG2TuneRequestSupport {}
 impl IMPEG2TuneRequestSupport_Vtbl {
@@ -25249,6 +25597,7 @@ impl IMPEG2TuneRequestSupport_Vtbl {
         iid == &<IMPEG2TuneRequestSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMPEG2_TIF_CONTROL_Impl: Sized {
     fn RegisterTIF(&self, punktif: &::core::option::Option<::windows::core::IUnknown>, ppvregistrationcontext: *mut u32) -> ::windows::core::Result<()>;
     fn UnregisterTIF(&self, pvregistrationcontext: u32) -> ::windows::core::Result<()>;
@@ -25310,6 +25659,7 @@ impl IMPEG2_TIF_CONTROL_Vtbl {
         iid == &<IMPEG2_TIF_CONTROL as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSEventBinder_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Bind(&self, peventobject: &::core::option::Option<super::super::System::Com::IDispatch>, eventname: &::windows::core::BSTR, eventhandler: &::windows::core::BSTR) -> ::windows::core::Result<i32>;
@@ -25346,6 +25696,7 @@ impl IMSEventBinder_Vtbl {
         iid == &<IMSEventBinder as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAnalogTuner_Impl: Sized + IMSVidTuner_Impl {
     fn Channel(&self) -> ::windows::core::Result<i32>;
@@ -25455,6 +25806,7 @@ impl IMSVidAnalogTuner_Vtbl {
         iid == &<IMSVidAnalogTuner as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidVideoInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAnalogTuner2_Impl: Sized + IMSVidAnalogTuner_Impl {
     fn TVFormats(&self) -> ::windows::core::Result<i32>;
@@ -25510,6 +25862,7 @@ impl IMSVidAnalogTuner2_Vtbl {
         iid == &<IMSVidAnalogTuner2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidVideoInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidTuner as ::windows::core::Interface>::IID || iid == &<IMSVidAnalogTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAnalogTunerEvent_Impl: Sized + IMSVidTunerEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -25523,6 +25876,7 @@ impl IMSVidAnalogTunerEvent_Vtbl {
         iid == &<IMSVidAnalogTunerEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidTunerEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAudioRenderer_Impl: Sized + IMSVidOutputDevice_Impl {
     fn SetVolume(&self, lvol: i32) -> ::windows::core::Result<()>;
@@ -25579,6 +25933,7 @@ impl IMSVidAudioRenderer_Vtbl {
         iid == &<IMSVidAudioRenderer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAudioRendererDevices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -25648,6 +26003,7 @@ impl IMSVidAudioRendererDevices_Vtbl {
         iid == &<IMSVidAudioRendererDevices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAudioRendererEvent_Impl: Sized + IMSVidOutputDeviceEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -25661,6 +26017,7 @@ impl IMSVidAudioRendererEvent_Vtbl {
         iid == &<IMSVidAudioRendererEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidAudioRendererEvent2_Impl: Sized + IMSVidAudioRendererEvent_Impl {
     fn AVDecAudioDualMono(&self) -> ::windows::core::Result<()>;
@@ -25733,6 +26090,7 @@ impl IMSVidAudioRendererEvent2_Vtbl {
         iid == &<IMSVidAudioRendererEvent2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidAudioRendererEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidClosedCaptioning_Impl: Sized + IMSVidFeature_Impl {
     fn Enable(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -25769,6 +26127,7 @@ impl IMSVidClosedCaptioning_Vtbl {
         iid == &<IMSVidClosedCaptioning as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidFeature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidClosedCaptioning2_Impl: Sized + IMSVidClosedCaptioning_Impl {
     fn Service(&self) -> ::windows::core::Result<MSVidCCService>;
@@ -25805,6 +26164,7 @@ impl IMSVidClosedCaptioning2_Vtbl {
         iid == &<IMSVidClosedCaptioning2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidFeature as ::windows::core::Interface>::IID || iid == &<IMSVidClosedCaptioning as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidClosedCaptioning3_Impl: Sized + IMSVidClosedCaptioning2_Impl {
     fn TeleTextFilter(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -25831,6 +26191,7 @@ impl IMSVidClosedCaptioning3_Vtbl {
         iid == &<IMSVidClosedCaptioning3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidFeature as ::windows::core::Interface>::IID || iid == &<IMSVidClosedCaptioning as ::windows::core::Interface>::IID || iid == &<IMSVidClosedCaptioning2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMSVidCompositionSegment_Impl: Sized + IMSVidGraphSegment_Impl {
     fn Compose(&self, upstream: &::core::option::Option<IMSVidGraphSegment>, downstream: &::core::option::Option<IMSVidGraphSegment>) -> ::windows::core::Result<()>;
@@ -25880,6 +26241,7 @@ impl IMSVidCompositionSegment_Vtbl {
         iid == &<IMSVidCompositionSegment as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<IMSVidGraphSegment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidCtl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AutoSize(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -26323,6 +26685,7 @@ impl IMSVidCtl_Vtbl {
         iid == &<IMSVidCtl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidDataServices_Impl: Sized + IMSVidFeature_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -26336,6 +26699,7 @@ impl IMSVidDataServices_Vtbl {
         iid == &<IMSVidDataServices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidFeature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidDataServicesEvent_Impl: Sized + IMSVidDeviceEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -26349,6 +26713,7 @@ impl IMSVidDataServicesEvent_Vtbl {
         iid == &<IMSVidDataServicesEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidDevice_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -26476,6 +26841,7 @@ impl IMSVidDevice_Vtbl {
         iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMSVidDevice2_Impl: Sized {
     fn DevicePath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -26499,6 +26865,7 @@ impl IMSVidDevice2_Vtbl {
         iid == &<IMSVidDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidDeviceEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StateChange(&self, lpd: &::core::option::Option<IMSVidDevice>, oldstate: i32, newstate: i32) -> ::windows::core::Result<()>;
@@ -26519,6 +26886,7 @@ impl IMSVidDeviceEvent_Vtbl {
         iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidEVR_Impl: Sized + IMSVidVideoRenderer_Impl {
     fn Presenter(&self) -> ::windows::core::Result<super::MediaFoundation::IMFVideoPresenter>;
@@ -26575,6 +26943,7 @@ impl IMSVidEVR_Vtbl {
         iid == &<IMSVidEVR as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidVideoRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidEVREvent_Impl: Sized + IMSVidOutputDeviceEvent_Impl {
     fn OnUserEvent(&self, leventcode: i32) -> ::windows::core::Result<()>;
@@ -26595,6 +26964,7 @@ impl IMSVidEVREvent_Vtbl {
         iid == &<IMSVidEVREvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidEncoder_Impl: Sized + IMSVidFeature_Impl {
     fn VideoEncoderInterface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -26637,6 +27007,7 @@ impl IMSVidEncoder_Vtbl {
         iid == &<IMSVidEncoder as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidFeature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFeature_Impl: Sized + IMSVidDevice_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -26650,6 +27021,7 @@ impl IMSVidFeature_Vtbl {
         iid == &<IMSVidFeature as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFeatureEvent_Impl: Sized + IMSVidDeviceEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -26663,6 +27035,7 @@ impl IMSVidFeatureEvent_Vtbl {
         iid == &<IMSVidFeatureEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFeatures_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -26732,6 +27105,7 @@ impl IMSVidFeatures_Vtbl {
         iid == &<IMSVidFeatures as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFilePlayback_Impl: Sized + IMSVidPlayback_Impl {
     fn FileName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -26768,6 +27142,7 @@ impl IMSVidFilePlayback_Vtbl {
         iid == &<IMSVidFilePlayback as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidPlayback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFilePlayback2_Impl: Sized + IMSVidFilePlayback_Impl {
     fn Set_SourceFilter(&self, filename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -26798,6 +27173,7 @@ impl IMSVidFilePlayback2_Vtbl {
         iid == &<IMSVidFilePlayback2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidPlayback as ::windows::core::Interface>::IID || iid == &<IMSVidFilePlayback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidFilePlaybackEvent_Impl: Sized + IMSVidPlaybackEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -26811,6 +27187,7 @@ impl IMSVidFilePlaybackEvent_Vtbl {
         iid == &<IMSVidFilePlaybackEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidPlaybackEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidGenericSink_Impl: Sized + IMSVidOutputDevice_Impl {
     fn SetSinkFilter(&self, bstrname: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -26854,6 +27231,7 @@ impl IMSVidGenericSink_Vtbl {
         iid == &<IMSVidGenericSink as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidGenericSink2_Impl: Sized + IMSVidGenericSink_Impl {
     fn AddFilter(&self, bstrname: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -26884,6 +27262,7 @@ impl IMSVidGenericSink2_Vtbl {
         iid == &<IMSVidGenericSink2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidGenericSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMSVidGraphSegment_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn Init(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -27035,6 +27414,7 @@ impl IMSVidGraphSegment_Vtbl {
         iid == &<IMSVidGraphSegment as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMSVidGraphSegmentContainer_Impl: Sized {
     fn Graph(&self) -> ::windows::core::Result<IGraphBuilder>;
@@ -27176,6 +27556,7 @@ impl IMSVidGraphSegmentContainer_Vtbl {
         iid == &<IMSVidGraphSegmentContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMSVidGraphSegmentUserInput_Impl: Sized {
     fn Click(&self) -> ::windows::core::Result<()>;
     fn DblClick(&self) -> ::windows::core::Result<()>;
@@ -27245,6 +27626,7 @@ impl IMSVidGraphSegmentUserInput_Vtbl {
         iid == &<IMSVidGraphSegmentUserInput as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidInputDevice_Impl: Sized + IMSVidDevice_Impl {
     fn IsViewable(&self, v: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -27281,6 +27663,7 @@ impl IMSVidInputDevice_Vtbl {
         iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidInputDeviceEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -27294,6 +27677,7 @@ impl IMSVidInputDeviceEvent_Vtbl {
         iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidInputDevices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -27363,6 +27747,7 @@ impl IMSVidInputDevices_Vtbl {
         iid == &<IMSVidInputDevices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidOutputDevice_Impl: Sized + IMSVidDevice_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -27376,6 +27761,7 @@ impl IMSVidOutputDevice_Vtbl {
         iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidOutputDeviceEvent_Impl: Sized + IMSVidDeviceEvent_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -27389,6 +27775,7 @@ impl IMSVidOutputDeviceEvent_Vtbl {
         iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidOutputDevices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -27458,6 +27845,7 @@ impl IMSVidOutputDevices_Vtbl {
         iid == &<IMSVidOutputDevices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidPlayback_Impl: Sized + IMSVidInputDevice_Impl {
     fn EnableResetOnStop(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -27608,6 +27996,7 @@ impl IMSVidPlayback_Vtbl {
         iid == &<IMSVidPlayback as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidPlaybackEvent_Impl: Sized + IMSVidInputDeviceEvent_Impl {
     fn EndOfMedia(&self, lpd: &::core::option::Option<IMSVidPlayback>) -> ::windows::core::Result<()>;
@@ -27628,6 +28017,7 @@ impl IMSVidPlaybackEvent_Vtbl {
         iid == &<IMSVidPlaybackEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidRect_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Top(&self) -> ::windows::core::Result<i32>;
@@ -27751,6 +28141,7 @@ impl IMSVidRect_Vtbl {
         iid == &<IMSVidRect as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferRecordingControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartTime(&self) -> ::windows::core::Result<i32>;
@@ -27859,6 +28250,7 @@ impl IMSVidStreamBufferRecordingControl_Vtbl {
         iid == &<IMSVidStreamBufferRecordingControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSink_Impl: Sized + IMSVidOutputDevice_Impl {
     fn get_ContentRecorder(&self, pszfilename: &::windows::core::BSTR) -> ::windows::core::Result<IMSVidStreamBufferRecordingControl>;
@@ -27941,6 +28333,7 @@ impl IMSVidStreamBufferSink_Vtbl {
         iid == &<IMSVidStreamBufferSink as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSink2_Impl: Sized + IMSVidStreamBufferSink_Impl {
     fn UnlockProfile(&self) -> ::windows::core::Result<()>;
@@ -27961,6 +28354,7 @@ impl IMSVidStreamBufferSink2_Vtbl {
         iid == &<IMSVidStreamBufferSink2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSink3_Impl: Sized + IMSVidStreamBufferSink2_Impl {
     fn SetMinSeek(&self) -> ::windows::core::Result<i32>;
@@ -28175,6 +28569,7 @@ impl IMSVidStreamBufferSink3_Vtbl {
         iid == &<IMSVidStreamBufferSink3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSink as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSink2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSinkEvent_Impl: Sized + IMSVidOutputDeviceEvent_Impl {
     fn CertificateFailure(&self) -> ::windows::core::Result<()>;
@@ -28212,6 +28607,7 @@ impl IMSVidStreamBufferSinkEvent_Vtbl {
         iid == &<IMSVidStreamBufferSinkEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSinkEvent2_Impl: Sized + IMSVidStreamBufferSinkEvent_Impl {
     fn EncryptionOn(&self) -> ::windows::core::Result<()>;
@@ -28242,6 +28638,7 @@ impl IMSVidStreamBufferSinkEvent2_Vtbl {
         iid == &<IMSVidStreamBufferSinkEvent2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSinkEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSinkEvent3_Impl: Sized + IMSVidStreamBufferSinkEvent2_Impl {
     fn LicenseChange(&self, dwprot: i32) -> ::windows::core::Result<()>;
@@ -28262,6 +28659,7 @@ impl IMSVidStreamBufferSinkEvent3_Vtbl {
         iid == &<IMSVidStreamBufferSinkEvent3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSinkEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSinkEvent2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSinkEvent4_Impl: Sized + IMSVidStreamBufferSinkEvent3_Impl {
     fn WriteFailureClear(&self) -> ::windows::core::Result<()>;
@@ -28282,6 +28680,7 @@ impl IMSVidStreamBufferSinkEvent4_Vtbl {
         iid == &<IMSVidStreamBufferSinkEvent4 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSinkEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSinkEvent2 as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSinkEvent3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSource_Impl: Sized + IMSVidFilePlayback_Impl {
     fn Start(&self) -> ::windows::core::Result<i32>;
@@ -28365,6 +28764,7 @@ impl IMSVidStreamBufferSource_Vtbl {
         iid == &<IMSVidStreamBufferSource as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidPlayback as ::windows::core::Interface>::IID || iid == &<IMSVidFilePlayback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSource2_Impl: Sized + IMSVidStreamBufferSource_Impl {
     fn put_RateEx(&self, dwrate: f64, dwframespersecond: u32) -> ::windows::core::Result<()>;
@@ -28440,6 +28840,7 @@ impl IMSVidStreamBufferSource2_Vtbl {
         iid == &<IMSVidStreamBufferSource2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidPlayback as ::windows::core::Interface>::IID || iid == &<IMSVidFilePlayback as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSourceEvent_Impl: Sized + IMSVidFilePlaybackEvent_Impl {
     fn CertificateFailure(&self) -> ::windows::core::Result<()>;
@@ -28519,6 +28920,7 @@ impl IMSVidStreamBufferSourceEvent_Vtbl {
         iid == &<IMSVidStreamBufferSourceEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidPlaybackEvent as ::windows::core::Interface>::IID || iid == &<IMSVidFilePlaybackEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSourceEvent2_Impl: Sized + IMSVidStreamBufferSourceEvent_Impl {
     fn RateChange(&self, qwnewrate: f64, qwoldrate: f64) -> ::windows::core::Result<()>;
@@ -28539,6 +28941,7 @@ impl IMSVidStreamBufferSourceEvent2_Vtbl {
         iid == &<IMSVidStreamBufferSourceEvent2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidPlaybackEvent as ::windows::core::Interface>::IID || iid == &<IMSVidFilePlaybackEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSourceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferSourceEvent3_Impl: Sized + IMSVidStreamBufferSourceEvent2_Impl {
     fn BroadcastEvent(&self, guid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -28590,6 +28993,7 @@ impl IMSVidStreamBufferSourceEvent3_Vtbl {
         iid == &<IMSVidStreamBufferSourceEvent3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidPlaybackEvent as ::windows::core::Interface>::IID || iid == &<IMSVidFilePlaybackEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSourceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidStreamBufferSourceEvent2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidStreamBufferV2SourceEvent_Impl: Sized + IMSVidFilePlaybackEvent_Impl {
     fn RatingsChanged(&self) -> ::windows::core::Result<()>;
@@ -28669,6 +29073,7 @@ impl IMSVidStreamBufferV2SourceEvent_Vtbl {
         iid == &<IMSVidStreamBufferV2SourceEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidPlaybackEvent as ::windows::core::Interface>::IID || iid == &<IMSVidFilePlaybackEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidTuner_Impl: Sized + IMSVidVideoInputDevice_Impl {
     fn Tune(&self) -> ::windows::core::Result<ITuneRequest>;
@@ -28725,6 +29130,7 @@ impl IMSVidTuner_Vtbl {
         iid == &<IMSVidTuner as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidVideoInputDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidTunerEvent_Impl: Sized + IMSVidInputDeviceEvent_Impl {
     fn TuneChanged(&self, lpd: &::core::option::Option<IMSVidTuner>) -> ::windows::core::Result<()>;
@@ -28745,6 +29151,7 @@ impl IMSVidTunerEvent_Vtbl {
         iid == &<IMSVidTunerEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVMR9_Impl: Sized + IMSVidVideoRenderer_Impl {
     fn Allocator_ID(&self) -> ::windows::core::Result<i32>;
@@ -28814,6 +29221,7 @@ impl IMSVidVMR9_Vtbl {
         iid == &<IMSVidVMR9 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidVideoRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IMSVidVRGraphSegment_Impl: Sized + IMSVidGraphSegment_Impl {
     fn Set_VMRendererMode(&self, dwmode: i32) -> ::windows::core::Result<()>;
@@ -29025,6 +29433,7 @@ impl IMSVidVRGraphSegment_Vtbl {
         iid == &<IMSVidVRGraphSegment as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<IMSVidGraphSegment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVideoInputDevice_Impl: Sized + IMSVidInputDevice_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -29038,6 +29447,7 @@ impl IMSVidVideoInputDevice_Vtbl {
         iid == &<IMSVidVideoInputDevice as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVideoRenderer_Impl: Sized + IMSVidOutputDevice_Impl {
     fn CustomCompositorClass(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -29366,6 +29776,7 @@ impl IMSVidVideoRenderer_Vtbl {
         iid == &<IMSVidVideoRenderer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVideoRenderer2_Impl: Sized + IMSVidVideoRenderer_Impl {
     fn Allocator(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -29455,6 +29866,7 @@ impl IMSVidVideoRenderer2_Vtbl {
         iid == &<IMSVidVideoRenderer2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidVideoRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVideoRendererDevices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -29524,6 +29936,7 @@ impl IMSVidVideoRendererDevices_Vtbl {
         iid == &<IMSVidVideoRendererDevices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVideoRendererEvent_Impl: Sized + IMSVidOutputDeviceEvent_Impl {
     fn OverlayUnavailable(&self) -> ::windows::core::Result<()>;
@@ -29544,6 +29957,7 @@ impl IMSVidVideoRendererEvent_Vtbl {
         iid == &<IMSVidVideoRendererEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidVideoRendererEvent2_Impl: Sized + IMSVidOutputDeviceEvent_Impl {
     fn OverlayUnavailable(&self) -> ::windows::core::Result<()>;
@@ -29564,6 +29978,7 @@ impl IMSVidVideoRendererEvent2_Vtbl {
         iid == &<IMSVidVideoRendererEvent2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidOutputDeviceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidWebDVD_Impl: Sized + IMSVidPlayback_Impl {
     fn OnDVDEvent(&self, levent: i32, lparam1: isize, lparam2: isize) -> ::windows::core::Result<()>;
@@ -30551,6 +30966,7 @@ impl IMSVidWebDVD_Vtbl {
         iid == &<IMSVidWebDVD as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidPlayback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidWebDVD2_Impl: Sized + IMSVidWebDVD_Impl {
     fn get_Bookmark(&self, ppdata: *mut *mut u8, pdatalength: *mut u32) -> ::windows::core::Result<()>;
@@ -30581,6 +30997,7 @@ impl IMSVidWebDVD2_Vtbl {
         iid == &<IMSVidWebDVD2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidInputDevice as ::windows::core::Interface>::IID || iid == &<IMSVidPlayback as ::windows::core::Interface>::IID || iid == &<IMSVidWebDVD as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidWebDVDAdm_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ChangePassword(&self, strusername: &::windows::core::BSTR, strold: &::windows::core::BSTR, strnew: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -30737,6 +31154,7 @@ impl IMSVidWebDVDAdm_Vtbl {
         iid == &<IMSVidWebDVDAdm as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidWebDVDEvent_Impl: Sized + IMSVidPlaybackEvent_Impl {
     fn DVDNotify(&self, leventcode: i32, lparam1: &super::super::System::Com::VARIANT, lparam2: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -30914,6 +31332,7 @@ impl IMSVidWebDVDEvent_Vtbl {
         iid == &<IMSVidWebDVDEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidInputDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidPlaybackEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidXDS_Impl: Sized + IMSVidFeature_Impl {
     fn ChannelChangeInterface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -30940,6 +31359,7 @@ impl IMSVidXDS_Vtbl {
         iid == &<IMSVidXDS as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDevice as ::windows::core::Interface>::IID || iid == &<IMSVidFeature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSVidXDSEvent_Impl: Sized + IMSVidFeatureEvent_Impl {
     fn RatingChange(&self, prevratingsystem: EnTvRat_System, prevlevel: EnTvRat_GenericLevel, prevattributes: BfEnTvRat_GenericAttributes, newratingsystem: EnTvRat_System, newlevel: EnTvRat_GenericLevel, newattributes: BfEnTvRat_GenericAttributes) -> ::windows::core::Result<()>;
@@ -30960,6 +31380,7 @@ impl IMSVidXDSEvent_Vtbl {
         iid == &<IMSVidXDSEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSVidDeviceEvent as ::windows::core::Interface>::IID || iid == &<IMSVidFeatureEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMceBurnerControl_Impl: Sized {
     fn GetBurnerNoDecryption(&self) -> ::windows::core::Result<()>;
 }
@@ -30977,6 +31398,7 @@ impl IMceBurnerControl_Vtbl {
         iid == &<IMceBurnerControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMediaControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Run(&self) -> ::windows::core::Result<()>;
@@ -31080,6 +31502,7 @@ impl IMediaControl_Vtbl {
         iid == &<IMediaControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMediaEvent_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetEventHandle(&self) -> ::windows::core::Result<isize>;
@@ -31150,6 +31573,7 @@ impl IMediaEvent_Vtbl {
         iid == &<IMediaEvent as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMediaEventEx_Impl: Sized + IMediaEvent_Impl {
     fn SetNotifyWindow(&self, hwnd: isize, lmsg: i32, linstancedata: isize) -> ::windows::core::Result<()>;
@@ -31193,6 +31617,7 @@ impl IMediaEventEx_Vtbl {
         iid == &<IMediaEventEx as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMediaEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMediaEventSink_Impl: Sized {
     fn Notify(&self, eventcode: i32, eventparam1: isize, eventparam2: isize) -> ::windows::core::Result<()>;
 }
@@ -31210,6 +31635,7 @@ impl IMediaEventSink_Vtbl {
         iid == &<IMediaEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMediaFilter_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -31274,6 +31700,7 @@ impl IMediaFilter_Vtbl {
         iid == &<IMediaFilter as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMediaParamInfo_Impl: Sized {
     fn GetParamCount(&self) -> ::windows::core::Result<u32>;
     fn GetParamInfo(&self, dwparamindex: u32) -> ::windows::core::Result<MP_PARAMINFO>;
@@ -31359,6 +31786,7 @@ impl IMediaParamInfo_Vtbl {
         iid == &<IMediaParamInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMediaParams_Impl: Sized {
     fn GetParam(&self, dwparamindex: u32) -> ::windows::core::Result<f32>;
     fn SetParam(&self, dwparamindex: u32, value: f32) -> ::windows::core::Result<()>;
@@ -31413,6 +31841,7 @@ impl IMediaParams_Vtbl {
         iid == &<IMediaParams as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMediaPosition_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Duration(&self) -> ::windows::core::Result<f64>;
@@ -31548,6 +31977,7 @@ impl IMediaPosition_Vtbl {
         iid == &<IMediaPosition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IMediaPropertyBag_Impl: Sized + super::super::System::Com::StructuredStorage::IPropertyBag_Impl {
     fn EnumProperty(&self, iproperty: u32, pvarpropertyname: *mut super::super::System::Com::VARIANT, pvarpropertyvalue: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -31571,6 +32001,7 @@ impl IMediaPropertyBag_Vtbl {
         iid == &<IMediaPropertyBag as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::StructuredStorage::IPropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IMediaSample_Impl: Sized {
     fn GetPointer(&self) -> ::windows::core::Result<*mut u8>;
@@ -31711,6 +32142,7 @@ impl IMediaSample_Vtbl {
         iid == &<IMediaSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IMediaSample2_Impl: Sized + IMediaSample_Impl {
     fn GetProperties(&self, cbproperties: u32, pbproperties: *mut u8) -> ::windows::core::Result<()>;
@@ -31741,6 +32173,7 @@ impl IMediaSample2_Vtbl {
         iid == &<IMediaSample2 as ::windows::core::Interface>::IID || iid == &<IMediaSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMediaSample2Config_Impl: Sized {
     fn GetSurface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -31764,6 +32197,7 @@ impl IMediaSample2Config_Vtbl {
         iid == &<IMediaSample2Config as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMediaSeeking_Impl: Sized {
     fn GetCapabilities(&self) -> ::windows::core::Result<u32>;
     fn CheckCapabilities(&self, pcapabilities: *mut u32) -> ::windows::core::Result<()>;
@@ -31944,6 +32378,7 @@ impl IMediaSeeking_Vtbl {
         iid == &<IMediaSeeking as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMediaStream_Impl: Sized {
     fn GetMultiMediaStream(&self) -> ::windows::core::Result<IMultiMediaStream>;
     fn GetInformation(&self, ppurposeid: *mut ::windows::core::GUID, ptype: *mut STREAM_TYPE) -> ::windows::core::Result<()>;
@@ -32017,6 +32452,7 @@ impl IMediaStream_Vtbl {
         iid == &<IMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMediaStreamFilter_Impl: Sized + IBaseFilter_Impl {
     fn AddMediaStream(&self, pammediastream: &::core::option::Option<IAMMediaStream>) -> ::windows::core::Result<()>;
@@ -32120,6 +32556,7 @@ impl IMediaStreamFilter_Vtbl {
         iid == &<IMediaStreamFilter as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<IMediaFilter as ::windows::core::Interface>::IID || iid == &<IBaseFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMediaTypeInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -32162,6 +32599,7 @@ impl IMediaTypeInfo_Vtbl {
         iid == &<IMediaTypeInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMemAllocator_Impl: Sized {
     fn SetProperties(&self, prequest: *const ALLOCATOR_PROPERTIES) -> ::windows::core::Result<ALLOCATOR_PROPERTIES>;
     fn GetProperties(&self) -> ::windows::core::Result<ALLOCATOR_PROPERTIES>;
@@ -32229,6 +32667,7 @@ impl IMemAllocator_Vtbl {
         iid == &<IMemAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMemAllocatorCallbackTemp_Impl: Sized + IMemAllocator_Impl {
     fn SetNotify(&self, pnotify: &::core::option::Option<IMemAllocatorNotifyCallbackTemp>) -> ::windows::core::Result<()>;
     fn GetFreeCount(&self) -> ::windows::core::Result<i32>;
@@ -32262,6 +32701,7 @@ impl IMemAllocatorCallbackTemp_Vtbl {
         iid == &<IMemAllocatorCallbackTemp as ::windows::core::Interface>::IID || iid == &<IMemAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMemAllocatorNotifyCallbackTemp_Impl: Sized {
     fn NotifyRelease(&self) -> ::windows::core::Result<()>;
 }
@@ -32279,6 +32719,7 @@ impl IMemAllocatorNotifyCallbackTemp_Vtbl {
         iid == &<IMemAllocatorNotifyCallbackTemp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMemInputPin_Impl: Sized {
     fn GetAllocator(&self) -> ::windows::core::Result<IMemAllocator>;
@@ -32355,6 +32796,7 @@ impl IMemInputPin_Vtbl {
         iid == &<IMemInputPin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMemoryData_Impl: Sized {
     fn SetBuffer(&self, cbsize: u32, pbdata: *const u8, dwflags: u32) -> ::windows::core::Result<()>;
     fn GetInfo(&self, pdwlength: *mut u32, ppbdata: *mut *mut u8, pcbactualdata: *mut u32) -> ::windows::core::Result<()>;
@@ -32389,6 +32831,7 @@ impl IMemoryData_Vtbl {
         iid == &<IMemoryData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IMixerOCX_Impl: Sized {
     fn OnDisplayChange(&self, ulbitsperpixel: u32, ulscreenwidth: u32, ulscreenheight: u32) -> ::windows::core::Result<()>;
@@ -32467,6 +32910,7 @@ impl IMixerOCX_Vtbl {
         iid == &<IMixerOCX as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMixerOCXNotify_Impl: Sized {
     fn OnInvalidateRect(&self, lpcrect: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -32504,6 +32948,7 @@ impl IMixerOCXNotify_Vtbl {
         iid == &<IMixerOCXNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMixerPinConfig_Impl: Sized {
     fn SetRelativePosition(&self, dwleft: u32, dwtop: u32, dwright: u32, dwbottom: u32) -> ::windows::core::Result<()>;
@@ -32604,6 +33049,7 @@ impl IMixerPinConfig_Vtbl {
         iid == &<IMixerPinConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IMixerPinConfig2_Impl: Sized + IMixerPinConfig_Impl {
     fn SetOverlaySurfaceColorControls(&self, pcolorcontrol: *mut super::super::Graphics::DirectDraw::DDCOLORCONTROL) -> ::windows::core::Result<()>;
@@ -32634,6 +33080,7 @@ impl IMixerPinConfig2_Vtbl {
         iid == &<IMixerPinConfig2 as ::windows::core::Interface>::IID || iid == &<IMixerPinConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMpeg2Data_Impl: Sized {
     fn GetSection(&self, pid: u16, tid: u8, pfilter: *const MPEG2_FILTER, dwtimeout: u32) -> ::windows::core::Result<ISectionList>;
@@ -32689,6 +33136,7 @@ impl IMpeg2Data_Vtbl {
         iid == &<IMpeg2Data as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IMpeg2Demultiplexer_Impl: Sized {
     fn CreateOutputPin(&self, pmediatype: *mut super::MediaFoundation::AM_MEDIA_TYPE, pszpinname: &::windows::core::PCWSTR, ppipin: *mut ::core::option::Option<IPin>) -> ::windows::core::Result<()>;
@@ -32726,6 +33174,7 @@ impl IMpeg2Demultiplexer_Vtbl {
         iid == &<IMpeg2Demultiplexer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMpeg2Stream_Impl: Sized {
     fn Initialize(&self, requesttype: MPEG_REQUEST_TYPE, pmpeg2data: &::core::option::Option<IMpeg2Data>, pcontext: *const MPEG_CONTEXT, pid: u16, tid: u8, pfilter: *const MPEG2_FILTER, hdatareadyevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -32756,6 +33205,7 @@ impl IMpeg2Stream_Vtbl {
         iid == &<IMpeg2Stream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IMpeg2TableFilter_Impl: Sized {
     fn AddPID(&self, p: u16) -> ::windows::core::Result<()>;
     fn AddTable(&self, p: u16, t: u8) -> ::windows::core::Result<()>;
@@ -32811,6 +33261,7 @@ impl IMpeg2TableFilter_Vtbl {
         iid == &<IMpeg2TableFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IMpegAudioDecoder_Impl: Sized {
     fn FrequencyDivider(&self) -> ::windows::core::Result<u32>;
@@ -32954,6 +33405,7 @@ impl IMpegAudioDecoder_Vtbl {
         iid == &<IMpegAudioDecoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMultiMediaStream_Impl: Sized {
     fn GetInformation(&self, pdwflags: *mut MMSSF_GET_INFORMATION_FLAGS, pstreamtype: *mut STREAM_TYPE) -> ::windows::core::Result<()>;
@@ -33069,6 +33521,7 @@ impl IMultiMediaStream_Vtbl {
         iid == &<IMultiMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IOverlay_Impl: Sized {
     fn GetPalette(&self, pdwcolors: *mut u32, pppalette: *mut *mut super::super::Graphics::Gdi::PALETTEENTRY) -> ::windows::core::Result<()>;
@@ -33173,6 +33626,7 @@ impl IOverlay_Vtbl {
         iid == &<IOverlay as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IOverlayNotify_Impl: Sized {
     fn OnPaletteChange(&self, dwcolors: u32, ppalette: *const super::super::Graphics::Gdi::PALETTEENTRY) -> ::windows::core::Result<()>;
@@ -33217,6 +33671,7 @@ impl IOverlayNotify_Vtbl {
         iid == &<IOverlayNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IOverlayNotify2_Impl: Sized + IOverlayNotify_Impl {
     fn OnDisplayChange(&self, hmonitor: super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::Result<()>;
@@ -33237,6 +33692,7 @@ impl IOverlayNotify2_Vtbl {
         iid == &<IOverlayNotify2 as ::windows::core::Interface>::IID || iid == &<IOverlayNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPAT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -33372,6 +33828,7 @@ impl IPAT_Vtbl {
         iid == &<IPAT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IPBDAAttributesDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u16>;
@@ -33418,6 +33875,7 @@ impl IPBDAAttributesDescriptor_Vtbl {
         iid == &<IPBDAAttributesDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IPBDAEntitlementDescriptor_Impl: Sized {
     fn GetTag(&self) -> ::windows::core::Result<u8>;
     fn GetLength(&self) -> ::windows::core::Result<u16>;
@@ -33464,6 +33922,7 @@ impl IPBDAEntitlementDescriptor_Vtbl {
         iid == &<IPBDAEntitlementDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IPBDASiParser_Impl: Sized {
     fn Initialize(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetEIT(&self, dwsize: u32, pbuffer: *const u8) -> ::windows::core::Result<IPBDA_EIT>;
@@ -33510,6 +33969,7 @@ impl IPBDASiParser_Vtbl {
         iid == &<IPBDASiParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IPBDA_EIT_Impl: Sized {
     fn Initialize(&self, size: u32, pbuffer: *const u8) -> ::windows::core::Result<()>;
     fn GetTableId(&self) -> ::windows::core::Result<u8>;
@@ -33654,6 +34114,7 @@ impl IPBDA_EIT_Vtbl {
         iid == &<IPBDA_EIT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IPBDA_Services_Impl: Sized {
     fn Initialize(&self, size: u32, pbuffer: *const u8) -> ::windows::core::Result<()>;
     fn GetCountOfRecords(&self) -> ::windows::core::Result<u32>;
@@ -33700,6 +34161,7 @@ impl IPBDA_Services_Vtbl {
         iid == &<IPBDA_Services as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -33915,6 +34377,7 @@ impl IPMT_Vtbl {
         iid == &<IPMT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IPSITables_Impl: Sized {
     fn GetTable(&self, dwtsid: u32, dwtid_pid: u32, dwhashedver: u32, dwpara4: u32) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -33938,6 +34401,7 @@ impl IPSITables_Vtbl {
         iid == &<IPSITables as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPTFilterLicenseRenewal_Impl: Sized {
     fn RenewLicenses(&self, wszfilename: &::windows::core::PCWSTR, wszexpiredkid: &::windows::core::PCWSTR, dwcallersid: u32, bhighpriority: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -33968,6 +34432,7 @@ impl IPTFilterLicenseRenewal_Vtbl {
         iid == &<IPTFilterLicenseRenewal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPersistMediaPropertyBag_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn InitNew(&self) -> ::windows::core::Result<()>;
@@ -34005,6 +34470,7 @@ impl IPersistMediaPropertyBag_Vtbl {
         iid == &<IPersistMediaPropertyBag as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPersistTuneXml_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn InitNew(&self) -> ::windows::core::Result<()>;
@@ -34048,6 +34514,7 @@ impl IPersistTuneXml_Vtbl {
         iid == &<IPersistTuneXml as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPersistTuneXmlUtility_Impl: Sized {
     fn Deserialize(&self, varvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -34074,6 +34541,7 @@ impl IPersistTuneXmlUtility_Vtbl {
         iid == &<IPersistTuneXmlUtility as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPersistTuneXmlUtility2_Impl: Sized + IPersistTuneXmlUtility_Impl {
     fn Serialize(&self, pitunerequest: &::core::option::Option<ITuneRequest>) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -34100,6 +34568,7 @@ impl IPersistTuneXmlUtility2_Vtbl {
         iid == &<IPersistTuneXmlUtility2 as ::windows::core::Interface>::IID || iid == &<IPersistTuneXmlUtility as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_System_Com"))]
 pub trait IPin_Impl: Sized {
     fn Connect(&self, preceivepin: &::core::option::Option<IPin>, pmt: *const super::MediaFoundation::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
@@ -34257,6 +34726,7 @@ impl IPin_Vtbl {
         iid == &<IPin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IPinConnection_Impl: Sized {
     fn DynamicQueryAccept(&self, pmt: *const super::MediaFoundation::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
@@ -34301,6 +34771,7 @@ impl IPinConnection_Vtbl {
         iid == &<IPinConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPinFlowControl_Impl: Sized {
     fn Block(&self, dwblockflags: u32, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -34321,6 +34792,7 @@ impl IPinFlowControl_Vtbl {
         iid == &<IPinFlowControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPinInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Pin(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -34476,6 +34948,7 @@ impl IPinInfo_Vtbl {
         iid == &<IPinInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IQualProp_Impl: Sized {
     fn FramesDroppedInRenderer(&self) -> ::windows::core::Result<i32>;
     fn FramesDrawn(&self) -> ::windows::core::Result<i32>;
@@ -34567,6 +35040,7 @@ impl IQualProp_Vtbl {
         iid == &<IQualProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IQualityControl_Impl: Sized {
     fn Notify(&self, pself: &::core::option::Option<IBaseFilter>, q: &Quality) -> ::windows::core::Result<()>;
@@ -34597,6 +35071,7 @@ impl IQualityControl_Vtbl {
         iid == &<IQualityControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IQueueCommand_Impl: Sized {
     fn InvokeAtStreamTime(&self, pcmd: *mut ::core::option::Option<IDeferredCommand>, time: f64, iid: *const ::windows::core::GUID, dispidmethod: i32, wflags: i16, cargs: i32, pdispparams: *const super::super::System::Com::VARIANT, pvarresult: *mut super::super::System::Com::VARIANT, puargerr: *mut i16) -> ::windows::core::Result<()>;
@@ -34627,6 +35102,7 @@ impl IQueueCommand_Vtbl {
         iid == &<IQueueCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRegFilterInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -34669,6 +35145,7 @@ impl IRegFilterInfo_Vtbl {
         iid == &<IRegFilterInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IRegisterServiceProvider_Impl: Sized {
     fn RegisterService(&self, guidservice: *const ::windows::core::GUID, punkobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -34686,6 +35163,7 @@ impl IRegisterServiceProvider_Vtbl {
         iid == &<IRegisterServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IRegisterTuner_Impl: Sized {
     fn Register(&self, ptuner: &::core::option::Option<ITuner>, pgraph: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
     fn Unregister(&self) -> ::windows::core::Result<()>;
@@ -34713,6 +35191,7 @@ impl IRegisterTuner_Vtbl {
         iid == &<IRegisterTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IResourceConsumer_Impl: Sized {
     fn AcquireResource(&self, idresource: i32) -> ::windows::core::Result<()>;
     fn ReleaseResource(&self, idresource: i32) -> ::windows::core::Result<()>;
@@ -34740,6 +35219,7 @@ impl IResourceConsumer_Vtbl {
         iid == &<IResourceConsumer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResourceManager_Impl: Sized {
     fn Register(&self, pname: &::windows::core::PCWSTR, cresource: i32) -> ::windows::core::Result<i32>;
@@ -34824,6 +35304,7 @@ impl IResourceManager_Vtbl {
         iid == &<IResourceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISBE2Crossbar_Impl: Sized {
     fn EnableDefaultMode(&self, defaultflags: u32) -> ::windows::core::Result<()>;
     fn GetInitialProfile(&self) -> ::windows::core::Result<ISBE2MediaTypeProfile>;
@@ -34877,6 +35358,7 @@ impl ISBE2Crossbar_Vtbl {
         iid == &<ISBE2Crossbar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISBE2EnumStream_Impl: Sized {
     fn Next(&self, crequest: u32, pstreamdesc: *mut SBE2_STREAM_DESC, pcreceived: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, crecords: u32) -> ::windows::core::Result<()>;
@@ -34924,6 +35406,7 @@ impl ISBE2EnumStream_Vtbl {
         iid == &<ISBE2EnumStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISBE2FileScan_Impl: Sized {
     fn RepairFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -34941,6 +35424,7 @@ impl ISBE2FileScan_Vtbl {
         iid == &<ISBE2FileScan as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISBE2GlobalEvent_Impl: Sized {
     fn GetEvent(&self, idevt: *const ::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32, pspanning: *mut super::super::Foundation::BOOL, pcb: *mut u32, pb: *mut u8) -> ::windows::core::Result<()>;
@@ -34961,6 +35445,7 @@ impl ISBE2GlobalEvent_Vtbl {
         iid == &<ISBE2GlobalEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISBE2GlobalEvent2_Impl: Sized + ISBE2GlobalEvent_Impl {
     fn GetEventEx(&self, idevt: *const ::windows::core::GUID, param1: u32, param2: u32, param3: u32, param4: u32, pspanning: *mut super::super::Foundation::BOOL, pcb: *mut u32, pb: *mut u8, pstreamtime: *mut i64) -> ::windows::core::Result<()>;
@@ -34981,6 +35466,7 @@ impl ISBE2GlobalEvent2_Vtbl {
         iid == &<ISBE2GlobalEvent2 as ::windows::core::Interface>::IID || iid == &<ISBE2GlobalEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait ISBE2MediaTypeProfile_Impl: Sized {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
@@ -35037,6 +35523,7 @@ impl ISBE2MediaTypeProfile_Vtbl {
         iid == &<ISBE2MediaTypeProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISBE2SpanningEvent_Impl: Sized {
     fn GetEvent(&self, idevt: *const ::windows::core::GUID, streamid: u32, pcb: *mut u32, pb: *mut u8) -> ::windows::core::Result<()>;
 }
@@ -35054,6 +35541,7 @@ impl ISBE2SpanningEvent_Vtbl {
         iid == &<ISBE2SpanningEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISBE2StreamMap_Impl: Sized {
     fn MapStream(&self, stream: u32) -> ::windows::core::Result<()>;
     fn UnmapStream(&self, stream: u32) -> ::windows::core::Result<()>;
@@ -35094,6 +35582,7 @@ impl ISBE2StreamMap_Vtbl {
         iid == &<ISBE2StreamMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISCTE_EAS_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
     fn GetVersionNumber(&self) -> ::windows::core::Result<u8>;
@@ -35460,6 +35949,7 @@ impl ISCTE_EAS_Vtbl {
         iid == &<ISCTE_EAS as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISIInbandEPG_Impl: Sized {
     fn StartSIEPGScan(&self) -> ::windows::core::Result<()>;
@@ -35503,6 +35993,7 @@ impl ISIInbandEPG_Vtbl {
         iid == &<ISIInbandEPG as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISIInbandEPGEvent_Impl: Sized {
     fn SIObjectEvent(&self, pidvb_eit: &::core::option::Option<IDVB_EIT2>, dwtable_id: u32, dwservice_id: u32) -> ::windows::core::Result<()>;
 }
@@ -35520,6 +36011,7 @@ impl ISIInbandEPGEvent_Vtbl {
         iid == &<ISIInbandEPGEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IScanningTuner_Impl: Sized + ITuner_Impl {
     fn SeekUp(&self) -> ::windows::core::Result<()>;
@@ -35571,6 +36063,7 @@ impl IScanningTuner_Vtbl {
         iid == &<IScanningTuner as ::windows::core::Interface>::IID || iid == &<ITuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IScanningTunerEx_Impl: Sized + IScanningTuner_Impl {
     fn GetCurrentLocator(&self, pilocator: *const ::core::option::Option<ILocator>) -> ::windows::core::Result<()>;
@@ -35649,6 +36142,7 @@ impl IScanningTunerEx_Vtbl {
         iid == &<IScanningTunerEx as ::windows::core::Interface>::IID || iid == &<ITuner as ::windows::core::Interface>::IID || iid == &<IScanningTuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISectionList_Impl: Sized {
     fn Initialize(&self, requesttype: MPEG_REQUEST_TYPE, pmpeg2data: &::core::option::Option<IMpeg2Data>, pcontext: *const MPEG_CONTEXT, pid: u16, tid: u8, pfilter: *const MPEG2_FILTER, timeout: u32, hdoneevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -35720,6 +36214,7 @@ impl ISectionList_Vtbl {
         iid == &<ISectionList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISeekingPassThru_Impl: Sized {
     fn Init(&self, bsupportrendering: super::super::Foundation::BOOL, ppin: &::core::option::Option<IPin>) -> ::windows::core::Result<()>;
@@ -35740,6 +36235,7 @@ impl ISeekingPassThru_Vtbl {
         iid == &<ISeekingPassThru as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ISelector_Impl: Sized {
     fn NumSources(&self) -> ::windows::core::Result<u32>;
     fn SourceNodeId(&self) -> ::windows::core::Result<u32>;
@@ -35786,6 +36282,7 @@ impl ISelector_Vtbl {
         iid == &<ISelector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IServiceLocationDescriptor_Impl: Sized {
     fn GetPCR_PID(&self) -> ::windows::core::Result<u16>;
     fn GetNumberOfElements(&self) -> ::windows::core::Result<u8>;
@@ -35858,6 +36355,7 @@ impl IServiceLocationDescriptor_Vtbl {
         iid == &<IServiceLocationDescriptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Ole")]
 pub trait ISpecifyParticularPages_Impl: Sized {
     fn GetPages(&self, guidwhatpages: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::System::Ole::CAUUID>;
@@ -35884,6 +36382,7 @@ impl ISpecifyParticularPages_Vtbl {
         iid == &<ISpecifyParticularPages as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferConfigure_Impl: Sized {
     fn SetDirectory(&self, pszdirectoryname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetDirectory(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -35951,6 +36450,7 @@ impl IStreamBufferConfigure_Vtbl {
         iid == &<IStreamBufferConfigure as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferConfigure2_Impl: Sized + IStreamBufferConfigure_Impl {
     fn SetMultiplexedPacketSize(&self, cbbytesperpacket: u32) -> ::windows::core::Result<()>;
     fn GetMultiplexedPacketSize(&self) -> ::windows::core::Result<u32>;
@@ -35998,6 +36498,7 @@ impl IStreamBufferConfigure2_Vtbl {
         iid == &<IStreamBufferConfigure2 as ::windows::core::Interface>::IID || iid == &<IStreamBufferConfigure as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStreamBufferConfigure3_Impl: Sized + IStreamBufferConfigure2_Impl {
     fn SetStartRecConfig(&self, fstartstopscur: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -36054,6 +36555,7 @@ impl IStreamBufferConfigure3_Vtbl {
         iid == &<IStreamBufferConfigure3 as ::windows::core::Interface>::IID || iid == &<IStreamBufferConfigure as ::windows::core::Interface>::IID || iid == &<IStreamBufferConfigure2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferDataCounters_Impl: Sized {
     fn GetData(&self) -> ::windows::core::Result<SBE_PIN_DATA>;
     fn ResetData(&self) -> ::windows::core::Result<()>;
@@ -36087,6 +36589,7 @@ impl IStreamBufferDataCounters_Vtbl {
         iid == &<IStreamBufferDataCounters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait IStreamBufferInitialize_Impl: Sized {
     fn SetHKEY(&self, hkeyroot: super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
@@ -36117,6 +36620,7 @@ impl IStreamBufferInitialize_Vtbl {
         iid == &<IStreamBufferInitialize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferMediaSeeking_Impl: Sized + IMediaSeeking_Impl {}
 impl ::windows::core::RuntimeName for IStreamBufferMediaSeeking {}
 impl IStreamBufferMediaSeeking_Vtbl {
@@ -36127,6 +36631,7 @@ impl IStreamBufferMediaSeeking_Vtbl {
         iid == &<IStreamBufferMediaSeeking as ::windows::core::Interface>::IID || iid == &<IMediaSeeking as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferMediaSeeking2_Impl: Sized + IStreamBufferMediaSeeking_Impl {
     fn SetRateEx(&self, drate: f64, dwframespersec: u32) -> ::windows::core::Result<()>;
 }
@@ -36144,6 +36649,7 @@ impl IStreamBufferMediaSeeking2_Vtbl {
         iid == &<IStreamBufferMediaSeeking2 as ::windows::core::Interface>::IID || iid == &<IMediaSeeking as ::windows::core::Interface>::IID || iid == &<IStreamBufferMediaSeeking as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferRecComp_Impl: Sized {
     fn Initialize(&self, psztargetfilename: &::windows::core::PCWSTR, pszsbrecprofileref: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Append(&self, pszsbrecording: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -36205,6 +36711,7 @@ impl IStreamBufferRecComp_Vtbl {
         iid == &<IStreamBufferRecComp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStreamBufferRecordControl_Impl: Sized {
     fn Start(&self, prtstart: *mut i64) -> ::windows::core::Result<()>;
@@ -36242,6 +36749,7 @@ impl IStreamBufferRecordControl_Vtbl {
         iid == &<IStreamBufferRecordControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferRecordingAttribute_Impl: Sized {
     fn SetAttribute(&self, ulreserved: u32, pszattributename: &::windows::core::PCWSTR, streambufferattributetype: STREAMBUFFER_ATTR_DATATYPE, pbattribute: *const u8, cbattributelength: u16) -> ::windows::core::Result<()>;
     fn GetAttributeCount(&self, ulreserved: u32) -> ::windows::core::Result<u16>;
@@ -36302,6 +36810,7 @@ impl IStreamBufferRecordingAttribute_Vtbl {
         iid == &<IStreamBufferRecordingAttribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferSink_Impl: Sized {
     fn LockProfile(&self, pszstreambufferfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn CreateRecorder(&self, pszfilename: &::windows::core::PCWSTR, dwrecordtype: u32) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -36342,6 +36851,7 @@ impl IStreamBufferSink_Vtbl {
         iid == &<IStreamBufferSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferSink2_Impl: Sized + IStreamBufferSink_Impl {
     fn UnlockProfile(&self) -> ::windows::core::Result<()>;
 }
@@ -36359,6 +36869,7 @@ impl IStreamBufferSink2_Vtbl {
         iid == &<IStreamBufferSink2 as ::windows::core::Interface>::IID || iid == &<IStreamBufferSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferSink3_Impl: Sized + IStreamBufferSink2_Impl {
     fn SetAvailableFilter(&self, prtmin: *mut i64) -> ::windows::core::Result<()>;
 }
@@ -36376,6 +36887,7 @@ impl IStreamBufferSink3_Vtbl {
         iid == &<IStreamBufferSink3 as ::windows::core::Interface>::IID || iid == &<IStreamBufferSink as ::windows::core::Interface>::IID || iid == &<IStreamBufferSink2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBufferSource_Impl: Sized {
     fn SetStreamSink(&self, pistreambuffersink: &::core::option::Option<IStreamBufferSink>) -> ::windows::core::Result<()>;
 }
@@ -36393,6 +36905,7 @@ impl IStreamBufferSource_Vtbl {
         iid == &<IStreamBufferSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IStreamBuilder_Impl: Sized {
     fn Render(&self, ppinout: &::core::option::Option<IPin>, pgraph: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
     fn Backout(&self, ppinout: &::core::option::Option<IPin>, pgraph: &::core::option::Option<IGraphBuilder>) -> ::windows::core::Result<()>;
@@ -36420,6 +36933,7 @@ impl IStreamBuilder_Vtbl {
         iid == &<IStreamBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStreamSample_Impl: Sized {
     fn GetMediaStream(&self, ppmediastream: *const ::core::option::Option<IMediaStream>) -> ::windows::core::Result<()>;
@@ -36471,6 +36985,7 @@ impl IStreamSample_Vtbl {
         iid == &<IStreamSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITSDT_Impl: Sized {
     fn Initialize(&self, psectionlist: &::core::option::Option<ISectionList>, pmpegdata: &::core::option::Option<IMpeg2Data>) -> ::windows::core::Result<()>;
@@ -36574,6 +37089,7 @@ impl ITSDT_Vtbl {
         iid == &<ITSDT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITuneRequest_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TuningSpace(&self) -> ::windows::core::Result<ITuningSpace>;
@@ -36649,6 +37165,7 @@ impl ITuneRequest_Vtbl {
         iid == &<ITuneRequest as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITuneRequestInfo_Impl: Sized {
     fn GetLocatorData(&self, request: &::core::option::Option<ITuneRequest>) -> ::windows::core::Result<()>;
@@ -36738,6 +37255,7 @@ impl ITuneRequestInfo_Vtbl {
         iid == &<ITuneRequestInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITuneRequestInfoEx_Impl: Sized + ITuneRequestInfo_Impl {
     fn CreateComponentListEx(&self, currentrequest: &::core::option::Option<ITuneRequest>) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -36764,6 +37282,7 @@ impl ITuneRequestInfoEx_Vtbl {
         iid == &<ITuneRequestInfoEx as ::windows::core::Interface>::IID || iid == &<ITuneRequestInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITuner_Impl: Sized {
     fn TuningSpace(&self) -> ::windows::core::Result<ITuningSpace>;
@@ -36880,6 +37399,7 @@ impl ITuner_Vtbl {
         iid == &<ITuner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait ITunerCap_Impl: Sized {
     fn get_SupportedNetworkTypes(&self, ulcnetworktypesmax: u32, pulcnetworktypes: *mut u32, pguidnetworktypes: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn get_SupportedVideoFormats(&self, pulamtunermodetype: *mut u32, pulanalogvideostandard: *mut u32) -> ::windows::core::Result<()>;
@@ -36914,6 +37434,7 @@ impl ITunerCap_Vtbl {
         iid == &<ITunerCap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITunerCapEx_Impl: Sized {
     fn Has608_708Caption(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -36940,6 +37461,7 @@ impl ITunerCapEx_Vtbl {
         iid == &<ITunerCapEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITuningSpace_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UniqueName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -37161,6 +37683,7 @@ impl ITuningSpace_Vtbl {
         iid == &<ITuningSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITuningSpaceContainer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -37328,6 +37851,7 @@ impl ITuningSpaceContainer_Vtbl {
         iid == &<ITuningSpaceContainer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITuningSpaces_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -37396,6 +37920,7 @@ impl ITuningSpaces_Vtbl {
         iid == &<ITuningSpaces as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVMRAspectRatioControl_Impl: Sized {
     fn GetAspectRatioMode(&self, lpdwarmode: *mut u32) -> ::windows::core::Result<()>;
     fn SetAspectRatioMode(&self, dwarmode: u32) -> ::windows::core::Result<()>;
@@ -37423,6 +37948,7 @@ impl IVMRAspectRatioControl_Vtbl {
         iid == &<IVMRAspectRatioControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVMRAspectRatioControl9_Impl: Sized {
     fn GetAspectRatioMode(&self) -> ::windows::core::Result<u32>;
     fn SetAspectRatioMode(&self, dwarmode: u32) -> ::windows::core::Result<()>;
@@ -37456,6 +37982,7 @@ impl IVMRAspectRatioControl9_Vtbl {
         iid == &<IVMRAspectRatioControl9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVMRDeinterlaceControl_Impl: Sized {
     fn GetNumberOfDeinterlaceModes(&self, lpvideodescription: *mut VMRVideoDesc, lpdwnumdeinterlacemodes: *mut u32, lpdeinterlacemodes: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -37521,6 +38048,7 @@ impl IVMRDeinterlaceControl_Vtbl {
         iid == &<IVMRDeinterlaceControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVMRDeinterlaceControl9_Impl: Sized {
     fn GetNumberOfDeinterlaceModes(&self, lpvideodescription: *const VMR9VideoDesc, lpdwnumdeinterlacemodes: *mut u32, lpdeinterlacemodes: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetDeinterlaceModeCaps(&self, lpdeinterlacemode: *const ::windows::core::GUID, lpvideodescription: *const VMR9VideoDesc) -> ::windows::core::Result<VMR9DeinterlaceCaps>;
@@ -37607,6 +38135,7 @@ impl IVMRDeinterlaceControl9_Vtbl {
         iid == &<IVMRDeinterlaceControl9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVMRFilterConfig_Impl: Sized {
     fn SetImageCompositor(&self, lpvmrimgcompositor: &::core::option::Option<IVMRImageCompositor>) -> ::windows::core::Result<()>;
     fn SetNumberOfStreams(&self, dwmaxstreams: u32) -> ::windows::core::Result<()>;
@@ -37669,6 +38198,7 @@ impl IVMRFilterConfig_Vtbl {
         iid == &<IVMRFilterConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVMRFilterConfig9_Impl: Sized {
     fn SetImageCompositor(&self, lpvmrimgcompositor: &::core::option::Option<IVMRImageCompositor9>) -> ::windows::core::Result<()>;
     fn SetNumberOfStreams(&self, dwmaxstreams: u32) -> ::windows::core::Result<()>;
@@ -37749,6 +38279,7 @@ impl IVMRFilterConfig9_Vtbl {
         iid == &<IVMRFilterConfig9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Media_MediaFoundation"))]
 pub trait IVMRImageCompositor_Impl: Sized {
     fn InitCompositionTarget(&self, pd3ddevice: &::core::option::Option<::windows::core::IUnknown>, pddsrendertarget: &::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface7>) -> ::windows::core::Result<()>;
@@ -37793,6 +38324,7 @@ impl IVMRImageCompositor_Vtbl {
         iid == &<IVMRImageCompositor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Media_MediaFoundation"))]
 pub trait IVMRImageCompositor9_Impl: Sized {
     fn InitCompositionDevice(&self, pd3ddevice: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -37837,6 +38369,7 @@ impl IVMRImageCompositor9_Vtbl {
         iid == &<IVMRImageCompositor9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IVMRImagePresenter_Impl: Sized {
     fn StartPresenting(&self, dwuserid: usize) -> ::windows::core::Result<()>;
@@ -37874,6 +38407,7 @@ impl IVMRImagePresenter_Vtbl {
         iid == &<IVMRImagePresenter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IVMRImagePresenter9_Impl: Sized {
     fn StartPresenting(&self, dwuserid: usize) -> ::windows::core::Result<()>;
@@ -37911,6 +38445,7 @@ impl IVMRImagePresenter9_Vtbl {
         iid == &<IVMRImagePresenter9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVMRImagePresenterConfig_Impl: Sized {
     fn SetRenderingPrefs(&self, dwrenderflags: u32) -> ::windows::core::Result<()>;
     fn GetRenderingPrefs(&self, dwrenderflags: *mut u32) -> ::windows::core::Result<()>;
@@ -37938,6 +38473,7 @@ impl IVMRImagePresenterConfig_Vtbl {
         iid == &<IVMRImagePresenterConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVMRImagePresenterConfig9_Impl: Sized {
     fn SetRenderingPrefs(&self, dwrenderflags: u32) -> ::windows::core::Result<()>;
     fn GetRenderingPrefs(&self) -> ::windows::core::Result<u32>;
@@ -37971,6 +38507,7 @@ impl IVMRImagePresenterConfig9_Vtbl {
         iid == &<IVMRImagePresenterConfig9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 pub trait IVMRImagePresenterExclModeConfig_Impl: Sized + IVMRImagePresenterConfig_Impl {
     fn SetXlcModeDDObjAndPrimarySurface(&self, lpddobj: &::core::option::Option<super::super::Graphics::DirectDraw::IDirectDraw7>, lpprimarysurf: &::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface7>) -> ::windows::core::Result<()>;
@@ -38001,6 +38538,7 @@ impl IVMRImagePresenterExclModeConfig_Vtbl {
         iid == &<IVMRImagePresenterExclModeConfig as ::windows::core::Interface>::IID || iid == &<IVMRImagePresenterConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRMixerBitmap_Impl: Sized {
     fn SetAlphaBitmap(&self, pbmpparms: *const VMRALPHABITMAP) -> ::windows::core::Result<()>;
@@ -38038,6 +38576,7 @@ impl IVMRMixerBitmap_Vtbl {
         iid == &<IVMRMixerBitmap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRMixerBitmap9_Impl: Sized {
     fn SetAlphaBitmap(&self, pbmpparms: *const VMR9AlphaBitmap) -> ::windows::core::Result<()>;
@@ -38081,6 +38620,7 @@ impl IVMRMixerBitmap9_Vtbl {
         iid == &<IVMRMixerBitmap9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVMRMixerControl_Impl: Sized {
     fn SetAlpha(&self, dwstreamid: u32, alpha: f32) -> ::windows::core::Result<()>;
@@ -38167,6 +38707,7 @@ impl IVMRMixerControl_Vtbl {
         iid == &<IVMRMixerControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVMRMixerControl9_Impl: Sized {
     fn SetAlpha(&self, dwstreamid: u32, alpha: f32) -> ::windows::core::Result<()>;
@@ -38298,6 +38839,7 @@ impl IVMRMixerControl9_Vtbl {
         iid == &<IVMRMixerControl9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRMonitorConfig_Impl: Sized {
     fn SetMonitor(&self, pguid: *const VMRGUID) -> ::windows::core::Result<()>;
@@ -38349,6 +38891,7 @@ impl IVMRMonitorConfig_Vtbl {
         iid == &<IVMRMonitorConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRMonitorConfig9_Impl: Sized {
     fn SetMonitor(&self, udev: u32) -> ::windows::core::Result<()>;
@@ -38412,6 +38955,7 @@ impl IVMRMonitorConfig9_Vtbl {
         iid == &<IVMRMonitorConfig9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_DirectDraw")]
 pub trait IVMRSurface_Impl: Sized {
     fn IsSurfaceLocked(&self) -> ::windows::core::Result<()>;
@@ -38462,6 +39006,7 @@ impl IVMRSurface_Vtbl {
         iid == &<IVMRSurface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 pub trait IVMRSurface9_Impl: Sized {
     fn IsSurfaceLocked(&self) -> ::windows::core::Result<()>;
@@ -38518,6 +39063,7 @@ impl IVMRSurface9_Vtbl {
         iid == &<IVMRSurface9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRSurfaceAllocator_Impl: Sized {
     fn AllocateSurface(&self, dwuserid: usize, lpallocinfo: *mut VMRALLOCATIONINFO, lpdwactualbuffers: *mut u32, lplpsurface: *mut ::core::option::Option<super::super::Graphics::DirectDraw::IDirectDrawSurface7>) -> ::windows::core::Result<()>;
@@ -38562,6 +39108,7 @@ impl IVMRSurfaceAllocator_Vtbl {
         iid == &<IVMRSurfaceAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IVMRSurfaceAllocator9_Impl: Sized {
     fn InitializeDevice(&self, dwuserid: usize, lpallocinfo: *const VMR9AllocationInfo, lpnumbuffers: *mut u32) -> ::windows::core::Result<()>;
@@ -38612,6 +39159,7 @@ impl IVMRSurfaceAllocator9_Vtbl {
         iid == &<IVMRSurfaceAllocator9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IVMRSurfaceAllocatorEx9_Impl: Sized + IVMRSurfaceAllocator9_Impl {
     fn GetSurfaceEx(&self, dwuserid: usize, surfaceindex: u32, surfaceflags: u32, lplpsurface: *mut ::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, lprcdst: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -38632,6 +39180,7 @@ impl IVMRSurfaceAllocatorEx9_Vtbl {
         iid == &<IVMRSurfaceAllocatorEx9 as ::windows::core::Interface>::IID || iid == &<IVMRSurfaceAllocator9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRSurfaceAllocatorNotify_Impl: Sized {
     fn AdviseSurfaceAllocator(&self, dwuserid: usize, lpivrmsurfaceallocator: &::core::option::Option<IVMRSurfaceAllocator>) -> ::windows::core::Result<()>;
@@ -38690,6 +39239,7 @@ impl IVMRSurfaceAllocatorNotify_Vtbl {
         iid == &<IVMRSurfaceAllocatorNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRSurfaceAllocatorNotify9_Impl: Sized {
     fn AdviseSurfaceAllocator(&self, dwuserid: usize, lpivrmsurfaceallocator: &::core::option::Option<IVMRSurfaceAllocator9>) -> ::windows::core::Result<()>;
@@ -38741,6 +39291,7 @@ impl IVMRSurfaceAllocatorNotify9_Vtbl {
         iid == &<IVMRSurfaceAllocatorNotify9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IVMRVideoStreamControl_Impl: Sized {
     fn SetColorKey(&self, lpclrkey: *mut super::super::Graphics::DirectDraw::DDCOLORKEY) -> ::windows::core::Result<()>;
@@ -38785,6 +39336,7 @@ impl IVMRVideoStreamControl_Vtbl {
         iid == &<IVMRVideoStreamControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVMRVideoStreamControl9_Impl: Sized {
     fn SetStreamActiveState(&self, factive: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -38821,6 +39373,7 @@ impl IVMRVideoStreamControl9_Vtbl {
         iid == &<IVMRVideoStreamControl9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRWindowlessControl_Impl: Sized {
     fn GetNativeVideoSize(&self, lpwidth: *mut i32, lpheight: *mut i32, lparwidth: *mut i32, lparheight: *mut i32) -> ::windows::core::Result<()>;
@@ -38942,6 +39495,7 @@ impl IVMRWindowlessControl_Vtbl {
         iid == &<IVMRWindowlessControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IVMRWindowlessControl9_Impl: Sized {
     fn GetNativeVideoSize(&self, lpwidth: *mut i32, lpheight: *mut i32, lparwidth: *mut i32, lparheight: *mut i32) -> ::windows::core::Result<()>;
@@ -39067,6 +39621,7 @@ impl IVMRWindowlessControl9_Vtbl {
         iid == &<IVMRWindowlessControl9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IVPBaseConfig_Impl: Sized {
     fn GetConnectInfo(&self, pdwnumconnectinfo: *mut u32, pddvpconnectinfo: *mut super::super::Graphics::DirectDraw::DDVIDEOPORTCONNECT) -> ::windows::core::Result<()>;
@@ -39180,6 +39735,7 @@ impl IVPBaseConfig_Vtbl {
         iid == &<IVPBaseConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVPBaseNotify_Impl: Sized {
     fn RenegotiateVPParameters(&self) -> ::windows::core::Result<()>;
 }
@@ -39197,6 +39753,7 @@ impl IVPBaseNotify_Vtbl {
         iid == &<IVPBaseNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IVPConfig_Impl: Sized + IVPBaseConfig_Impl {
     fn IsVPDecimationAllowed(&self, pbisdecimationallowed: *mut i32) -> ::windows::core::Result<()>;
@@ -39227,6 +39784,7 @@ impl IVPConfig_Vtbl {
         iid == &<IVPConfig as ::windows::core::Interface>::IID || iid == &<IVPBaseConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVPManager_Impl: Sized {
     fn SetVideoPortIndex(&self, dwvideoportindex: u32) -> ::windows::core::Result<()>;
     fn GetVideoPortIndex(&self, pdwvideoportindex: *mut u32) -> ::windows::core::Result<()>;
@@ -39254,6 +39812,7 @@ impl IVPManager_Vtbl {
         iid == &<IVPManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVPNotify_Impl: Sized + IVPBaseNotify_Impl {
     fn SetDeinterlaceMode(&self, mode: AMVP_MODE) -> ::windows::core::Result<()>;
     fn GetDeinterlaceMode(&self, pmode: *mut AMVP_MODE) -> ::windows::core::Result<()>;
@@ -39281,6 +39840,7 @@ impl IVPNotify_Vtbl {
         iid == &<IVPNotify as ::windows::core::Interface>::IID || iid == &<IVPBaseNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVPNotify2_Impl: Sized + IVPNotify_Impl {
     fn SetVPSyncMaster(&self, bvpsyncmaster: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -39311,6 +39871,7 @@ impl IVPNotify2_Vtbl {
         iid == &<IVPNotify2 as ::windows::core::Interface>::IID || iid == &<IVPBaseNotify as ::windows::core::Interface>::IID || iid == &<IVPNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectDraw\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
 pub trait IVPVBIConfig_Impl: Sized + IVPBaseConfig_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectDraw"))]
@@ -39324,6 +39885,7 @@ impl IVPVBIConfig_Vtbl {
         iid == &<IVPVBIConfig as ::windows::core::Interface>::IID || iid == &<IVPBaseConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVPVBINotify_Impl: Sized + IVPBaseNotify_Impl {}
 impl ::windows::core::RuntimeName for IVPVBINotify {}
 impl IVPVBINotify_Vtbl {
@@ -39334,6 +39896,7 @@ impl IVPVBINotify_Vtbl {
         iid == &<IVPVBINotify as ::windows::core::Interface>::IID || iid == &<IVPBaseNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVideoEncoder_Impl: Sized + IEncoderAPI_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -39347,6 +39910,7 @@ impl IVideoEncoder_Vtbl {
         iid == &<IVideoEncoder as ::windows::core::Interface>::IID || iid == &<IEncoderAPI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVideoFrameStep_Impl: Sized {
     fn Step(&self, dwframes: u32, pstepobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn CanStep(&self, bmultiple: i32, pstepobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -39381,6 +39945,7 @@ impl IVideoFrameStep_Vtbl {
         iid == &<IVideoFrameStep as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IVideoProcAmp_Impl: Sized {
     fn get_BacklightCompensation(&self, pvalue: *mut i32, pflags: *mut i32) -> ::windows::core::Result<()>;
     fn put_BacklightCompensation(&self, value: i32, flags: i32) -> ::windows::core::Result<()>;
@@ -39667,6 +40232,7 @@ impl IVideoProcAmp_Vtbl {
         iid == &<IVideoProcAmp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVideoWindow_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetCaption(&self, strcaption: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -40052,6 +40618,7 @@ impl IVideoWindow_Vtbl {
         iid == &<IVideoWindow as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_Media_WindowsMediaFormat"))]
 pub trait IWMCodecAMVideoAccelerator_Impl: Sized {
     fn SetAcceleratorInterface(&self, piamva: &::core::option::Option<IAMVideoAccelerator>) -> ::windows::core::Result<()>;
@@ -40089,6 +40656,7 @@ impl IWMCodecAMVideoAccelerator_Vtbl {
         iid == &<IWMCodecAMVideoAccelerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation", feature = "Win32_Media_WindowsMediaFormat"))]
 pub trait IWMCodecVideoAccelerator_Impl: Sized {
     fn NegotiateConnection(&self, piamva: &::core::option::Option<IAMVideoAccelerator>, pmediatype: *const super::MediaFoundation::AM_MEDIA_TYPE) -> ::windows::core::Result<()>;
@@ -40119,6 +40687,7 @@ impl IWMCodecVideoAccelerator_Vtbl {
         iid == &<IWMCodecVideoAccelerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IXDSCodec_Impl: Sized {
     fn XDSToRatObjOK(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
     fn SetCCSubstreamService(&self, substreammask: i32) -> ::windows::core::Result<()>;
@@ -40199,6 +40768,7 @@ impl IXDSCodec_Vtbl {
         iid == &<IXDSCodec as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"implement\"`*"]
 pub trait IXDSCodecConfig_Impl: Sized {
     fn GetSecureChannelObject(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn SetPauseBufferTime(&self, dwpausebuffertime: u32) -> ::windows::core::Result<()>;
@@ -40232,6 +40802,7 @@ impl IXDSCodecConfig_Vtbl {
         iid == &<IXDSCodecConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXDSCodecEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -40245,6 +40816,7 @@ impl IXDSCodecEvents_Vtbl {
         iid == &<IXDSCodecEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IXDSToRat_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Init(&self) -> ::windows::core::Result<()>;
@@ -40275,6 +40847,7 @@ impl IXDSToRat_Vtbl {
         iid == &<IXDSToRat as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DirectShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IMSVidCtlEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 pub trait IDMOQualityControl_Impl: Sized {
     fn SetNow(&self, rtnow: i64) -> ::windows::core::Result<()>;
     fn SetStatus(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -38,6 +39,7 @@ impl IDMOQualityControl_Vtbl {
         iid == &<IDMOQualityControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 pub trait IDMOVideoOutputOptimizations_Impl: Sized {
     fn QueryOperationModePreferences(&self, uloutputstreamindex: u32) -> ::windows::core::Result<u32>;
     fn SetOperationMode(&self, uloutputstreamindex: u32, dwenabledfeatures: u32) -> ::windows::core::Result<()>;
@@ -97,6 +99,7 @@ impl IDMOVideoOutputOptimizations_Vtbl {
         iid == &<IDMOVideoOutputOptimizations as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 pub trait IEnumDMO_Impl: Sized {
     fn Next(&self, citemstofetch: u32, pclsid: *mut ::windows::core::GUID, names: *mut ::windows::core::PWSTR, pcitemsfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, citemstoskip: u32) -> ::windows::core::Result<()>;
@@ -144,6 +147,7 @@ impl IEnumDMO_Vtbl {
         iid == &<IEnumDMO as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 pub trait IMediaBuffer_Impl: Sized {
     fn SetLength(&self, cblength: u32) -> ::windows::core::Result<()>;
     fn GetMaxLength(&self) -> ::windows::core::Result<u32>;
@@ -184,6 +188,7 @@ impl IMediaBuffer_Vtbl {
         iid == &<IMediaBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMediaObject_Impl: Sized {
     fn GetStreamCount(&self, pcinputstreams: *mut u32, pcoutputstreams: *mut u32) -> ::windows::core::Result<()>;
@@ -383,6 +388,7 @@ impl IMediaObject_Vtbl {
         iid == &<IMediaObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 pub trait IMediaObjectInPlace_Impl: Sized {
     fn Process(&self, ulsize: u32, pdata: *mut u8, reftimestart: i64, dwflags: u32) -> ::windows::core::Result<()>;
     fn Clone(&self) -> ::windows::core::Result<IMediaObjectInPlace>;

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 pub trait IKsAggregateControl_Impl: Sized {
     fn KsAddAggregate(&self, aggregateclass: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn KsRemoveAggregate(&self, aggregateclass: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -25,6 +26,7 @@ impl IKsAggregateControl_Vtbl {
         iid == &<IKsAggregateControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 pub trait IKsControl_Impl: Sized {
     fn KsProperty(&self, property: *const KSIDENTIFIER, propertylength: u32, propertydata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::Result<()>;
     fn KsMethod(&self, method: *const KSIDENTIFIER, methodlength: u32, methoddata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::Result<()>;
@@ -59,6 +61,7 @@ impl IKsControl_Vtbl {
         iid == &<IKsControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IKsFormatSupport_Impl: Sized {
     fn IsFormatSupported(&self, pksformat: *mut KSDATAFORMAT, cbformat: u32, pbsupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -95,6 +98,7 @@ impl IKsFormatSupport_Vtbl {
         iid == &<IKsFormatSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 pub trait IKsJackContainerId_Impl: Sized {
     fn GetJackContainerId(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -118,6 +122,7 @@ impl IKsJackContainerId_Vtbl {
         iid == &<IKsJackContainerId as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IKsJackDescription_Impl: Sized {
     fn GetJackCount(&self) -> ::windows::core::Result<u32>;
@@ -160,6 +165,7 @@ impl IKsJackDescription_Vtbl {
         iid == &<IKsJackDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 pub trait IKsJackDescription2_Impl: Sized {
     fn GetJackCount(&self) -> ::windows::core::Result<u32>;
     fn GetJackDescription2(&self, njack: u32) -> ::windows::core::Result<KSJACK_DESCRIPTION2>;
@@ -199,6 +205,7 @@ impl IKsJackDescription2_Vtbl {
         iid == &<IKsJackDescription2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IKsJackSinkInformation_Impl: Sized {
     fn GetJackSinkInformation(&self) -> ::windows::core::Result<KSJACK_SINK_INFORMATION>;
@@ -225,6 +232,7 @@ impl IKsJackSinkInformation_Vtbl {
         iid == &<IKsJackSinkInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 pub trait IKsPropertySet_Impl: Sized {
     fn Set(&self, propset: *const ::windows::core::GUID, id: u32, instancedata: *const ::core::ffi::c_void, instancelength: u32, propertydata: *const ::core::ffi::c_void, datalength: u32) -> ::windows::core::Result<()>;
     fn Get(&self, propset: *const ::windows::core::GUID, id: u32, instancedata: *const ::core::ffi::c_void, instancelength: u32, propertydata: *mut ::core::ffi::c_void, datalength: u32, bytesreturned: *mut u32) -> ::windows::core::Result<()>;
@@ -265,6 +273,7 @@ impl IKsPropertySet_Vtbl {
         iid == &<IKsPropertySet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`, `\"implement\"`*"]
 pub trait IKsTopology_Impl: Sized {
     fn CreateNodeInstance(&self, nodeid: u32, flags: u32, desiredaccess: u32, unkouter: &::core::option::Option<::windows::core::IUnknown>, interfaceid: *const ::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/LibrarySharingServices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_LibrarySharingServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsMediaLibrarySharingDevice_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DeviceID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -60,6 +61,7 @@ impl IWindowsMediaLibrarySharingDevice_Vtbl {
         iid == &<IWindowsMediaLibrarySharingDevice as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_LibrarySharingServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsMediaLibrarySharingDeviceProperties_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IWindowsMediaLibrarySharingDeviceProperty>;
@@ -115,6 +117,7 @@ impl IWindowsMediaLibrarySharingDeviceProperties_Vtbl {
         iid == &<IWindowsMediaLibrarySharingDeviceProperties as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_LibrarySharingServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsMediaLibrarySharingDeviceProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -157,6 +160,7 @@ impl IWindowsMediaLibrarySharingDeviceProperty_Vtbl {
         iid == &<IWindowsMediaLibrarySharingDeviceProperty as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_LibrarySharingServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsMediaLibrarySharingDevices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IWindowsMediaLibrarySharingDevice>;
@@ -212,6 +216,7 @@ impl IWindowsMediaLibrarySharingDevices_Vtbl {
         iid == &<IWindowsMediaLibrarySharingDevices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_LibrarySharingServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsMediaLibrarySharingServices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn showShareMediaCPL(&self, device: &::windows::core::BSTR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IAdvancedMediaCapture_Impl: Sized {
     fn GetAdvancedMediaCaptureSettings(&self) -> ::windows::core::Result<IAdvancedMediaCaptureSettings>;
 }
@@ -24,6 +25,7 @@ impl IAdvancedMediaCapture_Vtbl {
         iid == &<IAdvancedMediaCapture as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IAdvancedMediaCaptureInitializationSettings_Impl: Sized {
     fn SetDirectxDeviceManager(&self, value: &::core::option::Option<IMFDXGIDeviceManager>) -> ::windows::core::Result<()>;
 }
@@ -41,6 +43,7 @@ impl IAdvancedMediaCaptureInitializationSettings_Vtbl {
         iid == &<IAdvancedMediaCaptureInitializationSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IAdvancedMediaCaptureSettings_Impl: Sized {
     fn GetDirectxDeviceManager(&self) -> ::windows::core::Result<IMFDXGIDeviceManager>;
 }
@@ -64,6 +67,7 @@ impl IAdvancedMediaCaptureSettings_Vtbl {
         iid == &<IAdvancedMediaCaptureSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IAudioSourceProvider_Impl: Sized {
     fn ProvideInput(&self, dwsamplecount: u32, pdwchannelcount: *mut u32, pinterleavedaudiodata: *mut f32) -> ::windows::core::Result<()>;
 }
@@ -81,6 +85,7 @@ impl IAudioSourceProvider_Vtbl {
         iid == &<IAudioSourceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IClusterDetector_Impl: Sized {
     fn Initialize(&self, wbaseentrylevel: u16, wclusterentrylevel: u16) -> ::windows::core::Result<()>;
     fn Detect(&self, dwmaxnumclusters: u32, fminclusterduration: f32, fmaxclusterduration: f32, psrctoc: &::core::option::Option<IToc>) -> ::windows::core::Result<IToc>;
@@ -114,6 +119,7 @@ impl IClusterDetector_Vtbl {
         iid == &<IClusterDetector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICodecAPI_Impl: Sized {
     fn IsSupported(&self, api: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -247,6 +253,7 @@ impl ICodecAPI_Vtbl {
         iid == &<ICodecAPI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecodeCommandList_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12CommandList_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -361,6 +368,7 @@ impl ID3D12VideoDecodeCommandList_Vtbl {
         iid == &<ID3D12VideoDecodeCommandList as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecodeCommandList1_Impl: Sized + ID3D12VideoDecodeCommandList_Impl {
     fn DecodeFrame1(&self, pdecoder: &::core::option::Option<ID3D12VideoDecoder>, poutputarguments: *const D3D12_VIDEO_DECODE_OUTPUT_STREAM_ARGUMENTS1, pinputarguments: *const D3D12_VIDEO_DECODE_INPUT_STREAM_ARGUMENTS);
@@ -381,6 +389,7 @@ impl ID3D12VideoDecodeCommandList1_Vtbl {
         iid == &<ID3D12VideoDecodeCommandList1 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDecodeCommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecodeCommandList2_Impl: Sized + ID3D12VideoDecodeCommandList1_Impl {
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>);
@@ -418,6 +427,7 @@ impl ID3D12VideoDecodeCommandList2_Vtbl {
         iid == &<ID3D12VideoDecodeCommandList2 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDecodeCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDecodeCommandList1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoDecoder_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_DECODER_DESC;
@@ -438,6 +448,7 @@ impl ID3D12VideoDecoder_Vtbl {
         iid == &<ID3D12VideoDecoder as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoDecoder1_Impl: Sized + ID3D12VideoDecoder_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -461,6 +472,7 @@ impl ID3D12VideoDecoder1_Vtbl {
         iid == &<ID3D12VideoDecoder1 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDecoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecoderHeap_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_DECODER_HEAP_DESC;
@@ -481,6 +493,7 @@ impl ID3D12VideoDecoderHeap_Vtbl {
         iid == &<ID3D12VideoDecoderHeap as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDecoderHeap1_Impl: Sized + ID3D12VideoDecoderHeap_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -504,6 +517,7 @@ impl ID3D12VideoDecoderHeap1_Vtbl {
         iid == &<ID3D12VideoDecoderHeap1 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDecoderHeap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDevice_Impl: Sized {
     fn CheckFeatureSupport(&self, featurevideo: D3D12_FEATURE_VIDEO, pfeaturesupportdata: *mut ::core::ffi::c_void, featuresupportdatasize: u32) -> ::windows::core::Result<()>;
@@ -548,6 +562,7 @@ impl ID3D12VideoDevice_Vtbl {
         iid == &<ID3D12VideoDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDevice1_Impl: Sized + ID3D12VideoDevice_Impl {
     fn CreateVideoMotionEstimator(&self, pdesc: *const D3D12_VIDEO_MOTION_ESTIMATOR_DESC, pprotectedresourcesession: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>, riid: *const ::windows::core::GUID, ppvideomotionestimator: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -578,6 +593,7 @@ impl ID3D12VideoDevice1_Vtbl {
         iid == &<ID3D12VideoDevice1 as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDevice2_Impl: Sized + ID3D12VideoDevice1_Impl {
     fn CreateVideoDecoder1(&self, pdesc: *const D3D12_VIDEO_DECODER_DESC, pprotectedresourcesession: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>, riid: *const ::windows::core::GUID, ppvideodecoder: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -629,6 +645,7 @@ impl ID3D12VideoDevice2_Vtbl {
         iid == &<ID3D12VideoDevice2 as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDevice as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDevice1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoDevice3_Impl: Sized + ID3D12VideoDevice2_Impl {
     fn CreateVideoEncoder(&self, pdesc: *const D3D12_VIDEO_ENCODER_DESC, riid: *const ::windows::core::GUID, ppvideoencoder: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -659,6 +676,7 @@ impl ID3D12VideoDevice3_Vtbl {
         iid == &<ID3D12VideoDevice3 as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDevice as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDevice1 as ::windows::core::Interface>::IID || iid == &<ID3D12VideoDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D12VideoEncodeCommandList_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12CommandList_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -787,6 +805,7 @@ impl ID3D12VideoEncodeCommandList_Vtbl {
         iid == &<ID3D12VideoEncodeCommandList as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D12VideoEncodeCommandList1_Impl: Sized + ID3D12VideoEncodeCommandList_Impl {
     fn InitializeExtensionCommand(&self, pextensioncommand: &::core::option::Option<ID3D12VideoExtensionCommand>, pinitializationparameters: *const ::core::ffi::c_void, initializationparameterssizeinbytes: usize);
@@ -817,6 +836,7 @@ impl ID3D12VideoEncodeCommandList1_Vtbl {
         iid == &<ID3D12VideoEncodeCommandList1 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoEncodeCommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoEncodeCommandList2_Impl: Sized + ID3D12VideoEncodeCommandList1_Impl {
     fn EncodeFrame(&self, pencoder: &::core::option::Option<ID3D12VideoEncoder>, pheap: &::core::option::Option<ID3D12VideoEncoderHeap>, pinputarguments: *const D3D12_VIDEO_ENCODER_ENCODEFRAME_INPUT_ARGUMENTS, poutputarguments: *const D3D12_VIDEO_ENCODER_ENCODEFRAME_OUTPUT_ARGUMENTS);
@@ -847,6 +867,7 @@ impl ID3D12VideoEncodeCommandList2_Vtbl {
         iid == &<ID3D12VideoEncodeCommandList2 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoEncodeCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoEncodeCommandList1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoEncoder_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetNodeMask(&self) -> u32;
@@ -912,6 +933,7 @@ impl ID3D12VideoEncoder_Vtbl {
         iid == &<ID3D12VideoEncoder as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoEncoderHeap_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetNodeMask(&self) -> u32;
@@ -977,6 +999,7 @@ impl ID3D12VideoEncoderHeap_Vtbl {
         iid == &<ID3D12VideoEncoderHeap as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ID3D12VideoExtensionCommand_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_EXTENSION_COMMAND_DESC;
@@ -1007,6 +1030,7 @@ impl ID3D12VideoExtensionCommand_Vtbl {
         iid == &<ID3D12VideoExtensionCommand as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoMotionEstimator_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_MOTION_ESTIMATOR_DESC;
@@ -1037,6 +1061,7 @@ impl ID3D12VideoMotionEstimator_Vtbl {
         iid == &<ID3D12VideoMotionEstimator as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoMotionVectorHeap_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetDesc(&self) -> D3D12_VIDEO_MOTION_VECTOR_HEAP_DESC;
@@ -1067,6 +1092,7 @@ impl ID3D12VideoMotionVectorHeap_Vtbl {
         iid == &<ID3D12VideoMotionVectorHeap as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D12VideoProcessCommandList_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12CommandList_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -1181,6 +1207,7 @@ impl ID3D12VideoProcessCommandList_Vtbl {
         iid == &<ID3D12VideoProcessCommandList as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D12VideoProcessCommandList1_Impl: Sized + ID3D12VideoProcessCommandList_Impl {
     fn ProcessFrames1(&self, pvideoprocessor: &::core::option::Option<ID3D12VideoProcessor>, poutputarguments: *const D3D12_VIDEO_PROCESS_OUTPUT_STREAM_ARGUMENTS, numinputstreams: u32, pinputarguments: *const D3D12_VIDEO_PROCESS_INPUT_STREAM_ARGUMENTS1);
@@ -1201,6 +1228,7 @@ impl ID3D12VideoProcessCommandList1_Vtbl {
         iid == &<ID3D12VideoProcessCommandList1 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoProcessCommandList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 pub trait ID3D12VideoProcessCommandList2_Impl: Sized + ID3D12VideoProcessCommandList1_Impl {
     fn SetProtectedResourceSession(&self, pprotectedresourcesession: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12ProtectedResourceSession>);
@@ -1238,6 +1266,7 @@ impl ID3D12VideoProcessCommandList2_Vtbl {
         iid == &<ID3D12VideoProcessCommandList2 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12CommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoProcessCommandList as ::windows::core::Interface>::IID || iid == &<ID3D12VideoProcessCommandList1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoProcessor_Impl: Sized + super::super::Graphics::Direct3D12::ID3D12Pageable_Impl {
     fn GetNodeMask(&self) -> u32;
@@ -1282,6 +1311,7 @@ impl ID3D12VideoProcessor_Vtbl {
         iid == &<ID3D12VideoProcessor as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait ID3D12VideoProcessor1_Impl: Sized + ID3D12VideoProcessor_Impl {
     fn GetProtectedResourceSession(&self, riid: *const ::windows::core::GUID, ppprotectedsession: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1305,6 +1335,7 @@ impl ID3D12VideoProcessor1_Vtbl {
         iid == &<ID3D12VideoProcessor1 as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Object as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12DeviceChild as ::windows::core::Interface>::IID || iid == &<super::super::Graphics::Direct3D12::ID3D12Pageable as ::windows::core::Interface>::IID || iid == &<ID3D12VideoProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDXVAHD_Device_Impl: Sized {
     fn CreateVideoSurface(&self, width: u32, height: u32, format: super::super::Graphics::Direct3D9::D3DFORMAT, pool: super::super::Graphics::Direct3D9::D3DPOOL, usage: u32, r#type: DXVAHD_SURFACE_TYPE, numsurfaces: u32, ppsurfaces: *mut ::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, psharedhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -1395,6 +1426,7 @@ impl IDXVAHD_Device_Vtbl {
         iid == &<IDXVAHD_Device as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDXVAHD_VideoProcessor_Impl: Sized {
     fn SetVideoProcessBltState(&self, state: DXVAHD_BLT_STATE, datasize: u32, pdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1446,6 +1478,7 @@ impl IDXVAHD_VideoProcessor_Vtbl {
         iid == &<IDXVAHD_VideoProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 pub trait IDirect3D9ExOverlayExtension_Impl: Sized {
     fn CheckDeviceOverlayType(&self, adapter: u32, devtype: super::super::Graphics::Direct3D9::D3DDEVTYPE, overlaywidth: u32, overlayheight: u32, overlayformat: super::super::Graphics::Direct3D9::D3DFORMAT, pdisplaymode: *mut super::super::Graphics::Direct3D9::D3DDISPLAYMODEEX, displayrotation: super::super::Graphics::Direct3D9::D3DDISPLAYROTATION, poverlaycaps: *mut D3DOVERLAYCAPS) -> ::windows::core::Result<()>;
@@ -1466,6 +1499,7 @@ impl IDirect3D9ExOverlayExtension_Vtbl {
         iid == &<IDirect3D9ExOverlayExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirect3DAuthenticatedChannel9_Impl: Sized {
     fn GetCertificateSize(&self, pcertificatesize: *mut u32) -> ::windows::core::Result<()>;
@@ -1517,6 +1551,7 @@ impl IDirect3DAuthenticatedChannel9_Vtbl {
         iid == &<IDirect3DAuthenticatedChannel9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D9")]
 pub trait IDirect3DCryptoSession9_Impl: Sized {
     fn GetCertificateSize(&self, pcertificatesize: *mut u32) -> ::windows::core::Result<()>;
@@ -1596,6 +1631,7 @@ impl IDirect3DCryptoSession9_Vtbl {
         iid == &<IDirect3DCryptoSession9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirect3DDevice9Video_Impl: Sized {
     fn GetContentProtectionCaps(&self, pcryptotype: *const ::windows::core::GUID, pdecodeprofile: *const ::windows::core::GUID, pcaps: *mut D3DCONTENTPROTECTIONCAPS) -> ::windows::core::Result<()>;
@@ -1633,6 +1669,7 @@ impl IDirect3DDevice9Video_Vtbl {
         iid == &<IDirect3DDevice9Video as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirect3DDeviceManager9_Impl: Sized {
     fn ResetDevice(&self, pdevice: &::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DDevice9>, resettoken: u32) -> ::windows::core::Result<()>;
@@ -1704,6 +1741,7 @@ impl IDirect3DDeviceManager9_Vtbl {
         iid == &<IDirect3DDeviceManager9 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirectXVideoAccelerationService_Impl: Sized {
     fn CreateSurface(&self, width: u32, height: u32, backbuffers: u32, format: super::super::Graphics::Direct3D9::D3DFORMAT, pool: super::super::Graphics::Direct3D9::D3DPOOL, usage: u32, dxvatype: DXVA2_VideoRenderTargetType, ppsurface: *mut ::core::option::Option<super::super::Graphics::Direct3D9::IDirect3DSurface9>, psharedhandle: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -1724,6 +1762,7 @@ impl IDirectXVideoAccelerationService_Vtbl {
         iid == &<IDirectXVideoAccelerationService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirectXVideoDecoder_Impl: Sized {
     fn GetVideoDecoderService(&self) -> ::windows::core::Result<IDirectXVideoDecoderService>;
@@ -1795,6 +1834,7 @@ impl IDirectXVideoDecoder_Vtbl {
         iid == &<IDirectXVideoDecoder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirectXVideoDecoderService_Impl: Sized + IDirectXVideoAccelerationService_Impl {
     fn GetDecoderDeviceGuids(&self, pcount: *mut u32, pguids: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1845,6 +1885,7 @@ impl IDirectXVideoDecoderService_Vtbl {
         iid == &<IDirectXVideoDecoderService as ::windows::core::Interface>::IID || iid == &<IDirectXVideoAccelerationService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IDirectXVideoMemoryConfiguration_Impl: Sized {
     fn GetAvailableSurfaceTypeByIndex(&self, dwtypeindex: u32) -> ::windows::core::Result<DXVA2_SurfaceType>;
     fn SetSurfaceType(&self, dwtype: DXVA2_SurfaceType) -> ::windows::core::Result<()>;
@@ -1878,6 +1919,7 @@ impl IDirectXVideoMemoryConfiguration_Vtbl {
         iid == &<IDirectXVideoMemoryConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirectXVideoProcessor_Impl: Sized {
     fn GetVideoProcessorService(&self) -> ::windows::core::Result<IDirectXVideoProcessorService>;
@@ -1960,6 +2002,7 @@ impl IDirectXVideoProcessor_Vtbl {
         iid == &<IDirectXVideoProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IDirectXVideoProcessorService_Impl: Sized + IDirectXVideoAccelerationService_Impl {
     fn RegisterVideoProcessorSoftwareDevice(&self, pcallbacks: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2056,6 +2099,7 @@ impl IDirectXVideoProcessorService_Vtbl {
         iid == &<IDirectXVideoProcessorService as ::windows::core::Interface>::IID || iid == &<IDirectXVideoAccelerationService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IEVRFilterConfig_Impl: Sized {
     fn SetNumberOfStreams(&self, dwmaxstreams: u32) -> ::windows::core::Result<()>;
     fn GetNumberOfStreams(&self) -> ::windows::core::Result<u32>;
@@ -2089,6 +2133,7 @@ impl IEVRFilterConfig_Vtbl {
         iid == &<IEVRFilterConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IEVRFilterConfigEx_Impl: Sized + IEVRFilterConfig_Impl {
     fn SetConfigPrefs(&self, dwconfigflags: u32) -> ::windows::core::Result<()>;
     fn GetConfigPrefs(&self) -> ::windows::core::Result<u32>;
@@ -2122,6 +2167,7 @@ impl IEVRFilterConfigEx_Vtbl {
         iid == &<IEVRFilterConfigEx as ::windows::core::Interface>::IID || iid == &<IEVRFilterConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEVRTrustedVideoPlugin_Impl: Sized {
     fn IsInTrustedVideoMode(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2178,6 +2224,7 @@ impl IEVRTrustedVideoPlugin_Vtbl {
         iid == &<IEVRTrustedVideoPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEVRVideoStreamControl_Impl: Sized {
     fn SetStreamActiveState(&self, factive: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2214,6 +2261,7 @@ impl IEVRVideoStreamControl_Vtbl {
         iid == &<IEVRVideoStreamControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IFileClient_Impl: Sized {
     fn GetObjectDiskSize(&self, pqwsize: *mut u64) -> ::windows::core::Result<()>;
     fn Write(&self, pfio: &::core::option::Option<IFileIo>) -> ::windows::core::Result<()>;
@@ -2248,6 +2296,7 @@ impl IFileClient_Vtbl {
         iid == &<IFileClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFileIo_Impl: Sized {
     fn Initialize(&self, eaccessmode: FILE_ACCESSMODE, eopenmode: FILE_OPENMODE, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -2334,6 +2383,7 @@ impl IFileIo_Vtbl {
         iid == &<IFileIo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMF2DBuffer_Impl: Sized {
     fn Lock2D(&self, ppbscanline0: *mut *mut u8, plpitch: *mut i32) -> ::windows::core::Result<()>;
@@ -2411,6 +2461,7 @@ impl IMF2DBuffer_Vtbl {
         iid == &<IMF2DBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMF2DBuffer2_Impl: Sized + IMF2DBuffer_Impl {
     fn Lock2DSize(&self, lockflags: MF2DBuffer_LockFlags, ppbscanline0: *mut *mut u8, plpitch: *mut i32, ppbbufferstart: *mut *mut u8, pcbbufferlength: *mut u32) -> ::windows::core::Result<()>;
@@ -2441,6 +2492,7 @@ impl IMF2DBuffer2_Vtbl {
         iid == &<IMF2DBuffer2 as ::windows::core::Interface>::IID || iid == &<IMF2DBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFASFContentInfo_Impl: Sized {
     fn GetHeaderSize(&self, pistartofcontent: &::core::option::Option<IMFMediaBuffer>) -> ::windows::core::Result<u64>;
@@ -2536,6 +2588,7 @@ impl IMFASFContentInfo_Vtbl {
         iid == &<IMFASFContentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFASFIndexer_Impl: Sized {
     fn SetFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -2667,6 +2720,7 @@ impl IMFASFIndexer_Vtbl {
         iid == &<IMFASFIndexer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFASFMultiplexer_Impl: Sized {
     fn Initialize(&self, picontentinfo: &::core::option::Option<IMFASFContentInfo>) -> ::windows::core::Result<()>;
     fn SetFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -2755,6 +2809,7 @@ impl IMFASFMultiplexer_Vtbl {
         iid == &<IMFASFMultiplexer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFASFMutualExclusion_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn SetType(&self, guidtype: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -2855,6 +2910,7 @@ impl IMFASFMutualExclusion_Vtbl {
         iid == &<IMFASFMutualExclusion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFASFProfile_Impl: Sized + IMFAttributes_Impl {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
@@ -3037,6 +3093,7 @@ impl IMFASFProfile_Vtbl {
         iid == &<IMFASFProfile as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFASFSplitter_Impl: Sized {
     fn Initialize(&self, picontentinfo: &::core::option::Option<IMFASFContentInfo>) -> ::windows::core::Result<()>;
     fn SetFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -3125,6 +3182,7 @@ impl IMFASFSplitter_Vtbl {
         iid == &<IMFASFSplitter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFASFStreamConfig_Impl: Sized + IMFAttributes_Impl {
     fn GetStreamType(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3235,6 +3293,7 @@ impl IMFASFStreamConfig_Vtbl {
         iid == &<IMFASFStreamConfig as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFASFStreamPrioritization_Impl: Sized {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
     fn GetStream(&self, dwstreamindex: u32, pwstreamnumber: *mut u16, pwstreamflags: *mut u16) -> ::windows::core::Result<()>;
@@ -3295,6 +3354,7 @@ impl IMFASFStreamPrioritization_Vtbl {
         iid == &<IMFASFStreamPrioritization as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFASFStreamSelector_Impl: Sized {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
     fn GetOutputCount(&self) -> ::windows::core::Result<u32>;
@@ -3466,6 +3526,7 @@ impl IMFASFStreamSelector_Vtbl {
         iid == &<IMFASFStreamSelector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFActivate_Impl: Sized + IMFAttributes_Impl {
     fn ActivateObject(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3503,6 +3564,7 @@ impl IMFActivate_Vtbl {
         iid == &<IMFActivate as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFAsyncCallback_Impl: Sized {
     fn GetParameters(&self, pdwflags: *mut u32, pdwqueue: *mut u32) -> ::windows::core::Result<()>;
     fn Invoke(&self, pasyncresult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
@@ -3530,6 +3592,7 @@ impl IMFAsyncCallback_Vtbl {
         iid == &<IMFAsyncCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFAsyncCallbackLogging_Impl: Sized + IMFAsyncCallback_Impl {
     fn GetObjectPointer(&self) -> *mut ::core::ffi::c_void;
     fn GetObjectTag(&self) -> u32;
@@ -3557,6 +3620,7 @@ impl IMFAsyncCallbackLogging_Vtbl {
         iid == &<IMFAsyncCallbackLogging as ::windows::core::Interface>::IID || iid == &<IMFAsyncCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFAsyncResult_Impl: Sized {
     fn GetState(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetStatus(&self) -> ::windows::core::Result<()>;
@@ -3617,6 +3681,7 @@ impl IMFAsyncResult_Vtbl {
         iid == &<IMFAsyncResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFAttributes_Impl: Sized {
     fn GetItem(&self, guidkey: *const ::windows::core::GUID, pvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -3903,6 +3968,7 @@ impl IMFAttributes_Vtbl {
         iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFAudioMediaType_Impl: Sized + IMFMediaType_Impl {
     fn GetAudioFormat(&self) -> *mut super::Audio::WAVEFORMATEX;
@@ -3923,6 +3989,7 @@ impl IMFAudioMediaType_Vtbl {
         iid == &<IMFAudioMediaType as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID || iid == &<IMFMediaType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFAudioPolicy_Impl: Sized {
     fn SetGroupingParam(&self, rguidclass: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetGroupingParam(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3996,6 +4063,7 @@ impl IMFAudioPolicy_Vtbl {
         iid == &<IMFAudioPolicy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFAudioStreamVolume_Impl: Sized {
     fn GetChannelCount(&self) -> ::windows::core::Result<u32>;
     fn SetChannelVolume(&self, dwindex: u32, flevel: f32) -> ::windows::core::Result<()>;
@@ -4056,6 +4124,7 @@ impl IMFAudioStreamVolume_Vtbl {
         iid == &<IMFAudioStreamVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFBufferListNotify_Impl: Sized {
     fn OnAddSourceBuffer(&self);
     fn OnRemoveSourceBuffer(&self);
@@ -4083,6 +4152,7 @@ impl IMFBufferListNotify_Vtbl {
         iid == &<IMFBufferListNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFByteStream_Impl: Sized {
     fn GetCapabilities(&self) -> ::windows::core::Result<u32>;
@@ -4252,6 +4322,7 @@ impl IMFByteStream_Vtbl {
         iid == &<IMFByteStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFByteStreamBuffering_Impl: Sized {
     fn SetBufferingParams(&self, pparams: *const MFBYTESTREAM_BUFFERING_PARAMS) -> ::windows::core::Result<()>;
@@ -4289,6 +4360,7 @@ impl IMFByteStreamBuffering_Vtbl {
         iid == &<IMFByteStreamBuffering as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFByteStreamCacheControl_Impl: Sized {
     fn StopBackgroundTransfer(&self) -> ::windows::core::Result<()>;
 }
@@ -4306,6 +4378,7 @@ impl IMFByteStreamCacheControl_Vtbl {
         iid == &<IMFByteStreamCacheControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFByteStreamCacheControl2_Impl: Sized + IMFByteStreamCacheControl_Impl {
     fn GetByteRanges(&self, pcranges: *mut u32, ppranges: *mut *mut MF_BYTE_STREAM_CACHE_RANGE) -> ::windows::core::Result<()>;
@@ -4349,6 +4422,7 @@ impl IMFByteStreamCacheControl2_Vtbl {
         iid == &<IMFByteStreamCacheControl2 as ::windows::core::Interface>::IID || iid == &<IMFByteStreamCacheControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFByteStreamHandler_Impl: Sized {
     fn BeginCreateObject(&self, pbytestream: &::core::option::Option<IMFByteStream>, pwszurl: &::windows::core::PCWSTR, dwflags: u32, pprops: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>, ppiunknowncancelcookie: *mut ::core::option::Option<::windows::core::IUnknown>, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -4399,6 +4473,7 @@ impl IMFByteStreamHandler_Vtbl {
         iid == &<IMFByteStreamHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFByteStreamProxyClassFactory_Impl: Sized {
     fn CreateByteStreamProxy(&self, pbytestream: &::core::option::Option<IMFByteStream>, pattributes: &::core::option::Option<IMFAttributes>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -4416,6 +4491,7 @@ impl IMFByteStreamProxyClassFactory_Vtbl {
         iid == &<IMFByteStreamProxyClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFByteStreamTimeSeek_Impl: Sized {
     fn IsTimeSeekSupported(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -4459,6 +4535,7 @@ impl IMFByteStreamTimeSeek_Vtbl {
         iid == &<IMFByteStreamTimeSeek as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCameraOcclusionStateMonitor_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -4493,6 +4570,7 @@ impl IMFCameraOcclusionStateMonitor_Vtbl {
         iid == &<IMFCameraOcclusionStateMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCameraOcclusionStateReport_Impl: Sized {
     fn GetOcclusionState(&self) -> ::windows::core::Result<u32>;
 }
@@ -4516,6 +4594,7 @@ impl IMFCameraOcclusionStateReport_Vtbl {
         iid == &<IMFCameraOcclusionStateReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCameraOcclusionStateReportCallback_Impl: Sized {
     fn OnOcclusionStateReport(&self, occlusionstatereport: &::core::option::Option<IMFCameraOcclusionStateReport>) -> ::windows::core::Result<()>;
 }
@@ -4533,6 +4612,7 @@ impl IMFCameraOcclusionStateReportCallback_Vtbl {
         iid == &<IMFCameraOcclusionStateReportCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCameraSyncObject_Impl: Sized {
     fn WaitOnSignal(&self, timeoutinms: u32) -> ::windows::core::Result<()>;
     fn Shutdown(&self);
@@ -4560,6 +4640,7 @@ impl IMFCameraSyncObject_Vtbl {
         iid == &<IMFCameraSyncObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFCaptureEngine_Impl: Sized {
     fn Initialize(&self, peventcallback: &::core::option::Option<IMFCaptureEngineOnEventCallback>, pattributes: &::core::option::Option<IMFAttributes>, paudiosource: &::core::option::Option<::windows::core::IUnknown>, pvideosource: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -4644,6 +4725,7 @@ impl IMFCaptureEngine_Vtbl {
         iid == &<IMFCaptureEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCaptureEngineClassFactory_Impl: Sized {
     fn CreateInstance(&self, clsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -4661,6 +4743,7 @@ impl IMFCaptureEngineClassFactory_Vtbl {
         iid == &<IMFCaptureEngineClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCaptureEngineOnEventCallback_Impl: Sized {
     fn OnEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
 }
@@ -4678,6 +4761,7 @@ impl IMFCaptureEngineOnEventCallback_Vtbl {
         iid == &<IMFCaptureEngineOnEventCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCaptureEngineOnSampleCallback_Impl: Sized {
     fn OnSample(&self, psample: &::core::option::Option<IMFSample>) -> ::windows::core::Result<()>;
 }
@@ -4695,6 +4779,7 @@ impl IMFCaptureEngineOnSampleCallback_Vtbl {
         iid == &<IMFCaptureEngineOnSampleCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCaptureEngineOnSampleCallback2_Impl: Sized + IMFCaptureEngineOnSampleCallback_Impl {
     fn OnSynchronizedEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
 }
@@ -4715,6 +4800,7 @@ impl IMFCaptureEngineOnSampleCallback2_Vtbl {
         iid == &<IMFCaptureEngineOnSampleCallback2 as ::windows::core::Interface>::IID || iid == &<IMFCaptureEngineOnSampleCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCapturePhotoConfirmation_Impl: Sized {
     fn SetPhotoConfirmationCallback(&self, pnotificationcallback: &::core::option::Option<IMFAsyncCallback>) -> ::windows::core::Result<()>;
     fn SetPixelFormat(&self, subtype: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -4755,6 +4841,7 @@ impl IMFCapturePhotoConfirmation_Vtbl {
         iid == &<IMFCapturePhotoConfirmation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCapturePhotoSink_Impl: Sized + IMFCaptureSink_Impl {
     fn SetOutputFileName(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetSampleCallback(&self, pcallback: &::core::option::Option<IMFCaptureEngineOnSampleCallback>) -> ::windows::core::Result<()>;
@@ -4789,6 +4876,7 @@ impl IMFCapturePhotoSink_Vtbl {
         iid == &<IMFCapturePhotoSink as ::windows::core::Interface>::IID || iid == &<IMFCaptureSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFCapturePreviewSink_Impl: Sized + IMFCaptureSink_Impl {
     fn SetRenderHandle(&self, handle: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -4880,6 +4968,7 @@ impl IMFCapturePreviewSink_Vtbl {
         iid == &<IMFCapturePreviewSink as ::windows::core::Interface>::IID || iid == &<IMFCaptureSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCaptureRecordSink_Impl: Sized + IMFCaptureSink_Impl {
     fn SetOutputByteStream(&self, pbytestream: &::core::option::Option<IMFByteStream>, guidcontainertype: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SetOutputFileName(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -4941,6 +5030,7 @@ impl IMFCaptureRecordSink_Vtbl {
         iid == &<IMFCaptureRecordSink as ::windows::core::Interface>::IID || iid == &<IMFCaptureSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCaptureSink_Impl: Sized {
     fn GetOutputMediaType(&self, dwsinkstreamindex: u32, ppmediatype: *mut ::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
     fn GetService(&self, dwsinkstreamindex: u32, rguidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppunknown: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -4989,6 +5079,7 @@ impl IMFCaptureSink_Vtbl {
         iid == &<IMFCaptureSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCaptureSink2_Impl: Sized + IMFCaptureSink_Impl {
     fn SetOutputMediaType(&self, dwstreamindex: u32, pmediatype: &::core::option::Option<IMFMediaType>, pencodingattributes: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
 }
@@ -5006,6 +5097,7 @@ impl IMFCaptureSink2_Vtbl {
         iid == &<IMFCaptureSink2 as ::windows::core::Interface>::IID || iid == &<IMFCaptureSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFCaptureSource_Impl: Sized {
     fn GetCaptureDeviceSource(&self, mfcaptureenginedevicetype: MF_CAPTURE_ENGINE_DEVICE_TYPE, ppmediasource: *mut ::core::option::Option<IMFMediaSource>) -> ::windows::core::Result<()>;
@@ -5150,6 +5242,7 @@ impl IMFCaptureSource_Vtbl {
         iid == &<IMFCaptureSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCdmSuspendNotify_Impl: Sized {
     fn Begin(&self) -> ::windows::core::Result<()>;
     fn End(&self) -> ::windows::core::Result<()>;
@@ -5173,6 +5266,7 @@ impl IMFCdmSuspendNotify_Vtbl {
         iid == &<IMFCdmSuspendNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFClock_Impl: Sized {
     fn GetClockCharacteristics(&self) -> ::windows::core::Result<u32>;
     fn GetCorrelatedTime(&self, dwreserved: u32, pllclocktime: *mut i64, phnssystemtime: *mut i64) -> ::windows::core::Result<()>;
@@ -5245,6 +5339,7 @@ impl IMFClock_Vtbl {
         iid == &<IMFClock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFClockConsumer_Impl: Sized {
     fn SetPresentationClock(&self, ppresentationclock: &::core::option::Option<IMFPresentationClock>) -> ::windows::core::Result<()>;
     fn GetPresentationClock(&self) -> ::windows::core::Result<IMFPresentationClock>;
@@ -5278,6 +5373,7 @@ impl IMFClockConsumer_Vtbl {
         iid == &<IMFClockConsumer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFClockStateSink_Impl: Sized {
     fn OnClockStart(&self, hnssystemtime: i64, llclockstartoffset: i64) -> ::windows::core::Result<()>;
     fn OnClockStop(&self, hnssystemtime: i64) -> ::windows::core::Result<()>;
@@ -5326,6 +5422,7 @@ impl IMFClockStateSink_Vtbl {
         iid == &<IMFClockStateSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFCollection_Impl: Sized {
     fn GetElementCount(&self) -> ::windows::core::Result<u32>;
     fn GetElement(&self, dwelementindex: u32) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -5399,6 +5496,7 @@ impl IMFCollection_Vtbl {
         iid == &<IMFCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFContentDecryptionModule_Impl: Sized {
     fn SetContentEnabler(&self, contentenabler: &::core::option::Option<IMFContentEnabler>, result: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
     fn GetSuspendNotify(&self) -> ::windows::core::Result<IMFCdmSuspendNotify>;
@@ -5479,6 +5577,7 @@ impl IMFContentDecryptionModule_Vtbl {
         iid == &<IMFContentDecryptionModule as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFContentDecryptionModuleAccess_Impl: Sized {
     fn CreateContentDecryptionModule(&self, contentdecryptionmoduleproperties: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<IMFContentDecryptionModule>;
@@ -5534,6 +5633,7 @@ impl IMFContentDecryptionModuleAccess_Vtbl {
         iid == &<IMFContentDecryptionModuleAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IMFContentDecryptionModuleFactory_Impl: Sized {
     fn IsTypeSupported(&self, keysystem: &::windows::core::PCWSTR, contenttype: &::windows::core::PCWSTR) -> super::super::Foundation::BOOL;
@@ -5570,6 +5670,7 @@ impl IMFContentDecryptionModuleFactory_Vtbl {
         iid == &<IMFContentDecryptionModuleFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFContentDecryptionModuleSession_Impl: Sized {
     fn GetSessionId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -5660,6 +5761,7 @@ impl IMFContentDecryptionModuleSession_Vtbl {
         iid == &<IMFContentDecryptionModuleSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFContentDecryptionModuleSessionCallbacks_Impl: Sized {
     fn KeyMessage(&self, messagetype: MF_MEDIAKEYSESSION_MESSAGETYPE, message: *const u8, messagesize: u32, destinationurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn KeyStatusChanged(&self) -> ::windows::core::Result<()>;
@@ -5687,6 +5789,7 @@ impl IMFContentDecryptionModuleSessionCallbacks_Vtbl {
         iid == &<IMFContentDecryptionModuleSessionCallbacks as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFContentDecryptorContext_Impl: Sized {
     fn InitializeHardwareKey(&self, inputprivatedatabytecount: u32, inputprivatedata: *const ::core::ffi::c_void) -> ::windows::core::Result<u64>;
 }
@@ -5710,6 +5813,7 @@ impl IMFContentDecryptorContext_Vtbl {
         iid == &<IMFContentDecryptorContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFContentEnabler_Impl: Sized {
     fn GetEnableType(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -5787,6 +5891,7 @@ impl IMFContentEnabler_Vtbl {
         iid == &<IMFContentEnabler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFContentProtectionDevice_Impl: Sized {
     fn InvokeFunction(&self, functionid: u32, inputbufferbytecount: u32, inputbuffer: *const u8, outputbufferbytecount: *mut u32, outputbuffer: *mut u8) -> ::windows::core::Result<()>;
     fn GetPrivateDataByteCount(&self, privateinputbytecount: *mut u32, privateoutputbytecount: *mut u32) -> ::windows::core::Result<()>;
@@ -5814,6 +5919,7 @@ impl IMFContentProtectionDevice_Vtbl {
         iid == &<IMFContentProtectionDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFContentProtectionManager_Impl: Sized {
     fn BeginEnableContent(&self, penableractivate: &::core::option::Option<IMFActivate>, ptopo: &::core::option::Option<IMFTopology>, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndEnableContent(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
@@ -5841,6 +5947,7 @@ impl IMFContentProtectionManager_Vtbl {
         iid == &<IMFContentProtectionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFD3D12SynchronizationObject_Impl: Sized {
     fn SignalEventOnFinalResourceRelease(&self, hevent: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -5871,6 +5978,7 @@ impl IMFD3D12SynchronizationObject_Vtbl {
         iid == &<IMFD3D12SynchronizationObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D12"))]
 pub trait IMFD3D12SynchronizationObjectCommands_Impl: Sized {
     fn EnqueueResourceReady(&self, pproducercommandqueue: &::core::option::Option<super::super::Graphics::Direct3D12::ID3D12CommandQueue>) -> ::windows::core::Result<()>;
@@ -5915,6 +6023,7 @@ impl IMFD3D12SynchronizationObjectCommands_Vtbl {
         iid == &<IMFD3D12SynchronizationObjectCommands as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFDLNASinkInit_Impl: Sized {
     fn Initialize(&self, pbytestream: &::core::option::Option<IMFByteStream>, fpal: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5935,6 +6044,7 @@ impl IMFDLNASinkInit_Vtbl {
         iid == &<IMFDLNASinkInit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFDRMNetHelper_Impl: Sized {
     fn ProcessLicenseRequest(&self, plicenserequest: *const u8, cblicenserequest: u32, pplicenseresponse: *mut *mut u8, pcblicenseresponse: *mut u32, pbstrkid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn GetChainedLicenseResponse(&self, pplicenseresponse: *mut *mut u8, pcblicenseresponse: *mut u32) -> ::windows::core::Result<()>;
@@ -5962,6 +6072,7 @@ impl IMFDRMNetHelper_Vtbl {
         iid == &<IMFDRMNetHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFDXGIBuffer_Impl: Sized {
     fn GetResource(&self, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetSubresourceIndex(&self) -> ::windows::core::Result<u32>;
@@ -6009,6 +6120,7 @@ impl IMFDXGIBuffer_Vtbl {
         iid == &<IMFDXGIBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFDXGIDeviceManager_Impl: Sized {
     fn CloseDeviceHandle(&self, hdevice: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -6080,6 +6192,7 @@ impl IMFDXGIDeviceManager_Vtbl {
         iid == &<IMFDXGIDeviceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFDXGIDeviceManagerSource_Impl: Sized {
     fn GetManager(&self) -> ::windows::core::Result<IMFDXGIDeviceManager>;
 }
@@ -6103,6 +6216,7 @@ impl IMFDXGIDeviceManagerSource_Vtbl {
         iid == &<IMFDXGIDeviceManagerSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFDesiredSample_Impl: Sized {
     fn GetDesiredSampleTimeAndDuration(&self, phnssampletime: *mut i64, phnssampleduration: *mut i64) -> ::windows::core::Result<()>;
     fn SetDesiredSampleTimeAndDuration(&self, hnssampletime: i64, hnssampleduration: i64);
@@ -6137,6 +6251,7 @@ impl IMFDesiredSample_Vtbl {
         iid == &<IMFDesiredSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFDeviceTransform_Impl: Sized {
     fn InitializeTransform(&self, pattributes: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
     fn GetInputAvailableType(&self, dwinputstreamid: u32, dwtypeindex: u32) -> ::windows::core::Result<IMFMediaType>;
@@ -6338,6 +6453,7 @@ impl IMFDeviceTransform_Vtbl {
         iid == &<IMFDeviceTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFDeviceTransformCallback_Impl: Sized {
     fn OnBufferSent(&self, pcallbackattributes: &::core::option::Option<IMFAttributes>, pinid: u32) -> ::windows::core::Result<()>;
 }
@@ -6355,6 +6471,7 @@ impl IMFDeviceTransformCallback_Vtbl {
         iid == &<IMFDeviceTransformCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFExtendedCameraControl_Impl: Sized {
     fn GetCapabilities(&self) -> u64;
     fn SetFlags(&self, ulflags: u64) -> ::windows::core::Result<()>;
@@ -6410,6 +6527,7 @@ impl IMFExtendedCameraControl_Vtbl {
         iid == &<IMFExtendedCameraControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFExtendedCameraController_Impl: Sized {
     fn GetExtendedCameraControl(&self, dwstreamindex: u32, ulpropertyid: u32) -> ::windows::core::Result<IMFExtendedCameraControl>;
 }
@@ -6433,6 +6551,7 @@ impl IMFExtendedCameraController_Vtbl {
         iid == &<IMFExtendedCameraController as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFExtendedCameraIntrinsicModel_Impl: Sized {
     fn GetModel(&self) -> ::windows::core::Result<MFExtendedCameraIntrinsic_IntrinsicModel>;
     fn SetModel(&self, pintrinsicmodel: *const MFExtendedCameraIntrinsic_IntrinsicModel) -> ::windows::core::Result<()>;
@@ -6479,6 +6598,7 @@ impl IMFExtendedCameraIntrinsicModel_Vtbl {
         iid == &<IMFExtendedCameraIntrinsicModel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFExtendedCameraIntrinsics_Impl: Sized {
     fn InitializeFromBuffer(&self, pbbuffer: *const u8, dwbuffersize: u32) -> ::windows::core::Result<()>;
     fn GetBufferSize(&self) -> ::windows::core::Result<u32>;
@@ -6552,6 +6672,7 @@ impl IMFExtendedCameraIntrinsics_Vtbl {
         iid == &<IMFExtendedCameraIntrinsics as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFExtendedCameraIntrinsicsDistortionModel6KT_Impl: Sized {
     fn GetDistortionModel(&self) -> ::windows::core::Result<MFCameraIntrinsic_DistortionModel6KT>;
     fn SetDistortionModel(&self, pdistortionmodel: *const MFCameraIntrinsic_DistortionModel6KT) -> ::windows::core::Result<()>;
@@ -6585,6 +6706,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModel6KT_Vtbl {
         iid == &<IMFExtendedCameraIntrinsicsDistortionModel6KT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFExtendedCameraIntrinsicsDistortionModelArcTan_Impl: Sized {
     fn GetDistortionModel(&self) -> ::windows::core::Result<MFCameraIntrinsic_DistortionModelArcTan>;
     fn SetDistortionModel(&self, pdistortionmodel: *const MFCameraIntrinsic_DistortionModelArcTan) -> ::windows::core::Result<()>;
@@ -6618,6 +6740,7 @@ impl IMFExtendedCameraIntrinsicsDistortionModelArcTan_Vtbl {
         iid == &<IMFExtendedCameraIntrinsicsDistortionModelArcTan as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFExtendedDRMTypeSupport_Impl: Sized {
     fn IsTypeSupportedEx(&self, r#type: &::windows::core::BSTR, keysystem: &::windows::core::BSTR) -> ::windows::core::Result<MF_MEDIA_ENGINE_CANPLAY>;
 }
@@ -6641,6 +6764,7 @@ impl IMFExtendedDRMTypeSupport_Vtbl {
         iid == &<IMFExtendedDRMTypeSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFFieldOfUseMFTUnlock_Impl: Sized {
     fn Unlock(&self, punkmft: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -6658,6 +6782,7 @@ impl IMFFieldOfUseMFTUnlock_Vtbl {
         iid == &<IMFFieldOfUseMFTUnlock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFFinalizableMediaSink_Impl: Sized + IMFMediaSink_Impl {
     fn BeginFinalize(&self, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndFinalize(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
@@ -6685,6 +6810,7 @@ impl IMFFinalizableMediaSink_Vtbl {
         iid == &<IMFFinalizableMediaSink as ::windows::core::Interface>::IID || iid == &<IMFMediaSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFGetService_Impl: Sized {
     fn GetService(&self, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -6702,6 +6828,7 @@ impl IMFGetService_Vtbl {
         iid == &<IMFGetService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFHDCPStatus_Impl: Sized {
     fn Query(&self, pstatus: *mut MF_HDCP_STATUS, pfstatus: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -6728,6 +6855,7 @@ impl IMFHDCPStatus_Vtbl {
         iid == &<IMFHDCPStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFHttpDownloadRequest_Impl: Sized {
     fn AddHeader(&self, szheader: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -6898,6 +7026,7 @@ impl IMFHttpDownloadRequest_Vtbl {
         iid == &<IMFHttpDownloadRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFHttpDownloadSession_Impl: Sized {
     fn SetServer(&self, szservername: &::windows::core::PCWSTR, nport: u32) -> ::windows::core::Result<()>;
@@ -6941,6 +7070,7 @@ impl IMFHttpDownloadSession_Vtbl {
         iid == &<IMFHttpDownloadSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFHttpDownloadSessionProvider_Impl: Sized {
     fn CreateHttpDownloadSession(&self, wszscheme: &::windows::core::PCWSTR) -> ::windows::core::Result<IMFHttpDownloadSession>;
 }
@@ -6967,6 +7097,7 @@ impl IMFHttpDownloadSessionProvider_Vtbl {
         iid == &<IMFHttpDownloadSessionProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFImageSharingEngine_Impl: Sized {
     fn SetSource(&self, pstream: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetDevice(&self) -> ::windows::core::Result<DEVICE_INFO>;
@@ -7007,6 +7138,7 @@ impl IMFImageSharingEngine_Vtbl {
         iid == &<IMFImageSharingEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFImageSharingEngineClassFactory_Impl: Sized {
     fn CreateInstanceFromUDN(&self, puniquedevicename: &::windows::core::BSTR) -> ::windows::core::Result<IMFImageSharingEngine>;
 }
@@ -7030,6 +7162,7 @@ impl IMFImageSharingEngineClassFactory_Vtbl {
         iid == &<IMFImageSharingEngineClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFInputTrustAuthority_Impl: Sized {
     fn GetDecrypter(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn RequestAccess(&self, action: MFPOLICYMANAGER_ACTION) -> ::windows::core::Result<IMFActivate>;
@@ -7097,6 +7230,7 @@ impl IMFInputTrustAuthority_Vtbl {
         iid == &<IMFInputTrustAuthority as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFLocalMFTRegistration_Impl: Sized {
     fn RegisterMFTs(&self, pmfts: *const MFT_REGISTRATION_INFO, cmfts: u32) -> ::windows::core::Result<()>;
 }
@@ -7114,6 +7248,7 @@ impl IMFLocalMFTRegistration_Vtbl {
         iid == &<IMFLocalMFTRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaBuffer_Impl: Sized {
     fn Lock(&self, ppbbuffer: *mut *mut u8, pcbmaxlength: *mut u32, pcbcurrentlength: *mut u32) -> ::windows::core::Result<()>;
     fn Unlock(&self) -> ::windows::core::Result<()>;
@@ -7174,6 +7309,7 @@ impl IMFMediaBuffer_Vtbl {
         iid == &<IMFMediaBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaEngine_Impl: Sized {
     fn GetError(&self) -> ::windows::core::Result<IMFMediaError>;
@@ -7526,6 +7662,7 @@ impl IMFMediaEngine_Vtbl {
         iid == &<IMFMediaEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineAudioEndpointId_Impl: Sized {
     fn SetAudioEndpointId(&self, pszendpointid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetAudioEndpointId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -7559,6 +7696,7 @@ impl IMFMediaEngineAudioEndpointId_Vtbl {
         iid == &<IMFMediaEngineAudioEndpointId as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineClassFactory_Impl: Sized {
     fn CreateInstance(&self, dwflags: u32, pattr: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<IMFMediaEngine>;
     fn CreateTimeRange(&self) -> ::windows::core::Result<IMFMediaTimeRange>;
@@ -7611,6 +7749,7 @@ impl IMFMediaEngineClassFactory_Vtbl {
         iid == &<IMFMediaEngineClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineClassFactory2_Impl: Sized {
     fn CreateMediaKeys2(&self, keysystem: &::windows::core::BSTR, defaultcdmstorepath: &::windows::core::BSTR, inprivatecdmstorepath: &::windows::core::BSTR) -> ::windows::core::Result<IMFMediaKeys>;
 }
@@ -7634,6 +7773,7 @@ impl IMFMediaEngineClassFactory2_Vtbl {
         iid == &<IMFMediaEngineClassFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFMediaEngineClassFactory3_Impl: Sized {
     fn CreateMediaKeySystemAccess(&self, keysystem: &::windows::core::BSTR, ppsupportedconfigurationsarray: *const ::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>, usize: u32) -> ::windows::core::Result<IMFMediaKeySystemAccess>;
@@ -7663,6 +7803,7 @@ impl IMFMediaEngineClassFactory3_Vtbl {
         iid == &<IMFMediaEngineClassFactory3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineClassFactory4_Impl: Sized {
     fn CreateContentDecryptionModuleFactory(&self, keysystem: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -7683,6 +7824,7 @@ impl IMFMediaEngineClassFactory4_Vtbl {
         iid == &<IMFMediaEngineClassFactory4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaEngineClassFactoryEx_Impl: Sized + IMFMediaEngineClassFactory_Impl {
     fn CreateMediaSourceExtension(&self, dwflags: u32, pattr: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<IMFMediaSourceExtension>;
@@ -7738,6 +7880,7 @@ impl IMFMediaEngineClassFactoryEx_Vtbl {
         iid == &<IMFMediaEngineClassFactoryEx as ::windows::core::Interface>::IID || iid == &<IMFMediaEngineClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineEME_Impl: Sized {
     fn Keys(&self, keys: *mut ::core::option::Option<IMFMediaKeys>) -> ::windows::core::Result<()>;
     fn SetMediaKeys(&self, keys: &::core::option::Option<IMFMediaKeys>) -> ::windows::core::Result<()>;
@@ -7765,6 +7908,7 @@ impl IMFMediaEngineEME_Vtbl {
         iid == &<IMFMediaEngineEME as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineEMENotify_Impl: Sized {
     fn Encrypted(&self, pbinitdata: *const u8, cb: u32, bstrinitdatatype: &::windows::core::BSTR);
     fn WaitingForKey(&self);
@@ -7792,6 +7936,7 @@ impl IMFMediaEngineEMENotify_Vtbl {
         iid == &<IMFMediaEngineEMENotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaEngineEx_Impl: Sized + IMFMediaEngine_Impl {
     fn SetSourceFromByteStream(&self, pbytestream: &::core::option::Option<IMFByteStream>, purl: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8151,6 +8296,7 @@ impl IMFMediaEngineEx_Vtbl {
         iid == &<IMFMediaEngineEx as ::windows::core::Interface>::IID || iid == &<IMFMediaEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaEngineExtension_Impl: Sized {
     fn CanPlayType(&self, audioonly: super::super::Foundation::BOOL, mimetype: &::windows::core::BSTR) -> ::windows::core::Result<MF_MEDIA_ENGINE_CANPLAY>;
@@ -8207,6 +8353,7 @@ impl IMFMediaEngineExtension_Vtbl {
         iid == &<IMFMediaEngineExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineNeedKeyNotify_Impl: Sized {
     fn NeedKey(&self, initdata: *const u8, cb: u32);
 }
@@ -8224,6 +8371,7 @@ impl IMFMediaEngineNeedKeyNotify_Vtbl {
         iid == &<IMFMediaEngineNeedKeyNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineNotify_Impl: Sized {
     fn EventNotify(&self, event: u32, param1: usize, param2: u32) -> ::windows::core::Result<()>;
 }
@@ -8241,6 +8389,7 @@ impl IMFMediaEngineNotify_Vtbl {
         iid == &<IMFMediaEngineNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaEngineOPMInfo_Impl: Sized {
     fn GetOPMInfo(&self, pstatus: *mut MF_MEDIA_ENGINE_OPM_STATUS, pconstricted: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -8261,6 +8410,7 @@ impl IMFMediaEngineOPMInfo_Vtbl {
         iid == &<IMFMediaEngineOPMInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaEngineProtectedContent_Impl: Sized {
     fn ShareResources(&self, punkdevicecontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -8331,6 +8481,7 @@ impl IMFMediaEngineProtectedContent_Vtbl {
         iid == &<IMFMediaEngineProtectedContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineSrcElements_Impl: Sized {
     fn GetLength(&self) -> u32;
     fn GetURL(&self, index: u32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -8404,6 +8555,7 @@ impl IMFMediaEngineSrcElements_Vtbl {
         iid == &<IMFMediaEngineSrcElements as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineSrcElementsEx_Impl: Sized + IMFMediaEngineSrcElements_Impl {
     fn AddElementEx(&self, purl: &::windows::core::BSTR, ptype: &::windows::core::BSTR, pmedia: &::windows::core::BSTR, keysystem: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn GetKeySystem(&self, index: u32, ptype: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8431,6 +8583,7 @@ impl IMFMediaEngineSrcElementsEx_Vtbl {
         iid == &<IMFMediaEngineSrcElementsEx as ::windows::core::Interface>::IID || iid == &<IMFMediaEngineSrcElements as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaEngineSupportsSourceTransfer_Impl: Sized {
     fn ShouldTransferSource(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -8474,6 +8627,7 @@ impl IMFMediaEngineSupportsSourceTransfer_Vtbl {
         iid == &<IMFMediaEngineSupportsSourceTransfer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaEngineTransferSource_Impl: Sized {
     fn TransferSourceToMediaEngine(&self, destination: &::core::option::Option<IMFMediaEngine>) -> ::windows::core::Result<()>;
 }
@@ -8494,6 +8648,7 @@ impl IMFMediaEngineTransferSource_Vtbl {
         iid == &<IMFMediaEngineTransferSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaEngineWebSupport_Impl: Sized {
     fn ShouldDelayTheLoadEvent(&self) -> super::super::Foundation::BOOL;
@@ -8537,6 +8692,7 @@ impl IMFMediaEngineWebSupport_Vtbl {
         iid == &<IMFMediaEngineWebSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaError_Impl: Sized {
     fn GetErrorCode(&self) -> u16;
     fn GetExtendedErrorCode(&self) -> ::windows::core::Result<()>;
@@ -8578,6 +8734,7 @@ impl IMFMediaError_Vtbl {
         iid == &<IMFMediaError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaEvent_Impl: Sized + IMFAttributes_Impl {
     fn GetType(&self) -> ::windows::core::Result<u32>;
@@ -8646,6 +8803,7 @@ impl IMFMediaEvent_Vtbl {
         iid == &<IMFMediaEvent as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaEventGenerator_Impl: Sized {
     fn GetEvent(&self, dwflags: MEDIA_EVENT_GENERATOR_GET_EVENT_FLAGS) -> ::windows::core::Result<IMFMediaEvent>;
@@ -8702,6 +8860,7 @@ impl IMFMediaEventGenerator_Vtbl {
         iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaEventQueue_Impl: Sized {
     fn GetEvent(&self, dwflags: u32) -> ::windows::core::Result<IMFMediaEvent>;
@@ -8779,6 +8938,7 @@ impl IMFMediaEventQueue_Vtbl {
         iid == &<IMFMediaEventQueue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaKeySession_Impl: Sized {
     fn GetError(&self, code: *mut u16, systemcode: *mut u32) -> ::windows::core::Result<()>;
     fn KeySystem(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -8839,6 +8999,7 @@ impl IMFMediaKeySession_Vtbl {
         iid == &<IMFMediaKeySession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaKeySession2_Impl: Sized + IMFMediaKeySession_Impl {
     fn get_KeyStatuses(&self, pkeystatusesarray: *mut *mut MFMediaKeyStatus, pusize: *mut u32) -> ::windows::core::Result<()>;
@@ -8909,6 +9070,7 @@ impl IMFMediaKeySession2_Vtbl {
         iid == &<IMFMediaKeySession2 as ::windows::core::Interface>::IID || iid == &<IMFMediaKeySession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaKeySessionNotify_Impl: Sized {
     fn KeyMessage(&self, destinationurl: &::windows::core::BSTR, message: *const u8, cb: u32);
     fn KeyAdded(&self);
@@ -8943,6 +9105,7 @@ impl IMFMediaKeySessionNotify_Vtbl {
         iid == &<IMFMediaKeySessionNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaKeySessionNotify2_Impl: Sized + IMFMediaKeySessionNotify_Impl {
     fn KeyMessage2(&self, emessagetype: MF_MEDIAKEYSESSION_MESSAGETYPE, destinationurl: &::windows::core::BSTR, pbmessage: *const u8, cbmessage: u32);
     fn KeyStatusChange(&self);
@@ -8970,6 +9133,7 @@ impl IMFMediaKeySessionNotify2_Vtbl {
         iid == &<IMFMediaKeySessionNotify2 as ::windows::core::Interface>::IID || iid == &<IMFMediaKeySessionNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFMediaKeySystemAccess_Impl: Sized {
     fn CreateMediaKeys(&self, pcdmcustomconfig: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<IMFMediaKeys2>;
@@ -9025,6 +9189,7 @@ impl IMFMediaKeySystemAccess_Vtbl {
         iid == &<IMFMediaKeySystemAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaKeys_Impl: Sized {
     fn CreateSession(&self, mimetype: &::windows::core::BSTR, initdata: *const u8, cb: u32, customdata: *const u8, cbcustomdata: u32, notify: &::core::option::Option<IMFMediaKeySessionNotify>) -> ::windows::core::Result<IMFMediaKeySession>;
     fn KeySystem(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -9084,6 +9249,7 @@ impl IMFMediaKeys_Vtbl {
         iid == &<IMFMediaKeys as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaKeys2_Impl: Sized + IMFMediaKeys_Impl {
     fn CreateSession2(&self, esessiontype: MF_MEDIAKEYSESSION_TYPE, pmfmediakeysessionnotify2: &::core::option::Option<IMFMediaKeySessionNotify2>) -> ::windows::core::Result<IMFMediaKeySession2>;
     fn SetServerCertificate(&self, pbservercertificate: *const u8, cb: u32) -> ::windows::core::Result<()>;
@@ -9130,6 +9296,7 @@ impl IMFMediaKeys2_Vtbl {
         iid == &<IMFMediaKeys2 as ::windows::core::Interface>::IID || iid == &<IMFMediaKeys as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaSession_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn SetTopology(&self, dwsettopologyflags: u32, ptopology: &::core::option::Option<IMFTopology>) -> ::windows::core::Result<()>;
@@ -9234,6 +9401,7 @@ impl IMFMediaSession_Vtbl {
         iid == &<IMFMediaSession as ::windows::core::Interface>::IID || iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaSharingEngine_Impl: Sized + IMFMediaEngine_Impl {
     fn GetDevice(&self) -> ::windows::core::Result<DEVICE_INFO>;
@@ -9260,6 +9428,7 @@ impl IMFMediaSharingEngine_Vtbl {
         iid == &<IMFMediaSharingEngine as ::windows::core::Interface>::IID || iid == &<IMFMediaEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaSharingEngineClassFactory_Impl: Sized {
     fn CreateInstance(&self, dwflags: u32, pattr: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<IMFMediaSharingEngine>;
 }
@@ -9283,6 +9452,7 @@ impl IMFMediaSharingEngineClassFactory_Vtbl {
         iid == &<IMFMediaSharingEngineClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaSink_Impl: Sized {
     fn GetCharacteristics(&self) -> ::windows::core::Result<u32>;
     fn AddStreamSink(&self, dwstreamsinkidentifier: u32, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<IMFStreamSink>;
@@ -9395,6 +9565,7 @@ impl IMFMediaSink_Vtbl {
         iid == &<IMFMediaSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaSinkPreroll_Impl: Sized {
     fn NotifyPreroll(&self, hnsupcomingstarttime: i64) -> ::windows::core::Result<()>;
 }
@@ -9412,6 +9583,7 @@ impl IMFMediaSinkPreroll_Vtbl {
         iid == &<IMFMediaSinkPreroll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaSource_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn GetCharacteristics(&self) -> ::windows::core::Result<u32>;
@@ -9482,6 +9654,7 @@ impl IMFMediaSource_Vtbl {
         iid == &<IMFMediaSource as ::windows::core::Interface>::IID || iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaSource2_Impl: Sized + IMFMediaSourceEx_Impl {
     fn SetMediaType(&self, dwstreamid: u32, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
@@ -9502,6 +9675,7 @@ impl IMFMediaSource2_Vtbl {
         iid == &<IMFMediaSource2 as ::windows::core::Interface>::IID || iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID || iid == &<IMFMediaSource as ::windows::core::Interface>::IID || iid == &<IMFMediaSourceEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaSourceEx_Impl: Sized + IMFMediaSource_Impl {
     fn GetSourceAttributes(&self) -> ::windows::core::Result<IMFAttributes>;
@@ -9551,6 +9725,7 @@ impl IMFMediaSourceEx_Vtbl {
         iid == &<IMFMediaSourceEx as ::windows::core::Interface>::IID || iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID || iid == &<IMFMediaSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaSourceExtension_Impl: Sized {
     fn GetSourceBuffers(&self) -> ::core::option::Option<IMFSourceBufferList>;
@@ -9643,6 +9818,7 @@ impl IMFMediaSourceExtension_Vtbl {
         iid == &<IMFMediaSourceExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaSourceExtensionLiveSeekableRange_Impl: Sized {
     fn SetLiveSeekableRange(&self, start: f64, end: f64) -> ::windows::core::Result<()>;
     fn ClearLiveSeekableRange(&self) -> ::windows::core::Result<()>;
@@ -9670,6 +9846,7 @@ impl IMFMediaSourceExtensionLiveSeekableRange_Vtbl {
         iid == &<IMFMediaSourceExtensionLiveSeekableRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaSourceExtensionNotify_Impl: Sized {
     fn OnSourceOpen(&self);
     fn OnSourceEnded(&self);
@@ -9704,6 +9881,7 @@ impl IMFMediaSourceExtensionNotify_Vtbl {
         iid == &<IMFMediaSourceExtensionNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaSourcePresentationProvider_Impl: Sized {
     fn ForceEndOfPresentation(&self, ppresentationdescriptor: &::core::option::Option<IMFPresentationDescriptor>) -> ::windows::core::Result<()>;
 }
@@ -9721,6 +9899,7 @@ impl IMFMediaSourcePresentationProvider_Vtbl {
         iid == &<IMFMediaSourcePresentationProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaSourceTopologyProvider_Impl: Sized {
     fn GetMediaSourceTopology(&self, ppresentationdescriptor: &::core::option::Option<IMFPresentationDescriptor>) -> ::windows::core::Result<IMFTopology>;
 }
@@ -9744,6 +9923,7 @@ impl IMFMediaSourceTopologyProvider_Vtbl {
         iid == &<IMFMediaSourceTopologyProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaStream_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn GetMediaSource(&self) -> ::windows::core::Result<IMFMediaSource>;
@@ -9793,6 +9973,7 @@ impl IMFMediaStream_Vtbl {
         iid == &<IMFMediaStream as ::windows::core::Interface>::IID || iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaStream2_Impl: Sized + IMFMediaStream_Impl {
     fn SetStreamState(&self, value: MF_STREAM_STATE) -> ::windows::core::Result<()>;
@@ -9829,6 +10010,7 @@ impl IMFMediaStream2_Vtbl {
         iid == &<IMFMediaStream2 as ::windows::core::Interface>::IID || iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID || iid == &<IMFMediaStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaStreamSourceSampleRequest_Impl: Sized {
     fn SetSample(&self, value: &::core::option::Option<IMFSample>) -> ::windows::core::Result<()>;
 }
@@ -9846,6 +10028,7 @@ impl IMFMediaStreamSourceSampleRequest_Vtbl {
         iid == &<IMFMediaStreamSourceSampleRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFMediaTimeRange_Impl: Sized {
     fn GetLength(&self) -> u32;
@@ -9916,6 +10099,7 @@ impl IMFMediaTimeRange_Vtbl {
         iid == &<IMFMediaTimeRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMediaType_Impl: Sized + IMFAttributes_Impl {
     fn GetMajorType(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -9985,6 +10169,7 @@ impl IMFMediaType_Vtbl {
         iid == &<IMFMediaType as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMediaTypeHandler_Impl: Sized {
     fn IsMediaTypeSupported(&self, pmediatype: &::core::option::Option<IMFMediaType>, ppmediatype: *mut ::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
     fn GetMediaTypeCount(&self) -> ::windows::core::Result<u32>;
@@ -10064,6 +10249,7 @@ impl IMFMediaTypeHandler_Vtbl {
         iid == &<IMFMediaTypeHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFMetadata_Impl: Sized {
     fn SetLanguage(&self, pwszrfc1766: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -10153,6 +10339,7 @@ impl IMFMetadata_Vtbl {
         iid == &<IMFMetadata as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMetadataProvider_Impl: Sized {
     fn GetMFMetadata(&self, ppresentationdescriptor: &::core::option::Option<IMFPresentationDescriptor>, dwstreamidentifier: u32, dwflags: u32) -> ::windows::core::Result<IMFMetadata>;
 }
@@ -10176,6 +10363,7 @@ impl IMFMetadataProvider_Vtbl {
         iid == &<IMFMetadataProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMuxStreamAttributesManager_Impl: Sized {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
     fn GetAttributes(&self, dwmuxstreamindex: u32) -> ::windows::core::Result<IMFAttributes>;
@@ -10215,6 +10403,7 @@ impl IMFMuxStreamAttributesManager_Vtbl {
         iid == &<IMFMuxStreamAttributesManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMuxStreamMediaTypeManager_Impl: Sized {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
     fn GetMediaType(&self, dwmuxstreamindex: u32) -> ::windows::core::Result<IMFMediaType>;
@@ -10294,6 +10483,7 @@ impl IMFMuxStreamMediaTypeManager_Vtbl {
         iid == &<IMFMuxStreamMediaTypeManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFMuxStreamSampleManager_Impl: Sized {
     fn GetStreamCount(&self) -> ::windows::core::Result<u32>;
     fn GetSample(&self, dwmuxstreamindex: u32) -> ::windows::core::Result<IMFSample>;
@@ -10340,6 +10530,7 @@ impl IMFMuxStreamSampleManager_Vtbl {
         iid == &<IMFMuxStreamSampleManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFNetCredential_Impl: Sized {
     fn SetUser(&self, pbdata: *const u8, cbdata: u32, fdataisencrypted: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -10397,6 +10588,7 @@ impl IMFNetCredential_Vtbl {
         iid == &<IMFNetCredential as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFNetCredentialCache_Impl: Sized {
     fn GetCredential(&self, pszurl: &::windows::core::PCWSTR, pszrealm: &::windows::core::PCWSTR, dwauthenticationflags: u32, ppcred: *mut ::core::option::Option<IMFNetCredential>, pdwrequirementsflags: *mut u32) -> ::windows::core::Result<()>;
@@ -10434,6 +10626,7 @@ impl IMFNetCredentialCache_Vtbl {
         iid == &<IMFNetCredentialCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFNetCredentialManager_Impl: Sized {
     fn BeginGetCredentials(&self, pparam: *const MFNetCredentialManagerGetParam, pcallback: &::core::option::Option<IMFAsyncCallback>, pstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -10477,6 +10670,7 @@ impl IMFNetCredentialManager_Vtbl {
         iid == &<IMFNetCredentialManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFNetCrossOriginSupport_Impl: Sized {
     fn GetCrossOriginPolicy(&self) -> ::windows::core::Result<MF_CROSS_ORIGIN_POLICY>;
@@ -10532,6 +10726,7 @@ impl IMFNetCrossOriginSupport_Vtbl {
         iid == &<IMFNetCrossOriginSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFNetProxyLocator_Impl: Sized {
     fn FindFirstProxy(&self, pszhost: &::windows::core::PCWSTR, pszurl: &::windows::core::PCWSTR, freserved: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -10589,6 +10784,7 @@ impl IMFNetProxyLocator_Vtbl {
         iid == &<IMFNetProxyLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFNetProxyLocatorFactory_Impl: Sized {
     fn CreateProxyLocator(&self, pszprotocol: &::windows::core::PCWSTR) -> ::windows::core::Result<IMFNetProxyLocator>;
 }
@@ -10612,6 +10808,7 @@ impl IMFNetProxyLocatorFactory_Vtbl {
         iid == &<IMFNetProxyLocatorFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFNetResourceFilter_Impl: Sized {
     fn OnRedirect(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -10648,6 +10845,7 @@ impl IMFNetResourceFilter_Vtbl {
         iid == &<IMFNetResourceFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFNetSchemeHandlerConfig_Impl: Sized {
     fn GetNumberOfSupportedProtocols(&self) -> ::windows::core::Result<u32>;
     fn GetSupportedProtocolType(&self, nprotocolindex: u32) -> ::windows::core::Result<MFNETSOURCE_PROTOCOL_TYPE>;
@@ -10694,6 +10892,7 @@ impl IMFNetSchemeHandlerConfig_Vtbl {
         iid == &<IMFNetSchemeHandlerConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFObjectReferenceStream_Impl: Sized {
     fn SaveReference(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn LoadReference(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -10721,6 +10920,7 @@ impl IMFObjectReferenceStream_Vtbl {
         iid == &<IMFObjectReferenceStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFOutputPolicy_Impl: Sized + IMFAttributes_Impl {
     fn GenerateRequiredSchemas(&self, dwattributes: u32, guidoutputsubtype: &::windows::core::GUID, rgguidprotectionschemassupported: *const ::windows::core::GUID, cprotectionschemassupported: u32) -> ::windows::core::Result<IMFCollection>;
@@ -10776,6 +10976,7 @@ impl IMFOutputPolicy_Vtbl {
         iid == &<IMFOutputPolicy as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFOutputSchema_Impl: Sized + IMFAttributes_Impl {
     fn GetSchemaType(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -10831,6 +11032,7 @@ impl IMFOutputSchema_Vtbl {
         iid == &<IMFOutputSchema as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFOutputTrustAuthority_Impl: Sized {
     fn GetAction(&self) -> ::windows::core::Result<MFPOLICYMANAGER_ACTION>;
     fn SetPolicy(&self, pppolicy: *const ::core::option::Option<IMFOutputPolicy>, npolicy: u32, ppbticket: *mut *mut u8, pcbticket: *mut u32) -> ::windows::core::Result<()>;
@@ -10864,6 +11066,7 @@ impl IMFOutputTrustAuthority_Vtbl {
         iid == &<IMFOutputTrustAuthority as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFPMPClient_Impl: Sized {
     fn SetPMPHost(&self, ppmphost: &::core::option::Option<IMFPMPHost>) -> ::windows::core::Result<()>;
 }
@@ -10881,6 +11084,7 @@ impl IMFPMPClient_Vtbl {
         iid == &<IMFPMPClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFPMPClientApp_Impl: Sized {
     fn SetPMPHost(&self, ppmphost: &::core::option::Option<IMFPMPHostApp>) -> ::windows::core::Result<()>;
 }
@@ -10898,6 +11102,7 @@ impl IMFPMPClientApp_Vtbl {
         iid == &<IMFPMPClientApp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMFPMPHost_Impl: Sized {
     fn LockProcess(&self) -> ::windows::core::Result<()>;
@@ -10935,6 +11140,7 @@ impl IMFPMPHost_Vtbl {
         iid == &<IMFPMPHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMFPMPHostApp_Impl: Sized {
     fn LockProcess(&self) -> ::windows::core::Result<()>;
@@ -10972,6 +11178,7 @@ impl IMFPMPHostApp_Vtbl {
         iid == &<IMFPMPHostApp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFPMPServer_Impl: Sized {
     fn LockProcess(&self) -> ::windows::core::Result<()>;
     fn UnlockProcess(&self) -> ::windows::core::Result<()>;
@@ -11006,6 +11213,7 @@ impl IMFPMPServer_Vtbl {
         iid == &<IMFPMPServer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IMFPMediaItem_Impl: Sized {
     fn GetMediaPlayer(&self) -> ::windows::core::Result<IMFPMediaPlayer>;
@@ -11227,6 +11435,7 @@ impl IMFPMediaItem_Vtbl {
         iid == &<IMFPMediaItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFPMediaPlayer_Impl: Sized {
     fn Play(&self) -> ::windows::core::Result<()>;
@@ -11567,6 +11776,7 @@ impl IMFPMediaPlayer_Vtbl {
         iid == &<IMFPMediaPlayer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFPMediaPlayerCallback_Impl: Sized {
     fn OnMediaPlayerEvent(&self, peventheader: *const MFP_EVENT_HEADER);
@@ -11587,6 +11797,7 @@ impl IMFPMediaPlayerCallback_Vtbl {
         iid == &<IMFPMediaPlayerCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFPluginControl_Impl: Sized {
     fn GetPreferredClsid(&self, plugintype: u32, selector: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::GUID>;
@@ -11657,6 +11868,7 @@ impl IMFPluginControl_Vtbl {
         iid == &<IMFPluginControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFPluginControl2_Impl: Sized + IMFPluginControl_Impl {
     fn SetPolicy(&self, policy: MF_PLUGIN_CONTROL_POLICY) -> ::windows::core::Result<()>;
@@ -11677,6 +11889,7 @@ impl IMFPluginControl2_Vtbl {
         iid == &<IMFPluginControl2 as ::windows::core::Interface>::IID || iid == &<IMFPluginControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFPresentationClock_Impl: Sized + IMFClock_Impl {
     fn SetTimeSource(&self, ptimesource: &::core::option::Option<IMFPresentationTimeSource>) -> ::windows::core::Result<()>;
     fn GetTimeSource(&self) -> ::windows::core::Result<IMFPresentationTimeSource>;
@@ -11758,6 +11971,7 @@ impl IMFPresentationClock_Vtbl {
         iid == &<IMFPresentationClock as ::windows::core::Interface>::IID || iid == &<IMFClock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFPresentationDescriptor_Impl: Sized + IMFAttributes_Impl {
     fn GetStreamDescriptorCount(&self) -> ::windows::core::Result<u32>;
@@ -11821,6 +12035,7 @@ impl IMFPresentationDescriptor_Vtbl {
         iid == &<IMFPresentationDescriptor as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFPresentationTimeSource_Impl: Sized + IMFClock_Impl {
     fn GetUnderlyingClock(&self) -> ::windows::core::Result<IMFClock>;
 }
@@ -11844,6 +12059,7 @@ impl IMFPresentationTimeSource_Vtbl {
         iid == &<IMFPresentationTimeSource as ::windows::core::Interface>::IID || iid == &<IMFClock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFProtectedEnvironmentAccess_Impl: Sized {
     fn Call(&self, inputlength: u32, input: *const u8, outputlength: u32, output: *mut u8) -> ::windows::core::Result<()>;
     fn ReadGRL(&self, outputlength: *mut u32, output: *mut *mut u8) -> ::windows::core::Result<()>;
@@ -11871,6 +12087,7 @@ impl IMFProtectedEnvironmentAccess_Vtbl {
         iid == &<IMFProtectedEnvironmentAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFQualityAdvise_Impl: Sized {
     fn SetDropMode(&self, edropmode: MF_QUALITY_DROP_MODE) -> ::windows::core::Result<()>;
     fn SetQualityLevel(&self, equalitylevel: MF_QUALITY_LEVEL) -> ::windows::core::Result<()>;
@@ -11931,6 +12148,7 @@ impl IMFQualityAdvise_Vtbl {
         iid == &<IMFQualityAdvise as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFQualityAdvise2_Impl: Sized + IMFQualityAdvise_Impl {
     fn NotifyQualityEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<u32>;
 }
@@ -11954,6 +12172,7 @@ impl IMFQualityAdvise2_Vtbl {
         iid == &<IMFQualityAdvise2 as ::windows::core::Interface>::IID || iid == &<IMFQualityAdvise as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFQualityAdviseLimits_Impl: Sized {
     fn GetMaximumDropMode(&self) -> ::windows::core::Result<MF_QUALITY_DROP_MODE>;
     fn GetMinimumQualityLevel(&self) -> ::windows::core::Result<MF_QUALITY_LEVEL>;
@@ -11993,6 +12212,7 @@ impl IMFQualityAdviseLimits_Vtbl {
         iid == &<IMFQualityAdviseLimits as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFQualityManager_Impl: Sized {
     fn NotifyTopology(&self, ptopology: &::core::option::Option<IMFTopology>) -> ::windows::core::Result<()>;
     fn NotifyPresentationClock(&self, pclock: &::core::option::Option<IMFPresentationClock>) -> ::windows::core::Result<()>;
@@ -12048,6 +12268,7 @@ impl IMFQualityManager_Vtbl {
         iid == &<IMFQualityManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFRateControl_Impl: Sized {
     fn SetRate(&self, fthin: super::super::Foundation::BOOL, flrate: f32) -> ::windows::core::Result<()>;
@@ -12078,6 +12299,7 @@ impl IMFRateControl_Vtbl {
         iid == &<IMFRateControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFRateSupport_Impl: Sized {
     fn GetSlowestRate(&self, edirection: MFRATE_DIRECTION, fthin: super::super::Foundation::BOOL) -> ::windows::core::Result<f32>;
@@ -12127,6 +12349,7 @@ impl IMFRateSupport_Vtbl {
         iid == &<IMFRateSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFReadWriteClassFactory_Impl: Sized {
     fn CreateInstanceFromURL(&self, clsid: *const ::windows::core::GUID, pwszurl: &::windows::core::PCWSTR, pattributes: &::core::option::Option<IMFAttributes>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateInstanceFromObject(&self, clsid: *const ::windows::core::GUID, punkobject: &::core::option::Option<::windows::core::IUnknown>, pattributes: &::core::option::Option<IMFAttributes>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -12154,6 +12377,7 @@ impl IMFReadWriteClassFactory_Vtbl {
         iid == &<IMFReadWriteClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFRealTimeClient_Impl: Sized {
     fn RegisterThreads(&self, dwtaskindex: u32, wszclass: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn UnregisterThreads(&self) -> ::windows::core::Result<()>;
@@ -12188,6 +12412,7 @@ impl IMFRealTimeClient_Vtbl {
         iid == &<IMFRealTimeClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFRealTimeClientEx_Impl: Sized {
     fn RegisterThreadsEx(&self, pdwtaskindex: *mut u32, wszclassname: &::windows::core::PCWSTR, lbasepriority: i32) -> ::windows::core::Result<()>;
     fn UnregisterThreads(&self) -> ::windows::core::Result<()>;
@@ -12222,6 +12447,7 @@ impl IMFRealTimeClientEx_Vtbl {
         iid == &<IMFRealTimeClientEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFRelativePanelReport_Impl: Sized {
     fn GetRelativePanel(&self) -> ::windows::core::Result<u32>;
 }
@@ -12245,6 +12471,7 @@ impl IMFRelativePanelReport_Vtbl {
         iid == &<IMFRelativePanelReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFRelativePanelWatcher_Impl: Sized + IMFShutdown_Impl {
     fn BeginGetReport(&self, pcallback: &::core::option::Option<IMFAsyncCallback>, pstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndGetReport(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<IMFRelativePanelReport>;
@@ -12291,6 +12518,7 @@ impl IMFRelativePanelWatcher_Vtbl {
         iid == &<IMFRelativePanelWatcher as ::windows::core::Interface>::IID || iid == &<IMFShutdown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFRemoteAsyncCallback_Impl: Sized {
     fn Invoke(&self, hr: ::windows::core::HRESULT, premoteresult: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -12308,6 +12536,7 @@ impl IMFRemoteAsyncCallback_Vtbl {
         iid == &<IMFRemoteAsyncCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFRemoteDesktopPlugin_Impl: Sized {
     fn UpdateTopology(&self, ptopology: &::core::option::Option<IMFTopology>) -> ::windows::core::Result<()>;
 }
@@ -12325,6 +12554,7 @@ impl IMFRemoteDesktopPlugin_Vtbl {
         iid == &<IMFRemoteDesktopPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFRemoteProxy_Impl: Sized {
     fn GetRemoteObject(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetRemoteHost(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -12352,6 +12582,7 @@ impl IMFRemoteProxy_Vtbl {
         iid == &<IMFRemoteProxy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFSAMIStyle_Impl: Sized {
     fn GetStyleCount(&self) -> ::windows::core::Result<u32>;
@@ -12414,6 +12645,7 @@ impl IMFSAMIStyle_Vtbl {
         iid == &<IMFSAMIStyle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFSSLCertificateManager_Impl: Sized {
     fn GetClientCertificate(&self, pszurl: &::windows::core::PCWSTR, ppbdata: *mut *mut u8, pcbdata: *mut u32) -> ::windows::core::Result<()>;
@@ -12471,6 +12703,7 @@ impl IMFSSLCertificateManager_Vtbl {
         iid == &<IMFSSLCertificateManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFSample_Impl: Sized + IMFAttributes_Impl {
     fn GetSampleFlags(&self) -> ::windows::core::Result<u32>;
@@ -12627,6 +12860,7 @@ impl IMFSample_Vtbl {
         iid == &<IMFSample as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSampleAllocatorControl_Impl: Sized {
     fn SetDefaultAllocator(&self, dwoutputstreamid: u32, pallocator: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetAllocatorUsage(&self, dwoutputstreamid: u32, pdwinputstreamid: *mut u32, peusage: *mut MFSampleAllocatorUsage) -> ::windows::core::Result<()>;
@@ -12654,6 +12888,7 @@ impl IMFSampleAllocatorControl_Vtbl {
         iid == &<IMFSampleAllocatorControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSampleGrabberSinkCallback_Impl: Sized + IMFClockStateSink_Impl {
     fn OnSetPresentationClock(&self, ppresentationclock: &::core::option::Option<IMFPresentationClock>) -> ::windows::core::Result<()>;
     fn OnProcessSample(&self, guidmajormediatype: *const ::windows::core::GUID, dwsampleflags: u32, llsampletime: i64, llsampleduration: i64, psamplebuffer: *const u8, dwsamplesize: u32) -> ::windows::core::Result<()>;
@@ -12688,6 +12923,7 @@ impl IMFSampleGrabberSinkCallback_Vtbl {
         iid == &<IMFSampleGrabberSinkCallback as ::windows::core::Interface>::IID || iid == &<IMFClockStateSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSampleGrabberSinkCallback2_Impl: Sized + IMFSampleGrabberSinkCallback_Impl {
     fn OnProcessSampleEx(&self, guidmajormediatype: *const ::windows::core::GUID, dwsampleflags: u32, llsampletime: i64, llsampleduration: i64, psamplebuffer: *const u8, dwsamplesize: u32, pattributes: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
 }
@@ -12705,6 +12941,7 @@ impl IMFSampleGrabberSinkCallback2_Vtbl {
         iid == &<IMFSampleGrabberSinkCallback2 as ::windows::core::Interface>::IID || iid == &<IMFClockStateSink as ::windows::core::Interface>::IID || iid == &<IMFSampleGrabberSinkCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSampleOutputStream_Impl: Sized {
     fn BeginWriteSample(&self, psample: &::core::option::Option<IMFSample>, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndWriteSample(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
@@ -12739,6 +12976,7 @@ impl IMFSampleOutputStream_Vtbl {
         iid == &<IMFSampleOutputStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSampleProtection_Impl: Sized {
     fn GetInputProtectionVersion(&self) -> ::windows::core::Result<u32>;
     fn GetOutputProtectionVersion(&self) -> ::windows::core::Result<u32>;
@@ -12799,6 +13037,7 @@ impl IMFSampleProtection_Vtbl {
         iid == &<IMFSampleProtection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSaveJob_Impl: Sized {
     fn BeginSave(&self, pstream: &::core::option::Option<IMFByteStream>, pcallback: &::core::option::Option<IMFAsyncCallback>, pstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndSave(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
@@ -12846,6 +13085,7 @@ impl IMFSaveJob_Vtbl {
         iid == &<IMFSaveJob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFSchemeHandler_Impl: Sized {
     fn BeginCreateObject(&self, pwszurl: &::windows::core::PCWSTR, dwflags: u32, pprops: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>, ppiunknowncancelcookie: *mut ::core::option::Option<::windows::core::IUnknown>, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -12883,6 +13123,7 @@ impl IMFSchemeHandler_Vtbl {
         iid == &<IMFSchemeHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSecureBuffer_Impl: Sized {
     fn GetIdentifier(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -12906,6 +13147,7 @@ impl IMFSecureBuffer_Vtbl {
         iid == &<IMFSecureBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSecureChannel_Impl: Sized {
     fn GetCertificate(&self, ppcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::Result<()>;
     fn SetupSession(&self, pbencryptedsessionkey: *const u8, cbsessionkey: u32) -> ::windows::core::Result<()>;
@@ -12933,6 +13175,7 @@ impl IMFSecureChannel_Vtbl {
         iid == &<IMFSecureChannel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFSeekInfo_Impl: Sized {
     fn GetNearestKeyFrames(&self, pguidtimeformat: *const ::windows::core::GUID, pvarstartposition: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pvarpreviouskeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pvarnextkeyframe: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -12953,6 +13196,7 @@ impl IMFSeekInfo_Vtbl {
         iid == &<IMFSeekInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorActivitiesReport_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetActivityReport(&self, index: u32) -> ::windows::core::Result<IMFSensorActivityReport>;
@@ -13005,6 +13249,7 @@ impl IMFSensorActivitiesReport_Vtbl {
         iid == &<IMFSensorActivitiesReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorActivitiesReportCallback_Impl: Sized {
     fn OnActivitiesReport(&self, sensoractivitiesreport: &::core::option::Option<IMFSensorActivitiesReport>) -> ::windows::core::Result<()>;
 }
@@ -13022,6 +13267,7 @@ impl IMFSensorActivitiesReportCallback_Vtbl {
         iid == &<IMFSensorActivitiesReportCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorActivityMonitor_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -13045,6 +13291,7 @@ impl IMFSensorActivityMonitor_Vtbl {
         iid == &<IMFSensorActivityMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorActivityReport_Impl: Sized {
     fn GetFriendlyName(&self, friendlyname: ::windows::core::PWSTR, cchfriendlyname: u32, pcchwritten: *mut u32) -> ::windows::core::Result<()>;
     fn GetSymbolicLink(&self, symboliclink: ::windows::core::PWSTR, cchsymboliclink: u32, pcchwritten: *mut u32) -> ::windows::core::Result<()>;
@@ -13098,6 +13345,7 @@ impl IMFSensorActivityReport_Vtbl {
         iid == &<IMFSensorActivityReport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorDevice_Impl: Sized {
     fn GetDeviceId(&self) -> ::windows::core::Result<u64>;
     fn GetDeviceType(&self) -> ::windows::core::Result<MFSensorDeviceType>;
@@ -13210,6 +13458,7 @@ impl IMFSensorDevice_Vtbl {
         iid == &<IMFSensorDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorGroup_Impl: Sized {
     fn GetSymbolicLink(&self, symboliclink: ::windows::core::PWSTR, cchsymboliclink: i32, pcchwritten: *mut i32) -> ::windows::core::Result<()>;
     fn GetFlags(&self) -> ::windows::core::Result<u64>;
@@ -13309,6 +13558,7 @@ impl IMFSensorGroup_Vtbl {
         iid == &<IMFSensorGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFSensorProcessActivity_Impl: Sized {
     fn GetProcessId(&self) -> ::windows::core::Result<u32>;
@@ -13377,6 +13627,7 @@ impl IMFSensorProcessActivity_Vtbl {
         iid == &<IMFSensorProcessActivity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFSensorProfile_Impl: Sized {
     fn GetProfileId(&self) -> ::windows::core::Result<SENSORPROFILEID>;
@@ -13433,6 +13684,7 @@ impl IMFSensorProfile_Vtbl {
         iid == &<IMFSensorProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorProfileCollection_Impl: Sized {
     fn GetProfileCount(&self) -> u32;
     fn GetProfile(&self, index: u32) -> ::windows::core::Result<IMFSensorProfile>;
@@ -13500,6 +13752,7 @@ impl IMFSensorProfileCollection_Vtbl {
         iid == &<IMFSensorProfileCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFSensorStream_Impl: Sized + IMFAttributes_Impl {
     fn GetMediaTypeCount(&self) -> ::windows::core::Result<u32>;
@@ -13555,6 +13808,7 @@ impl IMFSensorStream_Vtbl {
         iid == &<IMFSensorStream as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSensorTransformFactory_Impl: Sized {
     fn GetFactoryAttributes(&self) -> ::windows::core::Result<IMFAttributes>;
     fn InitializeFactory(&self, dwmaxtransformcount: u32, psensordevices: &::core::option::Option<IMFCollection>, pattributes: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
@@ -13621,6 +13875,7 @@ impl IMFSensorTransformFactory_Vtbl {
         iid == &<IMFSensorTransformFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSequencerSource_Impl: Sized {
     fn AppendTopology(&self, ptopology: &::core::option::Option<IMFTopology>, dwflags: u32) -> ::windows::core::Result<u32>;
     fn DeleteTopology(&self, dwid: u32) -> ::windows::core::Result<()>;
@@ -13675,6 +13930,7 @@ impl IMFSequencerSource_Vtbl {
         iid == &<IMFSequencerSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSharingEngineClassFactory_Impl: Sized {
     fn CreateInstance(&self, dwflags: u32, pattr: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -13698,6 +13954,7 @@ impl IMFSharingEngineClassFactory_Vtbl {
         iid == &<IMFSharingEngineClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFShutdown_Impl: Sized {
     fn Shutdown(&self) -> ::windows::core::Result<()>;
     fn GetShutdownStatus(&self) -> ::windows::core::Result<MFSHUTDOWN_STATUS>;
@@ -13731,6 +13988,7 @@ impl IMFShutdown_Vtbl {
         iid == &<IMFShutdown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSignedLibrary_Impl: Sized {
     fn GetProcedureAddress(&self, name: &::windows::core::PCSTR, address: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -13748,6 +14006,7 @@ impl IMFSignedLibrary_Vtbl {
         iid == &<IMFSignedLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFSimpleAudioVolume_Impl: Sized {
     fn SetMasterVolume(&self, flevel: f32) -> ::windows::core::Result<()>;
@@ -13804,6 +14063,7 @@ impl IMFSimpleAudioVolume_Vtbl {
         iid == &<IMFSimpleAudioVolume as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSinkWriter_Impl: Sized {
     fn AddStream(&self, ptargetmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<u32>;
     fn SetInputMediaType(&self, dwstreamindex: u32, pinputmediatype: &::core::option::Option<IMFMediaType>, pencodingparameters: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
@@ -13906,6 +14166,7 @@ impl IMFSinkWriter_Vtbl {
         iid == &<IMFSinkWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSinkWriterCallback_Impl: Sized {
     fn OnFinalize(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnMarker(&self, dwstreamindex: u32, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -13933,6 +14194,7 @@ impl IMFSinkWriterCallback_Vtbl {
         iid == &<IMFSinkWriterCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSinkWriterCallback2_Impl: Sized + IMFSinkWriterCallback_Impl {
     fn OnTransformChange(&self) -> ::windows::core::Result<()>;
     fn OnStreamError(&self, dwstreamindex: u32, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -13960,6 +14222,7 @@ impl IMFSinkWriterCallback2_Vtbl {
         iid == &<IMFSinkWriterCallback2 as ::windows::core::Interface>::IID || iid == &<IMFSinkWriterCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSinkWriterEncoderConfig_Impl: Sized {
     fn SetTargetMediaType(&self, dwstreamindex: u32, ptargetmediatype: &::core::option::Option<IMFMediaType>, pencodingparameters: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
     fn PlaceEncodingParameters(&self, dwstreamindex: u32, pencodingparameters: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
@@ -13987,6 +14250,7 @@ impl IMFSinkWriterEncoderConfig_Vtbl {
         iid == &<IMFSinkWriterEncoderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSinkWriterEx_Impl: Sized + IMFSinkWriter_Impl {
     fn GetTransformForStream(&self, dwstreamindex: u32, dwtransformindex: u32, pguidcategory: *mut ::windows::core::GUID, pptransform: *mut ::core::option::Option<IMFTransform>) -> ::windows::core::Result<()>;
 }
@@ -14004,6 +14268,7 @@ impl IMFSinkWriterEx_Vtbl {
         iid == &<IMFSinkWriterEx as ::windows::core::Interface>::IID || iid == &<IMFSinkWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFSourceBuffer_Impl: Sized {
     fn GetUpdating(&self) -> super::super::Foundation::BOOL;
@@ -14110,6 +14375,7 @@ impl IMFSourceBuffer_Vtbl {
         iid == &<IMFSourceBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSourceBufferAppendMode_Impl: Sized {
     fn GetAppendMode(&self) -> MF_MSE_APPEND_MODE;
     fn SetAppendMode(&self, mode: MF_MSE_APPEND_MODE) -> ::windows::core::Result<()>;
@@ -14137,6 +14403,7 @@ impl IMFSourceBufferAppendMode_Vtbl {
         iid == &<IMFSourceBufferAppendMode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSourceBufferList_Impl: Sized {
     fn GetLength(&self) -> u32;
     fn GetSourceBuffer(&self, index: u32) -> ::core::option::Option<IMFSourceBuffer>;
@@ -14164,6 +14431,7 @@ impl IMFSourceBufferList_Vtbl {
         iid == &<IMFSourceBufferList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSourceBufferNotify_Impl: Sized {
     fn OnUpdateStart(&self);
     fn OnAbort(&self);
@@ -14212,6 +14480,7 @@ impl IMFSourceBufferNotify_Vtbl {
         iid == &<IMFSourceBufferNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSourceOpenMonitor_Impl: Sized {
     fn OnSourceEvent(&self, pevent: &::core::option::Option<IMFMediaEvent>) -> ::windows::core::Result<()>;
 }
@@ -14229,6 +14498,7 @@ impl IMFSourceOpenMonitor_Vtbl {
         iid == &<IMFSourceOpenMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFSourceReader_Impl: Sized {
     fn GetStreamSelection(&self, dwstreamindex: u32) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -14339,6 +14609,7 @@ impl IMFSourceReader_Vtbl {
         iid == &<IMFSourceReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSourceReaderCallback_Impl: Sized {
     fn OnReadSample(&self, hrstatus: ::windows::core::HRESULT, dwstreamindex: u32, dwstreamflags: u32, lltimestamp: i64, psample: &::core::option::Option<IMFSample>) -> ::windows::core::Result<()>;
     fn OnFlush(&self, dwstreamindex: u32) -> ::windows::core::Result<()>;
@@ -14373,6 +14644,7 @@ impl IMFSourceReaderCallback_Vtbl {
         iid == &<IMFSourceReaderCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSourceReaderCallback2_Impl: Sized + IMFSourceReaderCallback_Impl {
     fn OnTransformChange(&self) -> ::windows::core::Result<()>;
     fn OnStreamError(&self, dwstreamindex: u32, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -14400,6 +14672,7 @@ impl IMFSourceReaderCallback2_Vtbl {
         iid == &<IMFSourceReaderCallback2 as ::windows::core::Interface>::IID || iid == &<IMFSourceReaderCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFSourceReaderEx_Impl: Sized + IMFSourceReader_Impl {
     fn SetNativeMediaType(&self, dwstreamindex: u32, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<u32>;
@@ -14450,6 +14723,7 @@ impl IMFSourceReaderEx_Vtbl {
         iid == &<IMFSourceReaderEx as ::windows::core::Interface>::IID || iid == &<IMFSourceReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IMFSourceResolver_Impl: Sized {
     fn CreateObjectFromURL(&self, pwszurl: &::windows::core::PCWSTR, dwflags: u32, pprops: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>, pobjecttype: *mut MF_OBJECT_TYPE, ppobject: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -14515,6 +14789,7 @@ impl IMFSourceResolver_Vtbl {
         iid == &<IMFSourceResolver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio")]
 pub trait IMFSpatialAudioObjectBuffer_Impl: Sized + IMFMediaBuffer_Impl {
     fn SetID(&self, u32id: u32) -> ::windows::core::Result<()>;
@@ -14584,6 +14859,7 @@ impl IMFSpatialAudioObjectBuffer_Vtbl {
         iid == &<IMFSpatialAudioObjectBuffer as ::windows::core::Interface>::IID || iid == &<IMFMediaBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFSpatialAudioSample_Impl: Sized + IMFSample_Impl {
     fn GetObjectCount(&self) -> ::windows::core::Result<u32>;
@@ -14633,6 +14909,7 @@ impl IMFSpatialAudioSample_Vtbl {
         iid == &<IMFSpatialAudioSample as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID || iid == &<IMFSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFStreamDescriptor_Impl: Sized + IMFAttributes_Impl {
     fn GetStreamIdentifier(&self) -> ::windows::core::Result<u32>;
@@ -14675,6 +14952,7 @@ impl IMFStreamDescriptor_Vtbl {
         iid == &<IMFStreamDescriptor as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFStreamSink_Impl: Sized + IMFMediaEventGenerator_Impl {
     fn GetMediaSink(&self) -> ::windows::core::Result<IMFMediaSink>;
@@ -14751,6 +15029,7 @@ impl IMFStreamSink_Vtbl {
         iid == &<IMFStreamSink as ::windows::core::Interface>::IID || iid == &<IMFMediaEventGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFStreamingSinkConfig_Impl: Sized {
     fn StartStreaming(&self, fseekoffsetisbyteoffset: super::super::Foundation::BOOL, qwseekoffset: u64) -> ::windows::core::Result<()>;
@@ -14771,6 +15050,7 @@ impl IMFStreamingSinkConfig_Vtbl {
         iid == &<IMFStreamingSinkConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFSystemId_Impl: Sized {
     fn GetData(&self, size: *mut u32, data: *mut *mut u8) -> ::windows::core::Result<()>;
     fn Setup(&self, stage: u32, cbin: u32, pbin: *const u8, pcbout: *mut u32, ppbout: *mut *mut u8) -> ::windows::core::Result<()>;
@@ -14798,6 +15078,7 @@ impl IMFSystemId_Vtbl {
         iid == &<IMFSystemId as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFTimecodeTranslate_Impl: Sized {
     fn BeginConvertTimecodeToHNS(&self, ppropvartimecode: *const super::super::System::Com::StructuredStorage::PROPVARIANT, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -14854,6 +15135,7 @@ impl IMFTimecodeTranslate_Vtbl {
         iid == &<IMFTimecodeTranslate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFTimedText_Impl: Sized {
     fn RegisterNotifications(&self, notify: &::core::option::Option<IMFTimedTextNotify>) -> ::windows::core::Result<()>;
@@ -15016,6 +15298,7 @@ impl IMFTimedText_Vtbl {
         iid == &<IMFTimedText as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimedTextBinary_Impl: Sized {
     fn GetData(&self, data: *mut *mut u8, length: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -15033,6 +15316,7 @@ impl IMFTimedTextBinary_Vtbl {
         iid == &<IMFTimedTextBinary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimedTextBouten_Impl: Sized {
     fn GetBoutenType(&self) -> ::windows::core::Result<MF_TIMED_TEXT_BOUTEN_TYPE>;
     fn GetBoutenColor(&self) -> ::windows::core::Result<MFARGB>;
@@ -15085,6 +15369,7 @@ impl IMFTimedTextBouten_Vtbl {
         iid == &<IMFTimedTextBouten as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimedTextCue_Impl: Sized {
     fn GetId(&self) -> u32;
     fn GetOriginalId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -15187,6 +15472,7 @@ impl IMFTimedTextCue_Vtbl {
         iid == &<IMFTimedTextCue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimedTextCueList_Impl: Sized {
     fn GetLength(&self) -> u32;
     fn GetCueByIndex(&self, index: u32) -> ::windows::core::Result<IMFTimedTextCue>;
@@ -15267,6 +15553,7 @@ impl IMFTimedTextCueList_Vtbl {
         iid == &<IMFTimedTextCueList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimedTextFormattedText_Impl: Sized {
     fn GetText(&self, text: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn GetSubformattingCount(&self) -> u32;
@@ -15301,6 +15588,7 @@ impl IMFTimedTextFormattedText_Vtbl {
         iid == &<IMFTimedTextFormattedText as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFTimedTextNotify_Impl: Sized {
     fn TrackAdded(&self, trackid: u32);
@@ -15366,6 +15654,7 @@ impl IMFTimedTextNotify_Vtbl {
         iid == &<IMFTimedTextNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFTimedTextRegion_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -15514,6 +15803,7 @@ impl IMFTimedTextRegion_Vtbl {
         iid == &<IMFTimedTextRegion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimedTextRuby_Impl: Sized {
     fn GetRubyText(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetRubyPosition(&self) -> ::windows::core::Result<MF_TIMED_TEXT_RUBY_POSITION>;
@@ -15579,6 +15869,7 @@ impl IMFTimedTextRuby_Vtbl {
         iid == &<IMFTimedTextRuby as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFTimedTextStyle_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -15746,6 +16037,7 @@ impl IMFTimedTextStyle_Vtbl {
         iid == &<IMFTimedTextStyle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFTimedTextStyle2_Impl: Sized {
     fn GetRuby(&self, ruby: *mut ::core::option::Option<IMFTimedTextRuby>) -> ::windows::core::Result<()>;
@@ -15802,6 +16094,7 @@ impl IMFTimedTextStyle2_Vtbl {
         iid == &<IMFTimedTextStyle2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFTimedTextTrack_Impl: Sized {
     fn GetId(&self) -> u32;
@@ -15939,6 +16232,7 @@ impl IMFTimedTextTrack_Vtbl {
         iid == &<IMFTimedTextTrack as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimedTextTrackList_Impl: Sized {
     fn GetLength(&self) -> u32;
     fn GetTrack(&self, index: u32) -> ::windows::core::Result<IMFTimedTextTrack>;
@@ -15985,6 +16279,7 @@ impl IMFTimedTextTrackList_Vtbl {
         iid == &<IMFTimedTextTrackList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTimer_Impl: Sized {
     fn SetTimer(&self, dwflags: u32, llclocktime: i64, pcallback: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn CancelTimer(&self, punkkey: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -16018,6 +16313,7 @@ impl IMFTimer_Vtbl {
         iid == &<IMFTimer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTopoLoader_Impl: Sized {
     fn Load(&self, pinputtopo: &::core::option::Option<IMFTopology>, ppoutputtopo: *mut ::core::option::Option<IMFTopology>, pcurrenttopo: &::core::option::Option<IMFTopology>) -> ::windows::core::Result<()>;
 }
@@ -16035,6 +16331,7 @@ impl IMFTopoLoader_Vtbl {
         iid == &<IMFTopoLoader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFTopology_Impl: Sized + IMFAttributes_Impl {
     fn GetTopologyID(&self) -> ::windows::core::Result<u64>;
@@ -16157,6 +16454,7 @@ impl IMFTopology_Vtbl {
         iid == &<IMFTopology as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFTopologyNode_Impl: Sized + IMFAttributes_Impl {
     fn SetObject(&self, pobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -16327,6 +16625,7 @@ impl IMFTopologyNode_Vtbl {
         iid == &<IMFTopologyNode as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTopologyNodeAttributeEditor_Impl: Sized {
     fn UpdateNodeAttributes(&self, topoid: u64, cupdates: u32, pupdates: *const MFTOPONODE_ATTRIBUTE_UPDATE) -> ::windows::core::Result<()>;
 }
@@ -16344,6 +16643,7 @@ impl IMFTopologyNodeAttributeEditor_Vtbl {
         iid == &<IMFTopologyNodeAttributeEditor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTopologyServiceLookup_Impl: Sized {
     fn LookupService(&self, r#type: MF_SERVICE_LOOKUP_TYPE, dwindex: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobjects: *mut *mut ::core::ffi::c_void, pnobjects: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -16361,6 +16661,7 @@ impl IMFTopologyServiceLookup_Vtbl {
         iid == &<IMFTopologyServiceLookup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTopologyServiceLookupClient_Impl: Sized {
     fn InitServicePointers(&self, plookup: &::core::option::Option<IMFTopologyServiceLookup>) -> ::windows::core::Result<()>;
     fn ReleaseServicePointers(&self) -> ::windows::core::Result<()>;
@@ -16388,6 +16689,7 @@ impl IMFTopologyServiceLookupClient_Vtbl {
         iid == &<IMFTopologyServiceLookupClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTrackedSample_Impl: Sized {
     fn SetAllocator(&self, psampleallocator: &::core::option::Option<IMFAsyncCallback>, punkstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -16405,6 +16707,7 @@ impl IMFTrackedSample_Vtbl {
         iid == &<IMFTrackedSample as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTranscodeProfile_Impl: Sized {
     fn SetAudioAttributes(&self, pattrs: &::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
     fn GetAudioAttributes(&self, ppattrs: *mut ::core::option::Option<IMFAttributes>) -> ::windows::core::Result<()>;
@@ -16460,6 +16763,7 @@ impl IMFTranscodeProfile_Vtbl {
         iid == &<IMFTranscodeProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTranscodeSinkInfoProvider_Impl: Sized {
     fn SetOutputFile(&self, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetOutputByteStream(&self, pbytestreamactivate: &::core::option::Option<IMFActivate>) -> ::windows::core::Result<()>;
@@ -16507,6 +16811,7 @@ impl IMFTranscodeSinkInfoProvider_Vtbl {
         iid == &<IMFTranscodeSinkInfoProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTransform_Impl: Sized {
     fn GetStreamLimits(&self, pdwinputminimum: *mut u32, pdwinputmaximum: *mut u32, pdwoutputminimum: *mut u32, pdwoutputmaximum: *mut u32) -> ::windows::core::Result<()>;
     fn GetStreamCount(&self, pcinputstreams: *mut u32, pcoutputstreams: *mut u32) -> ::windows::core::Result<()>;
@@ -16747,6 +17052,7 @@ impl IMFTransform_Vtbl {
         iid == &<IMFTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFTrustedInput_Impl: Sized {
     fn GetInputTrustAuthority(&self, dwstreamid: u32, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -16770,6 +17076,7 @@ impl IMFTrustedInput_Vtbl {
         iid == &<IMFTrustedInput as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFTrustedOutput_Impl: Sized {
     fn GetOutputTrustAuthorityCount(&self) -> ::windows::core::Result<u32>;
@@ -16825,6 +17132,7 @@ impl IMFTrustedOutput_Vtbl {
         iid == &<IMFTrustedOutput as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoCaptureSampleAllocator_Impl: Sized + IMFVideoSampleAllocator_Impl {
     fn InitializeCaptureSampleAllocator(&self, cbsamplesize: u32, cbcapturemetadatasize: u32, cbalignment: u32, cminimumsamples: u32, pattributes: &::core::option::Option<IMFAttributes>, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
 }
@@ -16845,6 +17153,7 @@ impl IMFVideoCaptureSampleAllocator_Vtbl {
         iid == &<IMFVideoCaptureSampleAllocator as ::windows::core::Interface>::IID || iid == &<IMFVideoSampleAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoDeviceID_Impl: Sized {
     fn GetDeviceID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -16868,6 +17177,7 @@ impl IMFVideoDeviceID_Vtbl {
         iid == &<IMFVideoDeviceID as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IMFVideoDisplayControl_Impl: Sized {
     fn GetNativeVideoSize(&self, pszvideo: *mut super::super::Foundation::SIZE, pszarvideo: *mut super::super::Foundation::SIZE) -> ::windows::core::Result<()>;
@@ -17026,6 +17336,7 @@ impl IMFVideoDisplayControl_Vtbl {
         iid == &<IMFVideoDisplayControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFVideoMediaType_Impl: Sized + IMFMediaType_Impl {
     fn GetVideoFormat(&self) -> *mut MFVIDEOFORMAT;
@@ -17056,6 +17367,7 @@ impl IMFVideoMediaType_Vtbl {
         iid == &<IMFVideoMediaType as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID || iid == &<IMFMediaType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9", feature = "Win32_Graphics_Gdi"))]
 pub trait IMFVideoMixerBitmap_Impl: Sized {
     fn SetAlphaBitmap(&self, pbmpparms: *const MFVideoAlphaBitmap) -> ::windows::core::Result<()>;
@@ -17106,6 +17418,7 @@ impl IMFVideoMixerBitmap_Vtbl {
         iid == &<IMFVideoMixerBitmap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoMixerControl_Impl: Sized {
     fn SetStreamZOrder(&self, dwstreamid: u32, dwz: u32) -> ::windows::core::Result<()>;
     fn GetStreamZOrder(&self, dwstreamid: u32) -> ::windows::core::Result<u32>;
@@ -17159,6 +17472,7 @@ impl IMFVideoMixerControl_Vtbl {
         iid == &<IMFVideoMixerControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoMixerControl2_Impl: Sized + IMFVideoMixerControl_Impl {
     fn SetMixingPrefs(&self, dwmixflags: u32) -> ::windows::core::Result<()>;
     fn GetMixingPrefs(&self) -> ::windows::core::Result<u32>;
@@ -17192,6 +17506,7 @@ impl IMFVideoMixerControl2_Vtbl {
         iid == &<IMFVideoMixerControl2 as ::windows::core::Interface>::IID || iid == &<IMFVideoMixerControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoPositionMapper_Impl: Sized {
     fn MapOutputCoordinateToInputStream(&self, xout: f32, yout: f32, dwoutputstreamindex: u32, dwinputstreamindex: u32, pxin: *mut f32, pyin: *mut f32) -> ::windows::core::Result<()>;
 }
@@ -17212,6 +17527,7 @@ impl IMFVideoPositionMapper_Vtbl {
         iid == &<IMFVideoPositionMapper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoPresenter_Impl: Sized + IMFClockStateSink_Impl {
     fn ProcessMessage(&self, emessage: MFVP_MESSAGE_TYPE, ulparam: usize) -> ::windows::core::Result<()>;
     fn GetCurrentMediaType(&self) -> ::windows::core::Result<IMFVideoMediaType>;
@@ -17245,6 +17561,7 @@ impl IMFVideoPresenter_Vtbl {
         iid == &<IMFVideoPresenter as ::windows::core::Interface>::IID || iid == &<IMFClockStateSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct3D9\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct3D9"))]
 pub trait IMFVideoProcessor_Impl: Sized {
     fn GetAvailableVideoProcessorModes(&self, lpdwnumprocessingmodes: *mut u32, ppvideoprocessingmodes: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -17387,6 +17704,7 @@ impl IMFVideoProcessor_Vtbl {
         iid == &<IMFVideoProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFVideoProcessorControl_Impl: Sized {
     fn SetBorderColor(&self, pbordercolor: *const MFARGB) -> ::windows::core::Result<()>;
@@ -17445,6 +17763,7 @@ impl IMFVideoProcessorControl_Vtbl {
         iid == &<IMFVideoProcessorControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFVideoProcessorControl2_Impl: Sized + IMFVideoProcessorControl_Impl {
     fn SetRotationOverride(&self, uirotation: u32) -> ::windows::core::Result<()>;
@@ -17488,6 +17807,7 @@ impl IMFVideoProcessorControl2_Vtbl {
         iid == &<IMFVideoProcessorControl2 as ::windows::core::Interface>::IID || iid == &<IMFVideoProcessorControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMFVideoProcessorControl3_Impl: Sized + IMFVideoProcessorControl2_Impl {
     fn GetNaturalOutputType(&self) -> ::windows::core::Result<IMFMediaType>;
@@ -17538,6 +17858,7 @@ impl IMFVideoProcessorControl3_Vtbl {
         iid == &<IMFVideoProcessorControl3 as ::windows::core::Interface>::IID || iid == &<IMFVideoProcessorControl as ::windows::core::Interface>::IID || iid == &<IMFVideoProcessorControl2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoRenderer_Impl: Sized {
     fn InitializeRenderer(&self, pvideomixer: &::core::option::Option<IMFTransform>, pvideopresenter: &::core::option::Option<IMFVideoPresenter>) -> ::windows::core::Result<()>;
 }
@@ -17555,6 +17876,7 @@ impl IMFVideoRenderer_Vtbl {
         iid == &<IMFVideoRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoRendererEffectControl_Impl: Sized {
     fn OnAppServiceConnectionEstablished(&self, pappserviceconnection: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -17575,6 +17897,7 @@ impl IMFVideoRendererEffectControl_Vtbl {
         iid == &<IMFVideoRendererEffectControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoSampleAllocator_Impl: Sized {
     fn SetDirectXManager(&self, pmanager: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn UninitializeSampleAllocator(&self) -> ::windows::core::Result<()>;
@@ -17622,6 +17945,7 @@ impl IMFVideoSampleAllocator_Vtbl {
         iid == &<IMFVideoSampleAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoSampleAllocatorCallback_Impl: Sized {
     fn SetCallback(&self, pnotify: &::core::option::Option<IMFVideoSampleAllocatorNotify>) -> ::windows::core::Result<()>;
     fn GetFreeSampleCount(&self) -> ::windows::core::Result<i32>;
@@ -17655,6 +17979,7 @@ impl IMFVideoSampleAllocatorCallback_Vtbl {
         iid == &<IMFVideoSampleAllocatorCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoSampleAllocatorEx_Impl: Sized + IMFVideoSampleAllocator_Impl {
     fn InitializeSampleAllocatorEx(&self, cinitialsamples: u32, cmaximumsamples: u32, pattributes: &::core::option::Option<IMFAttributes>, pmediatype: &::core::option::Option<IMFMediaType>) -> ::windows::core::Result<()>;
 }
@@ -17675,6 +18000,7 @@ impl IMFVideoSampleAllocatorEx_Vtbl {
         iid == &<IMFVideoSampleAllocatorEx as ::windows::core::Interface>::IID || iid == &<IMFVideoSampleAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoSampleAllocatorNotify_Impl: Sized {
     fn NotifyRelease(&self) -> ::windows::core::Result<()>;
 }
@@ -17692,6 +18018,7 @@ impl IMFVideoSampleAllocatorNotify_Vtbl {
         iid == &<IMFVideoSampleAllocatorNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFVideoSampleAllocatorNotifyEx_Impl: Sized + IMFVideoSampleAllocatorNotify_Impl {
     fn NotifyPrune(&self, __midl__imfvideosampleallocatornotifyex0000: &::core::option::Option<IMFSample>) -> ::windows::core::Result<()>;
 }
@@ -17709,6 +18036,7 @@ impl IMFVideoSampleAllocatorNotifyEx_Vtbl {
         iid == &<IMFVideoSampleAllocatorNotifyEx as ::windows::core::Interface>::IID || iid == &<IMFVideoSampleAllocatorNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Devices_Properties\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Devices_Properties", feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IMFVirtualCamera_Impl: Sized + IMFAttributes_Impl {
     fn AddDeviceSourceInfo(&self, devicesourceinfo: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -17820,6 +18148,7 @@ impl IMFVirtualCamera_Vtbl {
         iid == &<IMFVirtualCamera as ::windows::core::Interface>::IID || iid == &<IMFAttributes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFWorkQueueServices_Impl: Sized {
     fn BeginRegisterTopologyWorkQueuesWithMMCSS(&self, pcallback: &::core::option::Option<IMFAsyncCallback>, pstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn EndRegisterTopologyWorkQueuesWithMMCSS(&self, presult: &::core::option::Option<IMFAsyncResult>) -> ::windows::core::Result<()>;
@@ -17935,6 +18264,7 @@ impl IMFWorkQueueServices_Vtbl {
         iid == &<IMFWorkQueueServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IMFWorkQueueServicesEx_Impl: Sized + IMFWorkQueueServices_Impl {
     fn GetTopologyWorkQueueMMCSSPriority(&self, dwtopologyworkqueueid: u32) -> ::windows::core::Result<i32>;
     fn BeginRegisterPlatformWorkQueueWithMMCSSEx(&self, dwplatformworkqueue: u32, wszclass: &::windows::core::PCWSTR, dwtaskid: u32, lpriority: i32, pcallback: &::core::option::Option<IMFAsyncCallback>, pstate: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -17981,6 +18311,7 @@ impl IMFWorkQueueServicesEx_Vtbl {
         iid == &<IMFWorkQueueServicesEx as ::windows::core::Interface>::IID || iid == &<IMFWorkQueueServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IOPMVideoOutput_Impl: Sized {
     fn StartInitialization(&self, prnrandomnumber: *mut OPM_RANDOM_NUMBER, ppbcertificate: *mut *mut u8, pulcertificatelength: *mut u32) -> ::windows::core::Result<()>;
     fn FinishInitialization(&self, pparameters: *const OPM_ENCRYPTED_INITIALIZATION_PARAMETERS) -> ::windows::core::Result<()>;
@@ -18041,6 +18372,7 @@ impl IOPMVideoOutput_Vtbl {
         iid == &<IOPMVideoOutput as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IPlayToControl_Impl: Sized {
     fn Connect(&self, pfactory: &::core::option::Option<IMFSharingEngineClassFactory>) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
@@ -18068,6 +18400,7 @@ impl IPlayToControl_Vtbl {
         iid == &<IPlayToControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IPlayToControlWithCapabilities_Impl: Sized + IPlayToControl_Impl {
     fn GetCapabilities(&self) -> ::windows::core::Result<PLAYTO_SOURCE_CREATEFLAGS>;
 }
@@ -18091,6 +18424,7 @@ impl IPlayToControlWithCapabilities_Vtbl {
         iid == &<IPlayToControlWithCapabilities as ::windows::core::Interface>::IID || iid == &<IPlayToControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IPlayToSourceClassFactory_Impl: Sized {
     fn CreateInstance(&self, dwflags: u32, pcontrol: &::core::option::Option<IPlayToControl>) -> ::windows::core::Result<::windows::core::IInspectable>;
 }
@@ -18114,6 +18448,7 @@ impl IPlayToSourceClassFactory_Vtbl {
         iid == &<IPlayToSourceClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IToc_Impl: Sized {
     fn SetDescriptor(&self, pdescriptor: *mut TOC_DESCRIPTOR) -> ::windows::core::Result<()>;
     fn GetDescriptor(&self, pdescriptor: *mut TOC_DESCRIPTOR) -> ::windows::core::Result<()>;
@@ -18210,6 +18545,7 @@ impl IToc_Vtbl {
         iid == &<IToc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait ITocCollection_Impl: Sized {
     fn GetEntryCount(&self, pdwentrycount: *mut u32) -> ::windows::core::Result<()>;
     fn GetEntryByIndex(&self, dwentryindex: u32) -> ::windows::core::Result<IToc>;
@@ -18264,6 +18600,7 @@ impl ITocCollection_Vtbl {
         iid == &<ITocCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait ITocEntry_Impl: Sized {
     fn SetTitle(&self, pwsztitle: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetTitle(&self, pwtitlesize: *mut u16, pwsztitle: ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -18333,6 +18670,7 @@ impl ITocEntry_Vtbl {
         iid == &<ITocEntry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait ITocEntryList_Impl: Sized {
     fn GetEntryCount(&self, pdwentrycount: *mut u32) -> ::windows::core::Result<()>;
     fn GetEntryByIndex(&self, dwentryindex: u32) -> ::windows::core::Result<ITocEntry>;
@@ -18387,6 +18725,7 @@ impl ITocEntryList_Vtbl {
         iid == &<ITocEntryList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait ITocParser_Impl: Sized {
     fn Init(&self, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetTocCount(&self, enumtocpostype: TOC_POS_TYPE, pdwtoccount: *mut u32) -> ::windows::core::Result<()>;
@@ -18468,6 +18807,7 @@ impl ITocParser_Vtbl {
         iid == &<ITocParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IValidateBinding_Impl: Sized {
     fn GetIdentifier(&self, guidlicensorid: &::windows::core::GUID, pbephemeron: *const u8, cbephemeron: u32, ppbblobvalidationid: *mut *mut u8, pcbblobsize: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -18485,6 +18825,7 @@ impl IValidateBinding_Vtbl {
         iid == &<IValidateBinding as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMCodecLeakyBucket_Impl: Sized {
     fn SetBufferSizeBits(&self, ulbuffersize: u32) -> ::windows::core::Result<()>;
     fn GetBufferSizeBits(&self, pulbuffersize: *mut u32) -> ::windows::core::Result<()>;
@@ -18526,6 +18867,7 @@ impl IWMCodecLeakyBucket_Vtbl {
         iid == &<IWMCodecLeakyBucket as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMCodecOutputTimestamp_Impl: Sized {
     fn GetNextOutputTime(&self, prttime: *mut i64) -> ::windows::core::Result<()>;
 }
@@ -18543,6 +18885,7 @@ impl IWMCodecOutputTimestamp_Vtbl {
         iid == &<IWMCodecOutputTimestamp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
 pub trait IWMCodecPrivateData_Impl: Sized {
     fn SetPartialOutputType(&self, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE) -> ::windows::core::Result<()>;
@@ -18573,6 +18916,7 @@ impl IWMCodecPrivateData_Vtbl {
         iid == &<IWMCodecPrivateData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
 pub trait IWMCodecProps_Impl: Sized {
     fn GetFormatProp(&self, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_PROP_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
@@ -18603,6 +18947,7 @@ impl IWMCodecProps_Vtbl {
         iid == &<IWMCodecProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DxMediaObjects"))]
 pub trait IWMCodecStrings_Impl: Sized {
     fn GetName(&self, pmt: *mut super::DxMediaObjects::DMO_MEDIA_TYPE, cchlength: u32, szname: ::windows::core::PWSTR, pcchlength: *mut u32) -> ::windows::core::Result<()>;
@@ -18633,6 +18978,7 @@ impl IWMCodecStrings_Vtbl {
         iid == &<IWMCodecStrings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMColorConvProps_Impl: Sized {
     fn SetMode(&self, lmode: i32) -> ::windows::core::Result<()>;
     fn SetFullCroppingParam(&self, lsrccropleft: i32, lsrccroptop: i32, ldstcropleft: i32, ldstcroptop: i32, lcropwidth: i32, lcropheight: i32) -> ::windows::core::Result<()>;
@@ -18660,6 +19006,7 @@ impl IWMColorConvProps_Vtbl {
         iid == &<IWMColorConvProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMColorLegalizerProps_Impl: Sized {
     fn SetColorLegalizerQuality(&self, lquality: i32) -> ::windows::core::Result<()>;
 }
@@ -18677,6 +19024,7 @@ impl IWMColorLegalizerProps_Vtbl {
         iid == &<IWMColorLegalizerProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMFrameInterpProps_Impl: Sized {
     fn SetFrameRateIn(&self, lframerate: i32, lscale: i32) -> ::windows::core::Result<()>;
@@ -18721,6 +19069,7 @@ impl IWMFrameInterpProps_Vtbl {
         iid == &<IWMFrameInterpProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMInterlaceProps_Impl: Sized {
     fn SetProcessType(&self, iprocesstype: i32) -> ::windows::core::Result<()>;
     fn SetInitInverseTeleCinePattern(&self, iinitpattern: i32) -> ::windows::core::Result<()>;
@@ -18755,6 +19104,7 @@ impl IWMInterlaceProps_Vtbl {
         iid == &<IWMInterlaceProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMResamplerProps_Impl: Sized {
     fn SetHalfFilterLength(&self, lhalffilterlen: i32) -> ::windows::core::Result<()>;
     fn SetUserChannelMtx(&self, userchannelmtx: *mut f32) -> ::windows::core::Result<()>;
@@ -18782,6 +19132,7 @@ impl IWMResamplerProps_Vtbl {
         iid == &<IWMResamplerProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMResizerProps_Impl: Sized {
     fn SetResizerQuality(&self, lquality: i32) -> ::windows::core::Result<()>;
     fn SetInterlaceMode(&self, lmode: i32) -> ::windows::core::Result<()>;
@@ -18830,6 +19181,7 @@ impl IWMResizerProps_Vtbl {
         iid == &<IWMResizerProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMSampleExtensionSupport_Impl: Sized {
     fn SetUseSampleExtensions(&self, fuseextensions: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -18850,6 +19202,7 @@ impl IWMSampleExtensionSupport_Vtbl {
         iid == &<IWMSampleExtensionSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMValidate_Impl: Sized {
     fn SetIdentifier(&self, guidvalidationid: &::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -18867,6 +19220,7 @@ impl IWMValidate_Vtbl {
         iid == &<IWMValidate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMVideoDecoderHurryup_Impl: Sized {
     fn SetHurryup(&self, lhurryup: i32) -> ::windows::core::Result<()>;
     fn GetHurryup(&self, plhurryup: *mut i32) -> ::windows::core::Result<()>;
@@ -18894,6 +19248,7 @@ impl IWMVideoDecoderHurryup_Vtbl {
         iid == &<IWMVideoDecoderHurryup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"Win32_Media_DxMediaObjects\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_DxMediaObjects")]
 pub trait IWMVideoDecoderReconBuffer_Impl: Sized {
     fn GetReconstructedVideoFrameSize(&self, pdwsize: *mut u32) -> ::windows::core::Result<()>;
@@ -18931,6 +19286,7 @@ impl IWMVideoDecoderReconBuffer_Vtbl {
         iid == &<IWMVideoDecoderReconBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait IWMVideoForceKeyFrame_Impl: Sized {
     fn SetKeyFrame(&self) -> ::windows::core::Result<()>;
 }
@@ -18948,6 +19304,7 @@ impl IWMVideoForceKeyFrame_Vtbl {
         iid == &<IWMVideoForceKeyFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 pub trait MFASYNCRESULT_Impl: Sized + IMFAsyncResult_Impl {}
 impl ::windows::core::RuntimeName for MFASYNCRESULT {}
 impl MFASYNCRESULT_Vtbl {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeed_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Xml(&self, count: i32, sortproperty: FEEDS_XML_SORT_PROPERTY, sortorder: FEEDS_XML_SORT_ORDER, filterflags: FEEDS_XML_FILTER_FLAGS, includeflags: FEEDS_XML_INCLUDE_FLAGS) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -508,6 +509,7 @@ impl IFeed_Vtbl {
         iid == &<IFeed as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeed2_Impl: Sized + IFeed_Impl {
     fn GetItemByEffectiveId(&self, itemeffectiveid: i32) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -590,6 +592,7 @@ impl IFeed2_Vtbl {
         iid == &<IFeed2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFeed as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedEnclosure_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Url(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -751,6 +754,7 @@ impl IFeedEnclosure_Vtbl {
         iid == &<IFeedEnclosure as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Error(&self) -> ::windows::core::Result<()>;
@@ -823,6 +827,7 @@ impl IFeedEvents_Vtbl {
         iid == &<IFeedEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedFolder_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Feeds(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -1055,6 +1060,7 @@ impl IFeedFolder_Vtbl {
         iid == &<IFeedFolder as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedFolderEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Error(&self) -> ::windows::core::Result<()>;
@@ -1183,6 +1189,7 @@ impl IFeedFolderEvents_Vtbl {
         iid == &<IFeedFolderEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Xml(&self, includeflags: FEEDS_XML_INCLUDE_FLAGS) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1408,6 +1415,7 @@ impl IFeedItem_Vtbl {
         iid == &<IFeedItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedItem2_Impl: Sized + IFeedItem_Impl {
     fn EffectiveId(&self) -> ::windows::core::Result<i32>;
@@ -1434,6 +1442,7 @@ impl IFeedItem2_Vtbl {
         iid == &<IFeedItem2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFeedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedsEnum_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1489,6 +1498,7 @@ impl IFeedsEnum_Vtbl {
         iid == &<IFeedsEnum as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFeedsManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RootFolder(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -1683,6 +1693,7 @@ impl IFeedsManager_Vtbl {
         iid == &<IFeedsManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPAudioRenderConfig_Impl: Sized {
     fn audioOutputDevice(&self, pbstroutputdevice: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn SetaudioOutputDevice(&self, bstroutputdevice: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1710,6 +1721,7 @@ impl IWMPAudioRenderConfig_Vtbl {
         iid == &<IWMPAudioRenderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPCdrom_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn driveSpecifier(&self, pbstrdrive: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1753,6 +1765,7 @@ impl IWMPCdrom_Vtbl {
         iid == &<IWMPCdrom as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPCdromBurn_Impl: Sized {
     fn isAvailable(&self, bstritem: &::windows::core::BSTR, pisavailable: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -1873,6 +1886,7 @@ impl IWMPCdromBurn_Vtbl {
         iid == &<IWMPCdromBurn as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPCdromCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -1922,6 +1936,7 @@ impl IWMPCdromCollection_Vtbl {
         iid == &<IWMPCdromCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPCdromRip_Impl: Sized {
     fn ripState(&self, pwmprs: *mut WMPRipState) -> ::windows::core::Result<()>;
     fn ripProgress(&self, plprogress: *mut i32) -> ::windows::core::Result<()>;
@@ -1963,6 +1978,7 @@ impl IWMPCdromRip_Vtbl {
         iid == &<IWMPCdromRip as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPClosedCaption_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SAMIStyle(&self, pbstrsamistyle: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2035,6 +2051,7 @@ impl IWMPClosedCaption_Vtbl {
         iid == &<IWMPClosedCaption as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPClosedCaption2_Impl: Sized + IWMPClosedCaption_Impl {
     fn SAMILangCount(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -2086,6 +2103,7 @@ impl IWMPClosedCaption2_Vtbl {
         iid == &<IWMPClosedCaption2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPClosedCaption as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPContentContainer_Impl: Sized {
     fn GetID(&self) -> ::windows::core::Result<u32>;
     fn GetPrice(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2177,6 +2195,7 @@ impl IWMPContentContainer_Vtbl {
         iid == &<IWMPContentContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPContentContainerList_Impl: Sized {
     fn GetTransactionType(&self) -> ::windows::core::Result<WMPTransactionType>;
     fn GetContainerCount(&self) -> ::windows::core::Result<u32>;
@@ -2229,6 +2248,7 @@ impl IWMPContentContainerList_Vtbl {
         iid == &<IWMPContentContainerList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPContentPartner_Impl: Sized {
     fn SetCallback(&self, pcallback: &::core::option::Option<IWMPContentPartnerCallback>) -> ::windows::core::Result<()>;
@@ -2430,6 +2450,7 @@ impl IWMPContentPartner_Vtbl {
         iid == &<IWMPContentPartner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPContentPartnerCallback_Impl: Sized {
     fn Notify(&self, r#type: WMPCallbackNotification, pcontext: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2537,6 +2558,7 @@ impl IWMPContentPartnerCallback_Vtbl {
         iid == &<IWMPContentPartnerCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPControls_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_isAvailable(&self, bstritem: &::windows::core::BSTR, pisavailable: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -2671,6 +2693,7 @@ impl IWMPControls_Vtbl {
         iid == &<IWMPControls as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPControls2_Impl: Sized + IWMPControls_Impl {
     fn step(&self, lstep: i32) -> ::windows::core::Result<()>;
@@ -2691,6 +2714,7 @@ impl IWMPControls2_Vtbl {
         iid == &<IWMPControls2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPControls as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPControls3_Impl: Sized + IWMPControls2_Impl {
     fn audioLanguageCount(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -2777,6 +2801,7 @@ impl IWMPControls3_Vtbl {
         iid == &<IWMPControls3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPControls as ::windows::core::Interface>::IID || iid == &<IWMPControls2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPConvert_Impl: Sized {
     fn ConvertFile(&self, bstrinputfile: &::windows::core::BSTR, bstrdestinationfolder: &::windows::core::BSTR, pbstroutputfile: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn GetErrorURL(&self, pbstrurl: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2804,6 +2829,7 @@ impl IWMPConvert_Vtbl {
         iid == &<IWMPConvert as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPCore_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn close(&self) -> ::windows::core::Result<()>;
@@ -3027,6 +3053,7 @@ impl IWMPCore_Vtbl {
         iid == &<IWMPCore as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPCore2_Impl: Sized + IWMPCore_Impl {
     fn dvd(&self) -> ::windows::core::Result<IWMPDVD>;
@@ -3053,6 +3080,7 @@ impl IWMPCore2_Vtbl {
         iid == &<IWMPCore2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPCore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPCore3_Impl: Sized + IWMPCore2_Impl {
     fn newPlaylist(&self, bstrname: &::windows::core::BSTR, bstrurl: &::windows::core::BSTR) -> ::windows::core::Result<IWMPPlaylist>;
@@ -3095,6 +3123,7 @@ impl IWMPCore3_Vtbl {
         iid == &<IWMPCore3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPCore as ::windows::core::Interface>::IID || iid == &<IWMPCore2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPDVD_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_isAvailable(&self, bstritem: &::windows::core::BSTR, pisavailable: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3153,6 +3182,7 @@ impl IWMPDVD_Vtbl {
         iid == &<IWMPDVD as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPDownloadCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn id(&self, plid: *mut i32) -> ::windows::core::Result<()>;
@@ -3223,6 +3253,7 @@ impl IWMPDownloadCollection_Vtbl {
         iid == &<IWMPDownloadCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPDownloadItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn sourceURL(&self, pbstrurl: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3295,6 +3326,7 @@ impl IWMPDownloadItem_Vtbl {
         iid == &<IWMPDownloadItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPDownloadItem2_Impl: Sized + IWMPDownloadItem_Impl {
     fn getItemInfo(&self, bstritemname: &::windows::core::BSTR, pbstrval: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3315,6 +3347,7 @@ impl IWMPDownloadItem2_Vtbl {
         iid == &<IWMPDownloadItem2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPDownloadItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPDownloadManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn getDownloadCollection(&self, lcollectionid: i32) -> ::windows::core::Result<IWMPDownloadCollection>;
@@ -3357,6 +3390,7 @@ impl IWMPDownloadManager_Vtbl {
         iid == &<IWMPDownloadManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IWMPEffects_Impl: Sized {
     fn Render(&self, plevels: *mut TimedLevel, hdc: super::super::Graphics::Gdi::HDC, prc: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -3450,6 +3484,7 @@ impl IWMPEffects_Vtbl {
         iid == &<IWMPEffects as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IWMPEffects2_Impl: Sized + IWMPEffects_Impl {
     fn SetCore(&self, pplayer: &::core::option::Option<IWMPCore>) -> ::windows::core::Result<()>;
@@ -3508,6 +3543,7 @@ impl IWMPEffects2_Vtbl {
         iid == &<IWMPEffects2 as ::windows::core::Interface>::IID || iid == &<IWMPEffects as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPError_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn clearErrorQueue(&self) -> ::windows::core::Result<()>;
@@ -3558,6 +3594,7 @@ impl IWMPError_Vtbl {
         iid == &<IWMPError as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPErrorItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn errorCode(&self, phr: *mut i32) -> ::windows::core::Result<()>;
@@ -3609,6 +3646,7 @@ impl IWMPErrorItem_Vtbl {
         iid == &<IWMPErrorItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPErrorItem2_Impl: Sized + IWMPErrorItem_Impl {
     fn condition(&self, plcondition: *mut i32) -> ::windows::core::Result<()>;
@@ -3629,6 +3667,7 @@ impl IWMPErrorItem2_Vtbl {
         iid == &<IWMPErrorItem2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPErrorItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPEvents_Impl: Sized {
     fn OpenStateChange(&self, newstate: i32);
@@ -3960,6 +3999,7 @@ impl IWMPEvents_Vtbl {
         iid == &<IWMPEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPEvents2_Impl: Sized + IWMPEvents_Impl {
     fn DeviceConnect(&self, pdevice: &::core::option::Option<IWMPSyncDevice>);
@@ -4018,6 +4058,7 @@ impl IWMPEvents2_Vtbl {
         iid == &<IWMPEvents2 as ::windows::core::Interface>::IID || iid == &<IWMPEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPEvents3_Impl: Sized + IWMPEvents2_Impl {
     fn CdromRipStateChange(&self, pcdromrip: &::core::option::Option<IWMPCdromRip>, wmprs: WMPRipState);
@@ -4111,6 +4152,7 @@ impl IWMPEvents3_Vtbl {
         iid == &<IWMPEvents3 as ::windows::core::Interface>::IID || iid == &<IWMPEvents as ::windows::core::Interface>::IID || iid == &<IWMPEvents2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPEvents4_Impl: Sized + IWMPEvents3_Impl {
     fn DeviceEstimation(&self, pdevice: &::core::option::Option<IWMPSyncDevice>, hrresult: ::windows::core::HRESULT, qwestimatedusedspace: i64, qwestimatedspace: i64);
@@ -4131,6 +4173,7 @@ impl IWMPEvents4_Vtbl {
         iid == &<IWMPEvents4 as ::windows::core::Interface>::IID || iid == &<IWMPEvents as ::windows::core::Interface>::IID || iid == &<IWMPEvents2 as ::windows::core::Interface>::IID || iid == &<IWMPEvents3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPFolderMonitorServices_Impl: Sized {
     fn count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn item(&self, lindex: i32, pbstrfolder: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4221,6 +4264,7 @@ impl IWMPFolderMonitorServices_Vtbl {
         iid == &<IWMPFolderMonitorServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPGraphCreation_Impl: Sized {
     fn GraphCreationPreRender(&self, pfiltergraph: &::core::option::Option<::windows::core::IUnknown>, preserved: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GraphCreationPostRender(&self, pfiltergraph: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -4255,6 +4299,7 @@ impl IWMPGraphCreation_Vtbl {
         iid == &<IWMPGraphCreation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPLibrary_Impl: Sized {
     fn name(&self, pbstrname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4305,6 +4350,7 @@ impl IWMPLibrary_Vtbl {
         iid == &<IWMPLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPLibrary2_Impl: Sized + IWMPLibrary_Impl {
     fn getItemInfo(&self, bstritemname: &::windows::core::BSTR, pbstrval: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4325,6 +4371,7 @@ impl IWMPLibrary2_Vtbl {
         iid == &<IWMPLibrary2 as ::windows::core::Interface>::IID || iid == &<IWMPLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPLibraryServices_Impl: Sized {
     fn getCountByType(&self, wmplt: WMPLibraryType, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn getLibraryByType(&self, wmplt: WMPLibraryType, lindex: i32) -> ::windows::core::Result<IWMPLibrary>;
@@ -4358,6 +4405,7 @@ impl IWMPLibraryServices_Vtbl {
         iid == &<IWMPLibraryServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPLibrarySharingServices_Impl: Sized {
     fn isLibraryShared(&self, pvbshared: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -4395,6 +4443,7 @@ impl IWMPLibrarySharingServices_Vtbl {
         iid == &<IWMPLibrarySharingServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPMedia_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_isIdentical(&self, piwmpmedia: &::core::option::Option<IWMPMedia>, pvbool: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -4537,6 +4586,7 @@ impl IWMPMedia_Vtbl {
         iid == &<IWMPMedia as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPMedia2_Impl: Sized + IWMPMedia_Impl {
     fn error(&self) -> ::windows::core::Result<IWMPErrorItem>;
@@ -4563,6 +4613,7 @@ impl IWMPMedia2_Vtbl {
         iid == &<IWMPMedia2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPMedia as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPMedia3_Impl: Sized + IWMPMedia2_Impl {
     fn getAttributeCountByType(&self, bstrtype: &::windows::core::BSTR, bstrlanguage: &::windows::core::BSTR, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -4593,6 +4644,7 @@ impl IWMPMedia3_Vtbl {
         iid == &<IWMPMedia3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPMedia as ::windows::core::Interface>::IID || iid == &<IWMPMedia2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPMediaCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn add(&self, bstrurl: &::windows::core::BSTR) -> ::windows::core::Result<IWMPMedia>;
@@ -4741,6 +4793,7 @@ impl IWMPMediaCollection_Vtbl {
         iid == &<IWMPMediaCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPMediaCollection2_Impl: Sized + IWMPMediaCollection_Impl {
     fn createQuery(&self) -> ::windows::core::Result<IWMPQuery>;
@@ -4809,6 +4862,7 @@ impl IWMPMediaCollection2_Vtbl {
         iid == &<IWMPMediaCollection2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPMediaCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPMediaPluginRegistrar_Impl: Sized {
     fn WMPRegisterPlayerPlugin(&self, pwszfriendlyname: &::windows::core::PCWSTR, pwszdescription: &::windows::core::PCWSTR, pwszuninstallstring: &::windows::core::PCWSTR, dwpriority: u32, guidplugintype: &::windows::core::GUID, clsid: &::windows::core::GUID, cmediatypes: u32, pmediatypes: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn WMPUnRegisterPlayerPlugin(&self, guidplugintype: &::windows::core::GUID, clsid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -4836,6 +4890,7 @@ impl IWMPMediaPluginRegistrar_Vtbl {
         iid == &<IWMPMediaPluginRegistrar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPMetadataPicture_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn mimeType(&self, pbstrmimetype: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4880,6 +4935,7 @@ impl IWMPMetadataPicture_Vtbl {
         iid == &<IWMPMetadataPicture as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPMetadataText_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn description(&self, pbstrdescription: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4910,6 +4966,7 @@ impl IWMPMetadataText_Vtbl {
         iid == &<IWMPMetadataText as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPNetwork_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn bandWidth(&self, plbandwidth: *mut i32) -> ::windows::core::Result<()>;
@@ -5122,6 +5179,7 @@ impl IWMPNetwork_Vtbl {
         iid == &<IWMPNetwork as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPNodeRealEstate_Impl: Sized {
     fn GetDesiredSize(&self, psize: *mut super::super::Foundation::SIZE) -> ::windows::core::Result<()>;
@@ -5187,6 +5245,7 @@ impl IWMPNodeRealEstate_Vtbl {
         iid == &<IWMPNodeRealEstate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPNodeRealEstateHost_Impl: Sized {
     fn OnDesiredSizeChange(&self, psize: *mut super::super::Foundation::SIZE) -> ::windows::core::Result<()>;
@@ -5217,6 +5276,7 @@ impl IWMPNodeRealEstateHost_Vtbl {
         iid == &<IWMPNodeRealEstateHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPNodeWindowed_Impl: Sized {
     fn SetOwnerWindow(&self, hwnd: isize) -> ::windows::core::Result<()>;
     fn GetOwnerWindow(&self, phwnd: *mut isize) -> ::windows::core::Result<()>;
@@ -5244,6 +5304,7 @@ impl IWMPNodeWindowed_Vtbl {
         iid == &<IWMPNodeWindowed as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPNodeWindowedHost_Impl: Sized {
     fn OnWindowMessageFromRenderer(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plret: *mut super::super::Foundation::LRESULT, pfhandled: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5267,6 +5328,7 @@ impl IWMPNodeWindowedHost_Vtbl {
         iid == &<IWMPNodeWindowedHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPNodeWindowless_Impl: Sized + IWMPWindowMessageSink_Impl {
     fn OnDraw(&self, hdc: isize, prcdraw: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -5287,6 +5349,7 @@ impl IWMPNodeWindowless_Vtbl {
         iid == &<IWMPNodeWindowless as ::windows::core::Interface>::IID || iid == &<IWMPWindowMessageSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPNodeWindowlessHost_Impl: Sized {
     fn InvalidateRect(&self, prc: *const super::super::Foundation::RECT, ferase: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5307,6 +5370,7 @@ impl IWMPNodeWindowlessHost_Vtbl {
         iid == &<IWMPNodeWindowlessHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlayer_Impl: Sized + IWMPCore_Impl {
     fn enabled(&self, pbenabled: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -5379,6 +5443,7 @@ impl IWMPPlayer_Vtbl {
         iid == &<IWMPPlayer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPCore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlayer2_Impl: Sized + IWMPCore_Impl {
     fn enabled(&self, pbenabled: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -5479,6 +5544,7 @@ impl IWMPPlayer2_Vtbl {
         iid == &<IWMPPlayer2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPCore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlayer3_Impl: Sized + IWMPCore2_Impl {
     fn enabled(&self, pbenabled: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -5579,6 +5645,7 @@ impl IWMPPlayer3_Vtbl {
         iid == &<IWMPPlayer3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPCore as ::windows::core::Interface>::IID || iid == &<IWMPCore2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlayer4_Impl: Sized + IWMPCore3_Impl {
     fn enabled(&self, pbenabled: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -5706,6 +5773,7 @@ impl IWMPPlayer4_Vtbl {
         iid == &<IWMPPlayer4 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPCore as ::windows::core::Interface>::IID || iid == &<IWMPCore2 as ::windows::core::Interface>::IID || iid == &<IWMPCore3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlayerApplication_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn switchToPlayerApplication(&self) -> ::windows::core::Result<()>;
@@ -5750,6 +5818,7 @@ impl IWMPPlayerApplication_Vtbl {
         iid == &<IWMPPlayerApplication as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPPlayerServices_Impl: Sized {
     fn activateUIPlugin(&self, bstrplugin: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn setTaskPane(&self, bstrtaskpane: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -5784,6 +5853,7 @@ impl IWMPPlayerServices_Vtbl {
         iid == &<IWMPPlayerServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPPlayerServices2_Impl: Sized + IWMPPlayerServices_Impl {
     fn setBackgroundProcessingPriority(&self, bstrpriority: &::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -5804,6 +5874,7 @@ impl IWMPPlayerServices2_Vtbl {
         iid == &<IWMPPlayerServices2 as ::windows::core::Interface>::IID || iid == &<IWMPPlayerServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlaylist_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -5924,6 +5995,7 @@ impl IWMPPlaylist_Vtbl {
         iid == &<IWMPPlaylist as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlaylistArray_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -5960,6 +6032,7 @@ impl IWMPPlaylistArray_Vtbl {
         iid == &<IWMPPlaylistArray as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPPlaylistCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn newPlaylist(&self, bstrname: &::windows::core::BSTR) -> ::windows::core::Result<IWMPPlaylist>;
@@ -6049,6 +6122,7 @@ impl IWMPPlaylistCollection_Vtbl {
         iid == &<IWMPPlaylistCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPPlugin_Impl: Sized {
     fn Init(&self, dwplaybackcontext: usize) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
@@ -6104,6 +6178,7 @@ impl IWMPPlugin_Vtbl {
         iid == &<IWMPPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPPluginEnable_Impl: Sized {
     fn SetEnable(&self, fenable: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -6134,6 +6209,7 @@ impl IWMPPluginEnable_Vtbl {
         iid == &<IWMPPluginEnable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IWMPPluginUI_Impl: Sized {
     fn SetCore(&self, pcore: &::core::option::Option<IWMPCore>) -> ::windows::core::Result<()>;
@@ -6199,6 +6275,7 @@ impl IWMPPluginUI_Vtbl {
         iid == &<IWMPPluginUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPQuery_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn addCondition(&self, bstrattribute: &::windows::core::BSTR, bstroperator: &::windows::core::BSTR, bstrvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6229,6 +6306,7 @@ impl IWMPQuery_Vtbl {
         iid == &<IWMPQuery as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWMPRemoteMediaServices_Impl: Sized {
     fn GetServiceType(&self, pbstrtype: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6273,6 +6351,7 @@ impl IWMPRemoteMediaServices_Vtbl {
         iid == &<IWMPRemoteMediaServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPRenderConfig_Impl: Sized {
     fn SetinProcOnly(&self, finproc: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -6303,6 +6382,7 @@ impl IWMPRenderConfig_Vtbl {
         iid == &<IWMPRenderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPServices_Impl: Sized {
     fn GetStreamTime(&self, prt: *mut i64) -> ::windows::core::Result<()>;
     fn GetStreamState(&self, pstate: *mut WMPServices_StreamState) -> ::windows::core::Result<()>;
@@ -6330,6 +6410,7 @@ impl IWMPServices_Vtbl {
         iid == &<IWMPServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPSettings_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_isAvailable(&self, bstritem: &::windows::core::BSTR, pisavailable: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -6507,6 +6588,7 @@ impl IWMPSettings_Vtbl {
         iid == &<IWMPSettings as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPSettings2_Impl: Sized + IWMPSettings_Impl {
     fn defaultAudioLanguage(&self, pllangid: *mut i32) -> ::windows::core::Result<()>;
@@ -6544,6 +6626,7 @@ impl IWMPSettings2_Vtbl {
         iid == &<IWMPSettings2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPSkinManager_Impl: Sized {
     fn SetVisualStyle(&self, bstrpath: &::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -6561,6 +6644,7 @@ impl IWMPSkinManager_Vtbl {
         iid == &<IWMPSkinManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPStringCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -6591,6 +6675,7 @@ impl IWMPStringCollection_Vtbl {
         iid == &<IWMPStringCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMPStringCollection2_Impl: Sized + IWMPStringCollection_Impl {
     fn isIdentical(&self, piwmpstringcollection2: &::core::option::Option<IWMPStringCollection2>, pvbool: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -6635,6 +6720,7 @@ impl IWMPStringCollection2_Vtbl {
         iid == &<IWMPStringCollection2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWMPStringCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPSubscriptionService_Impl: Sized {
     fn allowPlay(&self, hwnd: super::super::Foundation::HWND, pmedia: &::core::option::Option<IWMPMedia>, pfallowplay: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -6679,6 +6765,7 @@ impl IWMPSubscriptionService_Vtbl {
         iid == &<IWMPSubscriptionService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPSubscriptionService2_Impl: Sized + IWMPSubscriptionService_Impl {
     fn stopBackgroundProcessing(&self) -> ::windows::core::Result<()>;
@@ -6723,6 +6810,7 @@ impl IWMPSubscriptionService2_Vtbl {
         iid == &<IWMPSubscriptionService2 as ::windows::core::Interface>::IID || iid == &<IWMPSubscriptionService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPSubscriptionServiceCallback_Impl: Sized {
     fn onComplete(&self, hrresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -6740,6 +6828,7 @@ impl IWMPSubscriptionServiceCallback_Vtbl {
         iid == &<IWMPSubscriptionServiceCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPSyncDevice_Impl: Sized {
     fn friendlyName(&self, pbstrname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6868,6 +6957,7 @@ impl IWMPSyncDevice_Vtbl {
         iid == &<IWMPSyncDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPSyncDevice2_Impl: Sized + IWMPSyncDevice_Impl {
     fn setItemInfo(&self, bstritemname: &::windows::core::BSTR, bstrval: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6888,6 +6978,7 @@ impl IWMPSyncDevice2_Vtbl {
         iid == &<IWMPSyncDevice2 as ::windows::core::Interface>::IID || iid == &<IWMPSyncDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMPSyncDevice3_Impl: Sized + IWMPSyncDevice2_Impl {
     fn estimateSyncSize(&self, pnonruleplaylist: &::core::option::Option<IWMPPlaylist>, prulesplaylist: &::core::option::Option<IWMPPlaylist>) -> ::windows::core::Result<()>;
@@ -6918,6 +7009,7 @@ impl IWMPSyncDevice3_Vtbl {
         iid == &<IWMPSyncDevice3 as ::windows::core::Interface>::IID || iid == &<IWMPSyncDevice as ::windows::core::Interface>::IID || iid == &<IWMPSyncDevice2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPSyncServices_Impl: Sized {
     fn deviceCount(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
     fn getDevice(&self, lindex: i32) -> ::windows::core::Result<IWMPSyncDevice>;
@@ -6951,6 +7043,7 @@ impl IWMPSyncServices_Vtbl {
         iid == &<IWMPSyncServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPTranscodePolicy_Impl: Sized {
     fn allowTranscode(&self, pvballow: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -6971,6 +7064,7 @@ impl IWMPTranscodePolicy_Vtbl {
         iid == &<IWMPTranscodePolicy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IWMPUserEventSink_Impl: Sized {
     fn NotifyUserEvent(&self, eventcode: i32) -> ::windows::core::Result<()>;
 }
@@ -6988,6 +7082,7 @@ impl IWMPUserEventSink_Vtbl {
         iid == &<IWMPUserEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_MediaFoundation")]
 pub trait IWMPVideoRenderConfig_Impl: Sized {
     fn SetpresenterActivate(&self, pactivate: &::core::option::Option<super::MediaFoundation::IMFActivate>) -> ::windows::core::Result<()>;
@@ -7008,6 +7103,7 @@ impl IWMPVideoRenderConfig_Vtbl {
         iid == &<IWMPVideoRenderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMPWindowMessageSink_Impl: Sized {
     fn OnWindowMessage(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plret: *mut super::super::Foundation::LRESULT, pfhandled: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -7028,6 +7124,7 @@ impl IWMPWindowMessageSink_Vtbl {
         iid == &<IWMPWindowMessageSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXFeed_Impl: Sized {
     fn Xml(&self, uiitemcount: u32, sortproperty: FEEDS_XML_SORT_PROPERTY, sortorder: FEEDS_XML_SORT_ORDER, filterflags: FEEDS_XML_FILTER_FLAGS, includeflags: FEEDS_XML_INCLUDE_FLAGS) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -7520,6 +7617,7 @@ impl IXFeed_Vtbl {
         iid == &<IXFeed as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXFeed2_Impl: Sized + IXFeed_Impl {
     fn GetItemByEffectiveId(&self, uieffectiveid: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -7596,6 +7694,7 @@ impl IXFeed2_Vtbl {
         iid == &<IXFeed2 as ::windows::core::Interface>::IID || iid == &<IXFeed as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IXFeedEnclosure_Impl: Sized {
     fn Url(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn Type(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -7748,6 +7847,7 @@ impl IXFeedEnclosure_Vtbl {
         iid == &<IXFeedEnclosure as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IXFeedEvents_Impl: Sized {
     fn Error(&self) -> ::windows::core::Result<()>;
     fn FeedDeleted(&self, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -7817,6 +7917,7 @@ impl IXFeedEvents_Vtbl {
         iid == &<IXFeedEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXFeedFolder_Impl: Sized {
     fn Feeds(&self) -> ::windows::core::Result<IXFeedsEnum>;
@@ -8001,6 +8102,7 @@ impl IXFeedFolder_Vtbl {
         iid == &<IXFeedFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IXFeedFolderEvents_Impl: Sized {
     fn Error(&self) -> ::windows::core::Result<()>;
     fn FolderAdded(&self, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -8126,6 +8228,7 @@ impl IXFeedFolderEvents_Vtbl {
         iid == &<IXFeedFolderEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXFeedItem_Impl: Sized {
     fn Xml(&self, fxif: FEEDS_XML_INCLUDE_FLAGS) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -8339,6 +8442,7 @@ impl IXFeedItem_Vtbl {
         iid == &<IXFeedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXFeedItem2_Impl: Sized + IXFeedItem_Impl {
     fn EffectiveId(&self) -> ::windows::core::Result<u32>;
@@ -8365,6 +8469,7 @@ impl IXFeedItem2_Vtbl {
         iid == &<IXFeedItem2 as ::windows::core::Interface>::IID || iid == &<IXFeedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"implement\"`*"]
 pub trait IXFeedsEnum_Impl: Sized {
     fn Count(&self) -> ::windows::core::Result<u32>;
     fn Item(&self, uiindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -8394,6 +8499,7 @@ impl IXFeedsEnum_Vtbl {
         iid == &<IXFeedsEnum as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXFeedsManager_Impl: Sized {
     fn RootFolder(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -8564,6 +8670,7 @@ impl IXFeedsManager_Vtbl {
         iid == &<IXFeedsManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_MediaPlayer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _WMPOCXEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAVIEditStream_Impl: Sized {
     fn Cut(&self, plstart: *mut i32, pllength: *mut i32, ppresult: *mut ::core::option::Option<IAVIStream>) -> ::windows::core::Result<()>;
@@ -55,6 +56,7 @@ impl IAVIEditStream_Vtbl {
         iid == &<IAVIEditStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAVIFile_Impl: Sized {
     fn Info(&self, pfi: *mut AVIFILEINFOW, lsize: i32) -> ::windows::core::Result<()>;
@@ -120,6 +122,7 @@ impl IAVIFile_Vtbl {
         iid == &<IAVIFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAVIPersistFile_Impl: Sized + super::super::System::Com::IPersistFile_Impl {
     fn Reserved1(&self) -> ::windows::core::Result<()>;
@@ -140,6 +143,7 @@ impl IAVIPersistFile_Vtbl {
         iid == &<IAVIPersistFile as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersistFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAVIStream_Impl: Sized {
     fn Create(&self, lparam1: super::super::Foundation::LPARAM, lparam2: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -233,6 +237,7 @@ impl IAVIStream_Vtbl {
         iid == &<IAVIStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"implement\"`*"]
 pub trait IAVIStreaming_Impl: Sized {
     fn Begin(&self, lstart: i32, lend: i32, lrate: i32) -> ::windows::core::Result<()>;
     fn End(&self) -> ::windows::core::Result<()>;
@@ -256,6 +261,7 @@ impl IAVIStreaming_Vtbl {
         iid == &<IAVIStreaming as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IGetFrame_Impl: Sized {
     fn GetFrame(&self, lpos: i32) -> *mut ::core::ffi::c_void;

--- a/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPhotoAcquire_Impl: Sized {
     fn CreatePhotoSource(&self, pszdevice: &::windows::core::PCWSTR) -> ::windows::core::Result<IPhotoAcquireSource>;
@@ -47,6 +48,7 @@ impl IPhotoAcquire_Vtbl {
         iid == &<IPhotoAcquire as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPhotoAcquireDeviceSelectionDialog_Impl: Sized {
     fn SetTitle(&self, psztitle: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -84,6 +86,7 @@ impl IPhotoAcquireDeviceSelectionDialog_Vtbl {
         iid == &<IPhotoAcquireDeviceSelectionDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IPhotoAcquireItem_Impl: Sized {
     fn GetItemName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -205,6 +208,7 @@ impl IPhotoAcquireItem_Vtbl {
         iid == &<IPhotoAcquireItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPhotoAcquireOptionsDialog_Impl: Sized {
     fn Initialize(&self, pszregistryroot: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -262,6 +266,7 @@ impl IPhotoAcquireOptionsDialog_Vtbl {
         iid == &<IPhotoAcquireOptionsDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IPhotoAcquirePlugin_Impl: Sized {
     fn Initialize(&self, pphotoacquiresource: &::core::option::Option<IPhotoAcquireSource>, pphotoacquireprogresscb: &::core::option::Option<IPhotoAcquireProgressCB>) -> ::windows::core::Result<()>;
@@ -306,6 +311,7 @@ impl IPhotoAcquirePlugin_Vtbl {
         iid == &<IPhotoAcquirePlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPhotoAcquireProgressCB_Impl: Sized {
     fn Cancelled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -473,6 +479,7 @@ impl IPhotoAcquireProgressCB_Vtbl {
         iid == &<IPhotoAcquireProgressCB as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPhotoAcquireSettings_Impl: Sized {
     fn InitializeFromRegistry(&self, pszregistrykey: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -616,6 +623,7 @@ impl IPhotoAcquireSettings_Vtbl {
         iid == &<IPhotoAcquireSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPhotoAcquireSource_Impl: Sized {
     fn GetFriendlyName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -718,6 +726,7 @@ impl IPhotoAcquireSource_Vtbl {
         iid == &<IPhotoAcquireSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPhotoProgressActionCB_Impl: Sized {
     fn DoAction(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -738,6 +747,7 @@ impl IPhotoProgressActionCB_Vtbl {
         iid == &<IPhotoProgressActionCB as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPhotoProgressDialog_Impl: Sized {
     fn Create(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -898,6 +908,7 @@ impl IPhotoProgressDialog_Vtbl {
         iid == &<IPhotoProgressDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_PictureAcquisition\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IUserInputString_Impl: Sized {
     fn GetSubmitButtonText(&self) -> ::windows::core::Result<::windows::core::BSTR>;

--- a/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Speech/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait IEnumSpObjectTokens_Impl: Sized {
     fn Next(&self, celt: u32, pelt: *mut ::core::option::Option<ISpObjectToken>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -65,6 +66,7 @@ impl IEnumSpObjectTokens_Vtbl {
         iid == &<IEnumSpObjectTokens as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
 pub trait ISpAudio_Impl: Sized + ISpStreamFormat_Impl {
     fn SetState(&self, newstate: SPAUDIOSTATE, ullreserved: u64) -> ::windows::core::Result<()>;
@@ -158,6 +160,7 @@ impl ISpAudio_Vtbl {
         iid == &<ISpAudio as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID || iid == &<ISpStreamFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpContainerLexicon_Impl: Sized + ISpLexicon_Impl {
     fn AddLexicon(&self, paddlexicon: &::core::option::Option<ISpLexicon>, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -175,6 +178,7 @@ impl ISpContainerLexicon_Vtbl {
         iid == &<ISpContainerLexicon as ::windows::core::Interface>::IID || iid == &<ISpLexicon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpDataKey_Impl: Sized {
     fn SetData(&self, pszvaluename: &::windows::core::PCWSTR, cbdata: u32, pdata: *const u8) -> ::windows::core::Result<()>;
     fn GetData(&self, pszvaluename: &::windows::core::PCWSTR, pcbdata: *mut u32, pdata: *mut u8) -> ::windows::core::Result<()>;
@@ -302,6 +306,7 @@ impl ISpDataKey_Vtbl {
         iid == &<ISpDataKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpDisplayAlternates_Impl: Sized {
     fn GetDisplayAlternates(&self, pphrase: *const SPDISPLAYPHRASE, crequestcount: u32, ppcomemphrases: *mut *mut SPDISPLAYPHRASE, pcphrasesreturned: *mut u32) -> ::windows::core::Result<()>;
     fn SetFullStopTrailSpace(&self, ultrailspace: u32) -> ::windows::core::Result<()>;
@@ -329,6 +334,7 @@ impl ISpDisplayAlternates_Vtbl {
         iid == &<ISpDisplayAlternates as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpEnginePronunciation_Impl: Sized {
     fn Normalize(&self, pszword: &::windows::core::PCWSTR, pszleftcontext: &::windows::core::PCWSTR, pszrightcontext: &::windows::core::PCWSTR, langid: u16, pnormalizationlist: *mut SPNORMALIZATIONLIST) -> ::windows::core::Result<()>;
     fn GetPronunciations(&self, pszword: &::windows::core::PCWSTR, pszleftcontext: &::windows::core::PCWSTR, pszrightcontext: &::windows::core::PCWSTR, langid: u16, penginepronunciationlist: *mut SPWORDPRONUNCIATIONLIST) -> ::windows::core::Result<()>;
@@ -356,6 +362,7 @@ impl ISpEnginePronunciation_Vtbl {
         iid == &<ISpEnginePronunciation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpEventSink_Impl: Sized {
     fn AddEvents(&self, peventarray: *const SPEVENT, ulcount: u32) -> ::windows::core::Result<()>;
@@ -386,6 +393,7 @@ impl ISpEventSink_Vtbl {
         iid == &<ISpEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpEventSource_Impl: Sized + ISpNotifySource_Impl {
     fn SetInterest(&self, ulleventinterest: u64, ullqueuedinterest: u64) -> ::windows::core::Result<()>;
@@ -423,6 +431,7 @@ impl ISpEventSource_Vtbl {
         iid == &<ISpEventSource as ::windows::core::Interface>::IID || iid == &<ISpNotifySource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpEventSource2_Impl: Sized + ISpEventSource_Impl {
     fn GetEventsEx(&self, ulcount: u32, peventarray: *mut SPEVENTEX, pulfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -443,6 +452,7 @@ impl ISpEventSource2_Vtbl {
         iid == &<ISpEventSource2 as ::windows::core::Interface>::IID || iid == &<ISpNotifySource as ::windows::core::Interface>::IID || iid == &<ISpEventSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpGrammarBuilder_Impl: Sized {
     fn ResetGrammar(&self, newlanguage: u16) -> ::windows::core::Result<()>;
@@ -515,6 +525,7 @@ impl ISpGrammarBuilder_Vtbl {
         iid == &<ISpGrammarBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpGrammarBuilder2_Impl: Sized {
     fn AddTextSubset(&self, hfromstate: *mut SPSTATEHANDLE__, htostate: *mut SPSTATEHANDLE__, psz: &::windows::core::PCWSTR, ematchmode: SPMATCHINGMODE) -> ::windows::core::Result<()>;
     fn SetPhoneticAlphabet(&self, phoneticalphabet: PHONETICALPHABET) -> ::windows::core::Result<()>;
@@ -542,6 +553,7 @@ impl ISpGrammarBuilder2_Vtbl {
         iid == &<ISpGrammarBuilder2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpLexicon_Impl: Sized {
     fn GetPronunciations(&self, pszword: &::windows::core::PCWSTR, langid: u16, dwflags: u32, pwordpronunciationlist: *mut SPWORDPRONUNCIATIONLIST) -> ::windows::core::Result<()>;
     fn AddPronunciation(&self, pszword: &::windows::core::PCWSTR, langid: u16, epartofspeech: SPPARTOFSPEECH, pszpronunciation: *const u16) -> ::windows::core::Result<()>;
@@ -597,6 +609,7 @@ impl ISpLexicon_Vtbl {
         iid == &<ISpLexicon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
 pub trait ISpMMSysAudio_Impl: Sized + ISpAudio_Impl {
     fn GetDeviceId(&self, pudeviceid: *mut u32) -> ::windows::core::Result<()>;
@@ -648,6 +661,7 @@ impl ISpMMSysAudio_Vtbl {
         iid == &<ISpMMSysAudio as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID || iid == &<ISpStreamFormat as ::windows::core::Interface>::IID || iid == &<ISpAudio as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpNotifyCallback_Impl: Sized {
     fn NotifyCallback(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -678,6 +692,7 @@ impl ISpNotifyCallback {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpNotifySink_Impl: Sized {
     fn Notify(&self) -> ::windows::core::Result<()>;
 }
@@ -695,6 +710,7 @@ impl ISpNotifySink_Vtbl {
         iid == &<ISpNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpNotifySource_Impl: Sized {
     fn SetNotifySink(&self, pnotifysink: &::core::option::Option<ISpNotifySink>) -> ::windows::core::Result<()>;
@@ -760,6 +776,7 @@ impl ISpNotifySource_Vtbl {
         iid == &<ISpNotifySource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpNotifyTranslator_Impl: Sized + ISpNotifySink_Impl {
     fn InitWindowMessage(&self, hwnd: super::super::Foundation::HWND, msg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -818,6 +835,7 @@ impl ISpNotifyTranslator_Vtbl {
         iid == &<ISpNotifyTranslator as ::windows::core::Interface>::IID || iid == &<ISpNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpObjectToken_Impl: Sized + ISpDataKey_Impl {
     fn SetId(&self, pszcategoryid: &::windows::core::PCWSTR, psztokenid: &::windows::core::PCWSTR, fcreateifnotexist: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -922,6 +940,7 @@ impl ISpObjectToken_Vtbl {
         iid == &<ISpObjectToken as ::windows::core::Interface>::IID || iid == &<ISpDataKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpObjectTokenCategory_Impl: Sized + ISpDataKey_Impl {
     fn SetId(&self, pszcategoryid: &::windows::core::PCWSTR, fcreateifnotexist: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1004,6 +1023,7 @@ impl ISpObjectTokenCategory_Vtbl {
         iid == &<ISpObjectTokenCategory as ::windows::core::Interface>::IID || iid == &<ISpDataKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpObjectTokenInit_Impl: Sized + ISpObjectToken_Impl {
     fn InitFromDataKey(&self, pszcategoryid: &::windows::core::PCWSTR, psztokenid: &::windows::core::PCWSTR, pdatakey: &::core::option::Option<ISpDataKey>) -> ::windows::core::Result<()>;
@@ -1024,6 +1044,7 @@ impl ISpObjectTokenInit_Vtbl {
         iid == &<ISpObjectTokenInit as ::windows::core::Interface>::IID || iid == &<ISpDataKey as ::windows::core::Interface>::IID || iid == &<ISpObjectToken as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpObjectWithToken_Impl: Sized {
     fn SetObjectToken(&self, ptoken: &::core::option::Option<ISpObjectToken>) -> ::windows::core::Result<()>;
     fn GetObjectToken(&self) -> ::windows::core::Result<ISpObjectToken>;
@@ -1057,6 +1078,7 @@ impl ISpObjectWithToken_Vtbl {
         iid == &<ISpObjectWithToken as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpPhoneConverter_Impl: Sized + ISpObjectWithToken_Impl {
     fn PhoneToId(&self, pszphone: &::windows::core::PCWSTR) -> ::windows::core::Result<u16>;
     fn IdToPhone(&self, pid: *const u16, pszphone: ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -1090,6 +1112,7 @@ impl ISpPhoneConverter_Vtbl {
         iid == &<ISpPhoneConverter as ::windows::core::Interface>::IID || iid == &<ISpObjectWithToken as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpPhoneticAlphabetConverter_Impl: Sized {
     fn GetLangId(&self) -> ::windows::core::Result<u16>;
@@ -1153,6 +1176,7 @@ impl ISpPhoneticAlphabetConverter_Vtbl {
         iid == &<ISpPhoneticAlphabetConverter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpPhoneticAlphabetSelection_Impl: Sized {
     fn IsAlphabetUPS(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -1189,6 +1213,7 @@ impl ISpPhoneticAlphabetSelection_Vtbl {
         iid == &<ISpPhoneticAlphabetSelection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpPhrase_Impl: Sized {
     fn GetPhrase(&self) -> ::windows::core::Result<*mut SPPHRASE>;
@@ -1245,6 +1270,7 @@ impl ISpPhrase_Vtbl {
         iid == &<ISpPhrase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpPhrase2_Impl: Sized + ISpPhrase_Impl {
     fn GetXMLResult(&self, ppszcomemxmlresult: *mut ::windows::core::PWSTR, options: SPXMLRESULTOPTIONS) -> ::windows::core::Result<()>;
@@ -1288,6 +1314,7 @@ impl ISpPhrase2_Vtbl {
         iid == &<ISpPhrase2 as ::windows::core::Interface>::IID || iid == &<ISpPhrase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpPhraseAlt_Impl: Sized + ISpPhrase_Impl {
     fn GetAltInfo(&self, ppparent: *mut ::core::option::Option<ISpPhrase>, pulstartelementinparent: *mut u32, pcelementsinparent: *mut u32, pcelementsinalt: *mut u32) -> ::windows::core::Result<()>;
@@ -1318,6 +1345,7 @@ impl ISpPhraseAlt_Vtbl {
         iid == &<ISpPhraseAlt as ::windows::core::Interface>::IID || iid == &<ISpPhrase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpProperties_Impl: Sized {
     fn SetPropertyNum(&self, pname: &::windows::core::PCWSTR, lvalue: i32) -> ::windows::core::Result<()>;
     fn GetPropertyNum(&self, pname: &::windows::core::PCWSTR, plvalue: *mut i32) -> ::windows::core::Result<()>;
@@ -1365,6 +1393,7 @@ impl ISpProperties_Vtbl {
         iid == &<ISpProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio"))]
 pub trait ISpRecoContext_Impl: Sized + ISpEventSource_Impl {
     fn GetRecognizer(&self) -> ::windows::core::Result<ISpRecognizer>;
@@ -1531,6 +1560,7 @@ impl ISpRecoContext_Vtbl {
         iid == &<ISpRecoContext as ::windows::core::Interface>::IID || iid == &<ISpNotifySource as ::windows::core::Interface>::IID || iid == &<ISpEventSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpRecoContext2_Impl: Sized {
     fn SetGrammarOptions(&self, egrammaroptions: u32) -> ::windows::core::Result<()>;
     fn GetGrammarOptions(&self, pegrammaroptions: *mut u32) -> ::windows::core::Result<()>;
@@ -1565,6 +1595,7 @@ impl ISpRecoContext2_Vtbl {
         iid == &<ISpRecoContext2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpRecoGrammar_Impl: Sized + ISpGrammarBuilder_Impl {
     fn GetGrammarId(&self, pullgrammarid: *mut u64) -> ::windows::core::Result<()>;
@@ -1713,6 +1744,7 @@ impl ISpRecoGrammar_Vtbl {
         iid == &<ISpRecoGrammar as ::windows::core::Interface>::IID || iid == &<ISpGrammarBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_Urlmon")]
 pub trait ISpRecoGrammar2_Impl: Sized {
     fn GetRules(&self, ppcomemrules: *mut *mut SPRULE, punumrules: *mut u32) -> ::windows::core::Result<()>;
@@ -1785,6 +1817,7 @@ impl ISpRecoGrammar2_Vtbl {
         iid == &<ISpRecoGrammar2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpRecoResult_Impl: Sized + ISpPhrase_Impl {
     fn GetResultTimes(&self, ptimes: *mut SPRECORESULTTIMES) -> ::windows::core::Result<()>;
@@ -1862,6 +1895,7 @@ impl ISpRecoResult_Vtbl {
         iid == &<ISpRecoResult as ::windows::core::Interface>::IID || iid == &<ISpPhrase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpRecoResult2_Impl: Sized + ISpRecoResult_Impl {
     fn CommitAlternate(&self, pphrasealt: &::core::option::Option<ISpPhraseAlt>) -> ::windows::core::Result<ISpRecoResult>;
@@ -1905,6 +1939,7 @@ impl ISpRecoResult2_Vtbl {
         iid == &<ISpRecoResult2 as ::windows::core::Interface>::IID || iid == &<ISpPhrase as ::windows::core::Interface>::IID || iid == &<ISpRecoResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
 pub trait ISpRecognizer_Impl: Sized + ISpProperties_Impl {
     fn SetRecognizer(&self, precognizer: &::core::option::Option<ISpObjectToken>) -> ::windows::core::Result<()>;
@@ -2063,6 +2098,7 @@ impl ISpRecognizer_Vtbl {
         iid == &<ISpRecognizer as ::windows::core::Interface>::IID || iid == &<ISpProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpRecognizer2_Impl: Sized {
     fn EmulateRecognitionEx(&self, pphrase: &::core::option::Option<ISpPhrase>, dwcompareflags: u32) -> ::windows::core::Result<()>;
@@ -2100,6 +2136,7 @@ impl ISpRecognizer2_Vtbl {
         iid == &<ISpRecognizer2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait ISpRegDataKey_Impl: Sized + ISpDataKey_Impl {
     fn SetKey(&self, hkey: super::super::System::Registry::HKEY, freadonly: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2120,6 +2157,7 @@ impl ISpRegDataKey_Vtbl {
         iid == &<ISpRegDataKey as ::windows::core::Interface>::IID || iid == &<ISpDataKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISpResourceManager_Impl: Sized + super::super::System::Com::IServiceProvider_Impl {
     fn SetObject(&self, guidserviceid: *const ::windows::core::GUID, punkobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -2150,6 +2188,7 @@ impl ISpResourceManager_Vtbl {
         iid == &<ISpResourceManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpSerializeState_Impl: Sized {
     fn GetSerializedState(&self, ppbdata: *mut *mut u8, pulsize: *mut u32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn SetSerializedState(&self, pbdata: *const u8, ulsize: u32, dwreserved: u32) -> ::windows::core::Result<()>;
@@ -2177,6 +2216,7 @@ impl ISpSerializeState_Vtbl {
         iid == &<ISpSerializeState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpShortcut_Impl: Sized {
     fn AddShortcut(&self, pszdisplay: &::windows::core::PCWSTR, langid: u16, pszspoken: &::windows::core::PCWSTR, shtype: SPSHORTCUTTYPE) -> ::windows::core::Result<()>;
     fn RemoveShortcut(&self, pszdisplay: &::windows::core::PCWSTR, langid: u16, pszspoken: &::windows::core::PCWSTR, shtype: SPSHORTCUTTYPE) -> ::windows::core::Result<()>;
@@ -2252,6 +2292,7 @@ impl ISpShortcut_Vtbl {
         iid == &<ISpShortcut as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
 pub trait ISpStream_Impl: Sized + ISpStreamFormat_Impl {
     fn SetBaseStream(&self, pstream: &::core::option::Option<super::super::System::Com::IStream>, rguidformat: *const ::windows::core::GUID, pwaveformatex: *const super::Audio::WAVEFORMATEX) -> ::windows::core::Result<()>;
@@ -2302,6 +2343,7 @@ impl ISpStream_Vtbl {
         iid == &<ISpStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID || iid == &<ISpStreamFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
 pub trait ISpStreamFormat_Impl: Sized + super::super::System::Com::IStream_Impl {
     fn GetFormat(&self, pguidformatid: *const ::windows::core::GUID) -> ::windows::core::Result<*mut super::Audio::WAVEFORMATEX>;
@@ -2328,6 +2370,7 @@ impl ISpStreamFormat_Vtbl {
         iid == &<ISpStreamFormat as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com"))]
 pub trait ISpStreamFormatConverter_Impl: Sized + ISpStreamFormat_Impl {
     fn SetBaseStream(&self, pstream: &::core::option::Option<ISpStreamFormat>, fsetformattobasestreamformat: super::super::Foundation::BOOL, fwritetobasestream: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2404,6 +2447,7 @@ impl ISpStreamFormatConverter_Vtbl {
         iid == &<ISpStreamFormatConverter as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID || iid == &<ISpStreamFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"implement\"`*"]
 pub trait ISpTranscript_Impl: Sized {
     fn GetTranscript(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn AppendTranscript(&self, psztranscript: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -2437,6 +2481,7 @@ impl ISpTranscript_Vtbl {
         iid == &<ISpTranscript as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISpVoice_Impl: Sized + ISpEventSource_Impl {
     fn SetOutput(&self, punkoutput: &::core::option::Option<::windows::core::IUnknown>, fallowformatchanges: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2646,6 +2691,7 @@ impl ISpVoice_Vtbl {
         iid == &<ISpVoice as ::windows::core::Interface>::IID || iid == &<ISpNotifySource as ::windows::core::Interface>::IID || iid == &<ISpEventSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpXMLRecoResult_Impl: Sized + ISpRecoResult_Impl {
     fn GetXMLResult(&self, ppszcomemxmlresult: *mut ::windows::core::PWSTR, options: SPXMLRESULTOPTIONS) -> ::windows::core::Result<()>;
@@ -2676,6 +2722,7 @@ impl ISpXMLRecoResult_Vtbl {
         iid == &<ISpXMLRecoResult as ::windows::core::Interface>::IID || iid == &<ISpPhrase as ::windows::core::Interface>::IID || iid == &<ISpRecoResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechAudio_Impl: Sized + ISpeechBaseStream_Impl {
     fn Status(&self) -> ::windows::core::Result<ISpeechAudioStatus>;
@@ -2791,6 +2838,7 @@ impl ISpeechAudio_Vtbl {
         iid == &<ISpeechAudio as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISpeechBaseStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechAudioBufferInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MinNotification(&self) -> ::windows::core::Result<i32>;
@@ -2867,6 +2915,7 @@ impl ISpeechAudioBufferInfo_Vtbl {
         iid == &<ISpeechAudioBufferInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechAudioFormat_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<SpeechAudioFormatType>;
@@ -2943,6 +2992,7 @@ impl ISpeechAudioFormat_Vtbl {
         iid == &<ISpeechAudioFormat as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechAudioStatus_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FreeBufferSpace(&self) -> ::windows::core::Result<i32>;
@@ -3024,6 +3074,7 @@ impl ISpeechAudioStatus_Vtbl {
         iid == &<ISpeechAudioStatus as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechBaseStream_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Format(&self) -> ::windows::core::Result<ISpeechAudioFormat>;
@@ -3093,6 +3144,7 @@ impl ISpeechBaseStream_Vtbl {
         iid == &<ISpeechBaseStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechCustomStream_Impl: Sized + ISpeechBaseStream_Impl {
     fn BaseStream(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3129,6 +3181,7 @@ impl ISpeechCustomStream_Vtbl {
         iid == &<ISpeechCustomStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISpeechBaseStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechDataKey_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetBinaryValue(&self, valuename: &::windows::core::BSTR, value: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -3271,6 +3324,7 @@ impl ISpeechDataKey_Vtbl {
         iid == &<ISpeechDataKey as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechFileStream_Impl: Sized + ISpeechBaseStream_Impl {
     fn Open(&self, filename: &::windows::core::BSTR, filemode: SpeechStreamFileMode, doevents: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3297,6 +3351,7 @@ impl ISpeechFileStream_Vtbl {
         iid == &<ISpeechFileStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISpeechBaseStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechGrammarRule_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Attributes(&self) -> ::windows::core::Result<SpeechRuleAttributes>;
@@ -3392,6 +3447,7 @@ impl ISpeechGrammarRule_Vtbl {
         iid == &<ISpeechGrammarRule as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechGrammarRuleState_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Rule(&self) -> ::windows::core::Result<ISpeechGrammarRule>;
@@ -3455,6 +3511,7 @@ impl ISpeechGrammarRuleState_Vtbl {
         iid == &<ISpeechGrammarRuleState as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechGrammarRuleStateTransition_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<SpeechGrammarRuleStateTransitionType>;
@@ -3575,6 +3632,7 @@ impl ISpeechGrammarRuleStateTransition_Vtbl {
         iid == &<ISpeechGrammarRuleStateTransition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechGrammarRuleStateTransitions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3630,6 +3688,7 @@ impl ISpeechGrammarRuleStateTransitions_Vtbl {
         iid == &<ISpeechGrammarRuleStateTransitions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechGrammarRules_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3738,6 +3797,7 @@ impl ISpeechGrammarRules_Vtbl {
         iid == &<ISpeechGrammarRules as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechLexicon_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GenerationId(&self) -> ::windows::core::Result<i32>;
@@ -3822,6 +3882,7 @@ impl ISpeechLexicon_Vtbl {
         iid == &<ISpeechLexicon as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechLexiconPronunciation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<SpeechLexiconType>;
@@ -3903,6 +3964,7 @@ impl ISpeechLexiconPronunciation_Vtbl {
         iid == &<ISpeechLexiconPronunciation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechLexiconPronunciations_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3958,6 +4020,7 @@ impl ISpeechLexiconPronunciations_Vtbl {
         iid == &<ISpeechLexiconPronunciations as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechLexiconWord_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LangId(&self) -> ::windows::core::Result<i32>;
@@ -4026,6 +4089,7 @@ impl ISpeechLexiconWord_Vtbl {
         iid == &<ISpeechLexiconWord as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechLexiconWords_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4081,6 +4145,7 @@ impl ISpeechLexiconWords_Vtbl {
         iid == &<ISpeechLexiconWords as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechMMSysAudio_Impl: Sized + ISpeechAudio_Impl {
     fn DeviceId(&self) -> ::windows::core::Result<i32>;
@@ -4150,6 +4215,7 @@ impl ISpeechMMSysAudio_Vtbl {
         iid == &<ISpeechMMSysAudio as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISpeechBaseStream as ::windows::core::Interface>::IID || iid == &<ISpeechAudio as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechMemoryStream_Impl: Sized + ISpeechBaseStream_Impl {
     fn SetData(&self, data: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -4186,6 +4252,7 @@ impl ISpeechMemoryStream_Vtbl {
         iid == &<ISpeechMemoryStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISpeechBaseStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechObjectToken_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4347,6 +4414,7 @@ impl ISpeechObjectToken_Vtbl {
         iid == &<ISpeechObjectToken as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechObjectTokenCategory_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4429,6 +4497,7 @@ impl ISpeechObjectTokenCategory_Vtbl {
         iid == &<ISpeechObjectTokenCategory as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechObjectTokens_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4484,6 +4553,7 @@ impl ISpeechObjectTokens_Vtbl {
         iid == &<ISpeechObjectTokens as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhoneConverter_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LanguageId(&self) -> ::windows::core::Result<i32>;
@@ -4546,6 +4616,7 @@ impl ISpeechPhoneConverter_Vtbl {
         iid == &<ISpeechPhoneConverter as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseAlternate_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RecoResult(&self) -> ::windows::core::Result<ISpeechRecoResult>;
@@ -4621,6 +4692,7 @@ impl ISpeechPhraseAlternate_Vtbl {
         iid == &<ISpeechPhraseAlternate as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseAlternates_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4676,6 +4748,7 @@ impl ISpeechPhraseAlternates_Vtbl {
         iid == &<ISpeechPhraseAlternates as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseElement_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AudioTimeOffset(&self) -> ::windows::core::Result<i32>;
@@ -4861,6 +4934,7 @@ impl ISpeechPhraseElement_Vtbl {
         iid == &<ISpeechPhraseElement as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseElements_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4916,6 +4990,7 @@ impl ISpeechPhraseElements_Vtbl {
         iid == &<ISpeechPhraseElements as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LanguageId(&self) -> ::windows::core::Result<i32>;
@@ -5140,6 +5215,7 @@ impl ISpeechPhraseInfo_Vtbl {
         iid == &<ISpeechPhraseInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseInfoBuilder_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RestorePhraseFromMemory(&self, phraseinmemory: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<ISpeechPhraseInfo>;
@@ -5169,6 +5245,7 @@ impl ISpeechPhraseInfoBuilder_Vtbl {
         iid == &<ISpeechPhraseInfoBuilder as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseProperties_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -5224,6 +5301,7 @@ impl ISpeechPhraseProperties_Vtbl {
         iid == &<ISpeechPhraseProperties as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5357,6 +5435,7 @@ impl ISpeechPhraseProperty_Vtbl {
         iid == &<ISpeechPhraseProperty as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseReplacement_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DisplayAttributes(&self) -> ::windows::core::Result<SpeechDisplayAttributes>;
@@ -5425,6 +5504,7 @@ impl ISpeechPhraseReplacement_Vtbl {
         iid == &<ISpeechPhraseReplacement as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseReplacements_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -5480,6 +5560,7 @@ impl ISpeechPhraseReplacements_Vtbl {
         iid == &<ISpeechPhraseReplacements as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseRule_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5600,6 +5681,7 @@ impl ISpeechPhraseRule_Vtbl {
         iid == &<ISpeechPhraseRule as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechPhraseRules_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -5655,6 +5737,7 @@ impl ISpeechPhraseRules_Vtbl {
         iid == &<ISpeechPhraseRules as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecoContext_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Recognizer(&self) -> ::windows::core::Result<ISpeechRecognizer>;
@@ -5924,6 +6007,7 @@ impl ISpeechRecoContext_Vtbl {
         iid == &<ISpeechRecoContext as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecoGrammar_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -6103,6 +6187,7 @@ impl ISpeechRecoGrammar_Vtbl {
         iid == &<ISpeechRecoGrammar as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecoResult_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RecoContext(&self) -> ::windows::core::Result<ISpeechRecoContext>;
@@ -6237,6 +6322,7 @@ impl ISpeechRecoResult_Vtbl {
         iid == &<ISpeechRecoResult as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecoResult2_Impl: Sized + ISpeechRecoResult_Impl {
     fn SetTextFeedback(&self, feedback: &::windows::core::BSTR, wassuccessful: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -6257,6 +6343,7 @@ impl ISpeechRecoResult2_Vtbl {
         iid == &<ISpeechRecoResult2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISpeechRecoResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecoResultDispatch_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RecoContext(&self) -> ::windows::core::Result<ISpeechRecoContext>;
@@ -6418,6 +6505,7 @@ impl ISpeechRecoResultDispatch_Vtbl {
         iid == &<ISpeechRecoResultDispatch as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecoResultTimes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StreamTime(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -6486,6 +6574,7 @@ impl ISpeechRecoResultTimes_Vtbl {
         iid == &<ISpeechRecoResultTimes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecognizer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn putref_Recognizer(&self, recognizer: &::core::option::Option<ISpeechObjectToken>) -> ::windows::core::Result<()>;
@@ -6780,6 +6869,7 @@ impl ISpeechRecognizer_Vtbl {
         iid == &<ISpeechRecognizer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechRecognizerStatus_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AudioStatus(&self) -> ::windows::core::Result<ISpeechAudioStatus>;
@@ -6874,6 +6964,7 @@ impl ISpeechRecognizerStatus_Vtbl {
         iid == &<ISpeechRecognizerStatus as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechResourceLoader_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LoadResource(&self, bstrresourceuri: &::windows::core::BSTR, falwaysreload: super::super::Foundation::VARIANT_BOOL, pstream: *mut ::core::option::Option<::windows::core::IUnknown>, pbstrmimetype: *mut ::windows::core::BSTR, pfmodified: *mut super::super::Foundation::VARIANT_BOOL, pbstrredirecturl: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6911,6 +7002,7 @@ impl ISpeechResourceLoader_Vtbl {
         iid == &<ISpeechResourceLoader as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechTextSelectionInformation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetActiveOffset(&self, activeoffset: i32) -> ::windows::core::Result<()>;
@@ -7007,6 +7099,7 @@ impl ISpeechTextSelectionInformation_Vtbl {
         iid == &<ISpeechTextSelectionInformation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechVoice_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Status(&self) -> ::windows::core::Result<ISpeechVoiceStatus>;
@@ -7361,6 +7454,7 @@ impl ISpeechVoice_Vtbl {
         iid == &<ISpeechVoice as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechVoiceStatus_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CurrentStreamNumber(&self) -> ::windows::core::Result<i32>;
@@ -7533,6 +7627,7 @@ impl ISpeechVoiceStatus_Vtbl {
         iid == &<ISpeechVoiceStatus as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechWaveFormatEx_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FormatTag(&self) -> ::windows::core::Result<i16>;
@@ -7689,6 +7784,7 @@ impl ISpeechWaveFormatEx_Vtbl {
         iid == &<ISpeechWaveFormatEx as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISpeechXMLRecoResult_Impl: Sized + ISpeechRecoResult_Impl {
     fn GetXMLResult(&self, options: SPXMLRESULTOPTIONS) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7725,6 +7821,7 @@ impl ISpeechXMLRecoResult_Vtbl {
         iid == &<ISpeechXMLRecoResult as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISpeechRecoResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ISpeechRecoContextEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7738,6 +7835,7 @@ impl _ISpeechRecoContextEvents_Vtbl {
         iid == &<_ISpeechRecoContextEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_Speech\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ISpeechVoiceEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INSNetSourceCreator_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
@@ -94,6 +95,7 @@ impl INSNetSourceCreator_Vtbl {
         iid == &<INSNetSourceCreator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait INSSBuffer_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u32>;
     fn SetLength(&self, dwlength: u32) -> ::windows::core::Result<()>;
@@ -160,6 +162,7 @@ impl INSSBuffer_Vtbl {
         iid == &<INSSBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait INSSBuffer2_Impl: Sized + INSSBuffer_Impl {
     fn GetSampleProperties(&self, cbproperties: u32) -> ::windows::core::Result<u8>;
     fn SetSampleProperties(&self, cbproperties: u32, pbproperties: *const u8) -> ::windows::core::Result<()>;
@@ -193,6 +196,7 @@ impl INSSBuffer2_Vtbl {
         iid == &<INSSBuffer2 as ::windows::core::Interface>::IID || iid == &<INSSBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait INSSBuffer3_Impl: Sized + INSSBuffer2_Impl {
     fn SetProperty(&self, guidbufferproperty: &::windows::core::GUID, pvbufferproperty: *const ::core::ffi::c_void, dwbufferpropertysize: u32) -> ::windows::core::Result<()>;
     fn GetProperty(&self, guidbufferproperty: &::windows::core::GUID, pvbufferproperty: *mut ::core::ffi::c_void, pdwbufferpropertysize: *mut u32) -> ::windows::core::Result<()>;
@@ -220,6 +224,7 @@ impl INSSBuffer3_Vtbl {
         iid == &<INSSBuffer3 as ::windows::core::Interface>::IID || iid == &<INSSBuffer as ::windows::core::Interface>::IID || iid == &<INSSBuffer2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait INSSBuffer4_Impl: Sized + INSSBuffer3_Impl {
     fn GetPropertyCount(&self) -> ::windows::core::Result<u32>;
     fn GetPropertyByIndex(&self, dwbufferpropertyindex: u32, pguidbufferproperty: *mut ::windows::core::GUID, pvbufferproperty: *mut ::core::ffi::c_void, pdwbufferpropertysize: *mut u32) -> ::windows::core::Result<()>;
@@ -253,6 +258,7 @@ impl INSSBuffer4_Vtbl {
         iid == &<INSSBuffer4 as ::windows::core::Interface>::IID || iid == &<INSSBuffer as ::windows::core::Interface>::IID || iid == &<INSSBuffer2 as ::windows::core::Interface>::IID || iid == &<INSSBuffer3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMAddressAccess_Impl: Sized {
     fn GetAccessEntryCount(&self, aetype: WM_AETYPE) -> ::windows::core::Result<u32>;
     fn GetAccessEntry(&self, aetype: WM_AETYPE, dwentrynum: u32) -> ::windows::core::Result<WM_ADDRESS_ACCESSENTRY>;
@@ -306,6 +312,7 @@ impl IWMAddressAccess_Vtbl {
         iid == &<IWMAddressAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMAddressAccess2_Impl: Sized + IWMAddressAccess_Impl {
     fn GetAccessEntryEx(&self, aetype: WM_AETYPE, dwentrynum: u32, pbstraddress: *mut ::windows::core::BSTR, pbstrmask: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn AddAccessEntryEx(&self, aetype: WM_AETYPE, bstraddress: &::windows::core::BSTR, bstrmask: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -333,6 +340,7 @@ impl IWMAddressAccess2_Vtbl {
         iid == &<IWMAddressAccess2 as ::windows::core::Interface>::IID || iid == &<IWMAddressAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMAuthorizer_Impl: Sized {
     fn GetCertCount(&self) -> ::windows::core::Result<u32>;
     fn GetCert(&self, dwindex: u32) -> ::windows::core::Result<*mut u8>;
@@ -385,6 +393,7 @@ impl IWMAuthorizer_Vtbl {
         iid == &<IWMAuthorizer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMBackupRestoreProps_Impl: Sized {
     fn GetPropCount(&self) -> ::windows::core::Result<u16>;
     fn GetPropByIndex(&self, windex: u16, pwszname: ::windows::core::PWSTR, pcchnamelen: *mut u16, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::Result<()>;
@@ -446,6 +455,7 @@ impl IWMBackupRestoreProps_Vtbl {
         iid == &<IWMBackupRestoreProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMBandwidthSharing_Impl: Sized + IWMStreamList_Impl {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn SetType(&self, guidtype: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -493,6 +503,7 @@ impl IWMBandwidthSharing_Vtbl {
         iid == &<IWMBandwidthSharing as ::windows::core::Interface>::IID || iid == &<IWMStreamList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMClientConnections_Impl: Sized {
     fn GetClientCount(&self) -> ::windows::core::Result<u32>;
     fn GetClientProperties(&self, dwclientnum: u32) -> ::windows::core::Result<WM_CLIENT_PROPERTIES>;
@@ -532,6 +543,7 @@ impl IWMClientConnections_Vtbl {
         iid == &<IWMClientConnections as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMClientConnections2_Impl: Sized + IWMClientConnections_Impl {
     fn GetClientInfo(&self, dwclientnum: u32, pwsznetworkaddress: ::windows::core::PWSTR, pcchnetworkaddress: *mut u32, pwszport: ::windows::core::PWSTR, pcchport: *mut u32, pwszdnsname: ::windows::core::PWSTR, pcchdnsname: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -549,6 +561,7 @@ impl IWMClientConnections2_Vtbl {
         iid == &<IWMClientConnections2 as ::windows::core::Interface>::IID || iid == &<IWMClientConnections as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMCodecInfo_Impl: Sized {
     fn GetCodecInfoCount(&self, guidtype: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
     fn GetCodecFormatCount(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32) -> ::windows::core::Result<u32>;
@@ -601,6 +614,7 @@ impl IWMCodecInfo_Vtbl {
         iid == &<IWMCodecInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMCodecInfo2_Impl: Sized + IWMCodecInfo_Impl {
     fn GetCodecName(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, wszname: ::windows::core::PWSTR, pcchname: *mut u32) -> ::windows::core::Result<()>;
     fn GetCodecFormatDesc(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, dwformatindex: u32, ppistreamconfig: *mut ::core::option::Option<IWMStreamConfig>, wszdesc: ::windows::core::PWSTR, pcchdesc: *mut u32) -> ::windows::core::Result<()>;
@@ -628,6 +642,7 @@ impl IWMCodecInfo2_Vtbl {
         iid == &<IWMCodecInfo2 as ::windows::core::Interface>::IID || iid == &<IWMCodecInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMCodecInfo3_Impl: Sized + IWMCodecInfo2_Impl {
     fn GetCodecFormatProp(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, dwformatindex: u32, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetCodecProp(&self, guidtype: *const ::windows::core::GUID, dwcodecindex: u32, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
@@ -669,6 +684,7 @@ impl IWMCodecInfo3_Vtbl {
         iid == &<IWMCodecInfo3 as ::windows::core::Interface>::IID || iid == &<IWMCodecInfo as ::windows::core::Interface>::IID || iid == &<IWMCodecInfo2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMCredentialCallback_Impl: Sized {
     fn AcquireCredentials(&self, pwszrealm: &::windows::core::PCWSTR, pwszsite: &::windows::core::PCWSTR, pwszuser: ::windows::core::PWSTR, cchuser: u32, pwszpassword: ::windows::core::PWSTR, cchpassword: u32, hrstatus: ::windows::core::HRESULT, pdwflags: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -686,6 +702,7 @@ impl IWMCredentialCallback_Vtbl {
         iid == &<IWMCredentialCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMDRMEditor_Impl: Sized {
     fn GetDRMProperty(&self, pwstrname: &::windows::core::PCWSTR, pdwtype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::Result<()>;
 }
@@ -703,6 +720,7 @@ impl IWMDRMEditor_Vtbl {
         iid == &<IWMDRMEditor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMDRMMessageParser_Impl: Sized {
     fn ParseRegistrationReqMsg(&self, pbregistrationreqmsg: *const u8, cbregistrationreqmsg: u32, ppdevicecert: *mut ::core::option::Option<INSSBuffer>, pdeviceserialnumber: *mut DRM_VAL16) -> ::windows::core::Result<()>;
     fn ParseLicenseRequestMsg(&self, pblicenserequestmsg: *const u8, cblicenserequestmsg: u32, ppdevicecert: *mut ::core::option::Option<INSSBuffer>, pdeviceserialnumber: *mut DRM_VAL16, pbstraction: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -730,6 +748,7 @@ impl IWMDRMMessageParser_Vtbl {
         iid == &<IWMDRMMessageParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMDRMReader_Impl: Sized {
     fn AcquireLicense(&self, dwflags: u32) -> ::windows::core::Result<()>;
     fn CancelLicenseAcquisition(&self) -> ::windows::core::Result<()>;
@@ -799,6 +818,7 @@ impl IWMDRMReader_Vtbl {
         iid == &<IWMDRMReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMDRMReader2_Impl: Sized + IWMDRMReader_Impl {
     fn SetEvaluateOutputLevelLicenses(&self, fevaluate: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -843,6 +863,7 @@ impl IWMDRMReader2_Vtbl {
         iid == &<IWMDRMReader2 as ::windows::core::Interface>::IID || iid == &<IWMDRMReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMDRMReader3_Impl: Sized + IWMDRMReader2_Impl {
     fn GetInclusionList(&self, ppguids: *mut *mut ::windows::core::GUID, pcguids: *mut u32) -> ::windows::core::Result<()>;
@@ -863,6 +884,7 @@ impl IWMDRMReader3_Vtbl {
         iid == &<IWMDRMReader3 as ::windows::core::Interface>::IID || iid == &<IWMDRMReader as ::windows::core::Interface>::IID || iid == &<IWMDRMReader2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMDRMTranscryptionManager_Impl: Sized {
     fn CreateTranscryptor(&self) -> ::windows::core::Result<IWMDRMTranscryptor>;
 }
@@ -886,6 +908,7 @@ impl IWMDRMTranscryptionManager_Vtbl {
         iid == &<IWMDRMTranscryptionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMDRMTranscryptor_Impl: Sized {
     fn Initialize(&self, bstrfilename: &::windows::core::BSTR, pblicenserequestmsg: *mut u8, cblicenserequestmsg: u32, pplicenseresponsemsg: *mut ::core::option::Option<INSSBuffer>, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Seek(&self, hnstime: u64) -> ::windows::core::Result<()>;
@@ -927,6 +950,7 @@ impl IWMDRMTranscryptor_Vtbl {
         iid == &<IWMDRMTranscryptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMDRMTranscryptor2_Impl: Sized + IWMDRMTranscryptor_Impl {
     fn SeekEx(&self, cnsstarttime: u64, cnsduration: u64, flrate: f32, fincludefileheader: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -983,6 +1007,7 @@ impl IWMDRMTranscryptor2_Vtbl {
         iid == &<IWMDRMTranscryptor2 as ::windows::core::Interface>::IID || iid == &<IWMDRMTranscryptor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMDRMWriter_Impl: Sized {
     fn GenerateKeySeed(&self, pwszkeyseed: ::windows::core::PWSTR, pcwchlength: *mut u32) -> ::windows::core::Result<()>;
     fn GenerateKeyID(&self, pwszkeyid: ::windows::core::PWSTR, pcwchlength: *mut u32) -> ::windows::core::Result<()>;
@@ -1024,6 +1049,7 @@ impl IWMDRMWriter_Vtbl {
         iid == &<IWMDRMWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMDRMWriter2_Impl: Sized + IWMDRMWriter_Impl {
     fn SetWMDRMNetEncryption(&self, fsamplesencrypted: super::super::Foundation::BOOL, pbkeyid: *const u8, cbkeyid: u32) -> ::windows::core::Result<()>;
@@ -1044,6 +1070,7 @@ impl IWMDRMWriter2_Vtbl {
         iid == &<IWMDRMWriter2 as ::windows::core::Interface>::IID || iid == &<IWMDRMWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMDRMWriter3_Impl: Sized + IWMDRMWriter2_Impl {
     fn SetProtectStreamSamples(&self, pimportinitstruct: *const WMDRM_IMPORT_INIT_STRUCT) -> ::windows::core::Result<()>;
@@ -1064,6 +1091,7 @@ impl IWMDRMWriter3_Vtbl {
         iid == &<IWMDRMWriter3 as ::windows::core::Interface>::IID || iid == &<IWMDRMWriter as ::windows::core::Interface>::IID || iid == &<IWMDRMWriter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMDeviceRegistration_Impl: Sized {
     fn RegisterDevice(&self, dwregistertype: u32, pbcertificate: *const u8, cbcertificate: u32, serialnumber: &DRM_VAL16) -> ::windows::core::Result<IWMRegisteredDevice>;
     fn UnregisterDevice(&self, dwregistertype: u32, pbcertificate: *const u8, cbcertificate: u32, serialnumber: &DRM_VAL16) -> ::windows::core::Result<()>;
@@ -1149,6 +1177,7 @@ impl IWMDeviceRegistration_Vtbl {
         iid == &<IWMDeviceRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMGetSecureChannel_Impl: Sized {
     fn GetPeerSecureChannelInterface(&self) -> ::windows::core::Result<IWMSecureChannel>;
 }
@@ -1175,6 +1204,7 @@ impl IWMGetSecureChannel_Vtbl {
         iid == &<IWMGetSecureChannel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMHeaderInfo_Impl: Sized {
     fn GetAttributeCount(&self, wstreamnum: u16) -> ::windows::core::Result<u16>;
     fn GetAttributeByIndex(&self, windex: u16, pwstreamnum: *mut u16, pwszname: ::windows::core::PWSTR, pcchnamelen: *mut u16, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::Result<()>;
@@ -1290,6 +1320,7 @@ impl IWMHeaderInfo_Vtbl {
         iid == &<IWMHeaderInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMHeaderInfo2_Impl: Sized + IWMHeaderInfo_Impl {
     fn GetCodecInfoCount(&self) -> ::windows::core::Result<u32>;
     fn GetCodecInfo(&self, windex: u32, pcchname: *mut u16, pwszname: ::windows::core::PWSTR, pcchdescription: *mut u16, pwszdescription: ::windows::core::PWSTR, pcodectype: *mut WMT_CODEC_INFO_TYPE, pcbcodecinfo: *mut u16, pbcodecinfo: *mut u8) -> ::windows::core::Result<()>;
@@ -1323,6 +1354,7 @@ impl IWMHeaderInfo2_Vtbl {
         iid == &<IWMHeaderInfo2 as ::windows::core::Interface>::IID || iid == &<IWMHeaderInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMHeaderInfo3_Impl: Sized + IWMHeaderInfo2_Impl {
     fn GetAttributeCountEx(&self, wstreamnum: u16) -> ::windows::core::Result<u16>;
     fn GetAttributeIndices(&self, wstreamnum: u16, pwszname: &::windows::core::PCWSTR, pwlangindex: *const u16, pwindices: *mut u16, pwcount: *mut u16) -> ::windows::core::Result<()>;
@@ -1391,6 +1423,7 @@ impl IWMHeaderInfo3_Vtbl {
         iid == &<IWMHeaderInfo3 as ::windows::core::Interface>::IID || iid == &<IWMHeaderInfo as ::windows::core::Interface>::IID || iid == &<IWMHeaderInfo2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMIStreamProps_Impl: Sized {
     fn GetProperty(&self, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -1408,6 +1441,7 @@ impl IWMIStreamProps_Vtbl {
         iid == &<IWMIStreamProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMImageInfo_Impl: Sized {
     fn GetImageCount(&self) -> ::windows::core::Result<u32>;
     fn GetImage(&self, windex: u32, pcchmimetype: *mut u16, pwszmimetype: ::windows::core::PWSTR, pcchdescription: *mut u16, pwszdescription: ::windows::core::PWSTR, pimagetype: *mut u16, pcbimagedata: *mut u32, pbimagedata: *mut u8) -> ::windows::core::Result<()>;
@@ -1441,6 +1475,7 @@ impl IWMImageInfo_Vtbl {
         iid == &<IWMImageInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMIndexer_Impl: Sized {
     fn StartIndexing(&self, pwszurl: &::windows::core::PCWSTR, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
@@ -1468,6 +1503,7 @@ impl IWMIndexer_Vtbl {
         iid == &<IWMIndexer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMIndexer2_Impl: Sized + IWMIndexer_Impl {
     fn Configure(&self, wstreamnum: u16, nindexertype: WMT_INDEXER_TYPE, pvinterval: *const ::core::ffi::c_void, pvindextype: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1485,6 +1521,7 @@ impl IWMIndexer2_Vtbl {
         iid == &<IWMIndexer2 as ::windows::core::Interface>::IID || iid == &<IWMIndexer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMInputMediaProps_Impl: Sized + IWMMediaProps_Impl {
     fn GetConnectionName(&self, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::Result<()>;
@@ -1515,6 +1552,7 @@ impl IWMInputMediaProps_Vtbl {
         iid == &<IWMInputMediaProps as ::windows::core::Interface>::IID || iid == &<IWMMediaProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMLanguageList_Impl: Sized {
     fn GetLanguageCount(&self) -> ::windows::core::Result<u16>;
     fn GetLanguageDetails(&self, windex: u16, pwszlanguagestring: ::windows::core::PWSTR, pcchlanguagestringlength: *mut u16) -> ::windows::core::Result<()>;
@@ -1561,6 +1599,7 @@ impl IWMLanguageList_Vtbl {
         iid == &<IWMLanguageList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMLicenseBackup_Impl: Sized {
     fn BackupLicenses(&self, dwflags: u32, pcallback: &::core::option::Option<IWMStatusCallback>) -> ::windows::core::Result<()>;
     fn CancelLicenseBackup(&self) -> ::windows::core::Result<()>;
@@ -1588,6 +1627,7 @@ impl IWMLicenseBackup_Vtbl {
         iid == &<IWMLicenseBackup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMLicenseRestore_Impl: Sized {
     fn RestoreLicenses(&self, dwflags: u32, pcallback: &::core::option::Option<IWMStatusCallback>) -> ::windows::core::Result<()>;
     fn CancelLicenseRestore(&self) -> ::windows::core::Result<()>;
@@ -1615,6 +1655,7 @@ impl IWMLicenseRestore_Vtbl {
         iid == &<IWMLicenseRestore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMLicenseRevocationAgent_Impl: Sized {
     fn GetLRBChallenge(&self, pmachineid: *const u8, dwmachineidlength: u32, pchallenge: *const u8, dwchallengelength: u32, pchallengeoutput: *mut u8, pdwchallengeoutputlength: *mut u32) -> ::windows::core::Result<()>;
     fn ProcessLRB(&self, psignedlrb: *const u8, dwsignedlrblength: u32, psignedack: *mut u8, pdwsignedacklength: *mut u32) -> ::windows::core::Result<()>;
@@ -1642,6 +1683,7 @@ impl IWMLicenseRevocationAgent_Vtbl {
         iid == &<IWMLicenseRevocationAgent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMMediaProps_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1685,6 +1727,7 @@ impl IWMMediaProps_Vtbl {
         iid == &<IWMMediaProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMMetadataEditor_Impl: Sized {
     fn Open(&self, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -1719,6 +1762,7 @@ impl IWMMetadataEditor_Vtbl {
         iid == &<IWMMetadataEditor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMMetadataEditor2_Impl: Sized + IWMMetadataEditor_Impl {
     fn OpenEx(&self, pwszfilename: &::windows::core::PCWSTR, dwdesiredaccess: u32, dwsharemode: u32) -> ::windows::core::Result<()>;
 }
@@ -1736,6 +1780,7 @@ impl IWMMetadataEditor2_Vtbl {
         iid == &<IWMMetadataEditor2 as ::windows::core::Interface>::IID || iid == &<IWMMetadataEditor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMMutualExclusion_Impl: Sized + IWMStreamList_Impl {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn SetType(&self, guidtype: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1769,6 +1814,7 @@ impl IWMMutualExclusion_Vtbl {
         iid == &<IWMMutualExclusion as ::windows::core::Interface>::IID || iid == &<IWMStreamList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMMutualExclusion2_Impl: Sized + IWMMutualExclusion_Impl {
     fn GetName(&self, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::Result<()>;
     fn SetName(&self, pwszname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1858,6 +1904,7 @@ impl IWMMutualExclusion2_Vtbl {
         iid == &<IWMMutualExclusion2 as ::windows::core::Interface>::IID || iid == &<IWMStreamList as ::windows::core::Interface>::IID || iid == &<IWMMutualExclusion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMOutputMediaProps_Impl: Sized + IWMMediaProps_Impl {
     fn GetStreamGroupName(&self, pwszname: ::windows::core::PWSTR, pcchname: *mut u16) -> ::windows::core::Result<()>;
@@ -1888,6 +1935,7 @@ impl IWMOutputMediaProps_Vtbl {
         iid == &<IWMOutputMediaProps as ::windows::core::Interface>::IID || iid == &<IWMMediaProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMPacketSize_Impl: Sized {
     fn GetMaxPacketSize(&self) -> ::windows::core::Result<u32>;
     fn SetMaxPacketSize(&self, dwmaxpacketsize: u32) -> ::windows::core::Result<()>;
@@ -1921,6 +1969,7 @@ impl IWMPacketSize_Vtbl {
         iid == &<IWMPacketSize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMPacketSize2_Impl: Sized + IWMPacketSize_Impl {
     fn GetMinPacketSize(&self) -> ::windows::core::Result<u32>;
     fn SetMinPacketSize(&self, dwminpacketsize: u32) -> ::windows::core::Result<()>;
@@ -1954,6 +2003,7 @@ impl IWMPacketSize2_Vtbl {
         iid == &<IWMPacketSize2 as ::windows::core::Interface>::IID || iid == &<IWMPacketSize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMPlayerHook_Impl: Sized {
     fn PreDecode(&self) -> ::windows::core::Result<()>;
 }
@@ -1971,6 +2021,7 @@ impl IWMPlayerHook_Vtbl {
         iid == &<IWMPlayerHook as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMPlayerTimestampHook_Impl: Sized {
     fn MapTimestamp(&self, rtin: i64) -> ::windows::core::Result<i64>;
 }
@@ -1994,6 +2045,7 @@ impl IWMPlayerTimestampHook_Vtbl {
         iid == &<IWMPlayerTimestampHook as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMProfile_Impl: Sized {
     fn GetVersion(&self) -> ::windows::core::Result<WMT_VERSION>;
     fn GetName(&self, pwszname: ::windows::core::PWSTR, pcchname: *mut u32) -> ::windows::core::Result<()>;
@@ -2181,6 +2233,7 @@ impl IWMProfile_Vtbl {
         iid == &<IWMProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMProfile2_Impl: Sized + IWMProfile_Impl {
     fn GetProfileID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -2204,6 +2257,7 @@ impl IWMProfile2_Vtbl {
         iid == &<IWMProfile2 as ::windows::core::Interface>::IID || iid == &<IWMProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMProfile3_Impl: Sized + IWMProfile2_Impl {
     fn GetStorageFormat(&self) -> ::windows::core::Result<WMT_STORAGE_FORMAT>;
     fn SetStorageFormat(&self, nstorageformat: WMT_STORAGE_FORMAT) -> ::windows::core::Result<()>;
@@ -2343,6 +2397,7 @@ impl IWMProfile3_Vtbl {
         iid == &<IWMProfile3 as ::windows::core::Interface>::IID || iid == &<IWMProfile as ::windows::core::Interface>::IID || iid == &<IWMProfile2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMProfileManager_Impl: Sized {
     fn CreateEmptyProfile(&self, dwversion: WMT_VERSION) -> ::windows::core::Result<IWMProfile>;
     fn LoadProfileByID(&self, guidprofile: *const ::windows::core::GUID) -> ::windows::core::Result<IWMProfile>;
@@ -2428,6 +2483,7 @@ impl IWMProfileManager_Vtbl {
         iid == &<IWMProfileManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMProfileManager2_Impl: Sized + IWMProfileManager_Impl {
     fn GetSystemProfileVersion(&self, pdwversion: *mut WMT_VERSION) -> ::windows::core::Result<()>;
     fn SetSystemProfileVersion(&self, dwversion: WMT_VERSION) -> ::windows::core::Result<()>;
@@ -2455,6 +2511,7 @@ impl IWMProfileManager2_Vtbl {
         iid == &<IWMProfileManager2 as ::windows::core::Interface>::IID || iid == &<IWMProfileManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMProfileManagerLanguage_Impl: Sized {
     fn GetUserLanguageID(&self, wlangid: *mut u16) -> ::windows::core::Result<()>;
     fn SetUserLanguageID(&self, wlangid: u16) -> ::windows::core::Result<()>;
@@ -2482,6 +2539,7 @@ impl IWMProfileManagerLanguage_Vtbl {
         iid == &<IWMProfileManagerLanguage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMPropertyVault_Impl: Sized {
     fn GetPropertyCount(&self, pdwcount: *const u32) -> ::windows::core::Result<()>;
     fn GetPropertyByName(&self, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pdwsize: *mut u32) -> ::windows::core::Result<()>;
@@ -2537,6 +2595,7 @@ impl IWMPropertyVault_Vtbl {
         iid == &<IWMPropertyVault as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMProximityDetection_Impl: Sized {
     fn StartDetection(&self, pbregistrationmsg: *const u8, cbregistrationmsg: u32, pblocaladdress: *const u8, cblocaladdress: u32, dwextraportsallowed: u32, ppregistrationresponsemsg: *mut ::core::option::Option<INSSBuffer>, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -2554,6 +2613,7 @@ impl IWMProximityDetection_Vtbl {
         iid == &<IWMProximityDetection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMReader_Impl: Sized {
     fn Open(&self, pwszurl: &::windows::core::PCWSTR, pcallback: &::core::option::Option<IWMReaderCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -2668,6 +2728,7 @@ impl IWMReader_Vtbl {
         iid == &<IWMReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMReaderAccelerator_Impl: Sized {
     fn GetCodecInterface(&self, dwoutputnum: u32, riid: *const ::windows::core::GUID, ppvcodecinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2698,6 +2759,7 @@ impl IWMReaderAccelerator_Vtbl {
         iid == &<IWMReaderAccelerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMReaderAdvanced_Impl: Sized {
     fn SetUserProvidedClock(&self, fuserclock: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2908,6 +2970,7 @@ impl IWMReaderAdvanced_Vtbl {
         iid == &<IWMReaderAdvanced as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMReaderAdvanced2_Impl: Sized + IWMReaderAdvanced_Impl {
     fn SetPlayMode(&self, mode: WMT_PLAY_MODE) -> ::windows::core::Result<()>;
@@ -3047,6 +3110,7 @@ impl IWMReaderAdvanced2_Vtbl {
         iid == &<IWMReaderAdvanced2 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMReaderAdvanced3_Impl: Sized + IWMReaderAdvanced2_Impl {
     fn StopNetStreaming(&self) -> ::windows::core::Result<()>;
@@ -3077,6 +3141,7 @@ impl IWMReaderAdvanced3_Vtbl {
         iid == &<IWMReaderAdvanced3 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMReaderAdvanced4_Impl: Sized + IWMReaderAdvanced3_Impl {
     fn GetLanguageCount(&self, dwoutputnum: u32) -> ::windows::core::Result<u16>;
@@ -3180,6 +3245,7 @@ impl IWMReaderAdvanced4_Vtbl {
         iid == &<IWMReaderAdvanced4 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced2 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMReaderAdvanced5_Impl: Sized + IWMReaderAdvanced4_Impl {
     fn SetPlayerHook(&self, dwoutputnum: u32, phook: &::core::option::Option<IWMPlayerHook>) -> ::windows::core::Result<()>;
@@ -3200,6 +3266,7 @@ impl IWMReaderAdvanced5_Vtbl {
         iid == &<IWMReaderAdvanced5 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced2 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced3 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMReaderAdvanced6_Impl: Sized + IWMReaderAdvanced5_Impl {
     fn SetProtectStreamSamples(&self, pbcertificate: *const u8, cbcertificate: u32, dwcertificatetype: u32, dwflags: u32, pbinitializationvector: *mut u8, pcbinitializationvector: *mut u32) -> ::windows::core::Result<()>;
@@ -3220,6 +3287,7 @@ impl IWMReaderAdvanced6_Vtbl {
         iid == &<IWMReaderAdvanced6 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced2 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced3 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced4 as ::windows::core::Interface>::IID || iid == &<IWMReaderAdvanced5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMReaderAllocatorEx_Impl: Sized {
     fn AllocateForStreamEx(&self, wstreamnum: u16, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, dwflags: u32, cnssampletime: u64, cnssampleduration: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn AllocateForOutputEx(&self, dwoutputnum: u32, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, dwflags: u32, cnssampletime: u64, cnssampleduration: u64, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3247,6 +3315,7 @@ impl IWMReaderAllocatorEx_Vtbl {
         iid == &<IWMReaderAllocatorEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMReaderCallback_Impl: Sized + IWMStatusCallback_Impl {
     fn OnSample(&self, dwoutputnum: u32, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: &::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -3264,6 +3333,7 @@ impl IWMReaderCallback_Vtbl {
         iid == &<IWMReaderCallback as ::windows::core::Interface>::IID || iid == &<IWMStatusCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMReaderCallbackAdvanced_Impl: Sized {
     fn OnStreamSample(&self, wstreamnum: u16, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: &::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3322,6 +3392,7 @@ impl IWMReaderCallbackAdvanced_Vtbl {
         iid == &<IWMReaderCallbackAdvanced as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMReaderNetworkConfig_Impl: Sized {
     fn GetBufferingTime(&self) -> ::windows::core::Result<u64>;
@@ -3641,6 +3712,7 @@ impl IWMReaderNetworkConfig_Vtbl {
         iid == &<IWMReaderNetworkConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMReaderNetworkConfig2_Impl: Sized + IWMReaderNetworkConfig_Impl {
     fn GetEnableContentCaching(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3790,6 +3862,7 @@ impl IWMReaderNetworkConfig2_Vtbl {
         iid == &<IWMReaderNetworkConfig2 as ::windows::core::Interface>::IID || iid == &<IWMReaderNetworkConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMReaderPlaylistBurn_Impl: Sized {
     fn InitPlaylistBurn(&self, cfiles: u32, ppwszfilenames: *const ::windows::core::PCWSTR, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetInitResults(&self, cfiles: u32) -> ::windows::core::Result<::windows::core::HRESULT>;
@@ -3837,6 +3910,7 @@ impl IWMReaderPlaylistBurn_Vtbl {
         iid == &<IWMReaderPlaylistBurn as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMReaderStreamClock_Impl: Sized {
     fn GetTime(&self, pcnsnow: *const u64) -> ::windows::core::Result<()>;
     fn SetTimer(&self, cnswhen: u64, pvparam: *const ::core::ffi::c_void) -> ::windows::core::Result<u32>;
@@ -3877,6 +3951,7 @@ impl IWMReaderStreamClock_Vtbl {
         iid == &<IWMReaderStreamClock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMReaderTimecode_Impl: Sized {
     fn GetTimecodeRangeCount(&self, wstreamnum: u16) -> ::windows::core::Result<u16>;
     fn GetTimecodeRangeBounds(&self, wstreamnum: u16, wrangenum: u16, pstarttimecode: *mut u32, pendtimecode: *mut u32) -> ::windows::core::Result<()>;
@@ -3910,6 +3985,7 @@ impl IWMReaderTimecode_Vtbl {
         iid == &<IWMReaderTimecode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMReaderTypeNegotiation_Impl: Sized {
     fn TryOutputProps(&self, dwoutputnum: u32, poutput: &::core::option::Option<IWMOutputMediaProps>) -> ::windows::core::Result<()>;
 }
@@ -3927,6 +4003,7 @@ impl IWMReaderTypeNegotiation_Vtbl {
         iid == &<IWMReaderTypeNegotiation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMRegisterCallback_Impl: Sized {
     fn Advise(&self, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Unadvise(&self, pcallback: &::core::option::Option<IWMStatusCallback>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3954,6 +4031,7 @@ impl IWMRegisterCallback_Vtbl {
         iid == &<IWMRegisterCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMRegisteredDevice_Impl: Sized {
     fn GetDeviceSerialNumber(&self) -> ::windows::core::Result<DRM_VAL16>;
@@ -4122,6 +4200,7 @@ impl IWMRegisteredDevice_Vtbl {
         iid == &<IWMRegisteredDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMSBufferAllocator_Impl: Sized {
     fn AllocateBuffer(&self, dwmaxbuffersize: u32) -> ::windows::core::Result<INSSBuffer>;
     fn AllocatePageSizeBuffer(&self, dwmaxbuffersize: u32) -> ::windows::core::Result<INSSBuffer>;
@@ -4161,6 +4240,7 @@ impl IWMSBufferAllocator_Vtbl {
         iid == &<IWMSBufferAllocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMSInternalAdminNetSource_Impl: Sized {
     fn Initialize(&self, psharednamespace: &::core::option::Option<::windows::core::IUnknown>, pnamespacenode: &::core::option::Option<::windows::core::IUnknown>, pnetsourcecreator: &::core::option::Option<INSNetSourceCreator>, fembeddedinserver: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4272,6 +4352,7 @@ impl IWMSInternalAdminNetSource_Vtbl {
         iid == &<IWMSInternalAdminNetSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMSInternalAdminNetSource2_Impl: Sized {
     fn SetCredentialsEx(&self, bstrrealm: &::windows::core::BSTR, bstrurl: &::windows::core::BSTR, fproxy: super::super::Foundation::BOOL, bstrname: &::windows::core::BSTR, bstrpassword: &::windows::core::BSTR, fpersist: super::super::Foundation::BOOL, fconfirmedgood: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4316,6 +4397,7 @@ impl IWMSInternalAdminNetSource2_Vtbl {
         iid == &<IWMSInternalAdminNetSource2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMSInternalAdminNetSource3_Impl: Sized + IWMSInternalAdminNetSource2_Impl {
     fn GetNetSourceCreator2(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -4393,6 +4475,7 @@ impl IWMSInternalAdminNetSource3_Vtbl {
         iid == &<IWMSInternalAdminNetSource3 as ::windows::core::Interface>::IID || iid == &<IWMSInternalAdminNetSource2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMSecureChannel_Impl: Sized + IWMAuthorizer_Impl {
     fn WMSC_AddCertificate(&self, pcert: &::core::option::Option<IWMAuthorizer>) -> ::windows::core::Result<()>;
@@ -4492,6 +4575,7 @@ impl IWMSecureChannel_Vtbl {
         iid == &<IWMSecureChannel as ::windows::core::Interface>::IID || iid == &<IWMAuthorizer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMStatusCallback_Impl: Sized {
     fn OnStatus(&self, status: WMT_STATUS, hr: ::windows::core::HRESULT, dwtype: WMT_ATTR_DATATYPE, pvalue: *const u8, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -4509,6 +4593,7 @@ impl IWMStatusCallback_Vtbl {
         iid == &<IWMStatusCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMStreamConfig_Impl: Sized {
     fn GetStreamType(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetStreamNumber(&self) -> ::windows::core::Result<u16>;
@@ -4623,6 +4708,7 @@ impl IWMStreamConfig_Vtbl {
         iid == &<IWMStreamConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMStreamConfig2_Impl: Sized + IWMStreamConfig_Impl {
     fn GetTransportType(&self) -> ::windows::core::Result<WMT_TRANSPORT_TYPE>;
     fn SetTransportType(&self, ntransporttype: WMT_TRANSPORT_TYPE) -> ::windows::core::Result<()>;
@@ -4690,6 +4776,7 @@ impl IWMStreamConfig2_Vtbl {
         iid == &<IWMStreamConfig2 as ::windows::core::Interface>::IID || iid == &<IWMStreamConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMStreamConfig3_Impl: Sized + IWMStreamConfig2_Impl {
     fn GetLanguage(&self, pwszlanguagestring: ::windows::core::PWSTR, pcchlanguagestringlength: *mut u16) -> ::windows::core::Result<()>;
     fn SetLanguage(&self, pwszlanguagestring: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -4717,6 +4804,7 @@ impl IWMStreamConfig3_Vtbl {
         iid == &<IWMStreamConfig3 as ::windows::core::Interface>::IID || iid == &<IWMStreamConfig as ::windows::core::Interface>::IID || iid == &<IWMStreamConfig2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMStreamList_Impl: Sized {
     fn GetStreams(&self, pwstreamnumarray: *mut u16, pcstreams: *mut u16) -> ::windows::core::Result<()>;
     fn AddStream(&self, wstreamnum: u16) -> ::windows::core::Result<()>;
@@ -4751,6 +4839,7 @@ impl IWMStreamList_Vtbl {
         iid == &<IWMStreamList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMStreamPrioritization_Impl: Sized {
     fn GetPriorityRecords(&self, precordarray: *mut WM_STREAM_PRIORITY_RECORD, pcrecords: *mut u16) -> ::windows::core::Result<()>;
@@ -4781,6 +4870,7 @@ impl IWMStreamPrioritization_Vtbl {
         iid == &<IWMStreamPrioritization as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMSyncReader_Impl: Sized {
     fn Open(&self, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -5004,6 +5094,7 @@ impl IWMSyncReader_Vtbl {
         iid == &<IWMSyncReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWMSyncReader2_Impl: Sized + IWMSyncReader_Impl {
     fn SetRangeByTimecode(&self, wstreamnum: u16, pstart: *const WMT_TIMECODE_EXTENSION_DATA, pend: *const WMT_TIMECODE_EXTENSION_DATA) -> ::windows::core::Result<()>;
@@ -5080,6 +5171,7 @@ impl IWMSyncReader2_Vtbl {
         iid == &<IWMSyncReader2 as ::windows::core::Interface>::IID || iid == &<IWMSyncReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMVideoMediaProps_Impl: Sized + IWMMediaProps_Impl {
     fn GetMaxKeyFrameSpacing(&self) -> ::windows::core::Result<i64>;
@@ -5136,6 +5228,7 @@ impl IWMVideoMediaProps_Vtbl {
         iid == &<IWMVideoMediaProps as ::windows::core::Interface>::IID || iid == &<IWMMediaProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMWatermarkInfo_Impl: Sized {
     fn GetWatermarkEntryCount(&self, wmettype: WMT_WATERMARK_ENTRY_TYPE) -> ::windows::core::Result<u32>;
     fn GetWatermarkEntry(&self, wmettype: WMT_WATERMARK_ENTRY_TYPE, dwentrynum: u32) -> ::windows::core::Result<WMT_WATERMARK_ENTRY>;
@@ -5175,6 +5268,7 @@ impl IWMWatermarkInfo_Vtbl {
         iid == &<IWMWatermarkInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMWriter_Impl: Sized {
     fn SetProfileByID(&self, guidprofile: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SetProfile(&self, pprofile: &::core::option::Option<IWMProfile>) -> ::windows::core::Result<()>;
@@ -5309,6 +5403,7 @@ impl IWMWriter_Vtbl {
         iid == &<IWMWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterAdvanced_Impl: Sized {
     fn GetSinkCount(&self) -> ::windows::core::Result<u32>;
@@ -5438,6 +5533,7 @@ impl IWMWriterAdvanced_Vtbl {
         iid == &<IWMWriterAdvanced as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterAdvanced2_Impl: Sized + IWMWriterAdvanced_Impl {
     fn GetInputSetting(&self, dwinputnum: u32, pszname: &::windows::core::PCWSTR, ptype: *mut WMT_ATTR_DATATYPE, pvalue: *mut u8, pcblength: *mut u16) -> ::windows::core::Result<()>;
@@ -5468,6 +5564,7 @@ impl IWMWriterAdvanced2_Vtbl {
         iid == &<IWMWriterAdvanced2 as ::windows::core::Interface>::IID || iid == &<IWMWriterAdvanced as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterAdvanced3_Impl: Sized + IWMWriterAdvanced2_Impl {
     fn GetStatisticsEx(&self, wstreamnum: u16) -> ::windows::core::Result<WM_WRITER_STATISTICS_EX>;
@@ -5504,6 +5601,7 @@ impl IWMWriterAdvanced3_Vtbl {
         iid == &<IWMWriterAdvanced3 as ::windows::core::Interface>::IID || iid == &<IWMWriterAdvanced as ::windows::core::Interface>::IID || iid == &<IWMWriterAdvanced2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterFileSink_Impl: Sized + IWMWriterSink_Impl {
     fn Open(&self, pwszfilename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -5524,6 +5622,7 @@ impl IWMWriterFileSink_Vtbl {
         iid == &<IWMWriterFileSink as ::windows::core::Interface>::IID || iid == &<IWMWriterSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterFileSink2_Impl: Sized + IWMWriterFileSink_Impl {
     fn Start(&self, cnsstarttime: u64) -> ::windows::core::Result<()>;
@@ -5613,6 +5712,7 @@ impl IWMWriterFileSink2_Vtbl {
         iid == &<IWMWriterFileSink2 as ::windows::core::Interface>::IID || iid == &<IWMWriterSink as ::windows::core::Interface>::IID || iid == &<IWMWriterFileSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterFileSink3_Impl: Sized + IWMWriterFileSink2_Impl {
     fn SetAutoIndexing(&self, fdoautoindexing: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5703,6 +5803,7 @@ impl IWMWriterFileSink3_Vtbl {
         iid == &<IWMWriterFileSink3 as ::windows::core::Interface>::IID || iid == &<IWMWriterSink as ::windows::core::Interface>::IID || iid == &<IWMWriterFileSink as ::windows::core::Interface>::IID || iid == &<IWMWriterFileSink2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterNetworkSink_Impl: Sized + IWMWriterSink_Impl {
     fn SetMaximumClients(&self, dwmaxclients: u32) -> ::windows::core::Result<()>;
@@ -5787,6 +5888,7 @@ impl IWMWriterNetworkSink_Vtbl {
         iid == &<IWMWriterNetworkSink as ::windows::core::Interface>::IID || iid == &<IWMWriterSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterPostView_Impl: Sized {
     fn SetPostViewCallback(&self, pcallback: &::core::option::Option<IWMWriterPostViewCallback>, pvcontext: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -5896,6 +5998,7 @@ impl IWMWriterPostView_Vtbl {
         iid == &<IWMWriterPostView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMWriterPostViewCallback_Impl: Sized + IWMStatusCallback_Impl {
     fn OnPostViewSample(&self, wstreamnumber: u16, cnssampletime: u64, cnssampleduration: u64, dwflags: u32, psample: &::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn AllocateForPostView(&self, wstreamnum: u16, cbbuffer: u32, ppbuffer: *mut ::core::option::Option<INSSBuffer>, pvcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -5923,6 +6026,7 @@ impl IWMWriterPostViewCallback_Vtbl {
         iid == &<IWMWriterPostViewCallback as ::windows::core::Interface>::IID || iid == &<IWMStatusCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"implement\"`*"]
 pub trait IWMWriterPreprocess_Impl: Sized {
     fn GetMaxPreprocessingPasses(&self, dwinputnum: u32, dwflags: u32) -> ::windows::core::Result<u32>;
     fn SetNumPreprocessingPasses(&self, dwinputnum: u32, dwflags: u32, dwnumpasses: u32) -> ::windows::core::Result<()>;
@@ -5977,6 +6081,7 @@ impl IWMWriterPreprocess_Vtbl {
         iid == &<IWMWriterPreprocess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterPushSink_Impl: Sized + IWMWriterSink_Impl {
     fn Connect(&self, pwszurl: &::windows::core::PCWSTR, pwsztemplateurl: &::windows::core::PCWSTR, fautodestroy: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -6014,6 +6119,7 @@ impl IWMWriterPushSink_Vtbl {
         iid == &<IWMWriterPushSink as ::windows::core::Interface>::IID || iid == &<IWMWriterSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media_WindowsMediaFormat\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWMWriterSink_Impl: Sized {
     fn OnHeader(&self, pheader: &::core::option::Option<INSSBuffer>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Media\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IReferenceClock_Impl: Sized {
     fn GetTime(&self) -> ::windows::core::Result<i64>;
@@ -60,6 +61,7 @@ impl IReferenceClock_Vtbl {
         iid == &<IReferenceClock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IReferenceClock2_Impl: Sized + IReferenceClock_Impl {}
 #[cfg(feature = "Win32_Foundation")]
@@ -73,6 +75,7 @@ impl IReferenceClock2_Vtbl {
         iid == &<IReferenceClock2 as ::windows::core::Interface>::IID || iid == &<IReferenceClock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Media\"`, `\"implement\"`*"]
 pub trait IReferenceClockTimerControl_Impl: Sized {
     fn SetDefaultTimerResolution(&self, timerresolution: i64) -> ::windows::core::Result<()>;
     fn GetDefaultTimerResolution(&self) -> ::windows::core::Result<i64>;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDummyMBNUCMExt_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -11,6 +12,7 @@ impl IDummyMBNUCMExt_Vtbl {
         iid == &<IDummyMBNUCMExt as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnConnection_Impl: Sized {
     fn ConnectionID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn InterfaceID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -109,6 +111,7 @@ impl IMbnConnection_Vtbl {
         iid == &<IMbnConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnConnectionContext_Impl: Sized {
     fn GetProvisionedContexts(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -151,6 +154,7 @@ impl IMbnConnectionContext_Vtbl {
         iid == &<IMbnConnectionContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnConnectionContextEvents_Impl: Sized {
     fn OnProvisionedContextListChange(&self, newinterface: &::core::option::Option<IMbnConnectionContext>) -> ::windows::core::Result<()>;
     fn OnSetProvisionedContextComplete(&self, newinterface: &::core::option::Option<IMbnConnectionContext>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -178,6 +182,7 @@ impl IMbnConnectionContextEvents_Vtbl {
         iid == &<IMbnConnectionContextEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnConnectionEvents_Impl: Sized {
     fn OnConnectComplete(&self, newconnection: &::core::option::Option<IMbnConnection>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnDisconnectComplete(&self, newconnection: &::core::option::Option<IMbnConnection>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -219,6 +224,7 @@ impl IMbnConnectionEvents_Vtbl {
         iid == &<IMbnConnectionEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnConnectionManager_Impl: Sized {
     fn GetConnection(&self, connectionid: &::windows::core::PCWSTR) -> ::windows::core::Result<IMbnConnection>;
@@ -261,6 +267,7 @@ impl IMbnConnectionManager_Vtbl {
         iid == &<IMbnConnectionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnConnectionManagerEvents_Impl: Sized {
     fn OnConnectionArrival(&self, newconnection: &::core::option::Option<IMbnConnection>) -> ::windows::core::Result<()>;
     fn OnConnectionRemoval(&self, oldconnection: &::core::option::Option<IMbnConnection>) -> ::windows::core::Result<()>;
@@ -288,6 +295,7 @@ impl IMbnConnectionManagerEvents_Vtbl {
         iid == &<IMbnConnectionManagerEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnConnectionProfile_Impl: Sized {
     fn GetProfileXmlData(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn UpdateProfile(&self, strprofile: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -328,6 +336,7 @@ impl IMbnConnectionProfile_Vtbl {
         iid == &<IMbnConnectionProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnConnectionProfileEvents_Impl: Sized {
     fn OnProfileUpdate(&self, newprofile: &::core::option::Option<IMbnConnectionProfile>) -> ::windows::core::Result<()>;
 }
@@ -345,6 +354,7 @@ impl IMbnConnectionProfileEvents_Vtbl {
         iid == &<IMbnConnectionProfileEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnConnectionProfileManager_Impl: Sized {
     fn GetConnectionProfiles(&self, mbninterface: &::core::option::Option<IMbnInterface>) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -394,6 +404,7 @@ impl IMbnConnectionProfileManager_Vtbl {
         iid == &<IMbnConnectionProfileManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnConnectionProfileManagerEvents_Impl: Sized {
     fn OnConnectionProfileArrival(&self, newconnectionprofile: &::core::option::Option<IMbnConnectionProfile>) -> ::windows::core::Result<()>;
     fn OnConnectionProfileRemoval(&self, oldconnectionprofile: &::core::option::Option<IMbnConnectionProfile>) -> ::windows::core::Result<()>;
@@ -421,6 +432,7 @@ impl IMbnConnectionProfileManagerEvents_Vtbl {
         iid == &<IMbnConnectionProfileManagerEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMbnDeviceService_Impl: Sized {
     fn QuerySupportedCommands(&self) -> ::windows::core::Result<u32>;
@@ -593,6 +605,7 @@ impl IMbnDeviceService_Vtbl {
         iid == &<IMbnDeviceService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnDeviceServiceStateEvents_Impl: Sized {
     fn OnSessionsStateChange(&self, interfaceid: &::windows::core::BSTR, statechange: MBN_DEVICE_SERVICE_SESSIONS_STATE) -> ::windows::core::Result<()>;
 }
@@ -610,6 +623,7 @@ impl IMbnDeviceServiceStateEvents_Vtbl {
         iid == &<IMbnDeviceServiceStateEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnDeviceServicesContext_Impl: Sized {
     fn EnumerateDeviceServices(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -678,6 +692,7 @@ impl IMbnDeviceServicesContext_Vtbl {
         iid == &<IMbnDeviceServicesContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnDeviceServicesEvents_Impl: Sized {
     fn OnQuerySupportedCommandsComplete(&self, deviceservice: &::core::option::Option<IMbnDeviceService>, commandidlist: *const super::super::System::Com::SAFEARRAY, status: ::windows::core::HRESULT, requestid: u32) -> ::windows::core::Result<()>;
@@ -771,6 +786,7 @@ impl IMbnDeviceServicesEvents_Vtbl {
         iid == &<IMbnDeviceServicesEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnDeviceServicesManager_Impl: Sized {
     fn GetDeviceServicesContext(&self, networkinterfaceid: &::windows::core::BSTR) -> ::windows::core::Result<IMbnDeviceServicesContext>;
 }
@@ -794,6 +810,7 @@ impl IMbnDeviceServicesManager_Vtbl {
         iid == &<IMbnDeviceServicesManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMbnInterface_Impl: Sized {
     fn InterfaceID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -947,6 +964,7 @@ impl IMbnInterface_Vtbl {
         iid == &<IMbnInterface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnInterfaceEvents_Impl: Sized {
     fn OnInterfaceCapabilityAvailable(&self, newinterface: &::core::option::Option<IMbnInterface>) -> ::windows::core::Result<()>;
     fn OnSubscriberInformationChange(&self, newinterface: &::core::option::Option<IMbnInterface>) -> ::windows::core::Result<()>;
@@ -1016,6 +1034,7 @@ impl IMbnInterfaceEvents_Vtbl {
         iid == &<IMbnInterfaceEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnInterfaceManager_Impl: Sized {
     fn GetInterface(&self, interfaceid: &::windows::core::PCWSTR) -> ::windows::core::Result<IMbnInterface>;
@@ -1058,6 +1077,7 @@ impl IMbnInterfaceManager_Vtbl {
         iid == &<IMbnInterfaceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnInterfaceManagerEvents_Impl: Sized {
     fn OnInterfaceArrival(&self, newinterface: &::core::option::Option<IMbnInterface>) -> ::windows::core::Result<()>;
     fn OnInterfaceRemoval(&self, oldinterface: &::core::option::Option<IMbnInterface>) -> ::windows::core::Result<()>;
@@ -1085,6 +1105,7 @@ impl IMbnInterfaceManagerEvents_Vtbl {
         iid == &<IMbnInterfaceManagerEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnMultiCarrier_Impl: Sized {
     fn SetHomeProvider(&self, homeprovider: *const MBN_PROVIDER2) -> ::windows::core::Result<u32>;
@@ -1173,6 +1194,7 @@ impl IMbnMultiCarrier_Vtbl {
         iid == &<IMbnMultiCarrier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnMultiCarrierEvents_Impl: Sized {
     fn OnSetHomeProviderComplete(&self, mbninterface: &::core::option::Option<IMbnMultiCarrier>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnCurrentCellularClassChange(&self, mbninterface: &::core::option::Option<IMbnMultiCarrier>) -> ::windows::core::Result<()>;
@@ -1221,6 +1243,7 @@ impl IMbnMultiCarrierEvents_Vtbl {
         iid == &<IMbnMultiCarrierEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnPin_Impl: Sized {
     fn PinType(&self) -> ::windows::core::Result<MBN_PIN_TYPE>;
     fn PinFormat(&self) -> ::windows::core::Result<MBN_PIN_FORMAT>;
@@ -1377,6 +1400,7 @@ impl IMbnPin_Vtbl {
         iid == &<IMbnPin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnPinEvents_Impl: Sized {
     fn OnEnableComplete(&self, pin: &::core::option::Option<IMbnPin>, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnDisableComplete(&self, pin: &::core::option::Option<IMbnPin>, pininfo: *const MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1425,6 +1449,7 @@ impl IMbnPinEvents_Vtbl {
         iid == &<IMbnPinEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnPinManager_Impl: Sized {
     fn GetPinList(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -1480,6 +1505,7 @@ impl IMbnPinManager_Vtbl {
         iid == &<IMbnPinManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnPinManagerEvents_Impl: Sized {
     fn OnPinListAvailable(&self, pinmanager: &::core::option::Option<IMbnPinManager>) -> ::windows::core::Result<()>;
     fn OnGetPinStateComplete(&self, pinmanager: &::core::option::Option<IMbnPinManager>, pininfo: &MBN_PIN_INFO, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1507,6 +1533,7 @@ impl IMbnPinManagerEvents_Vtbl {
         iid == &<IMbnPinManagerEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnRadio_Impl: Sized {
     fn SoftwareRadioState(&self) -> ::windows::core::Result<MBN_RADIO>;
     fn HardwareRadioState(&self) -> ::windows::core::Result<MBN_RADIO>;
@@ -1559,6 +1586,7 @@ impl IMbnRadio_Vtbl {
         iid == &<IMbnRadio as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnRadioEvents_Impl: Sized {
     fn OnRadioStateChange(&self, newinterface: &::core::option::Option<IMbnRadio>) -> ::windows::core::Result<()>;
     fn OnSetSoftwareRadioStateComplete(&self, newinterface: &::core::option::Option<IMbnRadio>, requestid: u32, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1586,6 +1614,7 @@ impl IMbnRadioEvents_Vtbl {
         iid == &<IMbnRadioEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnRegistration_Impl: Sized {
     fn GetRegisterState(&self) -> ::windows::core::Result<MBN_REGISTER_STATE>;
     fn GetRegisterMode(&self) -> ::windows::core::Result<MBN_REGISTER_MODE>;
@@ -1729,6 +1758,7 @@ impl IMbnRegistration_Vtbl {
         iid == &<IMbnRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnRegistrationEvents_Impl: Sized {
     fn OnRegisterModeAvailable(&self, newinterface: &::core::option::Option<IMbnRegistration>) -> ::windows::core::Result<()>;
     fn OnRegisterStateChange(&self, newinterface: &::core::option::Option<IMbnRegistration>) -> ::windows::core::Result<()>;
@@ -1770,6 +1800,7 @@ impl IMbnRegistrationEvents_Vtbl {
         iid == &<IMbnRegistrationEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnServiceActivation_Impl: Sized {
     fn Activate(&self, vendorspecificdata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<u32>;
@@ -1796,6 +1827,7 @@ impl IMbnServiceActivation_Vtbl {
         iid == &<IMbnServiceActivation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnServiceActivationEvents_Impl: Sized {
     fn OnActivationComplete(&self, serviceactivation: &::core::option::Option<IMbnServiceActivation>, vendorspecificdata: *const super::super::System::Com::SAFEARRAY, requestid: u32, status: ::windows::core::HRESULT, networkerror: u32) -> ::windows::core::Result<()>;
@@ -1816,6 +1848,7 @@ impl IMbnServiceActivationEvents_Vtbl {
         iid == &<IMbnServiceActivationEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnSignal_Impl: Sized {
     fn GetSignalStrength(&self) -> ::windows::core::Result<u32>;
     fn GetSignalError(&self) -> ::windows::core::Result<u32>;
@@ -1855,6 +1888,7 @@ impl IMbnSignal_Vtbl {
         iid == &<IMbnSignal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnSignalEvents_Impl: Sized {
     fn OnSignalStateChange(&self, newinterface: &::core::option::Option<IMbnSignal>) -> ::windows::core::Result<()>;
 }
@@ -1872,6 +1906,7 @@ impl IMbnSignalEvents_Vtbl {
         iid == &<IMbnSignalEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnSms_Impl: Sized {
     fn GetSmsConfiguration(&self) -> ::windows::core::Result<IMbnSmsConfiguration>;
@@ -1992,6 +2027,7 @@ impl IMbnSms_Vtbl {
         iid == &<IMbnSms as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"implement\"`*"]
 pub trait IMbnSmsConfiguration_Impl: Sized {
     fn ServiceCenterAddress(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn SetServiceCenterAddress(&self, scaddress: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -2071,6 +2107,7 @@ impl IMbnSmsConfiguration_Vtbl {
         iid == &<IMbnSmsConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMbnSmsEvents_Impl: Sized {
     fn OnSmsConfigurationChange(&self, sms: &::core::option::Option<IMbnSms>) -> ::windows::core::Result<()>;
@@ -2136,6 +2173,7 @@ impl IMbnSmsEvents_Vtbl {
         iid == &<IMbnSmsEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnSmsReadMsgPdu_Impl: Sized {
     fn Index(&self) -> ::windows::core::Result<u32>;
@@ -2204,6 +2242,7 @@ impl IMbnSmsReadMsgPdu_Vtbl {
         iid == &<IMbnSmsReadMsgPdu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnSmsReadMsgTextCdma_Impl: Sized {
     fn Index(&self) -> ::windows::core::Result<u32>;
@@ -2324,6 +2363,7 @@ impl IMbnSmsReadMsgTextCdma_Vtbl {
         iid == &<IMbnSmsReadMsgTextCdma as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnSubscriberInformation_Impl: Sized {
     fn SubscriberID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2379,6 +2419,7 @@ impl IMbnSubscriberInformation_Vtbl {
         iid == &<IMbnSubscriberInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnVendorSpecificEvents_Impl: Sized {
     fn OnEventNotification(&self, vendoroperation: &::core::option::Option<IMbnVendorSpecificOperation>, vendorspecificdata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -2409,6 +2450,7 @@ impl IMbnVendorSpecificEvents_Vtbl {
         iid == &<IMbnVendorSpecificEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_MobileBroadband\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMbnVendorSpecificOperation_Impl: Sized {
     fn SetVendorSpecific(&self, vendorspecificdata: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<u32>;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait IEnumNetCfgBindingInterface_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<INetCfgBindingInterface>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -45,6 +46,7 @@ impl IEnumNetCfgBindingInterface_Vtbl {
         iid == &<IEnumNetCfgBindingInterface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait IEnumNetCfgBindingPath_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<INetCfgBindingPath>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -92,6 +94,7 @@ impl IEnumNetCfgBindingPath_Vtbl {
         iid == &<IEnumNetCfgBindingPath as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait IEnumNetCfgComponent_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<INetCfgComponent>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -139,6 +142,7 @@ impl IEnumNetCfgComponent_Vtbl {
         iid == &<IEnumNetCfgComponent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfg_Impl: Sized {
     fn Initialize(&self, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Uninitialize(&self) -> ::windows::core::Result<()>;
@@ -201,6 +205,7 @@ impl INetCfg_Vtbl {
         iid == &<INetCfg as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgBindingInterface_Impl: Sized {
     fn GetName(&self, ppszwinterfacename: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn GetUpperComponent(&self, ppnccitem: *mut ::core::option::Option<INetCfgComponent>) -> ::windows::core::Result<()>;
@@ -235,6 +240,7 @@ impl INetCfgBindingInterface_Vtbl {
         iid == &<INetCfgBindingInterface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetCfgBindingPath_Impl: Sized {
     fn IsSamePathAs(&self, ppath: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
@@ -313,6 +319,7 @@ impl INetCfgBindingPath_Vtbl {
         iid == &<INetCfgBindingPath as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgClass_Impl: Sized {
     fn FindComponent(&self, pszwinfid: &::windows::core::PCWSTR, ppnccitem: *mut ::core::option::Option<INetCfgComponent>) -> ::windows::core::Result<()>;
     fn EnumComponents(&self, ppenumcomponent: *mut ::core::option::Option<IEnumNetCfgComponent>) -> ::windows::core::Result<()>;
@@ -340,6 +347,7 @@ impl INetCfgClass_Vtbl {
         iid == &<INetCfgClass as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetCfgClassSetup_Impl: Sized {
     fn SelectAndInstall(&self, hwndparent: super::super::Foundation::HWND, pobotoken: *const OBO_TOKEN, ppnccitem: *mut ::core::option::Option<INetCfgComponent>) -> ::windows::core::Result<()>;
@@ -377,6 +385,7 @@ impl INetCfgClassSetup_Vtbl {
         iid == &<INetCfgClassSetup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetCfgClassSetup2_Impl: Sized + INetCfgClassSetup_Impl {
     fn UpdateNonEnumeratedComponent(&self, picomp: &::core::option::Option<INetCfgComponent>, dwsetupflags: u32, dwupgradefrombuildno: u32) -> ::windows::core::Result<()>;
@@ -400,6 +409,7 @@ impl INetCfgClassSetup2_Vtbl {
         iid == &<INetCfgClassSetup2 as ::windows::core::Interface>::IID || iid == &<INetCfgClassSetup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait INetCfgComponent_Impl: Sized {
     fn GetDisplayName(&self, ppszwdisplayname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -512,6 +522,7 @@ impl INetCfgComponent_Vtbl {
         iid == &<INetCfgComponent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgComponentBindings_Impl: Sized {
     fn BindTo(&self, pnccitem: &::core::option::Option<INetCfgComponent>) -> ::windows::core::Result<()>;
     fn UnbindFrom(&self, pnccitem: &::core::option::Option<INetCfgComponent>) -> ::windows::core::Result<()>;
@@ -581,6 +592,7 @@ impl INetCfgComponentBindings_Vtbl {
         iid == &<INetCfgComponentBindings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetCfgComponentControl_Impl: Sized {
     fn Initialize(&self, picomp: &::core::option::Option<INetCfgComponent>, pinetcfg: &::core::option::Option<INetCfg>, finstalling: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -625,6 +637,7 @@ impl INetCfgComponentControl_Vtbl {
         iid == &<INetCfgComponentControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgComponentNotifyBinding_Impl: Sized {
     fn QueryBindingPath(&self, dwchangeflag: u32, pipath: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
     fn NotifyBindingPath(&self, dwchangeflag: u32, pipath: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
@@ -652,6 +665,7 @@ impl INetCfgComponentNotifyBinding_Vtbl {
         iid == &<INetCfgComponentNotifyBinding as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgComponentNotifyGlobal_Impl: Sized {
     fn GetSupportedNotifications(&self) -> ::windows::core::Result<u32>;
     fn SysQueryBindingPath(&self, dwchangeflag: u32, pipath: &::core::option::Option<INetCfgBindingPath>) -> ::windows::core::Result<()>;
@@ -699,6 +713,7 @@ impl INetCfgComponentNotifyGlobal_Vtbl {
         iid == &<INetCfgComponentNotifyGlobal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetCfgComponentPropertyUi_Impl: Sized {
     fn QueryPropertyUi(&self, punkreserved: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -757,6 +772,7 @@ impl INetCfgComponentPropertyUi_Vtbl {
         iid == &<INetCfgComponentPropertyUi as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgComponentSetup_Impl: Sized {
     fn Install(&self, dwsetupflags: u32) -> ::windows::core::Result<()>;
     fn Upgrade(&self, dwsetupflags: u32, dwupgradefombuildno: u32) -> ::windows::core::Result<()>;
@@ -798,6 +814,7 @@ impl INetCfgComponentSetup_Vtbl {
         iid == &<INetCfgComponentSetup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgComponentSysPrep_Impl: Sized {
     fn SaveAdapterParameters(&self, pncsp: &::core::option::Option<INetCfgSysPrep>, pszwanswersections: &::windows::core::PCWSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn RestoreAdapterParameters(&self, pszwanswerfile: &::windows::core::PCWSTR, pszwanswersection: &::windows::core::PCWSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -825,6 +842,7 @@ impl INetCfgComponentSysPrep_Vtbl {
         iid == &<INetCfgComponentSysPrep as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgComponentUpperEdge_Impl: Sized {
     fn GetInterfaceIdsForAdapter(&self, padapter: &::core::option::Option<INetCfgComponent>, pdwnuminterfaces: *mut u32, ppguidinterfaceids: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn AddInterfacesToAdapter(&self, padapter: &::core::option::Option<INetCfgComponent>, dwnuminterfaces: u32) -> ::windows::core::Result<()>;
@@ -859,6 +877,7 @@ impl INetCfgComponentUpperEdge_Vtbl {
         iid == &<INetCfgComponentUpperEdge as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgLock_Impl: Sized {
     fn AcquireWriteLock(&self, cmstimeout: u32, pszwclientdescription: &::windows::core::PCWSTR, ppszwclientdescription: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn ReleaseWriteLock(&self) -> ::windows::core::Result<()>;
@@ -893,6 +912,7 @@ impl INetCfgLock_Vtbl {
         iid == &<INetCfgLock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetCfgPnpReconfigCallback_Impl: Sized {
     fn SendPnpReconfig(&self, layer: NCPNP_RECONFIG_LAYER, pszwupper: &::windows::core::PCWSTR, pszwlower: &::windows::core::PCWSTR, pvdata: *const ::core::ffi::c_void, dwsizeofdata: u32) -> ::windows::core::Result<()>;
 }
@@ -910,6 +930,7 @@ impl INetCfgPnpReconfigCallback_Vtbl {
         iid == &<INetCfgPnpReconfigCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetCfgSysPrep_Impl: Sized {
     fn HrSetupSetFirstDword(&self, pwszsection: &::windows::core::PCWSTR, pwszkey: &::windows::core::PCWSTR, dwvalue: u32) -> ::windows::core::Result<()>;
@@ -954,6 +975,7 @@ impl INetCfgSysPrep_Vtbl {
         iid == &<INetCfgSysPrep as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait INetLanConnectionUiInfo_Impl: Sized {
     fn GetDeviceGuid(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -977,6 +999,7 @@ impl INetLanConnectionUiInfo_Vtbl {
         iid == &<INetLanConnectionUiInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetRasConnectionIpUiInfo_Impl: Sized {
     fn GetUiInfo(&self) -> ::windows::core::Result<RASCON_IPUI>;
@@ -1003,6 +1026,7 @@ impl INetRasConnectionIpUiInfo_Vtbl {
         iid == &<INetRasConnectionIpUiInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
 pub trait IProvisioningDomain_Impl: Sized {
     fn Add(&self, pszwpathtofolder: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1035,6 +1059,7 @@ impl IProvisioningDomain_Vtbl {
         iid == &<IProvisioningDomain as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetManagement\"`, `\"implement\"`*"]
 pub trait IProvisioningProfileWireless_Impl: Sized {
     fn CreateProfile(&self, bstrxmlwirelessconfigprofile: &::windows::core::BSTR, bstrxmlconnectionconfigprofile: &::windows::core::BSTR, padapterinstanceguid: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkDiagnosticsFramework/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkDiagnosticsFramework\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetDiagExtensibleHelper_Impl: Sized {
     fn ResolveAttributes(&self, celt: u32, rgkeyattributes: *const HELPER_ATTRIBUTE, pcelt: *mut u32, prgmatchvalues: *mut *mut HELPER_ATTRIBUTE) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl INetDiagExtensibleHelper_Vtbl {
         iid == &<INetDiagExtensibleHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkDiagnosticsFramework\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetDiagHelper_Impl: Sized {
     fn Initialize(&self, celt: u32, rgattributes: *const HELPER_ATTRIBUTE) -> ::windows::core::Result<()>;
@@ -178,6 +180,7 @@ impl INetDiagHelper_Vtbl {
         iid == &<INetDiagHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkDiagnosticsFramework\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetDiagHelperEx_Impl: Sized {
     fn ReconfirmLowHealth(&self, celt: u32, presults: *const HypothesisResult, ppwszupdateddescription: *mut ::windows::core::PWSTR, pupdatedstatus: *mut DIAGNOSIS_STATUS) -> ::windows::core::Result<()>;
@@ -215,6 +218,7 @@ impl INetDiagHelperEx_Vtbl {
         iid == &<INetDiagHelperEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkDiagnosticsFramework\"`, `\"implement\"`*"]
 pub trait INetDiagHelperInfo_Impl: Sized {
     fn GetAttributeInfo(&self, pcelt: *mut u32, pprgattributeinfos: *mut *mut HelperAttributeInfo) -> ::windows::core::Result<()>;
 }
@@ -232,6 +236,7 @@ impl INetDiagHelperInfo_Vtbl {
         iid == &<INetDiagHelperInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkDiagnosticsFramework\"`, `\"implement\"`*"]
 pub trait INetDiagHelperUtilFactory_Impl: Sized {
     fn CreateUtilityInstance(&self, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkPolicyServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISdo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetPropertyInfo(&self, id: i32) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -81,6 +82,7 @@ impl ISdo_Vtbl {
         iid == &<ISdo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkPolicyServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISdoCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -177,6 +179,7 @@ impl ISdoCollection_Vtbl {
         iid == &<ISdoCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkPolicyServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISdoDictionaryOld_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EnumAttributes(&self, id: *mut super::super::System::Com::VARIANT, pvalues: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -246,6 +249,7 @@ impl ISdoDictionaryOld_Vtbl {
         iid == &<ISdoDictionaryOld as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkPolicyServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISdoMachine_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Attach(&self, bstrcomputername: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -373,6 +377,7 @@ impl ISdoMachine_Vtbl {
         iid == &<ISdoMachine as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkPolicyServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISdoMachine2_Impl: Sized + ISdoMachine_Impl {
     fn GetTemplatesSDO(&self, bstrservicename: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -430,6 +435,7 @@ impl ISdoMachine2_Vtbl {
         iid == &<ISdoMachine2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISdoMachine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkPolicyServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISdoServiceControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartService(&self) -> ::windows::core::Result<()>;
@@ -480,6 +486,7 @@ impl ISdoServiceControl_Vtbl {
         iid == &<ISdoServiceControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_NetworkPolicyServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITemplateSdo_Impl: Sized + ISdo_Impl {
     fn AddToCollection(&self, bstrname: &::windows::core::BSTR, pcollection: &::core::option::Option<super::super::System::Com::IDispatch>, ppitem: *mut ::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IDot11AdHocInterface_Impl: Sized {
     fn GetDeviceSignature(&self, psignature: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetFriendlyName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -98,6 +99,7 @@ impl IDot11AdHocInterface_Vtbl {
         iid == &<IDot11AdHocInterface as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IDot11AdHocInterfaceNotificationSink_Impl: Sized {
     fn OnConnectionStatusChange(&self, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::Result<()>;
 }
@@ -115,6 +117,7 @@ impl IDot11AdHocInterfaceNotificationSink_Vtbl {
         iid == &<IDot11AdHocInterfaceNotificationSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDot11AdHocManager_Impl: Sized {
     fn CreateNetwork(&self, name: &::windows::core::PCWSTR, password: &::windows::core::PCWSTR, geographicalid: i32, pinterface: &::core::option::Option<IDot11AdHocInterface>, psecurity: &::core::option::Option<IDot11AdHocSecuritySettings>, pcontextguid: *const ::windows::core::GUID) -> ::windows::core::Result<IDot11AdHocNetwork>;
@@ -190,6 +193,7 @@ impl IDot11AdHocManager_Vtbl {
         iid == &<IDot11AdHocManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IDot11AdHocManagerNotificationSink_Impl: Sized {
     fn OnNetworkAdd(&self, piadhocnetwork: &::core::option::Option<IDot11AdHocNetwork>) -> ::windows::core::Result<()>;
     fn OnNetworkRemove(&self, signature: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -231,6 +235,7 @@ impl IDot11AdHocManagerNotificationSink_Vtbl {
         iid == &<IDot11AdHocManagerNotificationSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDot11AdHocNetwork_Impl: Sized {
     fn GetStatus(&self, estatus: *mut DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::Result<()>;
@@ -355,6 +360,7 @@ impl IDot11AdHocNetwork_Vtbl {
         iid == &<IDot11AdHocNetwork as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IDot11AdHocNetworkNotificationSink_Impl: Sized {
     fn OnStatusChange(&self, estatus: DOT11_ADHOC_NETWORK_CONNECTION_STATUS) -> ::windows::core::Result<()>;
     fn OnConnectFail(&self, efailreason: DOT11_ADHOC_CONNECT_FAIL_REASON) -> ::windows::core::Result<()>;
@@ -382,6 +388,7 @@ impl IDot11AdHocNetworkNotificationSink_Vtbl {
         iid == &<IDot11AdHocNetworkNotificationSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IDot11AdHocSecuritySettings_Impl: Sized {
     fn GetDot11AuthAlgorithm(&self, pauth: *mut DOT11_ADHOC_AUTH_ALGORITHM) -> ::windows::core::Result<()>;
     fn GetDot11CipherAlgorithm(&self, pcipher: *mut DOT11_ADHOC_CIPHER_ALGORITHM) -> ::windows::core::Result<()>;
@@ -409,6 +416,7 @@ impl IDot11AdHocSecuritySettings_Vtbl {
         iid == &<IDot11AdHocSecuritySettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IEnumDot11AdHocInterfaces_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IDot11AdHocInterface>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -456,6 +464,7 @@ impl IEnumDot11AdHocInterfaces_Vtbl {
         iid == &<IEnumDot11AdHocInterfaces as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IEnumDot11AdHocNetworks_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IDot11AdHocNetwork>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -503,6 +512,7 @@ impl IEnumDot11AdHocNetworks_Vtbl {
         iid == &<IEnumDot11AdHocNetworks as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WiFi\"`, `\"implement\"`*"]
 pub trait IEnumDot11AdHocSecuritySettings_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IDot11AdHocSecuritySettings>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsConnectNow\"`, `\"implement\"`*"]
 pub trait IWCNConnectNotify_Impl: Sized {
     fn ConnectSucceeded(&self) -> ::windows::core::Result<()>;
     fn ConnectFailed(&self, hrfailure: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -25,6 +26,7 @@ impl IWCNConnectNotify_Vtbl {
         iid == &<IWCNConnectNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsConnectNow\"`, `\"implement\"`*"]
 pub trait IWCNDevice_Impl: Sized {
     fn SetPassword(&self, r#type: WCN_PASSWORD_TYPE, dwpasswordlength: u32, pbpassword: *const u8) -> ::windows::core::Result<()>;
     fn Connect(&self, pnotify: &::core::option::Option<IWCNConnectNotify>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDynamicPortMapping_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ExternalIPAddress(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -172,6 +173,7 @@ impl IDynamicPortMapping_Vtbl {
         iid == &<IDynamicPortMapping as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDynamicPortMappingCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -247,6 +249,7 @@ impl IDynamicPortMappingCollection_Vtbl {
         iid == &<IDynamicPortMappingCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"implement\"`*"]
 pub trait IEnumNetConnection_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<INetConnection>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -294,6 +297,7 @@ impl IEnumNetConnection_Vtbl {
         iid == &<IEnumNetConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumNetSharingEveryConnection_Impl: Sized {
     fn Next(&self, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -344,6 +348,7 @@ impl IEnumNetSharingEveryConnection_Vtbl {
         iid == &<IEnumNetSharingEveryConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumNetSharingPortMapping_Impl: Sized {
     fn Next(&self, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -394,6 +399,7 @@ impl IEnumNetSharingPortMapping_Vtbl {
         iid == &<IEnumNetSharingPortMapping as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumNetSharingPrivateConnection_Impl: Sized {
     fn Next(&self, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -444,6 +450,7 @@ impl IEnumNetSharingPrivateConnection_Vtbl {
         iid == &<IEnumNetSharingPrivateConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumNetSharingPublicConnection_Impl: Sized {
     fn Next(&self, celt: u32, rgvar: *mut super::super::System::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -494,6 +501,7 @@ impl IEnumNetSharingPublicConnection_Vtbl {
         iid == &<IEnumNetSharingPublicConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INATEventManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetExternalIPAddressCallback(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -524,6 +532,7 @@ impl INATEventManager_Vtbl {
         iid == &<INATEventManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"implement\"`*"]
 pub trait INATExternalIPAddressCallback_Impl: Sized {
     fn NewExternalIPAddress(&self, bstrnewexternalipaddress: &::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -541,6 +550,7 @@ impl INATExternalIPAddressCallback_Vtbl {
         iid == &<INATExternalIPAddressCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"implement\"`*"]
 pub trait INATNumberOfEntriesCallback_Impl: Sized {
     fn NewNumberOfEntries(&self, lnewnumberofentries: i32) -> ::windows::core::Result<()>;
 }
@@ -558,6 +568,7 @@ impl INATNumberOfEntriesCallback_Vtbl {
         iid == &<INATNumberOfEntriesCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"implement\"`*"]
 pub trait INetConnection_Impl: Sized {
     fn Connect(&self) -> ::windows::core::Result<()>;
     fn Disconnect(&self) -> ::windows::core::Result<()>;
@@ -638,6 +649,7 @@ impl INetConnection_Vtbl {
         iid == &<INetConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetConnectionConnectUi_Impl: Sized {
     fn SetConnection(&self, pcon: &::core::option::Option<INetConnection>) -> ::windows::core::Result<()>;
@@ -675,6 +687,7 @@ impl INetConnectionConnectUi_Vtbl {
         iid == &<INetConnectionConnectUi as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"implement\"`*"]
 pub trait INetConnectionManager_Impl: Sized {
     fn EnumConnections(&self, flags: NETCONMGR_ENUM_FLAGS) -> ::windows::core::Result<IEnumNetConnection>;
 }
@@ -698,6 +711,7 @@ impl INetConnectionManager_Vtbl {
         iid == &<INetConnectionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetConnectionProps_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Guid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -792,6 +806,7 @@ impl INetConnectionProps_Vtbl {
         iid == &<INetConnectionProps as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwAuthorizedApplication_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -928,6 +943,7 @@ impl INetFwAuthorizedApplication_Vtbl {
         iid == &<INetFwAuthorizedApplication as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwAuthorizedApplications_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -997,6 +1013,7 @@ impl INetFwAuthorizedApplications_Vtbl {
         iid == &<INetFwAuthorizedApplications as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwIcmpSettings_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AllowOutboundDestinationUnreachable(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -1213,6 +1230,7 @@ impl INetFwIcmpSettings_Vtbl {
         iid == &<INetFwIcmpSettings as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwMgr_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn LocalPolicy(&self) -> ::windows::core::Result<INetFwPolicy>;
@@ -1276,6 +1294,7 @@ impl INetFwMgr_Vtbl {
         iid == &<INetFwMgr as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwOpenPort_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1445,6 +1464,7 @@ impl INetFwOpenPort_Vtbl {
         iid == &<INetFwOpenPort as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwOpenPorts_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1514,6 +1534,7 @@ impl INetFwOpenPorts_Vtbl {
         iid == &<INetFwOpenPorts as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwPolicy_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CurrentProfile(&self) -> ::windows::core::Result<INetFwProfile>;
@@ -1556,6 +1577,7 @@ impl INetFwPolicy_Vtbl {
         iid == &<INetFwPolicy as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwPolicy2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CurrentProfileTypes(&self) -> ::windows::core::Result<i32>;
@@ -1804,6 +1826,7 @@ impl INetFwPolicy2_Vtbl {
         iid == &<INetFwPolicy2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwProduct_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RuleCategories(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1873,6 +1896,7 @@ impl INetFwProduct_Vtbl {
         iid == &<INetFwProduct as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwProducts_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1941,6 +1965,7 @@ impl INetFwProducts_Vtbl {
         iid == &<INetFwProducts as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwProfile_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<NET_FW_PROFILE_TYPE>;
@@ -2115,6 +2140,7 @@ impl INetFwProfile_Vtbl {
         iid == &<INetFwProfile as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwRemoteAdminSettings_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IpVersion(&self) -> ::windows::core::Result<NET_FW_IP_VERSION>;
@@ -2211,6 +2237,7 @@ impl INetFwRemoteAdminSettings_Vtbl {
         iid == &<INetFwRemoteAdminSettings as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwRule_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2587,6 +2614,7 @@ impl INetFwRule_Vtbl {
         iid == &<INetFwRule as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwRule2_Impl: Sized + INetFwRule_Impl {
     fn EdgeTraversalOptions(&self) -> ::windows::core::Result<i32>;
@@ -2623,6 +2651,7 @@ impl INetFwRule2_Vtbl {
         iid == &<INetFwRule2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<INetFwRule as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwRule3_Impl: Sized + INetFwRule2_Impl {
     fn LocalAppPackageId(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2759,6 +2788,7 @@ impl INetFwRule3_Vtbl {
         iid == &<INetFwRule3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<INetFwRule as ::windows::core::Interface>::IID || iid == &<INetFwRule2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwRules_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2828,6 +2858,7 @@ impl INetFwRules_Vtbl {
         iid == &<INetFwRules as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwService_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2976,6 +3007,7 @@ impl INetFwService_Vtbl {
         iid == &<INetFwService as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwServiceRestriction_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RestrictService(&self, servicename: &::windows::core::BSTR, appname: &::windows::core::BSTR, restrictservice: super::super::Foundation::VARIANT_BOOL, servicesidrestricted: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3025,6 +3057,7 @@ impl INetFwServiceRestriction_Vtbl {
         iid == &<INetFwServiceRestriction as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetFwServices_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3080,6 +3113,7 @@ impl INetFwServices_Vtbl {
         iid == &<INetFwServices as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingConfiguration_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SharingEnabled(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3196,6 +3230,7 @@ impl INetSharingConfiguration_Vtbl {
         iid == &<INetSharingConfiguration as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingEveryConnectionCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3238,6 +3273,7 @@ impl INetSharingEveryConnectionCollection_Vtbl {
         iid == &<INetSharingEveryConnectionCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SharingInstalled(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3332,6 +3368,7 @@ impl INetSharingManager_Vtbl {
         iid == &<INetSharingManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingPortMapping_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Disable(&self) -> ::windows::core::Result<()>;
@@ -3382,6 +3419,7 @@ impl INetSharingPortMapping_Vtbl {
         iid == &<INetSharingPortMapping as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingPortMappingCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3424,6 +3462,7 @@ impl INetSharingPortMappingCollection_Vtbl {
         iid == &<INetSharingPortMappingCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingPortMappingProps_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3544,6 +3583,7 @@ impl INetSharingPortMappingProps_Vtbl {
         iid == &<INetSharingPortMappingProps as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingPrivateConnectionCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3586,6 +3626,7 @@ impl INetSharingPrivateConnectionCollection_Vtbl {
         iid == &<INetSharingPrivateConnectionCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetSharingPublicConnectionCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3628,6 +3669,7 @@ impl INetSharingPublicConnectionCollection_Vtbl {
         iid == &<INetSharingPublicConnectionCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IStaticPortMapping_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ExternalIPAddress(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3763,6 +3805,7 @@ impl IStaticPortMapping_Vtbl {
         iid == &<IStaticPortMapping as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IStaticPortMappingCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3838,6 +3881,7 @@ impl IStaticPortMappingCollection_Vtbl {
         iid == &<IStaticPortMappingCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_NetworkManagement_WindowsFirewall\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUPnPNAT_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StaticPortMappingCollection(&self) -> ::windows::core::Result<IStaticPortMappingCollection>;

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADs_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -153,6 +154,7 @@ impl IADs_Vtbl {
         iid == &<IADs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsADSystemInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UserName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -332,6 +334,7 @@ impl IADsADSystemInfo_Vtbl {
         iid == &<IADsADSystemInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsAccessControlEntry_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AccessMask(&self) -> ::windows::core::Result<i32>;
@@ -488,6 +491,7 @@ impl IADsAccessControlEntry_Vtbl {
         iid == &<IADsAccessControlEntry as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsAccessControlList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AclRevision(&self) -> ::windows::core::Result<i32>;
@@ -584,6 +588,7 @@ impl IADsAccessControlList_Vtbl {
         iid == &<IADsAccessControlList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsAcl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ProtectedAttrName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -673,6 +678,7 @@ impl IADsAcl_Vtbl {
         iid == &<IADsAcl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"implement\"`*"]
 pub trait IADsAggregatee_Impl: Sized {
     fn ConnectAsAggregatee(&self, pouterunknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn DisconnectAsAggregatee(&self) -> ::windows::core::Result<()>;
@@ -714,6 +720,7 @@ impl IADsAggregatee_Vtbl {
         iid == &<IADsAggregatee as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"implement\"`*"]
 pub trait IADsAggregator_Impl: Sized {
     fn ConnectAsAggregator(&self, paggregatee: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn DisconnectAsAggregator(&self) -> ::windows::core::Result<()>;
@@ -741,6 +748,7 @@ impl IADsAggregator_Vtbl {
         iid == &<IADsAggregator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsBackLink_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn RemoteID(&self) -> ::windows::core::Result<i32>;
@@ -797,6 +805,7 @@ impl IADsBackLink_Vtbl {
         iid == &<IADsBackLink as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsCaseIgnoreList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CaseIgnoreList(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -833,6 +842,7 @@ impl IADsCaseIgnoreList_Vtbl {
         iid == &<IADsCaseIgnoreList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsClass_Impl: Sized + IADs_Impl {
     fn PrimaryInterface(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1155,6 +1165,7 @@ impl IADsClass_Vtbl {
         iid == &<IADsClass as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1211,6 +1222,7 @@ impl IADsCollection_Vtbl {
         iid == &<IADsCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsComputer_Impl: Sized + IADs_Impl {
     fn ComputerID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1553,6 +1565,7 @@ impl IADsComputer_Vtbl {
         iid == &<IADsComputer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsComputerOperations_Impl: Sized + IADs_Impl {
     fn Status(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -1585,6 +1598,7 @@ impl IADsComputerOperations_Vtbl {
         iid == &<IADsComputerOperations as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsContainer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1726,6 +1740,7 @@ impl IADsContainer_Vtbl {
         iid == &<IADsContainer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsDNWithBinary_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn BinaryValue(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1782,6 +1797,7 @@ impl IADsDNWithBinary_Vtbl {
         iid == &<IADsDNWithBinary as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsDNWithString_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StringValue(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1838,6 +1854,7 @@ impl IADsDNWithString_Vtbl {
         iid == &<IADsDNWithString as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsDeleteOps_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DeleteObject(&self, lnflags: i32) -> ::windows::core::Result<()>;
@@ -1858,6 +1875,7 @@ impl IADsDeleteOps_Vtbl {
         iid == &<IADsDeleteOps as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsDomain_Impl: Sized + IADs_Impl {
     fn IsWorkgroup(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2047,6 +2065,7 @@ impl IADsDomain_Vtbl {
         iid == &<IADsDomain as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsEmail_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<i32>;
@@ -2103,6 +2122,7 @@ impl IADsEmail_Vtbl {
         iid == &<IADsEmail as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsExtension_Impl: Sized {
     fn Operate(&self, dwcode: u32, vardata1: &super::super::System::Com::VARIANT, vardata2: &super::super::System::Com::VARIANT, vardata3: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2146,6 +2166,7 @@ impl IADsExtension_Vtbl {
         iid == &<IADsExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsFaxNumber_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TelephoneNumber(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2202,6 +2223,7 @@ impl IADsFaxNumber_Vtbl {
         iid == &<IADsFaxNumber as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsFileService_Impl: Sized + IADsService_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2258,6 +2280,7 @@ impl IADsFileService_Vtbl {
         iid == &<IADsFileService as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID || iid == &<IADsService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsFileServiceOperations_Impl: Sized + IADsServiceOperations_Impl {
     fn Sessions(&self) -> ::windows::core::Result<IADsCollection>;
@@ -2300,6 +2323,7 @@ impl IADsFileServiceOperations_Vtbl {
         iid == &<IADsFileServiceOperations as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID || iid == &<IADsServiceOperations as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsFileShare_Impl: Sized + IADs_Impl {
     fn CurrentUserCount(&self) -> ::windows::core::Result<i32>;
@@ -2409,6 +2433,7 @@ impl IADsFileShare_Vtbl {
         iid == &<IADsFileShare as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsGroup_Impl: Sized + IADs_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2485,6 +2510,7 @@ impl IADsGroup_Vtbl {
         iid == &<IADsGroup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsHold_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ObjectName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2541,6 +2567,7 @@ impl IADsHold_Vtbl {
         iid == &<IADsHold as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsLargeInteger_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn HighPart(&self) -> ::windows::core::Result<i32>;
@@ -2597,6 +2624,7 @@ impl IADsLargeInteger_Vtbl {
         iid == &<IADsLargeInteger as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsLocality_Impl: Sized + IADs_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2693,6 +2721,7 @@ impl IADsLocality_Vtbl {
         iid == &<IADsLocality as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsMembers_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2755,6 +2784,7 @@ impl IADsMembers_Vtbl {
         iid == &<IADsMembers as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsNameTranslate_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetChaseReferral(&self, lnchasereferral: i32) -> ::windows::core::Result<()>;
@@ -2832,6 +2862,7 @@ impl IADsNameTranslate_Vtbl {
         iid == &<IADsNameTranslate as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsNamespaces_Impl: Sized + IADs_Impl {
     fn DefaultContainer(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2868,6 +2899,7 @@ impl IADsNamespaces_Vtbl {
         iid == &<IADsNamespaces as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsNetAddress_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AddressType(&self) -> ::windows::core::Result<i32>;
@@ -2924,6 +2956,7 @@ impl IADsNetAddress_Vtbl {
         iid == &<IADsNetAddress as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsO_Impl: Sized + IADs_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3060,6 +3093,7 @@ impl IADsO_Vtbl {
         iid == &<IADsO as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsOU_Impl: Sized + IADs_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3216,6 +3250,7 @@ impl IADsOU_Vtbl {
         iid == &<IADsOU as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsObjectOptions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetOption(&self, lnoption: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3252,6 +3287,7 @@ impl IADsObjectOptions_Vtbl {
         iid == &<IADsObjectOptions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsOctetList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OctetList(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3288,6 +3324,7 @@ impl IADsOctetList_Vtbl {
         iid == &<IADsOctetList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsOpenDSObject_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OpenDSObject(&self, lpszdnname: &::windows::core::BSTR, lpszusername: &::windows::core::BSTR, lpszpassword: &::windows::core::BSTR, lnreserved: i32) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -3314,6 +3351,7 @@ impl IADsOpenDSObject_Vtbl {
         iid == &<IADsOpenDSObject as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPath_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<i32>;
@@ -3390,6 +3428,7 @@ impl IADsPath_Vtbl {
         iid == &<IADsPath as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPathname_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Set(&self, bstradspath: &::windows::core::BSTR, lnsettype: i32) -> ::windows::core::Result<()>;
@@ -3519,6 +3558,7 @@ impl IADsPathname_Vtbl {
         iid == &<IADsPathname as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPostalAddress_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn PostalAddress(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3555,6 +3595,7 @@ impl IADsPostalAddress_Vtbl {
         iid == &<IADsPostalAddress as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPrintJob_Impl: Sized + IADs_Impl {
     fn HostPrintQueue(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3769,6 +3810,7 @@ impl IADsPrintJob_Vtbl {
         iid == &<IADsPrintJob as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPrintJobOperations_Impl: Sized + IADs_Impl {
     fn Status(&self) -> ::windows::core::Result<i32>;
@@ -3858,6 +3900,7 @@ impl IADsPrintJobOperations_Vtbl {
         iid == &<IADsPrintJobOperations as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPrintQueue_Impl: Sized + IADs_Impl {
     fn PrinterPath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4134,6 +4177,7 @@ impl IADsPrintQueue_Vtbl {
         iid == &<IADsPrintQueue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPrintQueueOperations_Impl: Sized + IADs_Impl {
     fn Status(&self) -> ::windows::core::Result<i32>;
@@ -4197,6 +4241,7 @@ impl IADsPrintQueueOperations_Vtbl {
         iid == &<IADsPrintQueueOperations as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsProperty_Impl: Sized + IADs_Impl {
     fn OID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4326,6 +4371,7 @@ impl IADsProperty_Vtbl {
         iid == &<IADsProperty as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPropertyEntry_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Clear(&self) -> ::windows::core::Result<()>;
@@ -4429,6 +4475,7 @@ impl IADsPropertyEntry_Vtbl {
         iid == &<IADsPropertyEntry as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPropertyList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn PropertyCount(&self) -> ::windows::core::Result<i32>;
@@ -4526,6 +4573,7 @@ impl IADsPropertyList_Vtbl {
         iid == &<IADsPropertyList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPropertyValue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Clear(&self) -> ::windows::core::Result<()>;
@@ -4789,6 +4837,7 @@ impl IADsPropertyValue_Vtbl {
         iid == &<IADsPropertyValue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsPropertyValue2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetObjectProperty(&self, lnadstype: *mut i32, pvprop: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -4819,6 +4868,7 @@ impl IADsPropertyValue2_Vtbl {
         iid == &<IADsPropertyValue2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsReplicaPointer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ServerName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4935,6 +4985,7 @@ impl IADsReplicaPointer_Vtbl {
         iid == &<IADsReplicaPointer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsResource_Impl: Sized + IADs_Impl {
     fn User(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5003,6 +5054,7 @@ impl IADsResource_Vtbl {
         iid == &<IADsResource as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsSecurityDescriptor_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Revision(&self) -> ::windows::core::Result<i32>;
@@ -5232,6 +5284,7 @@ impl IADsSecurityDescriptor_Vtbl {
         iid == &<IADsSecurityDescriptor as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsSecurityUtility_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetSecurityDescriptor(&self, varpath: &super::super::System::Com::VARIANT, lpathformat: i32, lformat: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -5301,6 +5354,7 @@ impl IADsSecurityUtility_Vtbl {
         iid == &<IADsSecurityUtility as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsService_Impl: Sized + IADs_Impl {
     fn HostComputer(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5557,6 +5611,7 @@ impl IADsService_Vtbl {
         iid == &<IADsService as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsServiceOperations_Impl: Sized + IADs_Impl {
     fn Status(&self) -> ::windows::core::Result<i32>;
@@ -5621,6 +5676,7 @@ impl IADsServiceOperations_Vtbl {
         iid == &<IADsServiceOperations as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsSession_Impl: Sized + IADs_Impl {
     fn User(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5715,6 +5771,7 @@ impl IADsSession_Vtbl {
         iid == &<IADsSession as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsSyntax_Impl: Sized + IADs_Impl {
     fn OleAutoDataType(&self) -> ::windows::core::Result<i32>;
@@ -5751,6 +5808,7 @@ impl IADsSyntax_Vtbl {
         iid == &<IADsSyntax as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsTimestamp_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn WholeSeconds(&self) -> ::windows::core::Result<i32>;
@@ -5807,6 +5865,7 @@ impl IADsTimestamp_Vtbl {
         iid == &<IADsTimestamp as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsTypedName_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ObjectName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5883,6 +5942,7 @@ impl IADsTypedName_Vtbl {
         iid == &<IADsTypedName as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsUser_Impl: Sized + IADs_Impl {
     fn BadLoginAddress(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6824,6 +6884,7 @@ impl IADsUser_Vtbl {
         iid == &<IADsUser as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IADs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsWinNTSystemInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UserName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6892,6 +6953,7 @@ impl IADsWinNTSystemInfo_Vtbl {
         iid == &<IADsWinNTSystemInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ICommonQuery_Impl: Sized {
     fn OpenQueryWindow(&self, hwndparent: super::super::Foundation::HWND, pquerywnd: *mut OPENQUERYWINDOW, ppdataobject: *mut ::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
@@ -6912,6 +6974,7 @@ impl ICommonQuery_Vtbl {
         iid == &<ICommonQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDirectoryObject_Impl: Sized {
     fn GetObjectInformation(&self) -> ::windows::core::Result<*mut ADS_OBJECT_INFO>;
@@ -6981,6 +7044,7 @@ impl IDirectoryObject_Vtbl {
         iid == &<IDirectoryObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectorySchemaMgmt_Impl: Sized {
     fn EnumAttributes(&self, ppszattrnames: *const ::windows::core::PCWSTR, dwnumattributes: u32, ppattrdefinition: *const *const ADS_ATTR_DEF, pdwnumattributes: *const u32) -> ::windows::core::Result<()>;
@@ -7053,6 +7117,7 @@ impl IDirectorySchemaMgmt_Vtbl {
         iid == &<IDirectorySchemaMgmt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDirectorySearch_Impl: Sized {
     fn SetSearchPreference(&self, psearchprefs: *const ADS_SEARCHPREF_INFO, dwnumprefs: u32) -> ::windows::core::Result<()>;
@@ -7151,6 +7216,7 @@ impl IDirectorySearch_Vtbl {
         iid == &<IDirectorySearch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDsAdminCreateObj_Impl: Sized {
     fn Initialize(&self, padscontainerobj: &::core::option::Option<IADsContainer>, padscopysource: &::core::option::Option<IADs>, lpszclassname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -7187,6 +7253,7 @@ impl IDsAdminCreateObj_Vtbl {
         iid == &<IDsAdminCreateObj as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDsAdminNewObj_Impl: Sized {
     fn SetButtons(&self, ncurrindex: u32, bvalid: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -7217,6 +7284,7 @@ impl IDsAdminNewObj_Vtbl {
         iid == &<IDsAdminNewObj as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IDsAdminNewObjExt_Impl: Sized {
     fn Initialize(&self, padscontainerobj: &::core::option::Option<IADsContainer>, padscopysource: &::core::option::Option<IADs>, lpszclassname: &::windows::core::PCWSTR, pdsadminnewobj: &::core::option::Option<IDsAdminNewObj>, pdispinfo: *mut DSA_NEWOBJ_DISPINFO) -> ::windows::core::Result<()>;
@@ -7275,6 +7343,7 @@ impl IDsAdminNewObjExt_Vtbl {
         iid == &<IDsAdminNewObjExt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"implement\"`*"]
 pub trait IDsAdminNewObjPrimarySite_Impl: Sized {
     fn CreateNew(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Commit(&self) -> ::windows::core::Result<()>;
@@ -7302,6 +7371,7 @@ impl IDsAdminNewObjPrimarySite_Vtbl {
         iid == &<IDsAdminNewObjPrimarySite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDsAdminNotifyHandler_Impl: Sized {
     fn Initialize(&self, pextrainfo: &::core::option::Option<super::super::System::Com::IDataObject>, pueventflags: *mut u32) -> ::windows::core::Result<()>;
@@ -7346,6 +7416,7 @@ impl IDsAdminNotifyHandler_Vtbl {
         iid == &<IDsAdminNotifyHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDsBrowseDomainTree_Impl: Sized {
     fn BrowseTo(&self, hwndparent: super::super::Foundation::HWND, ppsztargetpath: *mut ::windows::core::PWSTR, dwflags: u32) -> ::windows::core::Result<()>;
@@ -7397,6 +7468,7 @@ impl IDsBrowseDomainTree_Vtbl {
         iid == &<IDsBrowseDomainTree as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IDsDisplaySpecifier_Impl: Sized {
     fn SetServer(&self, pszserver: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszpassword: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
@@ -7490,6 +7562,7 @@ impl IDsDisplaySpecifier_Vtbl {
         iid == &<IDsDisplaySpecifier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDsObjectPicker_Impl: Sized {
     fn Initialize(&self, pinitinfo: *mut DSOP_INIT_INFO) -> ::windows::core::Result<()>;
@@ -7526,6 +7599,7 @@ impl IDsObjectPicker_Vtbl {
         iid == &<IDsObjectPicker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDsObjectPickerCredentials_Impl: Sized + IDsObjectPicker_Impl {
     fn SetCredentials(&self, szusername: &::windows::core::PCWSTR, szpassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -7546,6 +7620,7 @@ impl IDsObjectPickerCredentials_Vtbl {
         iid == &<IDsObjectPickerCredentials as ::windows::core::Interface>::IID || iid == &<IDsObjectPicker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IPersistQuery_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn WriteString(&self, psection: &::windows::core::PCWSTR, pvaluename: &::windows::core::PCWSTR, pvalue: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -7611,6 +7686,7 @@ impl IPersistQuery_Vtbl {
         iid == &<IPersistQuery as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrivateDispatch_Impl: Sized {
     fn ADSIInitializeDispatchManager(&self, dwextensionid: i32) -> ::windows::core::Result<()>;
@@ -7680,6 +7756,7 @@ impl IPrivateDispatch_Vtbl {
         iid == &<IPrivateDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"implement\"`*"]
 pub trait IPrivateUnknown_Impl: Sized {
     fn ADSIInitializeObject(&self, lpszusername: &::windows::core::BSTR, lpszpassword: &::windows::core::BSTR, lnreserved: i32) -> ::windows::core::Result<()>;
     fn ADSIReleaseObject(&self) -> ::windows::core::Result<()>;
@@ -7707,6 +7784,7 @@ impl IPrivateUnknown_Vtbl {
         iid == &<IPrivateUnknown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_ActiveDirectory\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IQueryForm_Impl: Sized {
     fn Initialize(&self, hkform: super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/BackgroundIntelligentTransferService/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait AsyncIBackgroundCopyCallback_Impl: Sized {
     fn Begin_JobTransferred(&self, pjob: &::core::option::Option<IBackgroundCopyJob>) -> ::windows::core::Result<()>;
     fn Finish_JobTransferred(&self) -> ::windows::core::Result<()>;
@@ -53,6 +54,7 @@ impl AsyncIBackgroundCopyCallback_Vtbl {
         iid == &<AsyncIBackgroundCopyCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBITSExtensionSetup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EnableBITSUploads(&self) -> ::windows::core::Result<()>;
@@ -109,6 +111,7 @@ impl IBITSExtensionSetup_Vtbl {
         iid == &<IBITSExtensionSetup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBITSExtensionSetupFactory_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetObject(&self, path: &::windows::core::BSTR) -> ::windows::core::Result<IBITSExtensionSetup>;
@@ -135,6 +138,7 @@ impl IBITSExtensionSetupFactory_Vtbl {
         iid == &<IBITSExtensionSetupFactory as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyCallback_Impl: Sized {
     fn JobTransferred(&self, pjob: &::core::option::Option<IBackgroundCopyJob>) -> ::windows::core::Result<()>;
     fn JobError(&self, pjob: &::core::option::Option<IBackgroundCopyJob>, perror: &::core::option::Option<IBackgroundCopyError>) -> ::windows::core::Result<()>;
@@ -169,6 +173,7 @@ impl IBackgroundCopyCallback_Vtbl {
         iid == &<IBackgroundCopyCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyCallback1_Impl: Sized {
     fn OnStatus(&self, pgroup: &::core::option::Option<IBackgroundCopyGroup>, pjob: &::core::option::Option<IBackgroundCopyJob1>, dwfileindex: u32, dwstatus: u32, dwnumofretries: u32, dwwin32result: u32, dwtransportresult: u32) -> ::windows::core::Result<()>;
     fn OnProgress(&self, progresstype: u32, pgroup: &::core::option::Option<IBackgroundCopyGroup>, pjob: &::core::option::Option<IBackgroundCopyJob1>, dwfileindex: u32, dwprogressvalue: u32) -> ::windows::core::Result<()>;
@@ -203,6 +208,7 @@ impl IBackgroundCopyCallback1_Vtbl {
         iid == &<IBackgroundCopyCallback1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyCallback2_Impl: Sized + IBackgroundCopyCallback_Impl {
     fn FileTransferred(&self, pjob: &::core::option::Option<IBackgroundCopyJob>, pfile: &::core::option::Option<IBackgroundCopyFile>) -> ::windows::core::Result<()>;
 }
@@ -220,6 +226,7 @@ impl IBackgroundCopyCallback2_Vtbl {
         iid == &<IBackgroundCopyCallback2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyCallback3_Impl: Sized + IBackgroundCopyCallback2_Impl {
     fn FileRangesTransferred(&self, job: &::core::option::Option<IBackgroundCopyJob>, file: &::core::option::Option<IBackgroundCopyFile>, rangecount: u32, ranges: *const BG_FILE_RANGE) -> ::windows::core::Result<()>;
 }
@@ -237,6 +244,7 @@ impl IBackgroundCopyCallback3_Vtbl {
         iid == &<IBackgroundCopyCallback3 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyCallback as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyCallback2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyError_Impl: Sized {
     fn GetError(&self, pcontext: *mut BG_ERROR_CONTEXT, pcode: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn GetFile(&self) -> ::windows::core::Result<IBackgroundCopyFile>;
@@ -309,6 +317,7 @@ impl IBackgroundCopyError_Vtbl {
         iid == &<IBackgroundCopyError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyFile_Impl: Sized {
     fn GetRemoteName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -364,6 +373,7 @@ impl IBackgroundCopyFile_Vtbl {
         iid == &<IBackgroundCopyFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyFile2_Impl: Sized + IBackgroundCopyFile_Impl {
     fn GetFileRanges(&self, rangecount: *mut u32, ranges: *mut *mut BG_FILE_RANGE) -> ::windows::core::Result<()>;
@@ -394,6 +404,7 @@ impl IBackgroundCopyFile2_Vtbl {
         iid == &<IBackgroundCopyFile2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyFile3_Impl: Sized + IBackgroundCopyFile2_Impl {
     fn GetTemporaryName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -456,6 +467,7 @@ impl IBackgroundCopyFile3_Vtbl {
         iid == &<IBackgroundCopyFile3 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyFile4_Impl: Sized + IBackgroundCopyFile3_Impl {
     fn GetPeerDownloadStats(&self, pfromorigin: *mut u64, pfrompeers: *mut u64) -> ::windows::core::Result<()>;
@@ -476,6 +488,7 @@ impl IBackgroundCopyFile4_Vtbl {
         iid == &<IBackgroundCopyFile4 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyFile5_Impl: Sized + IBackgroundCopyFile4_Impl {
     fn SetProperty(&self, propertyid: BITS_FILE_PROPERTY_ID, propertyvalue: &BITS_FILE_PROPERTY_VALUE) -> ::windows::core::Result<()>;
@@ -512,6 +525,7 @@ impl IBackgroundCopyFile5_Vtbl {
         iid == &<IBackgroundCopyFile5 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile3 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyFile6_Impl: Sized + IBackgroundCopyFile5_Impl {
     fn UpdateDownloadPosition(&self, offset: u64) -> ::windows::core::Result<()>;
@@ -549,6 +563,7 @@ impl IBackgroundCopyFile6_Vtbl {
         iid == &<IBackgroundCopyFile6 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile3 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile4 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyFile5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBackgroundCopyGroup_Impl: Sized {
     fn GetProp(&self, propid: GROUPPROP) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -718,6 +733,7 @@ impl IBackgroundCopyGroup_Vtbl {
         iid == &<IBackgroundCopyGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyJob_Impl: Sized {
     fn AddFileSet(&self, cfilecount: u32, pfileset: *const BG_FILE_INFO) -> ::windows::core::Result<()>;
@@ -1054,6 +1070,7 @@ impl IBackgroundCopyJob_Vtbl {
         iid == &<IBackgroundCopyJob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyJob1_Impl: Sized {
     fn CancelJob(&self) -> ::windows::core::Result<()>;
     fn GetProgress(&self, dwflags: u32) -> ::windows::core::Result<u32>;
@@ -1147,6 +1164,7 @@ impl IBackgroundCopyJob1_Vtbl {
         iid == &<IBackgroundCopyJob1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyJob2_Impl: Sized + IBackgroundCopyJob_Impl {
     fn SetNotifyCmdLine(&self, program: &::windows::core::PCWSTR, parameters: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1225,6 +1243,7 @@ impl IBackgroundCopyJob2_Vtbl {
         iid == &<IBackgroundCopyJob2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyJob3_Impl: Sized + IBackgroundCopyJob2_Impl {
     fn ReplaceRemotePrefix(&self, oldprefix: &::windows::core::PCWSTR, newprefix: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1275,6 +1294,7 @@ impl IBackgroundCopyJob3_Vtbl {
         iid == &<IBackgroundCopyJob3 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyJob4_Impl: Sized + IBackgroundCopyJob3_Impl {
     fn SetPeerCachingFlags(&self, flags: u32) -> ::windows::core::Result<()>;
@@ -1357,6 +1377,7 @@ impl IBackgroundCopyJob4_Vtbl {
         iid == &<IBackgroundCopyJob4 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBackgroundCopyJob5_Impl: Sized + IBackgroundCopyJob4_Impl {
     fn SetProperty(&self, propertyid: BITS_JOB_PROPERTY_ID, propertyvalue: &BITS_JOB_PROPERTY_VALUE) -> ::windows::core::Result<()>;
@@ -1393,6 +1414,7 @@ impl IBackgroundCopyJob5_Vtbl {
         iid == &<IBackgroundCopyJob5 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob3 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJob4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyJobHttpOptions_Impl: Sized {
     fn SetClientCertificateByID(&self, storelocation: BG_CERT_STORE_LOCATION, storename: &::windows::core::PCWSTR, pcerthashblob: *const u8) -> ::windows::core::Result<()>;
     fn SetClientCertificateByName(&self, storelocation: BG_CERT_STORE_LOCATION, storename: &::windows::core::PCWSTR, subjectname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1474,6 +1496,7 @@ impl IBackgroundCopyJobHttpOptions_Vtbl {
         iid == &<IBackgroundCopyJobHttpOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyJobHttpOptions2_Impl: Sized + IBackgroundCopyJobHttpOptions_Impl {
     fn SetHttpMethod(&self, method: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetHttpMethod(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1507,6 +1530,7 @@ impl IBackgroundCopyJobHttpOptions2_Vtbl {
         iid == &<IBackgroundCopyJobHttpOptions2 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJobHttpOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyJobHttpOptions3_Impl: Sized + IBackgroundCopyJobHttpOptions2_Impl {
     fn SetServerCertificateValidationInterface(&self, certvalidationcallback: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn MakeCustomHeadersWriteOnly(&self) -> ::windows::core::Result<()>;
@@ -1534,6 +1558,7 @@ impl IBackgroundCopyJobHttpOptions3_Vtbl {
         iid == &<IBackgroundCopyJobHttpOptions3 as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJobHttpOptions as ::windows::core::Interface>::IID || iid == &<IBackgroundCopyJobHttpOptions2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyManager_Impl: Sized {
     fn CreateJob(&self, displayname: &::windows::core::PCWSTR, r#type: BG_JOB_TYPE, pjobid: *mut ::windows::core::GUID, ppjob: *mut ::core::option::Option<IBackgroundCopyJob>) -> ::windows::core::Result<()>;
     fn GetJob(&self, jobid: *const ::windows::core::GUID) -> ::windows::core::Result<IBackgroundCopyJob>;
@@ -1593,6 +1618,7 @@ impl IBackgroundCopyManager_Vtbl {
         iid == &<IBackgroundCopyManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyQMgr_Impl: Sized {
     fn CreateGroup(&self, guidgroupid: &::windows::core::GUID) -> ::windows::core::Result<IBackgroundCopyGroup>;
     fn GetGroup(&self, groupid: &::windows::core::GUID) -> ::windows::core::Result<IBackgroundCopyGroup>;
@@ -1645,6 +1671,7 @@ impl IBackgroundCopyQMgr_Vtbl {
         iid == &<IBackgroundCopyQMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBackgroundCopyServerCertificateValidationCallback_Impl: Sized {
     fn ValidateServerCertificate(&self, job: &::core::option::Option<IBackgroundCopyJob>, file: &::core::option::Option<IBackgroundCopyFile>, certlength: u32, certdata: *const u8, certencodingtype: u32, certstorelength: u32, certstoredata: *const u8) -> ::windows::core::Result<()>;
 }
@@ -1665,6 +1692,7 @@ impl IBackgroundCopyServerCertificateValidationCallback_Vtbl {
         iid == &<IBackgroundCopyServerCertificateValidationCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBitsPeer_Impl: Sized {
     fn GetPeerName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1720,6 +1748,7 @@ impl IBitsPeer_Vtbl {
         iid == &<IBitsPeer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBitsPeerCacheAdministration_Impl: Sized {
     fn GetMaximumCacheSize(&self) -> ::windows::core::Result<u32>;
     fn SetMaximumCacheSize(&self, bytes: u32) -> ::windows::core::Result<()>;
@@ -1867,6 +1896,7 @@ impl IBitsPeerCacheAdministration_Vtbl {
         iid == &<IBitsPeerCacheAdministration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBitsPeerCacheRecord_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1962,6 +1992,7 @@ impl IBitsPeerCacheRecord_Vtbl {
         iid == &<IBitsPeerCacheRecord as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IBitsTokenOptions_Impl: Sized {
     fn SetHelperTokenFlags(&self, usageflags: BG_TOKEN) -> ::windows::core::Result<()>;
     fn GetHelperTokenFlags(&self) -> ::windows::core::Result<BG_TOKEN>;
@@ -2022,6 +2053,7 @@ impl IBitsTokenOptions_Vtbl {
         iid == &<IBitsTokenOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IEnumBackgroundCopyFiles_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IBackgroundCopyFile>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -2082,6 +2114,7 @@ impl IEnumBackgroundCopyFiles_Vtbl {
         iid == &<IEnumBackgroundCopyFiles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IEnumBackgroundCopyGroups_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -2142,6 +2175,7 @@ impl IEnumBackgroundCopyGroups_Vtbl {
         iid == &<IEnumBackgroundCopyGroups as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IEnumBackgroundCopyJobs_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IBackgroundCopyJob>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -2202,6 +2236,7 @@ impl IEnumBackgroundCopyJobs_Vtbl {
         iid == &<IEnumBackgroundCopyJobs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IEnumBackgroundCopyJobs1_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -2262,6 +2297,7 @@ impl IEnumBackgroundCopyJobs1_Vtbl {
         iid == &<IEnumBackgroundCopyJobs1 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IEnumBitsPeerCacheRecords_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IBitsPeerCacheRecord>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -2322,6 +2358,7 @@ impl IEnumBitsPeerCacheRecords_Vtbl {
         iid == &<IEnumBitsPeerCacheRecords as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_BackgroundIntelligentTransferService\"`, `\"implement\"`*"]
 pub trait IEnumBitsPeers_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IBitsPeer>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IGetClusterDataInfo_Impl: Sized {
     fn GetClusterName(&self, lpszname: ::windows::core::BSTR, pcchname: *mut i32) -> ::windows::core::Result<()>;
     fn GetClusterHandle(&self) -> *mut _HCLUSTER;
@@ -32,6 +33,7 @@ impl IGetClusterDataInfo_Vtbl {
         iid == &<IGetClusterDataInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IGetClusterGroupInfo_Impl: Sized {
     fn GetGroupHandle(&self, lobjindex: i32) -> *mut _HGROUP;
 }
@@ -49,6 +51,7 @@ impl IGetClusterGroupInfo_Vtbl {
         iid == &<IGetClusterGroupInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IGetClusterNetInterfaceInfo_Impl: Sized {
     fn GetNetInterfaceHandle(&self, lobjindex: i32) -> *mut _HNETINTERFACE;
 }
@@ -66,6 +69,7 @@ impl IGetClusterNetInterfaceInfo_Vtbl {
         iid == &<IGetClusterNetInterfaceInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IGetClusterNetworkInfo_Impl: Sized {
     fn GetNetworkHandle(&self, lobjindex: i32) -> *mut _HNETWORK;
 }
@@ -83,6 +87,7 @@ impl IGetClusterNetworkInfo_Vtbl {
         iid == &<IGetClusterNetworkInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IGetClusterNodeInfo_Impl: Sized {
     fn GetNodeHandle(&self, lobjindex: i32) -> *mut _HNODE;
 }
@@ -100,6 +105,7 @@ impl IGetClusterNodeInfo_Vtbl {
         iid == &<IGetClusterNodeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IGetClusterObjectInfo_Impl: Sized {
     fn GetObjectName(&self, lobjindex: i32, lpszname: ::windows::core::BSTR, pcchname: *mut i32) -> ::windows::core::Result<()>;
     fn GetObjectType(&self, lobjindex: i32) -> CLUADMEX_OBJECT_TYPE;
@@ -127,6 +133,7 @@ impl IGetClusterObjectInfo_Vtbl {
         iid == &<IGetClusterObjectInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IGetClusterResourceInfo_Impl: Sized {
     fn GetResourceHandle(&self, lobjindex: i32) -> *mut _HRESOURCE;
@@ -164,6 +171,7 @@ impl IGetClusterResourceInfo_Vtbl {
         iid == &<IGetClusterResourceInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IGetClusterUIInfo_Impl: Sized {
     fn GetClusterName(&self, lpszname: ::windows::core::BSTR, pcchname: *mut i32) -> ::windows::core::Result<()>;
@@ -208,6 +216,7 @@ impl IGetClusterUIInfo_Vtbl {
         iid == &<IGetClusterUIInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusApplication_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DomainNames(&self) -> ::windows::core::Result<ISDomainNames>;
@@ -263,6 +272,7 @@ impl ISClusApplication_Vtbl {
         iid == &<ISClusApplication as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusCryptoKeys_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -339,6 +349,7 @@ impl ISClusCryptoKeys_Vtbl {
         iid == &<ISClusCryptoKeys as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusDisk_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Signature(&self) -> ::windows::core::Result<i32>;
@@ -407,6 +418,7 @@ impl ISClusDisk_Vtbl {
         iid == &<ISClusDisk as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusDisks_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -462,6 +474,7 @@ impl ISClusDisks_Vtbl {
         iid == &<ISClusDisks as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNetInterface_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CommonProperties(&self) -> ::windows::core::Result<ISClusProperties>;
@@ -582,6 +595,7 @@ impl ISClusNetInterface_Vtbl {
         iid == &<ISClusNetInterface as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNetInterfaces_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -644,6 +658,7 @@ impl ISClusNetInterfaces_Vtbl {
         iid == &<ISClusNetInterfaces as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNetwork_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CommonProperties(&self) -> ::windows::core::Result<ISClusProperties>;
@@ -797,6 +812,7 @@ impl ISClusNetwork_Vtbl {
         iid == &<ISClusNetwork as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNetworkNetInterfaces_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -859,6 +875,7 @@ impl ISClusNetworkNetInterfaces_Vtbl {
         iid == &<ISClusNetworkNetInterfaces as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNetworks_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -921,6 +938,7 @@ impl ISClusNetworks_Vtbl {
         iid == &<ISClusNetworks as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNode_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CommonProperties(&self) -> ::windows::core::Result<ISClusProperties>;
@@ -1101,6 +1119,7 @@ impl ISClusNode_Vtbl {
         iid == &<ISClusNode as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNodeNetInterfaces_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1163,6 +1182,7 @@ impl ISClusNodeNetInterfaces_Vtbl {
         iid == &<ISClusNodeNetInterfaces as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusNodes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1225,6 +1245,7 @@ impl ISClusNodes_Vtbl {
         iid == &<ISClusNodes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusPartition_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Flags(&self) -> ::windows::core::Result<i32>;
@@ -1332,6 +1353,7 @@ impl ISClusPartition_Vtbl {
         iid == &<ISClusPartition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusPartitionEx_Impl: Sized + ISClusPartition_Impl {
     fn TotalSize(&self) -> ::windows::core::Result<i32>;
@@ -1413,6 +1435,7 @@ impl ISClusPartitionEx_Vtbl {
         iid == &<ISClusPartitionEx as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISClusPartition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusPartitions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1468,6 +1491,7 @@ impl ISClusPartitions_Vtbl {
         iid == &<ISClusPartitions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusProperties_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1615,6 +1639,7 @@ impl ISClusProperties_Vtbl {
         iid == &<ISClusProperties as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1802,6 +1827,7 @@ impl ISClusProperty_Vtbl {
         iid == &<ISClusProperty as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusPropertyValue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Value(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1917,6 +1943,7 @@ impl ISClusPropertyValue_Vtbl {
         iid == &<ISClusPropertyValue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusPropertyValueData_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1992,6 +2019,7 @@ impl ISClusPropertyValueData_Vtbl {
         iid == &<ISClusPropertyValueData as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusPropertyValues_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2067,6 +2095,7 @@ impl ISClusPropertyValues_Vtbl {
         iid == &<ISClusPropertyValues as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusRefObject_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Handle(&self) -> ::windows::core::Result<usize>;
@@ -2093,6 +2122,7 @@ impl ISClusRefObject_Vtbl {
         iid == &<ISClusRefObject as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusRegistryKeys_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2169,6 +2199,7 @@ impl ISClusRegistryKeys_Vtbl {
         iid == &<ISClusRegistryKeys as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResDependencies_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2265,6 +2296,7 @@ impl ISClusResDependencies_Vtbl {
         iid == &<ISClusResDependencies as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResDependents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2361,6 +2393,7 @@ impl ISClusResDependents_Vtbl {
         iid == &<ISClusResDependents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CommonProperties(&self) -> ::windows::core::Result<ISClusProperties>;
@@ -2573,6 +2606,7 @@ impl ISClusResGroup_Vtbl {
         iid == &<ISClusResGroup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResGroupPreferredOwnerNodes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2676,6 +2710,7 @@ impl ISClusResGroupPreferredOwnerNodes_Vtbl {
         iid == &<ISClusResGroupPreferredOwnerNodes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResGroupResources_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2758,6 +2793,7 @@ impl ISClusResGroupResources_Vtbl {
         iid == &<ISClusResGroupResources as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResGroups_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2840,6 +2876,7 @@ impl ISClusResGroups_Vtbl {
         iid == &<ISClusResGroups as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResPossibleOwnerNodes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2929,6 +2966,7 @@ impl ISClusResPossibleOwnerNodes_Vtbl {
         iid == &<ISClusResPossibleOwnerNodes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResType_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CommonProperties(&self) -> ::windows::core::Result<ISClusProperties>;
@@ -3069,6 +3107,7 @@ impl ISClusResType_Vtbl {
         iid == &<ISClusResType as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResTypePossibleOwnerNodes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3131,6 +3170,7 @@ impl ISClusResTypePossibleOwnerNodes_Vtbl {
         iid == &<ISClusResTypePossibleOwnerNodes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResTypeResources_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3213,6 +3253,7 @@ impl ISClusResTypeResources_Vtbl {
         iid == &<ISClusResTypeResources as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResTypes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3295,6 +3336,7 @@ impl ISClusResTypes_Vtbl {
         iid == &<ISClusResTypes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResource_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CommonProperties(&self) -> ::windows::core::Result<ISClusProperties>;
@@ -3679,6 +3721,7 @@ impl ISClusResource_Vtbl {
         iid == &<ISClusResource as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusResources_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3761,6 +3804,7 @@ impl ISClusResources_Vtbl {
         iid == &<ISClusResources as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusScsiAddress_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn PortNumber(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3829,6 +3873,7 @@ impl ISClusScsiAddress_Vtbl {
         iid == &<ISClusScsiAddress as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusVersion_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3975,6 +4020,7 @@ impl ISClusVersion_Vtbl {
         iid == &<ISClusVersion as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISCluster_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CommonProperties(&self) -> ::windows::core::Result<ISClusProperties>;
@@ -4234,6 +4280,7 @@ impl ISCluster_Vtbl {
         iid == &<ISCluster as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISClusterNames_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4309,6 +4356,7 @@ impl ISClusterNames_Vtbl {
         iid == &<ISClusterNames as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISDomainNames_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4371,6 +4419,7 @@ impl ISDomainNames_Vtbl {
         iid == &<ISDomainNames as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IWCContextMenuCallback_Impl: Sized {
     fn AddExtensionMenuItem(&self, lpszname: &::windows::core::BSTR, lpszstatusbartext: &::windows::core::BSTR, ncommandid: u32, nsubmenucommandid: u32, uflags: u32) -> ::windows::core::Result<()>;
 }
@@ -4388,6 +4437,7 @@ impl IWCContextMenuCallback_Vtbl {
         iid == &<IWCContextMenuCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IWCPropertySheetCallback_Impl: Sized {
     fn AddPropertySheetPage(&self, hpage: *const i32) -> ::windows::core::Result<()>;
 }
@@ -4405,6 +4455,7 @@ impl IWCPropertySheetCallback_Vtbl {
         iid == &<IWCPropertySheetCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWCWizard97Callback_Impl: Sized {
     fn AddWizard97Page(&self, hpage: *const i32) -> ::windows::core::Result<()>;
@@ -4435,6 +4486,7 @@ impl IWCWizard97Callback_Vtbl {
         iid == &<IWCWizard97Callback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWCWizardCallback_Impl: Sized {
     fn AddWizardPage(&self, hpage: *const i32) -> ::windows::core::Result<()>;
@@ -4465,6 +4517,7 @@ impl IWCWizardCallback_Vtbl {
         iid == &<IWCWizardCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IWEExtendContextMenu_Impl: Sized {
     fn AddContextMenuItems(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCContextMenuCallback>) -> ::windows::core::Result<()>;
 }
@@ -4482,6 +4535,7 @@ impl IWEExtendContextMenu_Vtbl {
         iid == &<IWEExtendContextMenu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IWEExtendPropertySheet_Impl: Sized {
     fn CreatePropertySheetPages(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCPropertySheetCallback>) -> ::windows::core::Result<()>;
 }
@@ -4499,6 +4553,7 @@ impl IWEExtendPropertySheet_Vtbl {
         iid == &<IWEExtendPropertySheet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IWEExtendWizard_Impl: Sized {
     fn CreateWizardPages(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCWizardCallback>) -> ::windows::core::Result<()>;
 }
@@ -4516,6 +4571,7 @@ impl IWEExtendWizard_Vtbl {
         iid == &<IWEExtendWizard as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IWEExtendWizard97_Impl: Sized {
     fn CreateWizard97Pages(&self, pidata: &::core::option::Option<::windows::core::IUnknown>, picallback: &::core::option::Option<IWCWizard97Callback>) -> ::windows::core::Result<()>;
 }
@@ -4533,6 +4589,7 @@ impl IWEExtendWizard97_Vtbl {
         iid == &<IWEExtendWizard97 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_Clustering\"`, `\"implement\"`*"]
 pub trait IWEInvokeCommand_Impl: Sized {
     fn InvokeCommand(&self, ncommandid: u32, pidata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/NetworkListManager/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumNetworkConnections_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
@@ -61,6 +62,7 @@ impl IEnumNetworkConnections_Vtbl {
         iid == &<IEnumNetworkConnections as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumNetworks_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
@@ -124,6 +126,7 @@ impl IEnumNetworks_Vtbl {
         iid == &<IEnumNetworks as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetwork_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -285,6 +288,7 @@ impl INetwork_Vtbl {
         iid == &<INetwork as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetworkConnection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetNetwork(&self) -> ::windows::core::Result<INetwork>;
@@ -392,6 +396,7 @@ impl INetworkConnection_Vtbl {
         iid == &<INetworkConnection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetworkConnectionCost_Impl: Sized {
     fn GetCost(&self) -> ::windows::core::Result<u32>;
@@ -434,6 +439,7 @@ impl INetworkConnectionCost_Vtbl {
         iid == &<INetworkConnectionCost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"implement\"`*"]
 pub trait INetworkConnectionCostEvents_Impl: Sized {
     fn ConnectionCostChanged(&self, connectionid: &::windows::core::GUID, newcost: u32) -> ::windows::core::Result<()>;
     fn ConnectionDataPlanStatusChanged(&self, connectionid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -461,6 +467,7 @@ impl INetworkConnectionCostEvents_Vtbl {
         iid == &<INetworkConnectionCostEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"implement\"`*"]
 pub trait INetworkConnectionEvents_Impl: Sized {
     fn NetworkConnectionConnectivityChanged(&self, connectionid: &::windows::core::GUID, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::Result<()>;
     fn NetworkConnectionPropertyChanged(&self, connectionid: &::windows::core::GUID, flags: NLM_CONNECTION_PROPERTY_CHANGE) -> ::windows::core::Result<()>;
@@ -488,6 +495,7 @@ impl INetworkConnectionEvents_Vtbl {
         iid == &<INetworkConnectionEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INetworkCostManager_Impl: Sized {
     fn GetCost(&self, pcost: *mut u32, pdestipaddr: *const NLM_SOCKADDR) -> ::windows::core::Result<()>;
@@ -525,6 +533,7 @@ impl INetworkCostManager_Vtbl {
         iid == &<INetworkCostManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"implement\"`*"]
 pub trait INetworkCostManagerEvents_Impl: Sized {
     fn CostChanged(&self, newcost: u32, pdestaddr: *const NLM_SOCKADDR) -> ::windows::core::Result<()>;
     fn DataPlanStatusChanged(&self, pdestaddr: *const NLM_SOCKADDR) -> ::windows::core::Result<()>;
@@ -552,6 +561,7 @@ impl INetworkCostManagerEvents_Vtbl {
         iid == &<INetworkCostManagerEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"implement\"`*"]
 pub trait INetworkEvents_Impl: Sized {
     fn NetworkAdded(&self, networkid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn NetworkDeleted(&self, networkid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -593,6 +603,7 @@ impl INetworkEvents_Vtbl {
         iid == &<INetworkEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetworkListManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetNetworks(&self, flags: NLM_ENUM_NETWORK) -> ::windows::core::Result<IEnumNetworks>;
@@ -714,6 +725,7 @@ impl INetworkListManager_Vtbl {
         iid == &<INetworkListManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_NetworkListManager\"`, `\"implement\"`*"]
 pub trait INetworkListManagerEvents_Impl: Sized {
     fn ConnectivityChanged(&self, newconnectivity: NLM_CONNECTIVITY) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/RemoteDifferentialCompression/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"implement\"`*"]
 pub trait IFindSimilarResults_Impl: Sized {
     fn GetSize(&self) -> ::windows::core::Result<u32>;
     fn GetNextFileId(&self, numtraitsmatched: *mut u32, similarityfileid: *mut SimilarityFileId) -> ::windows::core::Result<()>;
@@ -31,6 +32,7 @@ impl IFindSimilarResults_Vtbl {
         iid == &<IFindSimilarResults as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRdcComparator_Impl: Sized {
     fn Process(&self, endofinput: super::super::Foundation::BOOL, endofoutput: *mut super::super::Foundation::BOOL, inputbuffer: *mut RdcBufferPointer, outputbuffer: *mut RdcNeedPointer, rdc_errorcode: *mut RDC_ErrorCode) -> ::windows::core::Result<()>;
@@ -51,6 +53,7 @@ impl IRdcComparator_Vtbl {
         iid == &<IRdcComparator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRdcFileReader_Impl: Sized {
     fn GetFileSize(&self) -> ::windows::core::Result<u64>;
@@ -100,6 +103,7 @@ impl IRdcFileReader_Vtbl {
         iid == &<IRdcFileReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRdcFileWriter_Impl: Sized + IRdcFileReader_Impl {
     fn Write(&self, offsetfilestart: u64, bytestowrite: u32) -> ::windows::core::Result<u8>;
@@ -143,6 +147,7 @@ impl IRdcFileWriter_Vtbl {
         iid == &<IRdcFileWriter as ::windows::core::Interface>::IID || iid == &<IRdcFileReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRdcGenerator_Impl: Sized {
     fn GetGeneratorParameters(&self, level: u32) -> ::windows::core::Result<IRdcGeneratorParameters>;
@@ -179,6 +184,7 @@ impl IRdcGenerator_Vtbl {
         iid == &<IRdcGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"implement\"`*"]
 pub trait IRdcGeneratorFilterMaxParameters_Impl: Sized {
     fn GetHorizonSize(&self) -> ::windows::core::Result<u32>;
     fn SetHorizonSize(&self, horizonsize: u32) -> ::windows::core::Result<()>;
@@ -232,6 +238,7 @@ impl IRdcGeneratorFilterMaxParameters_Vtbl {
         iid == &<IRdcGeneratorFilterMaxParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"implement\"`*"]
 pub trait IRdcGeneratorParameters_Impl: Sized {
     fn GetGeneratorParametersType(&self) -> ::windows::core::Result<GeneratorParametersType>;
     fn GetParametersVersion(&self, currentversion: *mut u32, minimumcompatibleappversion: *mut u32) -> ::windows::core::Result<()>;
@@ -285,6 +292,7 @@ impl IRdcGeneratorParameters_Vtbl {
         iid == &<IRdcGeneratorParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"implement\"`*"]
 pub trait IRdcLibrary_Impl: Sized {
     fn ComputeDefaultRecursionDepth(&self, filesize: u64) -> ::windows::core::Result<u32>;
     fn CreateGeneratorParameters(&self, parameterstype: GeneratorParametersType, level: u32) -> ::windows::core::Result<IRdcGeneratorParameters>;
@@ -383,6 +391,7 @@ impl IRdcLibrary_Vtbl {
         iid == &<IRdcLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRdcSignatureReader_Impl: Sized {
     fn ReadHeader(&self) -> ::windows::core::Result<RDC_ErrorCode>;
@@ -419,6 +428,7 @@ impl IRdcSignatureReader_Vtbl {
         iid == &<IRdcSignatureReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"implement\"`*"]
 pub trait IRdcSimilarityGenerator_Impl: Sized {
     fn EnableSimilarity(&self) -> ::windows::core::Result<()>;
     fn Results(&self) -> ::windows::core::Result<SimilarityData>;
@@ -452,6 +462,7 @@ impl IRdcSimilarityGenerator_Vtbl {
         iid == &<IRdcSimilarityGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISimilarity_Impl: Sized {
     fn CreateTable(&self, path: &::windows::core::PCWSTR, truncate: super::super::Foundation::BOOL, securitydescriptor: *const u8, recordsize: u32) -> ::windows::core::Result<RdcCreatedTables>;
@@ -541,6 +552,7 @@ impl ISimilarity_Vtbl {
         iid == &<ISimilarity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISimilarityFileIdTable_Impl: Sized {
     fn CreateTable(&self, path: &::windows::core::PCWSTR, truncate: super::super::Foundation::BOOL, securitydescriptor: *const u8, recordsize: u32) -> ::windows::core::Result<RdcCreatedTables>;
@@ -636,6 +648,7 @@ impl ISimilarityFileIdTable_Vtbl {
         iid == &<ISimilarityFileIdTable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"implement\"`*"]
 pub trait ISimilarityReportProgress_Impl: Sized {
     fn ReportProgress(&self, percentcompleted: u32) -> ::windows::core::Result<()>;
 }
@@ -653,6 +666,7 @@ impl ISimilarityReportProgress_Vtbl {
         iid == &<ISimilarityReportProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISimilarityTableDumpState_Impl: Sized {
     fn GetNextData(&self, resultssize: u32, resultsused: *mut u32, eof: *mut super::super::Foundation::BOOL, results: *mut SimilarityDumpData) -> ::windows::core::Result<()>;
@@ -673,6 +687,7 @@ impl ISimilarityTableDumpState_Vtbl {
         iid == &<ISimilarityTableDumpState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISimilarityTraitsMappedView_Impl: Sized {
     fn Flush(&self) -> ::windows::core::Result<()>;
@@ -723,6 +738,7 @@ impl ISimilarityTraitsMappedView_Vtbl {
         iid == &<ISimilarityTraitsMappedView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"implement\"`*"]
 pub trait ISimilarityTraitsMapping_Impl: Sized {
     fn CloseMapping(&self);
     fn SetFileSize(&self, filesize: u64) -> ::windows::core::Result<()>;
@@ -809,6 +825,7 @@ impl ISimilarityTraitsMapping_Vtbl {
         iid == &<ISimilarityTraitsMapping as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_RemoteDifferentialCompression\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISimilarityTraitsTable_Impl: Sized {
     fn CreateTable(&self, path: &::windows::core::PCWSTR, truncate: super::super::Foundation::BOOL, securitydescriptor: *const u8) -> ::windows::core::Result<RdcCreatedTables>;

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Networking_WinInet\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IDialBranding_Impl: Sized {
     fn Initialize(&self, pwzconnectoid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -34,6 +35,7 @@ impl IDialBranding_Vtbl {
         iid == &<IDialBranding as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_WinInet\"`, `\"implement\"`*"]
 pub trait IDialEngine_Impl: Sized {
     fn Initialize(&self, pwzconnectoid: &::windows::core::PCWSTR, pides: &::core::option::Option<IDialEventSink>) -> ::windows::core::Result<()>;
     fn GetProperty(&self, pwzproperty: &::windows::core::PCWSTR, pwzvalue: &::windows::core::PCWSTR, dwbufsize: u32) -> ::windows::core::Result<()>;
@@ -108,6 +110,7 @@ impl IDialEngine_Vtbl {
         iid == &<IDialEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_WinInet\"`, `\"implement\"`*"]
 pub trait IDialEventSink_Impl: Sized {
     fn OnEvent(&self, dwevent: u32, dwstatus: u32) -> ::windows::core::Result<()>;
 }
@@ -125,6 +128,7 @@ impl IDialEventSink_Vtbl {
         iid == &<IDialEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_WinInet\"`, `\"implement\"`*"]
 pub trait IProofOfPossessionCookieInfoManager_Impl: Sized {
     fn GetCookieInfoForUri(&self, uri: &::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::Result<()>;
 }
@@ -142,6 +146,7 @@ impl IProofOfPossessionCookieInfoManager_Vtbl {
         iid == &<IProofOfPossessionCookieInfoManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Networking_WinInet\"`, `\"implement\"`*"]
 pub trait IProofOfPossessionCookieInfoManager2_Impl: Sized {
     fn GetCookieInfoWithUriForAccount(&self, webaccount: &::core::option::Option<::windows::core::IInspectable>, uri: &::windows::core::PCWSTR, cookieinfocount: *mut u32, cookieinfo: *mut *mut ProofOfPossessionCookieInfo) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"implement\"`*"]
 pub trait IContentPrefetcherTaskTrigger_Impl: Sized {
     fn TriggerContentPrefetcherTask(&self, packagefullname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn IsRegisteredForContentPrefetch(&self, packagefullname: &::windows::core::PCWSTR) -> ::windows::core::Result<u8>;

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait AsyncIAssociatedIdentityProvider_Impl: Sized {
     fn Begin_AssociateIdentity(&self, hwndparent: super::super::super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -62,6 +63,7 @@ impl AsyncIAssociatedIdentityProvider_Vtbl {
         iid == &<AsyncIAssociatedIdentityProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait AsyncIConnectedIdentityProvider_Impl: Sized {
     fn Begin_ConnectIdentity(&self, authbuffer: *const u8, authbuffersize: u32) -> ::windows::core::Result<()>;
@@ -160,6 +162,7 @@ impl AsyncIConnectedIdentityProvider_Vtbl {
         iid == &<AsyncIConnectedIdentityProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"implement\"`*"]
 pub trait AsyncIIdentityAdvise_Impl: Sized {
     fn Begin_IdentityUpdated(&self, dwidentityupdateevents: u32, lpszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Finish_IdentityUpdated(&self) -> ::windows::core::Result<()>;
@@ -187,6 +190,7 @@ impl AsyncIIdentityAdvise_Vtbl {
         iid == &<AsyncIIdentityAdvise as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait AsyncIIdentityAuthentication_Impl: Sized {
     fn Begin_SetIdentityCredential(&self, credbuffer: *const u8, credbufferlength: u32) -> ::windows::core::Result<()>;
@@ -231,6 +235,7 @@ impl AsyncIIdentityAuthentication_Vtbl {
         iid == &<AsyncIIdentityAuthentication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait AsyncIIdentityProvider_Impl: Sized {
     fn Begin_GetIdentityEnum(&self, eidentitytype: IDENTITY_TYPE, pfilterkey: *const super::super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pfilterpropvarvalue: *const super::super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -389,6 +394,7 @@ impl AsyncIIdentityProvider_Vtbl {
         iid == &<AsyncIIdentityProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait AsyncIIdentityStore_Impl: Sized {
     fn Begin_GetCount(&self) -> ::windows::core::Result<()>;
@@ -501,6 +507,7 @@ impl AsyncIIdentityStore_Vtbl {
         iid == &<AsyncIIdentityStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"implement\"`*"]
 pub trait AsyncIIdentityStoreEx_Impl: Sized {
     fn Begin_CreateConnectedIdentity(&self, localname: &::windows::core::PCWSTR, connectedname: &::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Finish_CreateConnectedIdentity(&self) -> ::windows::core::Result<()>;
@@ -542,6 +549,7 @@ impl AsyncIIdentityStoreEx_Vtbl {
         iid == &<AsyncIIdentityStoreEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IAssociatedIdentityProvider_Impl: Sized {
     fn AssociateIdentity(&self, hwndparent: super::super::super::super::Foundation::HWND) -> ::windows::core::Result<super::super::super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
@@ -585,6 +593,7 @@ impl IAssociatedIdentityProvider_Vtbl {
         iid == &<IAssociatedIdentityProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IConnectedIdentityProvider_Impl: Sized {
     fn ConnectIdentity(&self, authbuffer: *const u8, authbuffersize: u32) -> ::windows::core::Result<()>;
@@ -648,6 +657,7 @@ impl IConnectedIdentityProvider_Vtbl {
         iid == &<IConnectedIdentityProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"implement\"`*"]
 pub trait IIdentityAdvise_Impl: Sized {
     fn IdentityUpdated(&self, dwidentityupdateevents: IdentityUpdateEvent, lpszuniqueid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -665,6 +675,7 @@ impl IIdentityAdvise_Vtbl {
         iid == &<IIdentityAdvise as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IIdentityAuthentication_Impl: Sized {
     fn SetIdentityCredential(&self, credbuffer: *const u8, credbufferlength: u32) -> ::windows::core::Result<()>;
@@ -695,6 +706,7 @@ impl IIdentityAuthentication_Vtbl {
         iid == &<IIdentityAuthentication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IIdentityProvider_Impl: Sized {
     fn GetIdentityEnum(&self, eidentitytype: IDENTITY_TYPE, pfilterkey: *const super::super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pfilterpropvarvalue: *const super::super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<super::super::super::super::System::Com::IEnumUnknown>;
@@ -791,6 +803,7 @@ impl IIdentityProvider_Vtbl {
         iid == &<IIdentityProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IIdentityStore_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -861,6 +874,7 @@ impl IIdentityStore_Vtbl {
         iid == &<IIdentityStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity_Provider\"`, `\"implement\"`*"]
 pub trait IIdentityStoreEx_Impl: Sized {
     fn CreateConnectedIdentity(&self, localname: &::windows::core::PCWSTR, connectedname: &::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn DeleteConnectedIdentity(&self, connectedname: &::windows::core::PCWSTR, providerguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Authentication_Identity\"`, `\"implement\"`*"]
 pub trait ICcgDomainAuthCredentials_Impl: Sized {
     fn GetPasswordCredentials(&self, plugininput: &::windows::core::PCWSTR, domainname: *mut ::windows::core::PWSTR, username: *mut ::windows::core::PWSTR, password: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEffectivePermission_Impl: Sized {
     fn GetEffectivePermission(&self, pguidobjecttype: *const ::windows::core::GUID, pusersid: super::super::super::Foundation::PSID, pszservername: &::windows::core::PCWSTR, psd: super::super::PSECURITY_DESCRIPTOR, ppobjecttypelist: *mut *mut super::super::OBJECT_TYPE_LIST, pcobjecttypelistlength: *mut u32, ppgrantedaccesslist: *mut *mut u32, pcgrantedaccesslistlength: *mut u32) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl IEffectivePermission_Vtbl {
         iid == &<IEffectivePermission as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEffectivePermission2_Impl: Sized {
     fn ComputeEffectivePermissionWithSecondarySecurity(
@@ -89,6 +91,7 @@ impl IEffectivePermission2_Vtbl {
         iid == &<IEffectivePermission2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 pub trait ISecurityInformation_Impl: Sized {
     fn GetObjectInformation(&self, pobjectinfo: *mut SI_OBJECT_INFO) -> ::windows::core::Result<()>;
@@ -154,6 +157,7 @@ impl ISecurityInformation_Vtbl {
         iid == &<ISecurityInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISecurityInformation2_Impl: Sized {
     fn IsDaclCanonical(&self, pdacl: *const super::super::ACL) -> super::super::super::Foundation::BOOL;
@@ -190,6 +194,7 @@ impl ISecurityInformation2_Vtbl {
         iid == &<ISecurityInformation2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISecurityInformation3_Impl: Sized {
     fn GetFullResourceName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -226,6 +231,7 @@ impl ISecurityInformation3_Vtbl {
         iid == &<ISecurityInformation3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISecurityInformation4_Impl: Sized {
     fn GetSecondarySecurity(&self, psecurityobjects: *mut *mut SECURITY_OBJECT, psecurityobjectcount: *mut u32) -> ::windows::core::Result<()>;
@@ -246,6 +252,7 @@ impl ISecurityInformation4_Vtbl {
         iid == &<ISecurityInformation4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"implement\"`*"]
 pub trait ISecurityObjectTypeInfo_Impl: Sized {
     fn GetInheritSource(&self, si: u32, pacl: *mut super::super::ACL, ppinheritarray: *mut *mut super::INHERITED_FROMA) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzApplication_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -639,6 +640,7 @@ impl IAzApplication_Vtbl {
         iid == &<IAzApplication as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzApplication2_Impl: Sized + IAzApplication_Impl {
     fn InitializeClientContextFromToken2(&self, ultokenhandlelowpart: u32, ultokenhandlehighpart: u32, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IAzClientContext2>;
@@ -681,6 +683,7 @@ impl IAzApplication2_Vtbl {
         iid == &<IAzApplication2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzApplication3_Impl: Sized + IAzApplication2_Impl {
     fn ScopeExists(&self, bstrscopename: &::windows::core::BSTR) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -855,6 +858,7 @@ impl IAzApplication3_Vtbl {
         iid == &<IAzApplication3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzApplication as ::windows::core::Interface>::IID || iid == &<IAzApplication2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzApplicationGroup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1167,6 +1171,7 @@ impl IAzApplicationGroup_Vtbl {
         iid == &<IAzApplicationGroup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzApplicationGroup2_Impl: Sized + IAzApplicationGroup_Impl {
     fn BizRule(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1256,6 +1261,7 @@ impl IAzApplicationGroup2_Vtbl {
         iid == &<IAzApplicationGroup2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzApplicationGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzApplicationGroups_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1311,6 +1317,7 @@ impl IAzApplicationGroups_Vtbl {
         iid == &<IAzApplicationGroups as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzApplications_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1366,6 +1373,7 @@ impl IAzApplications_Vtbl {
         iid == &<IAzApplications as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzAuthorizationStore_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1871,6 +1879,7 @@ impl IAzAuthorizationStore_Vtbl {
         iid == &<IAzAuthorizationStore as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzAuthorizationStore2_Impl: Sized + IAzAuthorizationStore_Impl {
     fn OpenApplication2(&self, bstrapplicationname: &::windows::core::BSTR, varreserved: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IAzApplication2>;
@@ -1913,6 +1922,7 @@ impl IAzAuthorizationStore2_Vtbl {
         iid == &<IAzAuthorizationStore2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzAuthorizationStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzAuthorizationStore3_Impl: Sized + IAzAuthorizationStore2_Impl {
     fn IsUpdateNeeded(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -1982,6 +1992,7 @@ impl IAzAuthorizationStore3_Vtbl {
         iid == &<IAzAuthorizationStore3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzAuthorizationStore as ::windows::core::Interface>::IID || iid == &<IAzAuthorizationStore2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzBizRuleContext_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetBusinessRuleResult(&self, bresult: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2038,6 +2049,7 @@ impl IAzBizRuleContext_Vtbl {
         iid == &<IAzBizRuleContext as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzBizRuleInterfaces_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AddInterface(&self, bstrinterfacename: &::windows::core::BSTR, linterfaceflag: i32, varinterface: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2102,6 +2114,7 @@ impl IAzBizRuleInterfaces_Vtbl {
         iid == &<IAzBizRuleInterfaces as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzBizRuleParameters_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AddParameter(&self, bstrparametername: &::windows::core::BSTR, varparametervalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2172,6 +2185,7 @@ impl IAzBizRuleParameters_Vtbl {
         iid == &<IAzBizRuleParameters as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzClientContext_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AccessCheck(&self, bstrobjectname: &::windows::core::BSTR, varscopenames: &super::super::System::Com::VARIANT, varoperations: &super::super::System::Com::VARIANT, varparameternames: &super::super::System::Com::VARIANT, varparametervalues: &super::super::System::Com::VARIANT, varinterfacenames: &super::super::System::Com::VARIANT, varinterfaceflags: &super::super::System::Com::VARIANT, varinterfaces: &super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -2351,6 +2365,7 @@ impl IAzClientContext_Vtbl {
         iid == &<IAzClientContext as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzClientContext2_Impl: Sized + IAzClientContext_Impl {
     fn GetAssignedScopesPage(&self, loptions: i32, pagesize: i32, pvarcursor: *mut super::super::System::Com::VARIANT, pvarscopenames: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2415,6 +2430,7 @@ impl IAzClientContext2_Vtbl {
         iid == &<IAzClientContext2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzClientContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzClientContext3_Impl: Sized + IAzClientContext2_Impl {
     fn AccessCheck2(&self, bstrobjectname: &::windows::core::BSTR, bstrscopename: &::windows::core::BSTR, loperation: i32) -> ::windows::core::Result<u32>;
@@ -2535,6 +2551,7 @@ impl IAzClientContext3_Vtbl {
         iid == &<IAzClientContext3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzClientContext as ::windows::core::Interface>::IID || iid == &<IAzClientContext2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzNameResolver_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn NameFromSid(&self, bstrsid: &::windows::core::BSTR, psidtype: *mut i32, pbstrname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2565,6 +2582,7 @@ impl IAzNameResolver_Vtbl {
         iid == &<IAzNameResolver as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzObjectPicker_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetPrincipals(&self, hparentwnd: super::super::Foundation::HWND, bstrtitle: &::windows::core::BSTR, pvsidtypes: *mut super::super::System::Com::VARIANT, pvnames: *mut super::super::System::Com::VARIANT, pvsids: *mut super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2601,6 +2619,7 @@ impl IAzObjectPicker_Vtbl {
         iid == &<IAzObjectPicker as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzOperation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2737,6 +2756,7 @@ impl IAzOperation_Vtbl {
         iid == &<IAzOperation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzOperation2_Impl: Sized + IAzOperation_Impl {
     fn RoleAssignments(&self, bstrscopename: &::windows::core::BSTR, brecursive: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<IAzRoleAssignments>;
@@ -2763,6 +2783,7 @@ impl IAzOperation2_Vtbl {
         iid == &<IAzOperation2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzOperations_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -2818,6 +2839,7 @@ impl IAzOperations_Vtbl {
         iid == &<IAzOperations as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzPrincipalLocator_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn NameResolver(&self) -> ::windows::core::Result<IAzNameResolver>;
@@ -2860,6 +2882,7 @@ impl IAzPrincipalLocator_Vtbl {
         iid == &<IAzPrincipalLocator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzRole_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3125,6 +3148,7 @@ impl IAzRole_Vtbl {
         iid == &<IAzRole as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzRoleAssignment_Impl: Sized + IAzRole_Impl {
     fn AddRoleDefinition(&self, bstrroledefinition: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3181,6 +3205,7 @@ impl IAzRoleAssignment_Vtbl {
         iid == &<IAzRoleAssignment as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzRole as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzRoleAssignments_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3236,6 +3261,7 @@ impl IAzRoleAssignments_Vtbl {
         iid == &<IAzRoleAssignments as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzRoleDefinition_Impl: Sized + IAzTask_Impl {
     fn RoleAssignments(&self, bstrscopename: &::windows::core::BSTR, brecursive: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<IAzRoleAssignments>;
@@ -3292,6 +3318,7 @@ impl IAzRoleDefinition_Vtbl {
         iid == &<IAzRoleDefinition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzTask as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzRoleDefinitions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3347,6 +3374,7 @@ impl IAzRoleDefinitions_Vtbl {
         iid == &<IAzRoleDefinitions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzRoles_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3402,6 +3430,7 @@ impl IAzRoles_Vtbl {
         iid == &<IAzRoles as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzScope_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3804,6 +3833,7 @@ impl IAzScope_Vtbl {
         iid == &<IAzScope as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzScope2_Impl: Sized + IAzScope_Impl {
     fn RoleDefinitions(&self) -> ::windows::core::Result<IAzRoleDefinitions>;
@@ -3912,6 +3942,7 @@ impl IAzScope2_Vtbl {
         iid == &<IAzScope2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzScope as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzScopes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3967,6 +3998,7 @@ impl IAzScopes_Vtbl {
         iid == &<IAzScopes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzTask_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4231,6 +4263,7 @@ impl IAzTask_Vtbl {
         iid == &<IAzTask as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzTask2_Impl: Sized + IAzTask_Impl {
     fn RoleAssignments(&self, bstrscopename: &::windows::core::BSTR, brecursive: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<IAzRoleAssignments>;
@@ -4257,6 +4290,7 @@ impl IAzTask2_Vtbl {
         iid == &<IAzTask2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAzTask as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Authorization\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAzTasks_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<super::super::System::Com::VARIANT>;

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_ConfigurationSnapin\"`, `\"implement\"`*"]
 pub trait ISceSvcAttachmentData_Impl: Sized {
     fn GetData(&self, scesvchandle: *mut ::core::ffi::c_void, scetype: SCESVC_INFO_TYPE, ppvdata: *mut *mut ::core::ffi::c_void, psceenumhandle: *mut u32) -> ::windows::core::Result<()>;
     fn Initialize(&self, lpservicename: *mut i8, lptemplatename: *mut i8, lpscesvcpersistinfo: &::core::option::Option<ISceSvcAttachmentPersistInfo>, pscesvchandle: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -39,6 +40,7 @@ impl ISceSvcAttachmentData_Vtbl {
         iid == &<ISceSvcAttachmentData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_ConfigurationSnapin\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISceSvcAttachmentPersistInfo_Impl: Sized {
     fn Save(&self, lptemplatename: *mut i8, scesvchandle: *mut *mut ::core::ffi::c_void, ppvdata: *mut *mut ::core::ffi::c_void, pboverwriteall: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAlternativeName_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn InitializeFromString(&self, r#type: AlternativeNameType, strvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -87,6 +88,7 @@ impl IAlternativeName_Vtbl {
         iid == &<IAlternativeName as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAlternativeNames_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IAlternativeName>;
@@ -163,6 +165,7 @@ impl IAlternativeNames_Vtbl {
         iid == &<IAlternativeNames as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBinaryConverter_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn StringToString(&self, strencodedin: &::windows::core::BSTR, encodingin: EncodingType, encoding: EncodingType) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -218,6 +221,7 @@ impl IBinaryConverter_Vtbl {
         iid == &<IBinaryConverter as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBinaryConverter2_Impl: Sized + IBinaryConverter_Impl {
     fn StringArrayToVariantArray(&self, pvarstringarray: *const super::super::super::System::Com::VARIANT) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
@@ -260,6 +264,7 @@ impl IBinaryConverter2_Vtbl {
         iid == &<IBinaryConverter2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IBinaryConverter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICEnroll_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn createFilePKCS10(&self, dnname: &::windows::core::BSTR, usage: &::windows::core::BSTR, wszpkcs10filename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -836,6 +841,7 @@ impl ICEnroll_Vtbl {
         iid == &<ICEnroll as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICEnroll2_Impl: Sized + ICEnroll_Impl {
     fn addCertTypeToRequest(&self, certtype: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -906,6 +912,7 @@ impl ICEnroll2_Vtbl {
         iid == &<ICEnroll2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICEnroll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICEnroll3_Impl: Sized + ICEnroll2_Impl {
     fn InstallPKCS7(&self, pkcs7: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1068,6 +1075,7 @@ impl ICEnroll3_Vtbl {
         iid == &<ICEnroll3 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICEnroll as ::windows::core::Interface>::IID || iid == &<ICEnroll2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICEnroll4_Impl: Sized + ICEnroll3_Impl {
     fn SetPrivateKeyArchiveCertificate(&self, bstrcert: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1399,6 +1407,7 @@ impl ICEnroll4_Vtbl {
         iid == &<ICEnroll4 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICEnroll as ::windows::core::Interface>::IID || iid == &<ICEnroll2 as ::windows::core::Interface>::IID || iid == &<ICEnroll3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertAdmin_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn IsValidCertificate(&self, strconfig: &::windows::core::BSTR, strserialnumber: &::windows::core::BSTR) -> ::windows::core::Result<i32>;
@@ -1515,6 +1524,7 @@ impl ICertAdmin_Vtbl {
         iid == &<ICertAdmin as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertAdmin2_Impl: Sized + ICertAdmin_Impl {
     fn PublishCRLs(&self, strconfig: &::windows::core::BSTR, date: f64, crlflags: i32) -> ::windows::core::Result<()>;
@@ -1650,6 +1660,7 @@ impl ICertAdmin2_Vtbl {
         iid == &<ICertAdmin2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertConfig_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Reset(&self, index: i32) -> ::windows::core::Result<i32>;
@@ -1718,6 +1729,7 @@ impl ICertConfig_Vtbl {
         iid == &<ICertConfig as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertConfig2_Impl: Sized + ICertConfig_Impl {
     fn SetSharedFolder(&self, strsharedfolder: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1738,6 +1750,7 @@ impl ICertConfig2_Vtbl {
         iid == &<ICertConfig2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeAltName_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Decode(&self, strbinary: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1827,6 +1840,7 @@ impl ICertEncodeAltName_Vtbl {
         iid == &<ICertEncodeAltName as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeAltName2_Impl: Sized + ICertEncodeAltName_Impl {
     fn DecodeBlob(&self, strencodeddata: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -1883,6 +1897,7 @@ impl ICertEncodeAltName2_Vtbl {
         iid == &<ICertEncodeAltName2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertEncodeAltName as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeBitString_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Decode(&self, strbinary: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1945,6 +1960,7 @@ impl ICertEncodeBitString_Vtbl {
         iid == &<ICertEncodeBitString as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeBitString2_Impl: Sized + ICertEncodeBitString_Impl {
     fn DecodeBlob(&self, strencodeddata: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -1994,6 +2010,7 @@ impl ICertEncodeBitString2_Vtbl {
         iid == &<ICertEncodeBitString2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertEncodeBitString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeCRLDistInfo_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Decode(&self, strbinary: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2103,6 +2120,7 @@ impl ICertEncodeCRLDistInfo_Vtbl {
         iid == &<ICertEncodeCRLDistInfo as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeCRLDistInfo2_Impl: Sized + ICertEncodeCRLDistInfo_Impl {
     fn DecodeBlob(&self, strencodeddata: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -2139,6 +2157,7 @@ impl ICertEncodeCRLDistInfo2_Vtbl {
         iid == &<ICertEncodeCRLDistInfo2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertEncodeCRLDistInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeDateArray_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Decode(&self, strbinary: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2215,6 +2234,7 @@ impl ICertEncodeDateArray_Vtbl {
         iid == &<ICertEncodeDateArray as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeDateArray2_Impl: Sized + ICertEncodeDateArray_Impl {
     fn DecodeBlob(&self, strencodeddata: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -2251,6 +2271,7 @@ impl ICertEncodeDateArray2_Vtbl {
         iid == &<ICertEncodeDateArray2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertEncodeDateArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeLongArray_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Decode(&self, strbinary: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2327,6 +2348,7 @@ impl ICertEncodeLongArray_Vtbl {
         iid == &<ICertEncodeLongArray as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeLongArray2_Impl: Sized + ICertEncodeLongArray_Impl {
     fn DecodeBlob(&self, strencodeddata: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -2363,6 +2385,7 @@ impl ICertEncodeLongArray2_Vtbl {
         iid == &<ICertEncodeLongArray2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertEncodeLongArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeStringArray_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Decode(&self, strbinary: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2452,6 +2475,7 @@ impl ICertEncodeStringArray_Vtbl {
         iid == &<ICertEncodeStringArray as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertEncodeStringArray2_Impl: Sized + ICertEncodeStringArray_Impl {
     fn DecodeBlob(&self, strencodeddata: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -2488,6 +2512,7 @@ impl ICertEncodeStringArray2_Vtbl {
         iid == &<ICertEncodeStringArray2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertEncodeStringArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertExit_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, strconfig: &::windows::core::BSTR) -> ::windows::core::Result<CERT_EXIT_EVENT_MASK>;
@@ -2537,6 +2562,7 @@ impl ICertExit_Vtbl {
         iid == &<ICertExit as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertExit2_Impl: Sized + ICertExit_Impl {
     fn GetManageModule(&self) -> ::windows::core::Result<ICertManageModule>;
@@ -2563,6 +2589,7 @@ impl ICertExit2_Vtbl {
         iid == &<ICertExit2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertExit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertGetConfig_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetConfig(&self, flags: CERT_GET_CONFIG_FLAGS) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2589,6 +2616,7 @@ impl ICertGetConfig_Vtbl {
         iid == &<ICertGetConfig as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertManageModule_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetProperty(&self, strconfig: &::windows::core::BSTR, strstoragelocation: &::windows::core::BSTR, strpropertyname: &::windows::core::BSTR, flags: i32) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
@@ -2632,6 +2660,7 @@ impl ICertManageModule_Vtbl {
         iid == &<ICertManageModule as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPolicy_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, strconfig: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2688,6 +2717,7 @@ impl ICertPolicy_Vtbl {
         iid == &<ICertPolicy as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPolicy2_Impl: Sized + ICertPolicy_Impl {
     fn GetManageModule(&self) -> ::windows::core::Result<ICertManageModule>;
@@ -2714,6 +2744,7 @@ impl ICertPolicy2_Vtbl {
         iid == &<ICertPolicy2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertPolicy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertProperties_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ICertProperty>;
@@ -2797,6 +2828,7 @@ impl ICertProperties_Vtbl {
         iid == &<ICertProperties as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertProperty_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn InitializeFromCertificate(&self, machinecontext: super::super::super::Foundation::VARIANT_BOOL, encoding: EncodingType, strcertificate: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2874,6 +2906,7 @@ impl ICertProperty_Vtbl {
         iid == &<ICertProperty as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyArchived_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, archivedvalue: super::super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -2910,6 +2943,7 @@ impl ICertPropertyArchived_Vtbl {
         iid == &<ICertPropertyArchived as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyArchivedKeyHash_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, encoding: EncodingType, strarchivedkeyhashvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2946,6 +2980,7 @@ impl ICertPropertyArchivedKeyHash_Vtbl {
         iid == &<ICertPropertyArchivedKeyHash as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyAutoEnroll_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, strtemplatename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2982,6 +3017,7 @@ impl ICertPropertyAutoEnroll_Vtbl {
         iid == &<ICertPropertyAutoEnroll as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyBackedUp_Impl: Sized + ICertProperty_Impl {
     fn InitializeFromCurrentTime(&self, backedupvalue: super::super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3038,6 +3074,7 @@ impl ICertPropertyBackedUp_Vtbl {
         iid == &<ICertPropertyBackedUp as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyDescription_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, strdescription: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3074,6 +3111,7 @@ impl ICertPropertyDescription_Vtbl {
         iid == &<ICertPropertyDescription as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyEnrollment_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, requestid: i32, strcadnsname: &::windows::core::BSTR, strcaname: &::windows::core::BSTR, strfriendlyname: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3149,6 +3187,7 @@ impl ICertPropertyEnrollment_Vtbl {
         iid == &<ICertPropertyEnrollment as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyEnrollmentPolicyServer_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, propertyflags: EnrollmentPolicyServerPropertyFlags, authflags: X509EnrollmentAuthFlags, enrollmentserverauthflags: X509EnrollmentAuthFlags, urlflags: PolicyServerUrlFlags, strrequestid: &::windows::core::BSTR, strurl: &::windows::core::BSTR, strid: &::windows::core::BSTR, strenrollmentserverurl: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3276,6 +3315,7 @@ impl ICertPropertyEnrollmentPolicyServer_Vtbl {
         iid == &<ICertPropertyEnrollmentPolicyServer as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyFriendlyName_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, strfriendlyname: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3312,6 +3352,7 @@ impl ICertPropertyFriendlyName_Vtbl {
         iid == &<ICertPropertyFriendlyName as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyKeyProvInfo_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, pvalue: &::core::option::Option<IX509PrivateKey>) -> ::windows::core::Result<()>;
@@ -3348,6 +3389,7 @@ impl ICertPropertyKeyProvInfo_Vtbl {
         iid == &<ICertPropertyKeyProvInfo as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyRenewal_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, encoding: EncodingType, strrenewalvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3391,6 +3433,7 @@ impl ICertPropertyRenewal_Vtbl {
         iid == &<ICertPropertyRenewal as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertyRequestOriginator_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, strrequestoriginator: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3434,6 +3477,7 @@ impl ICertPropertyRequestOriginator_Vtbl {
         iid == &<ICertPropertyRequestOriginator as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertPropertySHA1Hash_Impl: Sized + ICertProperty_Impl {
     fn Initialize(&self, encoding: EncodingType, strrenewalvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3470,6 +3514,7 @@ impl ICertPropertySHA1Hash_Vtbl {
         iid == &<ICertPropertySHA1Hash as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertRequest_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Submit(&self, flags: i32, strrequest: &::windows::core::BSTR, strattributes: &::windows::core::BSTR, strconfig: &::windows::core::BSTR) -> ::windows::core::Result<i32>;
@@ -3577,6 +3622,7 @@ impl ICertRequest_Vtbl {
         iid == &<ICertRequest as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertRequest2_Impl: Sized + ICertRequest_Impl {
     fn GetIssuedCertificate(&self, strconfig: &::windows::core::BSTR, requestid: i32, strserialnumber: &::windows::core::BSTR) -> ::windows::core::Result<CR_DISP>;
@@ -3671,6 +3717,7 @@ impl ICertRequest2_Vtbl {
         iid == &<ICertRequest2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertRequest3_Impl: Sized + ICertRequest2_Impl {
     fn SetCredential(&self, hwnd: i32, authtype: X509EnrollmentAuthFlags, strcredential: &::windows::core::BSTR, strpassword: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3733,6 +3780,7 @@ impl ICertRequest3_Vtbl {
         iid == &<ICertRequest3 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertRequest as ::windows::core::Interface>::IID || iid == &<ICertRequest2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"implement\"`*"]
 pub trait ICertRequestD_Impl: Sized {
     fn Request(&self, dwflags: u32, pwszauthority: &::windows::core::PCWSTR, pdwrequestid: *mut u32, pdwdisposition: *mut u32, pwszattributes: &::windows::core::PCWSTR, pctbrequest: *const CERTTRANSBLOB, pctbcertchain: *mut CERTTRANSBLOB, pctbencodedcert: *mut CERTTRANSBLOB, pctbdispositionmessage: *mut CERTTRANSBLOB) -> ::windows::core::Result<()>;
     fn GetCACert(&self, fchain: u32, pwszauthority: &::windows::core::PCWSTR) -> ::windows::core::Result<CERTTRANSBLOB>;
@@ -3773,6 +3821,7 @@ impl ICertRequestD_Vtbl {
         iid == &<ICertRequestD as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"implement\"`*"]
 pub trait ICertRequestD2_Impl: Sized + ICertRequestD_Impl {
     fn Request2(&self, pwszauthority: &::windows::core::PCWSTR, dwflags: u32, pwszserialnumber: &::windows::core::PCWSTR, pdwrequestid: *mut u32, pdwdisposition: *mut u32, pwszattributes: &::windows::core::PCWSTR, pctbrequest: *const CERTTRANSBLOB, pctbfullresponse: *mut CERTTRANSBLOB, pctbencodedcert: *mut CERTTRANSBLOB, pctbdispositionmessage: *mut CERTTRANSBLOB) -> ::windows::core::Result<()>;
     fn GetCAProperty(&self, pwszauthority: &::windows::core::PCWSTR, propid: i32, propindex: i32, proptype: i32) -> ::windows::core::Result<CERTTRANSBLOB>;
@@ -3820,6 +3869,7 @@ impl ICertRequestD2_Vtbl {
         iid == &<ICertRequestD2 as ::windows::core::Interface>::IID || iid == &<ICertRequestD as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertServerExit_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn SetContext(&self, context: i32) -> ::windows::core::Result<()>;
@@ -3962,6 +4012,7 @@ impl ICertServerExit_Vtbl {
         iid == &<ICertServerExit as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertServerPolicy_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn SetContext(&self, context: i32) -> ::windows::core::Result<()>;
@@ -4118,6 +4169,7 @@ impl ICertServerPolicy_Vtbl {
         iid == &<ICertServerPolicy as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertView_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn OpenConnection(&self, strconfig: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4202,6 +4254,7 @@ impl ICertView_Vtbl {
         iid == &<ICertView as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertView2_Impl: Sized + ICertView_Impl {
     fn SetTable(&self, table: CVRC_TABLE) -> ::windows::core::Result<()>;
@@ -4222,6 +4275,7 @@ impl ICertView2_Vtbl {
         iid == &<ICertView2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificateAttestationChallenge_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, encoding: EncodingType, strpendingfullcmcresponsewithchallenge: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4271,6 +4325,7 @@ impl ICertificateAttestationChallenge_Vtbl {
         iid == &<ICertificateAttestationChallenge as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificateAttestationChallenge2_Impl: Sized + ICertificateAttestationChallenge_Impl {
     fn SetKeyContainerName(&self, value: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4301,6 +4356,7 @@ impl ICertificateAttestationChallenge2_Vtbl {
         iid == &<ICertificateAttestationChallenge2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICertificateAttestationChallenge as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificatePolicies_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ICertificatePolicy>;
@@ -4377,6 +4433,7 @@ impl ICertificatePolicies_Vtbl {
         iid == &<ICertificatePolicies as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificatePolicy_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, pvalue: &::core::option::Option<IObjectId>) -> ::windows::core::Result<()>;
@@ -4426,6 +4483,7 @@ impl ICertificatePolicy_Vtbl {
         iid == &<ICertificatePolicy as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificationAuthorities_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ICertificationAuthority>;
@@ -4522,6 +4580,7 @@ impl ICertificationAuthorities_Vtbl {
         iid == &<ICertificationAuthorities as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificationAuthority_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_Property(&self, property: EnrollmentCAProperty) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
@@ -4548,6 +4607,7 @@ impl ICertificationAuthority_Vtbl {
         iid == &<ICertificationAuthority as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICryptAttribute_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn InitializeFromObjectId(&self, pobjectid: &::core::option::Option<IObjectId>) -> ::windows::core::Result<()>;
@@ -4604,6 +4664,7 @@ impl ICryptAttribute_Vtbl {
         iid == &<ICryptAttribute as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICryptAttributes_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ICryptAttribute>;
@@ -4700,6 +4761,7 @@ impl ICryptAttributes_Vtbl {
         iid == &<ICryptAttributes as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICspAlgorithm_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetAlgorithmOid(&self, length: i32, algflags: AlgorithmFlags) -> ::windows::core::Result<IObjectId>;
@@ -4846,6 +4908,7 @@ impl ICspAlgorithm_Vtbl {
         iid == &<ICspAlgorithm as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICspAlgorithms_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ICspAlgorithm>;
@@ -4948,6 +5011,7 @@ impl ICspAlgorithms_Vtbl {
         iid == &<ICspAlgorithms as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICspInformation_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn InitializeFromName(&self, strname: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -5173,6 +5237,7 @@ impl ICspInformation_Vtbl {
         iid == &<ICspInformation as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICspInformations_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ICspInformation>;
@@ -5321,6 +5386,7 @@ impl ICspInformations_Vtbl {
         iid == &<ICspInformations as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICspStatus_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, pcsp: &::core::option::Option<ICspInformation>, palgorithm: &::core::option::Option<ICspAlgorithm>) -> ::windows::core::Result<()>;
@@ -5416,6 +5482,7 @@ impl ICspStatus_Vtbl {
         iid == &<ICspStatus as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICspStatuses_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ICspStatus>;
@@ -5544,6 +5611,7 @@ impl ICspStatuses_Vtbl {
         iid == &<ICspStatuses as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnroll_Impl: Sized {
     fn createFilePKCS10WStr(&self, dnname: &::windows::core::PCWSTR, usage: &::windows::core::PCWSTR, wszpkcs10filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -6050,6 +6118,7 @@ impl IEnroll_Vtbl {
         iid == &<IEnroll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnroll2_Impl: Sized + IEnroll_Impl {
     fn InstallPKCS7Blob(&self, pblobpkcs7: *mut super::CRYPT_INTEGER_BLOB) -> ::windows::core::Result<()>;
@@ -6192,6 +6261,7 @@ impl IEnroll2_Vtbl {
         iid == &<IEnroll2 as ::windows::core::Interface>::IID || iid == &<IEnroll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnroll4_Impl: Sized + IEnroll2_Impl {
     fn SetThumbPrintWStr(&self, thumbprintblob: &super::CRYPT_INTEGER_BLOB) -> ::windows::core::Result<()>;
@@ -6432,6 +6502,7 @@ impl IEnroll4_Vtbl {
         iid == &<IEnroll4 as ::windows::core::Interface>::IID || iid == &<IEnroll as ::windows::core::Interface>::IID || iid == &<IEnroll2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumCERTVIEWATTRIBUTE_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Next(&self, pindex: *mut i32) -> ::windows::core::Result<()>;
@@ -6496,6 +6567,7 @@ impl IEnumCERTVIEWATTRIBUTE_Vtbl {
         iid == &<IEnumCERTVIEWATTRIBUTE as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumCERTVIEWCOLUMN_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Next(&self, pindex: *mut i32) -> ::windows::core::Result<()>;
@@ -6588,6 +6660,7 @@ impl IEnumCERTVIEWCOLUMN_Vtbl {
         iid == &<IEnumCERTVIEWCOLUMN as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumCERTVIEWEXTENSION_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Next(&self, pindex: *mut i32) -> ::windows::core::Result<()>;
@@ -6659,6 +6732,7 @@ impl IEnumCERTVIEWEXTENSION_Vtbl {
         iid == &<IEnumCERTVIEWEXTENSION as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumCERTVIEWROW_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Next(&self, pindex: *mut i32) -> ::windows::core::Result<()>;
@@ -6755,6 +6829,7 @@ impl IEnumCERTVIEWROW_Vtbl {
         iid == &<IEnumCERTVIEWROW as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INDESPolicy_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
@@ -6812,6 +6887,7 @@ impl INDESPolicy_Vtbl {
         iid == &<INDESPolicy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IOCSPAdmin_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn OCSPServiceProperties(&self) -> ::windows::core::Result<IOCSPPropertyCollection>;
@@ -6934,6 +7010,7 @@ impl IOCSPAdmin_Vtbl {
         iid == &<IOCSPAdmin as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IOCSPCAConfiguration_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Identifier(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7208,6 +7285,7 @@ impl IOCSPCAConfiguration_Vtbl {
         iid == &<IOCSPCAConfiguration as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IOCSPCAConfigurationCollection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -7296,6 +7374,7 @@ impl IOCSPCAConfigurationCollection_Vtbl {
         iid == &<IOCSPCAConfigurationCollection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IOCSPProperty_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7358,6 +7437,7 @@ impl IOCSPProperty_Vtbl {
         iid == &<IOCSPProperty as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IOCSPPropertyCollection_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -7466,6 +7546,7 @@ impl IOCSPPropertyCollection_Vtbl {
         iid == &<IOCSPPropertyCollection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IObjectId_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn InitializeFromName(&self, name: CERTENROLL_OBJECTID) -> ::windows::core::Result<()>;
@@ -7562,6 +7643,7 @@ impl IObjectId_Vtbl {
         iid == &<IObjectId as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IObjectIds_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IObjectId>;
@@ -7645,6 +7727,7 @@ impl IObjectIds_Vtbl {
         iid == &<IObjectIds as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPolicyQualifier_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn InitializeEncode(&self, strqualifier: &::windows::core::BSTR, r#type: PolicyQualifierType) -> ::windows::core::Result<()>;
@@ -7720,6 +7803,7 @@ impl IPolicyQualifier_Vtbl {
         iid == &<IPolicyQualifier as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPolicyQualifiers_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IPolicyQualifier>;
@@ -7796,6 +7880,7 @@ impl IPolicyQualifiers_Vtbl {
         iid == &<IPolicyQualifiers as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISignerCertificate_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, machinecontext: super::super::super::Foundation::VARIANT_BOOL, verifytype: X509PrivateKeyVerify, encoding: EncodingType, strcertificate: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -7925,6 +8010,7 @@ impl ISignerCertificate_Vtbl {
         iid == &<ISignerCertificate as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISignerCertificates_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ISignerCertificate>;
@@ -8014,6 +8100,7 @@ impl ISignerCertificates_Vtbl {
         iid == &<ISignerCertificates as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISmimeCapabilities_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<ISmimeCapability>;
@@ -8104,6 +8191,7 @@ impl ISmimeCapabilities_Vtbl {
         iid == &<ISmimeCapabilities as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISmimeCapability_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, pobjectid: &::core::option::Option<IObjectId>, bitcount: i32) -> ::windows::core::Result<()>;
@@ -8153,6 +8241,7 @@ impl ISmimeCapability_Vtbl {
         iid == &<ISmimeCapability as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX500DistinguishedName_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Decode(&self, strencodedname: &::windows::core::BSTR, encoding: EncodingType, nameflags: X500NameFlags) -> ::windows::core::Result<()>;
@@ -8209,6 +8298,7 @@ impl IX500DistinguishedName_Vtbl {
         iid == &<IX500DistinguishedName as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509Attribute_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, pobjectid: &::core::option::Option<IObjectId>, encoding: EncodingType, strencodeddata: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8258,6 +8348,7 @@ impl IX509Attribute_Vtbl {
         iid == &<IX509Attribute as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509AttributeArchiveKey_Impl: Sized + IX509Attribute_Impl {
     fn InitializeEncode(&self, pkey: &::core::option::Option<IX509PrivateKey>, encoding: EncodingType, strcaxcert: &::windows::core::BSTR, palgorithm: &::core::option::Option<IObjectId>, encryptionstrength: i32) -> ::windows::core::Result<()>;
@@ -8327,6 +8418,7 @@ impl IX509AttributeArchiveKey_Vtbl {
         iid == &<IX509AttributeArchiveKey as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Attribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509AttributeArchiveKeyHash_Impl: Sized + IX509Attribute_Impl {
     fn InitializeEncodeFromEncryptedKeyBlob(&self, encoding: EncodingType, strencryptedkeyblob: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8370,6 +8462,7 @@ impl IX509AttributeArchiveKeyHash_Vtbl {
         iid == &<IX509AttributeArchiveKeyHash as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Attribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509AttributeClientId_Impl: Sized + IX509Attribute_Impl {
     fn InitializeEncode(&self, clientid: RequestClientInfoClientId, strmachinednsname: &::windows::core::BSTR, strusersamname: &::windows::core::BSTR, strprocessname: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8452,6 +8545,7 @@ impl IX509AttributeClientId_Vtbl {
         iid == &<IX509AttributeClientId as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Attribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509AttributeCspProvider_Impl: Sized + IX509Attribute_Impl {
     fn InitializeEncode(&self, keyspec: X509KeySpec, strprovidername: &::windows::core::BSTR, encoding: EncodingType, strsignature: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8521,6 +8615,7 @@ impl IX509AttributeCspProvider_Vtbl {
         iid == &<IX509AttributeCspProvider as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Attribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509AttributeExtensions_Impl: Sized + IX509Attribute_Impl {
     fn InitializeEncode(&self, pextensions: &::core::option::Option<IX509Extensions>) -> ::windows::core::Result<()>;
@@ -8564,6 +8659,7 @@ impl IX509AttributeExtensions_Vtbl {
         iid == &<IX509AttributeExtensions as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Attribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509AttributeOSVersion_Impl: Sized + IX509Attribute_Impl {
     fn InitializeEncode(&self, strosversion: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8607,6 +8703,7 @@ impl IX509AttributeOSVersion_Vtbl {
         iid == &<IX509AttributeOSVersion as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Attribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509AttributeRenewalCertificate_Impl: Sized + IX509Attribute_Impl {
     fn InitializeEncode(&self, encoding: EncodingType, strcert: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -8650,6 +8747,7 @@ impl IX509AttributeRenewalCertificate_Vtbl {
         iid == &<IX509AttributeRenewalCertificate as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Attribute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509Attributes_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IX509Attribute>;
@@ -8726,6 +8824,7 @@ impl IX509Attributes_Vtbl {
         iid == &<IX509Attributes as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequest_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, context: X509CertificateEnrollmentContext) -> ::windows::core::Result<()>;
@@ -8995,6 +9094,7 @@ impl IX509CertificateRequest_Vtbl {
         iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestCertificate_Impl: Sized + IX509CertificateRequestPkcs10_Impl {
     fn CheckPublicKeySignature(&self, ppublickey: &::core::option::Option<IX509PublicKey>) -> ::windows::core::Result<()>;
@@ -9118,6 +9218,7 @@ impl IX509CertificateRequestCertificate_Vtbl {
         iid == &<IX509CertificateRequestCertificate as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestCertificate2_Impl: Sized + IX509CertificateRequestCertificate_Impl {
     fn InitializeFromTemplate(&self, context: X509CertificateEnrollmentContext, ppolicyserver: &::core::option::Option<IX509EnrollmentPolicyServer>, ptemplate: &::core::option::Option<IX509CertificateTemplate>) -> ::windows::core::Result<()>;
@@ -9174,6 +9275,7 @@ impl IX509CertificateRequestCertificate2_Vtbl {
         iid == &<IX509CertificateRequestCertificate2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10 as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestCertificate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestCmc_Impl: Sized + IX509CertificateRequestPkcs7_Impl {
     fn InitializeFromInnerRequestTemplateName(&self, pinnerrequest: &::core::option::Option<IX509CertificateRequest>, strtemplatename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -9447,6 +9549,7 @@ impl IX509CertificateRequestCmc_Vtbl {
         iid == &<IX509CertificateRequestCmc as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestCmc2_Impl: Sized + IX509CertificateRequestCmc_Impl {
     fn InitializeFromTemplate(&self, context: X509CertificateEnrollmentContext, ppolicyserver: &::core::option::Option<IX509EnrollmentPolicyServer>, ptemplate: &::core::option::Option<IX509CertificateTemplate>) -> ::windows::core::Result<()>;
@@ -9517,6 +9620,7 @@ impl IX509CertificateRequestCmc2_Vtbl {
         iid == &<IX509CertificateRequestCmc2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs7 as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestCmc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestPkcs10_Impl: Sized + IX509CertificateRequest_Impl {
     fn InitializeFromTemplateName(&self, context: X509CertificateEnrollmentContext, strtemplatename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -9843,6 +9947,7 @@ impl IX509CertificateRequestPkcs10_Vtbl {
         iid == &<IX509CertificateRequestPkcs10 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestPkcs10V2_Impl: Sized + IX509CertificateRequestPkcs10_Impl {
     fn InitializeFromTemplate(&self, context: X509CertificateEnrollmentContext, ppolicyserver: &::core::option::Option<IX509EnrollmentPolicyServer>, ptemplate: &::core::option::Option<IX509CertificateTemplate>) -> ::windows::core::Result<()>;
@@ -9906,6 +10011,7 @@ impl IX509CertificateRequestPkcs10V2_Vtbl {
         iid == &<IX509CertificateRequestPkcs10V2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestPkcs10V3_Impl: Sized + IX509CertificateRequestPkcs10V2_Impl {
     fn AttestPrivateKey(&self) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;
@@ -10035,6 +10141,7 @@ impl IX509CertificateRequestPkcs10V3_Vtbl {
         iid == &<IX509CertificateRequestPkcs10V3 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10 as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10V2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestPkcs10V4_Impl: Sized + IX509CertificateRequestPkcs10V3_Impl {
     fn ClaimType(&self) -> ::windows::core::Result<KeyAttestationClaimType>;
@@ -10091,6 +10198,7 @@ impl IX509CertificateRequestPkcs10V4_Vtbl {
         iid == &<IX509CertificateRequestPkcs10V4 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10 as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10V2 as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs10V3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestPkcs7_Impl: Sized + IX509CertificateRequest_Impl {
     fn InitializeFromTemplateName(&self, context: X509CertificateEnrollmentContext, strtemplatename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -10175,6 +10283,7 @@ impl IX509CertificateRequestPkcs7_Vtbl {
         iid == &<IX509CertificateRequestPkcs7 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRequestPkcs7V2_Impl: Sized + IX509CertificateRequestPkcs7_Impl {
     fn InitializeFromTemplate(&self, context: X509CertificateEnrollmentContext, ppolicyserver: &::core::option::Option<IX509EnrollmentPolicyServer>, ptemplate: &::core::option::Option<IX509CertificateTemplate>) -> ::windows::core::Result<()>;
@@ -10231,6 +10340,7 @@ impl IX509CertificateRequestPkcs7V2_Vtbl {
         iid == &<IX509CertificateRequestPkcs7V2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequest as ::windows::core::Interface>::IID || iid == &<IX509CertificateRequestPkcs7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRevocationList_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self) -> ::windows::core::Result<()>;
@@ -10566,6 +10676,7 @@ impl IX509CertificateRevocationList_Vtbl {
         iid == &<IX509CertificateRevocationList as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRevocationListEntries_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IX509CertificateRevocationListEntry>;
@@ -10662,6 +10773,7 @@ impl IX509CertificateRevocationListEntries_Vtbl {
         iid == &<IX509CertificateRevocationListEntries as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateRevocationListEntry_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, encoding: EncodingType, serialnumber: &::windows::core::BSTR, revocationdate: f64) -> ::windows::core::Result<()>;
@@ -10757,6 +10869,7 @@ impl IX509CertificateRevocationListEntry_Vtbl {
         iid == &<IX509CertificateRevocationListEntry as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateTemplate_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_Property(&self, property: EnrollmentTemplateProperty) -> ::windows::core::Result<super::super::super::System::Com::VARIANT>;
@@ -10783,6 +10896,7 @@ impl IX509CertificateTemplate_Vtbl {
         iid == &<IX509CertificateTemplate as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateTemplateWritable_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, pvalue: &::core::option::Option<IX509CertificateTemplate>) -> ::windows::core::Result<()>;
@@ -10846,6 +10960,7 @@ impl IX509CertificateTemplateWritable_Vtbl {
         iid == &<IX509CertificateTemplateWritable as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509CertificateTemplates_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IX509CertificateTemplate>;
@@ -10948,6 +11063,7 @@ impl IX509CertificateTemplates_Vtbl {
         iid == &<IX509CertificateTemplates as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509EndorsementKey_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn ProviderName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -11077,6 +11193,7 @@ impl IX509EndorsementKey_Vtbl {
         iid == &<IX509EndorsementKey as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509Enrollment_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, context: X509CertificateEnrollmentContext) -> ::windows::core::Result<()>;
@@ -11338,6 +11455,7 @@ impl IX509Enrollment_Vtbl {
         iid == &<IX509Enrollment as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509Enrollment2_Impl: Sized + IX509Enrollment_Impl {
     fn InitializeFromTemplate(&self, context: X509CertificateEnrollmentContext, ppolicyserver: &::core::option::Option<IX509EnrollmentPolicyServer>, ptemplate: &::core::option::Option<IX509CertificateTemplate>) -> ::windows::core::Result<()>;
@@ -11407,6 +11525,7 @@ impl IX509Enrollment2_Vtbl {
         iid == &<IX509Enrollment2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Enrollment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509EnrollmentHelper_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn AddPolicyServer(&self, strenrollmentpolicyserveruri: &::windows::core::BSTR, strenrollmentpolicyid: &::windows::core::BSTR, enrollmentpolicyserverflags: PolicyServerUrlFlags, authflags: X509EnrollmentAuthFlags, strcredential: &::windows::core::BSTR, strpassword: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -11457,6 +11576,7 @@ impl IX509EnrollmentHelper_Vtbl {
         iid == &<IX509EnrollmentHelper as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509EnrollmentPolicyServer_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, bstrpolicyserverurl: &::windows::core::BSTR, bstrpolicyserverid: &::windows::core::BSTR, authflags: X509EnrollmentAuthFlags, fisuntrusted: super::super::super::Foundation::VARIANT_BOOL, context: X509CertificateEnrollmentContext) -> ::windows::core::Result<()>;
@@ -11749,6 +11869,7 @@ impl IX509EnrollmentPolicyServer_Vtbl {
         iid == &<IX509EnrollmentPolicyServer as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509EnrollmentStatus_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn AppendText(&self, strtext: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -11885,6 +12006,7 @@ impl IX509EnrollmentStatus_Vtbl {
         iid == &<IX509EnrollmentStatus as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509EnrollmentWebClassFactory_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn CreateObject(&self, strprogid: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -11911,6 +12033,7 @@ impl IX509EnrollmentWebClassFactory_Vtbl {
         iid == &<IX509EnrollmentWebClassFactory as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509Extension_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, pobjectid: &::core::option::Option<IObjectId>, encoding: EncodingType, strencodeddata: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -11980,6 +12103,7 @@ impl IX509Extension_Vtbl {
         iid == &<IX509Extension as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionAlternativeNames_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, pvalue: &::core::option::Option<IAlternativeNames>) -> ::windows::core::Result<()>;
@@ -12023,6 +12147,7 @@ impl IX509ExtensionAlternativeNames_Vtbl {
         iid == &<IX509ExtensionAlternativeNames as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionAuthorityKeyIdentifier_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, encoding: EncodingType, strkeyidentifier: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -12066,6 +12191,7 @@ impl IX509ExtensionAuthorityKeyIdentifier_Vtbl {
         iid == &<IX509ExtensionAuthorityKeyIdentifier as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionBasicConstraints_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, isca: super::super::super::Foundation::VARIANT_BOOL, pathlenconstraint: i32) -> ::windows::core::Result<()>;
@@ -12122,6 +12248,7 @@ impl IX509ExtensionBasicConstraints_Vtbl {
         iid == &<IX509ExtensionBasicConstraints as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionCertificatePolicies_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, pvalue: &::core::option::Option<ICertificatePolicies>) -> ::windows::core::Result<()>;
@@ -12165,6 +12292,7 @@ impl IX509ExtensionCertificatePolicies_Vtbl {
         iid == &<IX509ExtensionCertificatePolicies as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionEnhancedKeyUsage_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, pvalue: &::core::option::Option<IObjectIds>) -> ::windows::core::Result<()>;
@@ -12208,6 +12336,7 @@ impl IX509ExtensionEnhancedKeyUsage_Vtbl {
         iid == &<IX509ExtensionEnhancedKeyUsage as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionKeyUsage_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, usageflags: X509KeyUsageFlags) -> ::windows::core::Result<()>;
@@ -12251,6 +12380,7 @@ impl IX509ExtensionKeyUsage_Vtbl {
         iid == &<IX509ExtensionKeyUsage as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionMSApplicationPolicies_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, pvalue: &::core::option::Option<ICertificatePolicies>) -> ::windows::core::Result<()>;
@@ -12294,6 +12424,7 @@ impl IX509ExtensionMSApplicationPolicies_Vtbl {
         iid == &<IX509ExtensionMSApplicationPolicies as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionSmimeCapabilities_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, pvalue: &::core::option::Option<ISmimeCapabilities>) -> ::windows::core::Result<()>;
@@ -12337,6 +12468,7 @@ impl IX509ExtensionSmimeCapabilities_Vtbl {
         iid == &<IX509ExtensionSmimeCapabilities as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionSubjectKeyIdentifier_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, encoding: EncodingType, strkeyidentifier: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -12380,6 +12512,7 @@ impl IX509ExtensionSubjectKeyIdentifier_Vtbl {
         iid == &<IX509ExtensionSubjectKeyIdentifier as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionTemplate_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, ptemplateoid: &::core::option::Option<IObjectId>, majorversion: i32, minorversion: i32) -> ::windows::core::Result<()>;
@@ -12449,6 +12582,7 @@ impl IX509ExtensionTemplate_Vtbl {
         iid == &<IX509ExtensionTemplate as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509ExtensionTemplateName_Impl: Sized + IX509Extension_Impl {
     fn InitializeEncode(&self, strtemplatename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -12492,6 +12626,7 @@ impl IX509ExtensionTemplateName_Vtbl {
         iid == &<IX509ExtensionTemplateName as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509Extension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509Extensions_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IX509Extension>;
@@ -12588,6 +12723,7 @@ impl IX509Extensions_Vtbl {
         iid == &<IX509Extensions as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509MachineEnrollmentFactory_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn CreateObject(&self, strprogid: &::windows::core::BSTR) -> ::windows::core::Result<IX509EnrollmentHelper>;
@@ -12614,6 +12750,7 @@ impl IX509MachineEnrollmentFactory_Vtbl {
         iid == &<IX509MachineEnrollmentFactory as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509NameValuePair_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, strname: &::windows::core::BSTR, strvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -12663,6 +12800,7 @@ impl IX509NameValuePair_Vtbl {
         iid == &<IX509NameValuePair as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509NameValuePairs_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IX509NameValuePair>;
@@ -12739,6 +12877,7 @@ impl IX509NameValuePairs_Vtbl {
         iid == &<IX509NameValuePairs as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509PolicyServerListManager_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn get_ItemByIndex(&self, index: i32) -> ::windows::core::Result<IX509PolicyServerUrl>;
@@ -12822,6 +12961,7 @@ impl IX509PolicyServerListManager_Vtbl {
         iid == &<IX509PolicyServerListManager as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509PolicyServerUrl_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, context: X509CertificateEnrollmentContext) -> ::windows::core::Result<()>;
@@ -12979,6 +13119,7 @@ impl IX509PolicyServerUrl_Vtbl {
         iid == &<IX509PolicyServerUrl as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509PrivateKey_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Open(&self) -> ::windows::core::Result<()>;
@@ -13569,6 +13710,7 @@ impl IX509PrivateKey_Vtbl {
         iid == &<IX509PrivateKey as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509PrivateKey2_Impl: Sized + IX509PrivateKey_Impl {
     fn HardwareKeyUsage(&self) -> ::windows::core::Result<X509HardwareKeyUsageFlags>;
@@ -13685,6 +13827,7 @@ impl IX509PrivateKey2_Vtbl {
         iid == &<IX509PrivateKey2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509PrivateKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509PublicKey_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, pobjectid: &::core::option::Option<IObjectId>, strencodedkey: &::windows::core::BSTR, strencodedparameters: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -13780,6 +13923,7 @@ impl IX509PublicKey_Vtbl {
         iid == &<IX509PublicKey as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509SCEPEnrollment_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, prequest: &::core::option::Option<IX509CertificateRequestPkcs10>, strthumbprint: &::windows::core::BSTR, thumprintencoding: EncodingType, strservercertificates: &::windows::core::BSTR, encoding: EncodingType) -> ::windows::core::Result<()>;
@@ -14028,6 +14172,7 @@ impl IX509SCEPEnrollment_Vtbl {
         iid == &<IX509SCEPEnrollment as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509SCEPEnrollment2_Impl: Sized + IX509SCEPEnrollment_Impl {
     fn CreateChallengeAnswerMessage(&self, encoding: EncodingType) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -14116,6 +14261,7 @@ impl IX509SCEPEnrollment2_Vtbl {
         iid == &<IX509SCEPEnrollment2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IX509SCEPEnrollment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509SCEPEnrollmentHelper_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Initialize(&self, strserverurl: &::windows::core::BSTR, strrequestheaders: &::windows::core::BSTR, prequest: &::core::option::Option<IX509CertificateRequestPkcs10>, strcacertificatethumbprint: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -14198,6 +14344,7 @@ impl IX509SCEPEnrollmentHelper_Vtbl {
         iid == &<IX509SCEPEnrollmentHelper as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography_Certificates\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IX509SignatureInformation_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn HashAlgorithm(&self) -> ::windows::core::Result<IObjectId>;

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertSrvSetup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CAErrorId(&self) -> ::windows::core::Result<i32>;
@@ -220,6 +221,7 @@ impl ICertSrvSetup_Vtbl {
         iid == &<ICertSrvSetup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertSrvSetupKeyInformation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ProviderName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -356,6 +358,7 @@ impl ICertSrvSetupKeyInformation_Vtbl {
         iid == &<ICertSrvSetupKeyInformation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertSrvSetupKeyInformationCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -418,6 +421,7 @@ impl ICertSrvSetupKeyInformationCollection_Vtbl {
         iid == &<ICertSrvSetupKeyInformationCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificateEnrollmentPolicyServerSetup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ErrorString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -488,6 +492,7 @@ impl ICertificateEnrollmentPolicyServerSetup_Vtbl {
         iid == &<ICertificateEnrollmentPolicyServerSetup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICertificateEnrollmentServerSetup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ErrorString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -565,6 +570,7 @@ impl ICertificateEnrollmentServerSetup_Vtbl {
         iid == &<ICertificateEnrollmentServerSetup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSCEPSetup_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MSCEPErrorId(&self) -> ::windows::core::Result<i32>;

--- a/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_EnterpriseData\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProtectionPolicyManagerInterop_Impl: Sized {
     fn RequestAccessForWindowAsync(&self, appwindow: super::super::Foundation::HWND, sourceidentity: &::windows::core::HSTRING, targetidentity: &::windows::core::HSTRING, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -28,6 +29,7 @@ impl IProtectionPolicyManagerInterop_Vtbl {
         iid == &<IProtectionPolicyManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_EnterpriseData\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProtectionPolicyManagerInterop2_Impl: Sized {
     fn RequestAccessForAppWithWindowAsync(&self, appwindow: super::super::Foundation::HWND, sourceidentity: &::windows::core::HSTRING, apppackagefamilyname: &::windows::core::HSTRING, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -79,6 +81,7 @@ impl IProtectionPolicyManagerInterop2_Vtbl {
         iid == &<IProtectionPolicyManagerInterop2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_EnterpriseData\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProtectionPolicyManagerInterop3_Impl: Sized {
     fn RequestAccessWithBehaviorForWindowAsync(&self, appwindow: super::super::Foundation::HWND, sourceidentity: &::windows::core::HSTRING, targetidentity: &::windows::core::HSTRING, auditinfounk: &::core::option::Option<::windows::core::IUnknown>, messagefromapp: &::windows::core::HSTRING, behavior: u32, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_ExtensibleAuthenticationProtocol\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAccountingProviderConfig_Impl: Sized {
     fn Initialize(&self, pszmachinename: &::windows::core::PCWSTR) -> ::windows::core::Result<usize>;
@@ -55,6 +56,7 @@ impl IAccountingProviderConfig_Vtbl {
         iid == &<IAccountingProviderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_ExtensibleAuthenticationProtocol\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAuthenticationProviderConfig_Impl: Sized {
     fn Initialize(&self, pszmachinename: &::windows::core::PCWSTR) -> ::windows::core::Result<usize>;
@@ -112,6 +114,7 @@ impl IAuthenticationProviderConfig_Vtbl {
         iid == &<IAuthenticationProviderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_ExtensibleAuthenticationProtocol\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEAPProviderConfig_Impl: Sized {
     fn Initialize(&self, pszmachinename: &::windows::core::PCWSTR, dweaptypeid: u32) -> ::windows::core::Result<usize>;
@@ -170,6 +173,7 @@ impl IEAPProviderConfig_Vtbl {
         iid == &<IEAPProviderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_ExtensibleAuthenticationProtocol\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEAPProviderConfig2_Impl: Sized + IEAPProviderConfig_Impl {
     fn ServerInvokeConfigUI2(&self, dweaptypeid: u32, uconnectionparam: usize, hwnd: super::super::Foundation::HWND, pconfigdatain: *const u8, dwsizeofconfigdatain: u32, ppconfigdataout: *mut *mut u8, pdwsizeofconfigdataout: *mut u32) -> ::windows::core::Result<()>;
@@ -200,6 +204,7 @@ impl IEAPProviderConfig2_Vtbl {
         iid == &<IEAPProviderConfig2 as ::windows::core::Interface>::IID || iid == &<IEAPProviderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_ExtensibleAuthenticationProtocol\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEAPProviderConfig3_Impl: Sized + IEAPProviderConfig2_Impl {
     fn ServerInvokeCertificateConfigUI(&self, dweaptypeid: u32, uconnectionparam: usize, hwnd: super::super::Foundation::HWND, pconfigdatain: *const u8, dwsizeofconfigdatain: u32, ppconfigdataout: *mut *mut u8, pdwsizeofconfigdataout: *mut u32, ureserved: usize) -> ::windows::core::Result<()>;
@@ -223,6 +228,7 @@ impl IEAPProviderConfig3_Vtbl {
         iid == &<IEAPProviderConfig3 as ::windows::core::Interface>::IID || iid == &<IEAPProviderConfig as ::windows::core::Interface>::IID || iid == &<IEAPProviderConfig2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_ExtensibleAuthenticationProtocol\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRouterProtocolConfig_Impl: Sized {
     fn AddProtocol(&self, pszmachinename: &::windows::core::PCWSTR, dwtransportid: u32, dwprotocolid: u32, hwnd: super::super::Foundation::HWND, dwflags: u32, prouter: &::core::option::Option<::windows::core::IUnknown>, ureserved1: usize) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Security/Isolation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Isolation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Isolation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IIsolatedAppLauncher_Impl: Sized {
     fn Launch(&self, appusermodelid: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, telemetryparameters: *const IsolatedAppLauncherTelemetryParameters) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Tpm/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Security_Tpm\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITpmVirtualSmartCardManager_Impl: Sized {
     fn CreateVirtualSmartCard(&self, pszfriendlyname: &::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, fgenerate: super::super::Foundation::BOOL, pstatuscallback: &::core::option::Option<ITpmVirtualSmartCardManagerStatusCallback>, ppszinstanceid: *mut ::windows::core::PWSTR, pfneedreboot: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -50,6 +51,7 @@ impl ITpmVirtualSmartCardManager_Vtbl {
         iid == &<ITpmVirtualSmartCardManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Tpm\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITpmVirtualSmartCardManager2_Impl: Sized + ITpmVirtualSmartCardManager_Impl {
     fn CreateVirtualSmartCardWithPinPolicy(&self, pszfriendlyname: &::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, pbpinpolicy: *const u8, cbpinpolicy: u32, fgenerate: super::super::Foundation::BOOL, pstatuscallback: &::core::option::Option<ITpmVirtualSmartCardManagerStatusCallback>, ppszinstanceid: *mut ::windows::core::PWSTR, pfneedreboot: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -91,6 +93,7 @@ impl ITpmVirtualSmartCardManager2_Vtbl {
         iid == &<ITpmVirtualSmartCardManager2 as ::windows::core::Interface>::IID || iid == &<ITpmVirtualSmartCardManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Tpm\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITpmVirtualSmartCardManager3_Impl: Sized + ITpmVirtualSmartCardManager2_Impl {
     fn CreateVirtualSmartCardWithAttestation(&self, pszfriendlyname: &::windows::core::PCWSTR, badminalgid: u8, pbadminkey: *const u8, cbadminkey: u32, pbadminkcv: *const u8, cbadminkcv: u32, pbpuk: *const u8, cbpuk: u32, pbpin: *const u8, cbpin: u32, pbpinpolicy: *const u8, cbpinpolicy: u32, attestationtype: TPMVSC_ATTESTATION_TYPE, fgenerate: super::super::Foundation::BOOL, pstatuscallback: &::core::option::Option<ITpmVirtualSmartCardManagerStatusCallback>) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -136,6 +139,7 @@ impl ITpmVirtualSmartCardManager3_Vtbl {
         iid == &<ITpmVirtualSmartCardManager3 as ::windows::core::Interface>::IID || iid == &<ITpmVirtualSmartCardManager as ::windows::core::Interface>::IID || iid == &<ITpmVirtualSmartCardManager2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Security_Tpm\"`, `\"implement\"`*"]
 pub trait ITpmVirtualSmartCardManagerStatusCallback_Impl: Sized {
     fn ReportProgress(&self, status: TPMVSCMGR_STATUS) -> ::windows::core::Result<()>;
     fn ReportError(&self, error: TPMVSCMGR_ERROR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`, `\"implement\"`*"]
 pub trait IDedupBackupSupport_Impl: Sized {
     fn RestoreFiles(&self, numberoffiles: u32, filefullpaths: *const ::windows::core::BSTR, store: &::core::option::Option<IDedupReadFileCallback>, flags: u32, fileresults: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IDedupBackupSupport_Vtbl {
         iid == &<IDedupBackupSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDedupChunkLibrary_Impl: Sized {
     fn InitializeForPushBuffers(&self) -> ::windows::core::Result<()>;
@@ -65,6 +67,7 @@ impl IDedupChunkLibrary_Vtbl {
         iid == &<IDedupChunkLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDedupDataPort_Impl: Sized {
     fn GetStatus(&self, pstatus: *mut DedupDataPortVolumeStatus, pdataheadroommb: *mut u32) -> ::windows::core::Result<()>;
@@ -213,6 +216,7 @@ impl IDedupDataPort_Vtbl {
         iid == &<IDedupDataPort as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`, `\"implement\"`*"]
 pub trait IDedupDataPortManager_Impl: Sized {
     fn GetConfiguration(&self, pminchunksize: *mut u32, pmaxchunksize: *mut u32, pchunkingalgorithm: *mut DedupChunkingAlgorithm, phashingalgorithm: *mut DedupHashingAlgorithm, pcompressionalgorithm: *mut DedupCompressionAlgorithm) -> ::windows::core::Result<()>;
     fn GetVolumeStatus(&self, options: u32, path: &::windows::core::BSTR) -> ::windows::core::Result<DedupDataPortVolumeStatus>;
@@ -259,6 +263,7 @@ impl IDedupDataPortManager_Vtbl {
         iid == &<IDedupDataPortManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`, `\"implement\"`*"]
 pub trait IDedupIterateChunksHash32_Impl: Sized {
     fn PushBuffer(&self, pbuffer: *const u8, ulbufferlength: u32) -> ::windows::core::Result<()>;
     fn Next(&self, ulmaxchunks: u32, parrchunks: *mut DEDUP_CHUNK_INFO_HASH32, pulfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -300,6 +305,7 @@ impl IDedupIterateChunksHash32_Vtbl {
         iid == &<IDedupIterateChunksHash32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`, `\"implement\"`*"]
 pub trait IDedupReadFileCallback_Impl: Sized {
     fn ReadBackupFile(&self, filefullpath: &::windows::core::BSTR, fileoffset: i64, sizetoread: u32, filebuffer: *mut u8, returnedsize: *mut u32, flags: u32) -> ::windows::core::Result<()>;
     fn OrderContainersRestore(&self, numberofcontainers: u32, containerpaths: *const ::windows::core::BSTR, readplanentries: *mut u32, readplan: *mut *mut DEDUP_CONTAINER_EXTENT) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_EnhancedStorage\"`, `\"implement\"`*"]
 pub trait IEnhancedStorageACT_Impl: Sized {
     fn Authorize(&self, hwndparent: u32, dwflags: u32) -> ::windows::core::Result<()>;
     fn Unauthorize(&self) -> ::windows::core::Result<()>;
@@ -71,6 +72,7 @@ impl IEnhancedStorageACT_Vtbl {
         iid == &<IEnhancedStorageACT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_EnhancedStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnhancedStorageACT2_Impl: Sized + IEnhancedStorageACT_Impl {
     fn GetDeviceName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -113,6 +115,7 @@ impl IEnhancedStorageACT2_Vtbl {
         iid == &<IEnhancedStorageACT2 as ::windows::core::Interface>::IID || iid == &<IEnhancedStorageACT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_EnhancedStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnhancedStorageACT3_Impl: Sized + IEnhancedStorageACT2_Impl {
     fn UnauthorizeEx(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -162,6 +165,7 @@ impl IEnhancedStorageACT3_Vtbl {
         iid == &<IEnhancedStorageACT3 as ::windows::core::Interface>::IID || iid == &<IEnhancedStorageACT as ::windows::core::Interface>::IID || iid == &<IEnhancedStorageACT2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_EnhancedStorage\"`, `\"Win32_Devices_PortableDevices\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Devices_PortableDevices")]
 pub trait IEnhancedStorageSilo_Impl: Sized {
     fn GetInfo(&self) -> ::windows::core::Result<SILO_INFO>;
@@ -231,6 +235,7 @@ impl IEnhancedStorageSilo_Vtbl {
         iid == &<IEnhancedStorageSilo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_EnhancedStorage\"`, `\"implement\"`*"]
 pub trait IEnhancedStorageSiloAction_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -277,6 +282,7 @@ impl IEnhancedStorageSiloAction_Vtbl {
         iid == &<IEnhancedStorageSiloAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_EnhancedStorage\"`, `\"implement\"`*"]
 pub trait IEnumEnhancedStorageACT_Impl: Sized {
     fn GetACTs(&self, pppienhancedstorageacts: *mut *mut ::core::option::Option<IEnhancedStorageACT>, pcenhancedstorageacts: *mut u32) -> ::windows::core::Result<()>;
     fn GetMatchingACT(&self, szvolume: &::windows::core::PCWSTR) -> ::windows::core::Result<IEnhancedStorageACT>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileHistory/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_FileHistory\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFhConfigMgr_Impl: Sized {
     fn LoadConfiguration(&self) -> ::windows::core::Result<()>;
@@ -142,6 +143,7 @@ impl IFhConfigMgr_Vtbl {
         iid == &<IFhConfigMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileHistory\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFhReassociation_Impl: Sized {
     fn ValidateTarget(&self, targeturl: &::windows::core::BSTR) -> ::windows::core::Result<FH_DEVICE_VALIDATION_RESULT>;
@@ -199,6 +201,7 @@ impl IFhReassociation_Vtbl {
         iid == &<IFhReassociation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileHistory\"`, `\"implement\"`*"]
 pub trait IFhScopeIterator_Impl: Sized {
     fn MoveToNextItem(&self) -> ::windows::core::Result<()>;
     fn GetItem(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -232,6 +235,7 @@ impl IFhScopeIterator_Vtbl {
         iid == &<IFhScopeIterator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileHistory\"`, `\"implement\"`*"]
 pub trait IFhTarget_Impl: Sized {
     fn GetStringProperty(&self, propertytype: FH_TARGET_PROPERTY_TYPE) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetNumericalProperty(&self, propertytype: FH_TARGET_PROPERTY_TYPE) -> ::windows::core::Result<u64>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileServerResourceManager/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DIFsrmClassificationEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -11,6 +12,7 @@ impl DIFsrmClassificationEvents_Vtbl {
         iid == &<DIFsrmClassificationEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmAccessDeniedRemediationClient_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Show(&self, parentwnd: usize, accesspath: &::windows::core::BSTR, errortype: AdrClientErrorType, flags: i32, windowtitle: &::windows::core::BSTR, windowmessage: &::windows::core::BSTR) -> ::windows::core::Result<i32>;
@@ -37,6 +39,7 @@ impl IFsrmAccessDeniedRemediationClient_Vtbl {
         iid == &<IFsrmAccessDeniedRemediationClient as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmAction_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -106,6 +109,7 @@ impl IFsrmAction_Vtbl {
         iid == &<IFsrmAction as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmActionCommand_Impl: Sized + IFsrmAction_Impl {
     fn ExecutablePath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -262,6 +266,7 @@ impl IFsrmActionCommand_Vtbl {
         iid == &<IFsrmActionCommand as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmActionEmail_Impl: Sized + IFsrmAction_Impl {
     fn MailFrom(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -418,6 +423,7 @@ impl IFsrmActionEmail_Vtbl {
         iid == &<IFsrmActionEmail as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmActionEmail2_Impl: Sized + IFsrmActionEmail_Impl {
     fn AttachmentFileListSize(&self) -> ::windows::core::Result<i32>;
@@ -454,6 +460,7 @@ impl IFsrmActionEmail2_Vtbl {
         iid == &<IFsrmActionEmail2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmAction as ::windows::core::Interface>::IID || iid == &<IFsrmActionEmail as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmActionEventLog_Impl: Sized + IFsrmAction_Impl {
     fn EventType(&self) -> ::windows::core::Result<FsrmEventType>;
@@ -510,6 +517,7 @@ impl IFsrmActionEventLog_Vtbl {
         iid == &<IFsrmActionEventLog as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmActionReport_Impl: Sized + IFsrmAction_Impl {
     fn ReportTypes(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -566,6 +574,7 @@ impl IFsrmActionReport_Vtbl {
         iid == &<IFsrmActionReport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmAutoApplyQuota_Impl: Sized + IFsrmQuotaObject_Impl {
     fn ExcludeFolders(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -615,6 +624,7 @@ impl IFsrmAutoApplyQuota_Vtbl {
         iid == &<IFsrmAutoApplyQuota as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaBase as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmClassificationManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ClassificationReportFormats(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -934,6 +944,7 @@ impl IFsrmClassificationManager_Vtbl {
         iid == &<IFsrmClassificationManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmClassificationManager2_Impl: Sized + IFsrmClassificationManager_Impl {
     fn ClassifyFiles(&self, filepaths: *const super::super::System::Com::SAFEARRAY, propertynames: *const super::super::System::Com::SAFEARRAY, propertyvalues: *const super::super::System::Com::SAFEARRAY, options: FsrmGetFilePropertyOptions) -> ::windows::core::Result<()>;
@@ -954,6 +965,7 @@ impl IFsrmClassificationManager2_Vtbl {
         iid == &<IFsrmClassificationManager2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmClassificationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmClassificationRule_Impl: Sized + IFsrmRule_Impl {
     fn ExecutionOption(&self) -> ::windows::core::Result<FsrmExecutionOption>;
@@ -1030,6 +1042,7 @@ impl IFsrmClassificationRule_Vtbl {
         iid == &<IFsrmClassificationRule as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmRule as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmClassifierModuleDefinition_Impl: Sized + IFsrmPipelineModuleDefinition_Impl {
     fn PropertiesAffected(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -1106,6 +1119,7 @@ impl IFsrmClassifierModuleDefinition_Vtbl {
         iid == &<IFsrmClassifierModuleDefinition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmPipelineModuleDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmClassifierModuleImplementation_Impl: Sized + IFsrmPipelineModuleImplementation_Impl {
     fn LastModified(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1170,6 +1184,7 @@ impl IFsrmClassifierModuleImplementation_Vtbl {
         iid == &<IFsrmClassifierModuleImplementation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmPipelineModuleImplementation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmCollection_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1271,6 +1286,7 @@ impl IFsrmCollection_Vtbl {
         iid == &<IFsrmCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmCommittableCollection_Impl: Sized + IFsrmMutableCollection_Impl {
     fn Commit(&self, options: FsrmCommitOptions) -> ::windows::core::Result<IFsrmCollection>;
@@ -1297,6 +1313,7 @@ impl IFsrmCommittableCollection_Vtbl {
         iid == &<IFsrmCommittableCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmCollection as ::windows::core::Interface>::IID || iid == &<IFsrmMutableCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmDerivedObjectsResult_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DerivedObjects(&self) -> ::windows::core::Result<IFsrmCollection>;
@@ -1339,6 +1356,7 @@ impl IFsrmDerivedObjectsResult_Vtbl {
         iid == &<IFsrmDerivedObjectsResult as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmExportImport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ExportFileGroups(&self, filepath: &::windows::core::BSTR, filegroupnamessafearray: *const super::super::System::Com::VARIANT, remotehost: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1415,6 +1433,7 @@ impl IFsrmExportImport_Vtbl {
         iid == &<IFsrmExportImport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileCondition_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<FsrmFileConditionType>;
@@ -1451,6 +1470,7 @@ impl IFsrmFileCondition_Vtbl {
         iid == &<IFsrmFileCondition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileConditionProperty_Impl: Sized + IFsrmFileCondition_Impl {
     fn PropertyName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1567,6 +1587,7 @@ impl IFsrmFileConditionProperty_Vtbl {
         iid == &<IFsrmFileConditionProperty as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmFileCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileGroup_Impl: Sized + IFsrmObject_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1643,6 +1664,7 @@ impl IFsrmFileGroup_Vtbl {
         iid == &<IFsrmFileGroup as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileGroupImported_Impl: Sized + IFsrmFileGroup_Impl {
     fn OverwriteOnCommit(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -1679,6 +1701,7 @@ impl IFsrmFileGroupImported_Vtbl {
         iid == &<IFsrmFileGroupImported as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmFileGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileGroupManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateFileGroup(&self) -> ::windows::core::Result<IFsrmFileGroup>;
@@ -1760,6 +1783,7 @@ impl IFsrmFileGroupManager_Vtbl {
         iid == &<IFsrmFileGroupManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileManagementJob_Impl: Sized + IFsrmObject_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2287,6 +2311,7 @@ impl IFsrmFileManagementJob_Vtbl {
         iid == &<IFsrmFileManagementJob as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileManagementJobManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ActionVariables(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -2368,6 +2393,7 @@ impl IFsrmFileManagementJobManager_Vtbl {
         iid == &<IFsrmFileManagementJobManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileScreen_Impl: Sized + IFsrmFileScreenBase_Impl {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2456,6 +2482,7 @@ impl IFsrmFileScreen_Vtbl {
         iid == &<IFsrmFileScreen as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmFileScreenBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileScreenBase_Impl: Sized + IFsrmObject_Impl {
     fn BlockedFileGroups(&self) -> ::windows::core::Result<IFsrmMutableCollection>;
@@ -2538,6 +2565,7 @@ impl IFsrmFileScreenBase_Vtbl {
         iid == &<IFsrmFileScreenBase as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileScreenException_Impl: Sized + IFsrmObject_Impl {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2587,6 +2615,7 @@ impl IFsrmFileScreenException_Vtbl {
         iid == &<IFsrmFileScreenException as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileScreenManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ActionVariables(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -2720,6 +2749,7 @@ impl IFsrmFileScreenManager_Vtbl {
         iid == &<IFsrmFileScreenManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileScreenTemplate_Impl: Sized + IFsrmFileScreenBase_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2776,6 +2806,7 @@ impl IFsrmFileScreenTemplate_Vtbl {
         iid == &<IFsrmFileScreenTemplate as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmFileScreenBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileScreenTemplateImported_Impl: Sized + IFsrmFileScreenTemplate_Impl {
     fn OverwriteOnCommit(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2812,6 +2843,7 @@ impl IFsrmFileScreenTemplateImported_Vtbl {
         iid == &<IFsrmFileScreenTemplateImported as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmFileScreenBase as ::windows::core::Interface>::IID || iid == &<IFsrmFileScreenTemplate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmFileScreenTemplateManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateTemplate(&self) -> ::windows::core::Result<IFsrmFileScreenTemplate>;
@@ -2893,6 +2925,7 @@ impl IFsrmFileScreenTemplateManager_Vtbl {
         iid == &<IFsrmFileScreenTemplateManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmMutableCollection_Impl: Sized + IFsrmCollection_Impl {
     fn Add(&self, item: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2943,6 +2976,7 @@ impl IFsrmMutableCollection_Vtbl {
         iid == &<IFsrmMutableCollection as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmObject_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3006,6 +3040,7 @@ impl IFsrmObject_Vtbl {
         iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPathMapper_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetSharePathsForLocalPath(&self, localpath: &::windows::core::BSTR) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -3035,6 +3070,7 @@ impl IFsrmPathMapper_Vtbl {
         iid == &<IFsrmPathMapper as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPipelineModuleConnector_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ModuleImplementation(&self) -> ::windows::core::Result<IFsrmPipelineModuleImplementation>;
@@ -3110,6 +3146,7 @@ impl IFsrmPipelineModuleConnector_Vtbl {
         iid == &<IFsrmPipelineModuleConnector as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPipelineModuleDefinition_Impl: Sized + IFsrmObject_Impl {
     fn ModuleClsid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3319,6 +3356,7 @@ impl IFsrmPipelineModuleDefinition_Vtbl {
         iid == &<IFsrmPipelineModuleDefinition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPipelineModuleImplementation_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn OnLoad(&self, moduledefinition: &::core::option::Option<IFsrmPipelineModuleDefinition>) -> ::windows::core::Result<IFsrmPipelineModuleConnector>;
@@ -3355,6 +3393,7 @@ impl IFsrmPipelineModuleImplementation_Vtbl {
         iid == &<IFsrmPipelineModuleImplementation as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3423,6 +3462,7 @@ impl IFsrmProperty_Vtbl {
         iid == &<IFsrmProperty as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPropertyBag_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3700,6 +3740,7 @@ impl IFsrmPropertyBag_Vtbl {
         iid == &<IFsrmPropertyBag as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPropertyBag2_Impl: Sized + IFsrmPropertyBag_Impl {
     fn GetFieldValue(&self, field: FsrmPropertyBagField) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -3742,6 +3783,7 @@ impl IFsrmPropertyBag2_Vtbl {
         iid == &<IFsrmPropertyBag2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmPropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPropertyCondition_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3825,6 +3867,7 @@ impl IFsrmPropertyCondition_Vtbl {
         iid == &<IFsrmPropertyCondition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPropertyDefinition_Impl: Sized + IFsrmObject_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3941,6 +3984,7 @@ impl IFsrmPropertyDefinition_Vtbl {
         iid == &<IFsrmPropertyDefinition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPropertyDefinition2_Impl: Sized + IFsrmPropertyDefinition_Impl {
     fn PropertyDefinitionFlags(&self) -> ::windows::core::Result<i32>;
@@ -4016,6 +4060,7 @@ impl IFsrmPropertyDefinition2_Vtbl {
         iid == &<IFsrmPropertyDefinition2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmPropertyDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmPropertyDefinitionValue_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4084,6 +4129,7 @@ impl IFsrmPropertyDefinitionValue_Vtbl {
         iid == &<IFsrmPropertyDefinitionValue as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuota_Impl: Sized + IFsrmQuotaObject_Impl {
     fn QuotaUsed(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -4153,6 +4199,7 @@ impl IFsrmQuota_Vtbl {
         iid == &<IFsrmQuota as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaBase as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuotaBase_Impl: Sized + IFsrmObject_Impl {
     fn QuotaLimit(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -4269,6 +4316,7 @@ impl IFsrmQuotaBase_Vtbl {
         iid == &<IFsrmQuotaBase as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuotaManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ActionVariables(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -4435,6 +4483,7 @@ impl IFsrmQuotaManager_Vtbl {
         iid == &<IFsrmQuotaManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuotaManagerEx_Impl: Sized + IFsrmQuotaManager_Impl {
     fn IsAffectedByQuota(&self, path: &::windows::core::BSTR, options: FsrmEnumOptions) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -4461,6 +4510,7 @@ impl IFsrmQuotaManagerEx_Vtbl {
         iid == &<IFsrmQuotaManagerEx as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuotaObject_Impl: Sized + IFsrmQuotaBase_Impl {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4549,6 +4599,7 @@ impl IFsrmQuotaObject_Vtbl {
         iid == &<IFsrmQuotaObject as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuotaTemplate_Impl: Sized + IFsrmQuotaBase_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4605,6 +4656,7 @@ impl IFsrmQuotaTemplate_Vtbl {
         iid == &<IFsrmQuotaTemplate as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuotaTemplateImported_Impl: Sized + IFsrmQuotaTemplate_Impl {
     fn OverwriteOnCommit(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -4641,6 +4693,7 @@ impl IFsrmQuotaTemplateImported_Vtbl {
         iid == &<IFsrmQuotaTemplateImported as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaBase as ::windows::core::Interface>::IID || iid == &<IFsrmQuotaTemplate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmQuotaTemplateManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateTemplate(&self) -> ::windows::core::Result<IFsrmQuotaTemplate>;
@@ -4722,6 +4775,7 @@ impl IFsrmQuotaTemplateManager_Vtbl {
         iid == &<IFsrmQuotaTemplateManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmReport_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<FsrmReportType>;
@@ -4831,6 +4885,7 @@ impl IFsrmReport_Vtbl {
         iid == &<IFsrmReport as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmReportJob_Impl: Sized + IFsrmObject_Impl {
     fn Task(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5032,6 +5087,7 @@ impl IFsrmReportJob_Vtbl {
         iid == &<IFsrmReportJob as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmReportManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EnumReportJobs(&self, options: FsrmEnumOptions) -> ::windows::core::Result<IFsrmCollection>;
@@ -5160,6 +5216,7 @@ impl IFsrmReportManager_Vtbl {
         iid == &<IFsrmReportManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmReportScheduler_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn VerifyNamespaces(&self, namespacessafearray: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -5204,6 +5261,7 @@ impl IFsrmReportScheduler_Vtbl {
         iid == &<IFsrmReportScheduler as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmRule_Impl: Sized + IFsrmObject_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5346,6 +5404,7 @@ impl IFsrmRule_Vtbl {
         iid == &<IFsrmRule as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmSetting_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SmtpServer(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5489,6 +5548,7 @@ impl IFsrmSetting_Vtbl {
         iid == &<IFsrmSetting as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmStorageModuleDefinition_Impl: Sized + IFsrmPipelineModuleDefinition_Impl {
     fn Capabilities(&self) -> ::windows::core::Result<FsrmStorageModuleCaps>;
@@ -5565,6 +5625,7 @@ impl IFsrmStorageModuleDefinition_Vtbl {
         iid == &<IFsrmStorageModuleDefinition as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsrmObject as ::windows::core::Interface>::IID || iid == &<IFsrmPipelineModuleDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileServerResourceManager\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsrmStorageModuleImplementation_Impl: Sized + IFsrmPipelineModuleImplementation_Impl {
     fn UseDefinitions(&self, propertydefinitions: &::core::option::Option<IFsrmCollection>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_FileSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDiskQuotaControl_Impl: Sized + super::super::System::Com::IConnectionPointContainer_Impl {
     fn Initialize(&self, pszpath: &::windows::core::PCWSTR, breadwrite: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -191,6 +192,7 @@ impl IDiskQuotaControl_Vtbl {
         iid == &<IDiskQuotaControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IConnectionPointContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileSystem\"`, `\"implement\"`*"]
 pub trait IDiskQuotaEvents_Impl: Sized {
     fn OnUserNameChanged(&self, puser: &::core::option::Option<IDiskQuotaUser>) -> ::windows::core::Result<()>;
 }
@@ -208,6 +210,7 @@ impl IDiskQuotaEvents_Vtbl {
         iid == &<IDiskQuotaEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileSystem\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDiskQuotaUser_Impl: Sized {
     fn GetID(&self, pulid: *mut u32) -> ::windows::core::Result<()>;
@@ -329,6 +332,7 @@ impl IDiskQuotaUser_Vtbl {
         iid == &<IDiskQuotaUser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileSystem\"`, `\"implement\"`*"]
 pub trait IDiskQuotaUserBatch_Impl: Sized {
     fn Add(&self, puser: &::core::option::Option<IDiskQuotaUser>) -> ::windows::core::Result<()>;
     fn Remove(&self, puser: &::core::option::Option<IDiskQuotaUser>) -> ::windows::core::Result<()>;
@@ -370,6 +374,7 @@ impl IDiskQuotaUserBatch_Vtbl {
         iid == &<IDiskQuotaUserBatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_FileSystem\"`, `\"implement\"`*"]
 pub trait IEnumDiskQuotaUsers_Impl: Sized {
     fn Next(&self, cusers: u32, rgusers: *mut ::core::option::Option<IDiskQuotaUser>, pcusersfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cusers: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DDiscFormat2DataEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl DDiscFormat2DataEvents_Vtbl {
         iid == &<DDiscFormat2DataEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DDiscFormat2EraseEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, elapsedseconds: i32, estimatedtotalseconds: i32) -> ::windows::core::Result<()>;
@@ -38,6 +40,7 @@ impl DDiscFormat2EraseEvents_Vtbl {
         iid == &<DDiscFormat2EraseEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DDiscFormat2RawCDEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -58,6 +61,7 @@ impl DDiscFormat2RawCDEvents_Vtbl {
         iid == &<DDiscFormat2RawCDEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DDiscFormat2TrackAtOnceEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -78,6 +82,7 @@ impl DDiscFormat2TrackAtOnceEvents_Vtbl {
         iid == &<DDiscFormat2TrackAtOnceEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DDiscMaster2Events_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn NotifyDeviceAdded(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, uniqueid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -108,6 +113,7 @@ impl DDiscMaster2Events_Vtbl {
         iid == &<DDiscMaster2Events as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DFileSystemImageEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, currentfile: &::windows::core::BSTR, copiedsectors: i32, totalsectors: i32) -> ::windows::core::Result<()>;
@@ -128,6 +134,7 @@ impl DFileSystemImageEvents_Vtbl {
         iid == &<DFileSystemImageEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DFileSystemImageImportEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn UpdateImport(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, filesystem: FsiFileSystems, currentitem: &::windows::core::BSTR, importeddirectoryitems: i32, totaldirectoryitems: i32, importedfileitems: i32, totalfileitems: i32) -> ::windows::core::Result<()>;
@@ -148,6 +155,7 @@ impl DFileSystemImageImportEvents_Vtbl {
         iid == &<DFileSystemImageImportEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DWriteEngine2Events_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Update(&self, object: &::core::option::Option<super::super::System::Com::IDispatch>, progress: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -168,6 +176,7 @@ impl DWriteEngine2Events_Vtbl {
         iid == &<DWriteEngine2Events as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBlockRange_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartLba(&self) -> ::windows::core::Result<i32>;
@@ -210,6 +219,7 @@ impl IBlockRange_Vtbl {
         iid == &<IBlockRange as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBlockRangeList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn BlockRanges(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -236,6 +246,7 @@ impl IBlockRangeList_Vtbl {
         iid == &<IBlockRangeList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBootOptions_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn BootImage(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -345,6 +356,7 @@ impl IBootOptions_Vtbl {
         iid == &<IBootOptions as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"implement\"`*"]
 pub trait IBurnVerification_Impl: Sized {
     fn SetBurnVerificationLevel(&self, value: IMAPI_BURN_VERIFICATION_LEVEL) -> ::windows::core::Result<()>;
     fn BurnVerificationLevel(&self) -> ::windows::core::Result<IMAPI_BURN_VERIFICATION_LEVEL>;
@@ -378,6 +390,7 @@ impl IBurnVerification_Vtbl {
         iid == &<IBurnVerification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsRecorderSupported(&self, recorder: &::core::option::Option<IDiscRecorder2>) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -459,6 +472,7 @@ impl IDiscFormat2_Vtbl {
         iid == &<IDiscFormat2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2Data_Impl: Sized + IDiscFormat2_Impl {
     fn SetRecorder(&self, value: &::core::option::Option<IDiscRecorder2>) -> ::windows::core::Result<()>;
@@ -831,6 +845,7 @@ impl IDiscFormat2Data_Vtbl {
         iid == &<IDiscFormat2Data as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDiscFormat2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2DataEventArgs_Impl: Sized + IWriteEngine2EventArgs_Impl {
     fn ElapsedTime(&self) -> ::windows::core::Result<i32>;
@@ -899,6 +914,7 @@ impl IDiscFormat2DataEventArgs_Vtbl {
         iid == &<IDiscFormat2DataEventArgs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWriteEngine2EventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2Erase_Impl: Sized + IDiscFormat2_Impl {
     fn SetRecorder(&self, value: &::core::option::Option<IDiscRecorder2>) -> ::windows::core::Result<()>;
@@ -995,6 +1011,7 @@ impl IDiscFormat2Erase_Vtbl {
         iid == &<IDiscFormat2Erase as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDiscFormat2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2RawCD_Impl: Sized + IDiscFormat2_Impl {
     fn PrepareMedia(&self) -> ::windows::core::Result<()>;
@@ -1263,6 +1280,7 @@ impl IDiscFormat2RawCD_Vtbl {
         iid == &<IDiscFormat2RawCD as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDiscFormat2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2RawCDEventArgs_Impl: Sized + IWriteEngine2EventArgs_Impl {
     fn CurrentAction(&self) -> ::windows::core::Result<IMAPI_FORMAT2_RAW_CD_WRITE_ACTION>;
@@ -1318,6 +1336,7 @@ impl IDiscFormat2RawCDEventArgs_Vtbl {
         iid == &<IDiscFormat2RawCDEventArgs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWriteEngine2EventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2TrackAtOnce_Impl: Sized + IDiscFormat2_Impl {
     fn PrepareMedia(&self) -> ::windows::core::Result<()>;
@@ -1605,6 +1624,7 @@ impl IDiscFormat2TrackAtOnce_Vtbl {
         iid == &<IDiscFormat2TrackAtOnce as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDiscFormat2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscFormat2TrackAtOnceEventArgs_Impl: Sized + IWriteEngine2EventArgs_Impl {
     fn CurrentTrackNumber(&self) -> ::windows::core::Result<i32>;
@@ -1673,6 +1693,7 @@ impl IDiscFormat2TrackAtOnceEventArgs_Vtbl {
         iid == &<IDiscFormat2TrackAtOnceEventArgs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWriteEngine2EventArgs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"implement\"`*"]
 pub trait IDiscMaster_Impl: Sized {
     fn Open(&self) -> ::windows::core::Result<()>;
     fn EnumDiscMasterFormats(&self) -> ::windows::core::Result<IEnumDiscMasterFormats>;
@@ -1800,6 +1821,7 @@ impl IDiscMaster_Vtbl {
         iid == &<IDiscMaster as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscMaster2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
@@ -1868,6 +1890,7 @@ impl IDiscMaster2_Vtbl {
         iid == &<IDiscMaster2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"implement\"`*"]
 pub trait IDiscMasterProgressEvents_Impl: Sized {
     fn QueryCancel(&self) -> ::windows::core::Result<u8>;
     fn NotifyPnPActivity(&self) -> ::windows::core::Result<()>;
@@ -1950,6 +1973,7 @@ impl IDiscMasterProgressEvents_Vtbl {
         iid == &<IDiscMasterProgressEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IDiscRecorder_Impl: Sized {
     fn Init(&self, pbyuniqueid: *const u8, nulidsize: u32, nuldrivenumber: u32) -> ::windows::core::Result<()>;
@@ -2101,6 +2125,7 @@ impl IDiscRecorder_Vtbl {
         iid == &<IDiscRecorder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDiscRecorder2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EjectMedia(&self) -> ::windows::core::Result<()>;
@@ -2348,6 +2373,7 @@ impl IDiscRecorder2_Vtbl {
         iid == &<IDiscRecorder2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDiscRecorder2Ex_Impl: Sized {
     fn SendCommandNoData(&self, cdb: *const u8, cdbsize: u32, sensebuffer: *mut u8, timeout: u32) -> ::windows::core::Result<()>;
@@ -2508,6 +2534,7 @@ impl IDiscRecorder2Ex_Vtbl {
         iid == &<IDiscRecorder2Ex as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"implement\"`*"]
 pub trait IEnumDiscMasterFormats_Impl: Sized {
     fn Next(&self, cformats: u32, lpiidformatid: *mut ::windows::core::GUID, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cformats: u32) -> ::windows::core::Result<()>;
@@ -2555,6 +2582,7 @@ impl IEnumDiscMasterFormats_Vtbl {
         iid == &<IEnumDiscMasterFormats as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"implement\"`*"]
 pub trait IEnumDiscRecorders_Impl: Sized {
     fn Next(&self, crecorders: u32, pprecorder: *mut ::core::option::Option<IDiscRecorder>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, crecorders: u32) -> ::windows::core::Result<()>;
@@ -2602,6 +2630,7 @@ impl IEnumDiscRecorders_Vtbl {
         iid == &<IEnumDiscRecorders as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumFsiItems_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IFsiItem>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -2652,6 +2681,7 @@ impl IEnumFsiItems_Vtbl {
         iid == &<IEnumFsiItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumProgressItems_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IProgressItem>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -2702,6 +2732,7 @@ impl IEnumProgressItems_Vtbl {
         iid == &<IEnumProgressItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFileSystemImage_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Root(&self) -> ::windows::core::Result<IFsiDirectoryItem>;
@@ -3260,6 +3291,7 @@ impl IFileSystemImage_Vtbl {
         iid == &<IFileSystemImage as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFileSystemImage2_Impl: Sized + IFileSystemImage_Impl {
     fn BootImageOptionsArray(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -3296,6 +3328,7 @@ impl IFileSystemImage2_Vtbl {
         iid == &<IFileSystemImage2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFileSystemImage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFileSystemImage3_Impl: Sized + IFileSystemImage2_Impl {
     fn CreateRedundantUdfMetadataFiles(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3345,6 +3378,7 @@ impl IFileSystemImage3_Vtbl {
         iid == &<IFileSystemImage3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFileSystemImage as ::windows::core::Interface>::IID || iid == &<IFileSystemImage2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFileSystemImageResult_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ImageStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -3426,6 +3460,7 @@ impl IFileSystemImageResult_Vtbl {
         iid == &<IFileSystemImageResult as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFileSystemImageResult2_Impl: Sized + IFileSystemImageResult_Impl {
     fn ModifiedBlocks(&self) -> ::windows::core::Result<IBlockRangeList>;
@@ -3452,6 +3487,7 @@ impl IFileSystemImageResult2_Vtbl {
         iid == &<IFileSystemImageResult2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFileSystemImageResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsiDirectoryItem_Impl: Sized + IFsiItem_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
@@ -3562,6 +3598,7 @@ impl IFsiDirectoryItem_Vtbl {
         iid == &<IFsiDirectoryItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsiItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsiDirectoryItem2_Impl: Sized + IFsiDirectoryItem_Impl {
     fn AddTreeWithNamedStreams(&self, sourcedirectory: &::windows::core::BSTR, includebasedirectory: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3582,6 +3619,7 @@ impl IFsiDirectoryItem2_Vtbl {
         iid == &<IFsiDirectoryItem2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsiItem as ::windows::core::Interface>::IID || iid == &<IFsiDirectoryItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsiFileItem_Impl: Sized + IFsiItem_Impl {
     fn DataSize(&self) -> ::windows::core::Result<i64>;
@@ -3657,6 +3695,7 @@ impl IFsiFileItem_Vtbl {
         iid == &<IFsiFileItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsiItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsiFileItem2_Impl: Sized + IFsiFileItem_Impl {
     fn FsiNamedStreams(&self) -> ::windows::core::Result<IFsiNamedStreams>;
@@ -3733,6 +3772,7 @@ impl IFsiFileItem2_Vtbl {
         iid == &<IFsiFileItem2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IFsiItem as ::windows::core::Interface>::IID || iid == &<IFsiFileItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsiItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3881,6 +3921,7 @@ impl IFsiItem_Vtbl {
         iid == &<IFsiItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFsiNamedStreams_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
@@ -3949,6 +3990,7 @@ impl IFsiNamedStreams_Vtbl {
         iid == &<IFsiNamedStreams as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IIsoImageManager_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4012,6 +4054,7 @@ impl IIsoImageManager_Vtbl {
         iid == &<IIsoImageManager as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IJolietDiscMaster_Impl: Sized {
     fn GetTotalDataBlocks(&self) -> ::windows::core::Result<i32>;
@@ -4094,6 +4137,7 @@ impl IJolietDiscMaster_Vtbl {
         iid == &<IJolietDiscMaster as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMultisession_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsSupportedOnCurrentMediaState(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -4156,6 +4200,7 @@ impl IMultisession_Vtbl {
         iid == &<IMultisession as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMultisessionRandomWrite_Impl: Sized + IMultisession_Impl {
     fn WriteUnitSize(&self) -> ::windows::core::Result<i32>;
@@ -4211,6 +4256,7 @@ impl IMultisessionRandomWrite_Vtbl {
         iid == &<IMultisessionRandomWrite as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMultisession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMultisessionSequential_Impl: Sized + IMultisession_Impl {
     fn IsFirstDataSession(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -4292,6 +4338,7 @@ impl IMultisessionSequential_Vtbl {
         iid == &<IMultisessionSequential as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMultisession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMultisessionSequential2_Impl: Sized + IMultisessionSequential_Impl {
     fn WriteUnitSize(&self) -> ::windows::core::Result<i32>;
@@ -4318,6 +4365,7 @@ impl IMultisessionSequential2_Vtbl {
         iid == &<IMultisessionSequential2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMultisession as ::windows::core::Interface>::IID || iid == &<IMultisessionSequential as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IProgressItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4386,6 +4434,7 @@ impl IProgressItem_Vtbl {
         iid == &<IProgressItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IProgressItems_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<super::super::System::Ole::IEnumVARIANT>;
@@ -4480,6 +4529,7 @@ impl IProgressItems_Vtbl {
         iid == &<IProgressItems as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRawCDImageCreator_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn CreateResultImage(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -4701,6 +4751,7 @@ impl IRawCDImageCreator_Vtbl {
         iid == &<IRawCDImageCreator as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRawCDImageTrackInfo_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartingLba(&self) -> ::windows::core::Result<i32>;
@@ -4856,6 +4907,7 @@ impl IRawCDImageTrackInfo_Vtbl {
         iid == &<IRawCDImageTrackInfo as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"implement\"`*"]
 pub trait IRedbookDiscMaster_Impl: Sized {
     fn GetTotalAudioTracks(&self) -> ::windows::core::Result<i32>;
     fn GetTotalAudioBlocks(&self) -> ::windows::core::Result<i32>;
@@ -4955,6 +5007,7 @@ impl IRedbookDiscMaster_Vtbl {
         iid == &<IRedbookDiscMaster as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStreamConcatenate_Impl: Sized + super::super::System::Com::IStream_Impl {
     fn Initialize(&self, stream1: &::core::option::Option<super::super::System::Com::IStream>, stream2: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -4999,6 +5052,7 @@ impl IStreamConcatenate_Vtbl {
         iid == &<IStreamConcatenate as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStreamInterleave_Impl: Sized + super::super::System::Com::IStream_Impl {
     fn Initialize(&self, streams: *const ::core::option::Option<super::super::System::Com::IStream>, interleavesizes: *const u32, streamcount: u32) -> ::windows::core::Result<()>;
@@ -5019,6 +5073,7 @@ impl IStreamInterleave_Vtbl {
         iid == &<IStreamInterleave as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStreamPseudoRandomBased_Impl: Sized + super::super::System::Com::IStream_Impl {
     fn SetSeed(&self, value: u32) -> ::windows::core::Result<()>;
@@ -5069,6 +5124,7 @@ impl IStreamPseudoRandomBased_Vtbl {
         iid == &<IStreamPseudoRandomBased as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWriteEngine2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn WriteSection(&self, data: &::core::option::Option<super::super::System::Com::IStream>, startingblockaddress: i32, numberofblocks: i32) -> ::windows::core::Result<()>;
@@ -5212,6 +5268,7 @@ impl IWriteEngine2_Vtbl {
         iid == &<IWriteEngine2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWriteEngine2EventArgs_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn StartLba(&self) -> ::windows::core::Result<i32>;
@@ -5319,6 +5376,7 @@ impl IWriteEngine2EventArgs_Vtbl {
         iid == &<IWriteEngine2EventArgs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWriteSpeedDescriptor_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MediaType(&self) -> ::windows::core::Result<IMAPI_MEDIA_PHYSICAL_TYPE>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IndexServer/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_IndexServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IFilter_Impl: Sized {
     fn Init(&self, grfflags: u32, cattributes: u32, aattributes: *const FULLPROPSPEC, pflags: *mut u32) -> i32;
@@ -49,6 +50,7 @@ impl IFilter_Vtbl {
         iid == &<IFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 pub trait IPhraseSink_Impl: Sized {
     fn PutSmallPhrase(&self, pwcnoun: &::windows::core::PCWSTR, cwcnoun: u32, pwcmodifier: &::windows::core::PCWSTR, cwcmodifier: u32, ulattachmenttype: u32) -> ::windows::core::Result<()>;
     fn PutPhrase(&self, pwcphrase: &::windows::core::PCWSTR, cwcphrase: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OfflineFiles/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"implement\"`*"]
 pub trait IEnumOfflineFilesItems_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IOfflineFilesItem>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -45,6 +46,7 @@ impl IEnumOfflineFilesItems_Vtbl {
         iid == &<IEnumOfflineFilesItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"implement\"`*"]
 pub trait IEnumOfflineFilesSettings_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IOfflineFilesSetting>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -92,6 +94,7 @@ impl IEnumOfflineFilesSettings_Vtbl {
         iid == &<IEnumOfflineFilesSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesCache_Impl: Sized {
     fn Synchronize(&self, hwndparent: super::super::Foundation::HWND, rgpszpaths: *const ::windows::core::PCWSTR, cpaths: u32, basync: super::super::Foundation::BOOL, dwsynccontrol: u32, pisyncconflicthandler: &::core::option::Option<IOfflineFilesSyncConflictHandler>, piprogress: &::core::option::Option<IOfflineFilesSyncProgress>, psyncid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -257,6 +260,7 @@ impl IOfflineFilesCache_Vtbl {
         iid == &<IOfflineFilesCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesCache2_Impl: Sized + IOfflineFilesCache_Impl {
     fn RenameItemEx(&self, pszpathoriginal: &::windows::core::PCWSTR, pszpathnew: &::windows::core::PCWSTR, breplaceifexists: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -277,6 +281,7 @@ impl IOfflineFilesCache2_Vtbl {
         iid == &<IOfflineFilesCache2 as ::windows::core::Interface>::IID || iid == &<IOfflineFilesCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesChangeInfo_Impl: Sized {
     fn IsDirty(&self, pbdirty: *mut super::super::Foundation::BOOL) -> ::windows::core::HRESULT;
@@ -365,6 +370,7 @@ impl IOfflineFilesChangeInfo_Vtbl {
         iid == &<IOfflineFilesChangeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesConnectionInfo_Impl: Sized {
     fn GetConnectState(&self, pconnectstate: *mut OFFLINEFILES_CONNECT_STATE, pofflinereason: *mut OFFLINEFILES_OFFLINE_REASON) -> ::windows::core::Result<()>;
@@ -415,6 +421,7 @@ impl IOfflineFilesConnectionInfo_Vtbl {
         iid == &<IOfflineFilesConnectionInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesDirectoryItem_Impl: Sized + IOfflineFilesItem_Impl {}
 #[cfg(feature = "Win32_Foundation")]
@@ -428,6 +435,7 @@ impl IOfflineFilesDirectoryItem_Vtbl {
         iid == &<IOfflineFilesDirectoryItem as ::windows::core::Interface>::IID || iid == &<IOfflineFilesItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"implement\"`*"]
 pub trait IOfflineFilesDirtyInfo_Impl: Sized {
     fn LocalDirtyByteCount(&self) -> ::windows::core::Result<i64>;
     fn RemoteDirtyByteCount(&self) -> ::windows::core::Result<i64>;
@@ -467,6 +475,7 @@ impl IOfflineFilesDirtyInfo_Vtbl {
         iid == &<IOfflineFilesDirtyInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOfflineFilesErrorInfo_Impl: Sized {
     fn GetRawData(&self) -> ::windows::core::Result<*mut super::super::System::Com::BYTE_BLOB>;
@@ -509,6 +518,7 @@ impl IOfflineFilesErrorInfo_Vtbl {
         iid == &<IOfflineFilesErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesEvents_Impl: Sized {
     fn CacheMoved(&self, pszoldpath: &::windows::core::PCWSTR, psznewpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -700,6 +710,7 @@ impl IOfflineFilesEvents_Vtbl {
         iid == &<IOfflineFilesEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesEvents2_Impl: Sized + IOfflineFilesEvents_Impl {
     fn ItemReconnectBegin(&self) -> ::windows::core::Result<()>;
@@ -779,6 +790,7 @@ impl IOfflineFilesEvents2_Vtbl {
         iid == &<IOfflineFilesEvents2 as ::windows::core::Interface>::IID || iid == &<IOfflineFilesEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesEvents3_Impl: Sized + IOfflineFilesEvents2_Impl {
     fn TransparentCacheItemNotify(&self, pszpath: &::windows::core::PCWSTR, eventtype: OFFLINEFILES_EVENTS, itemtype: OFFLINEFILES_ITEM_TYPE, bmodifieddata: super::super::Foundation::BOOL, bmodifiedattributes: super::super::Foundation::BOOL, pzsoldpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -816,6 +828,7 @@ impl IOfflineFilesEvents3_Vtbl {
         iid == &<IOfflineFilesEvents3 as ::windows::core::Interface>::IID || iid == &<IOfflineFilesEvents as ::windows::core::Interface>::IID || iid == &<IOfflineFilesEvents2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesEvents4_Impl: Sized + IOfflineFilesEvents3_Impl {
     fn PrefetchCloseHandleBegin(&self) -> ::windows::core::Result<()>;
@@ -846,6 +859,7 @@ impl IOfflineFilesEvents4_Vtbl {
         iid == &<IOfflineFilesEvents4 as ::windows::core::Interface>::IID || iid == &<IOfflineFilesEvents as ::windows::core::Interface>::IID || iid == &<IOfflineFilesEvents2 as ::windows::core::Interface>::IID || iid == &<IOfflineFilesEvents3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"implement\"`*"]
 pub trait IOfflineFilesEventsFilter_Impl: Sized {
     fn GetPathFilter(&self, ppszfilter: *mut ::windows::core::PWSTR, pmatch: *mut OFFLINEFILES_PATHFILTER_MATCH) -> ::windows::core::Result<()>;
     fn GetIncludedEvents(&self, celements: u32, prgevents: *mut OFFLINEFILES_EVENTS, pcevents: *mut u32) -> ::windows::core::Result<()>;
@@ -880,6 +894,7 @@ impl IOfflineFilesEventsFilter_Vtbl {
         iid == &<IOfflineFilesEventsFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesFileItem_Impl: Sized + IOfflineFilesItem_Impl {
     fn IsSparse(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -922,6 +937,7 @@ impl IOfflineFilesFileItem_Vtbl {
         iid == &<IOfflineFilesFileItem as ::windows::core::Interface>::IID || iid == &<IOfflineFilesItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesFileSysInfo_Impl: Sized {
     fn GetAttributes(&self, copy: OFFLINEFILES_ITEM_COPY) -> ::windows::core::Result<u32>;
@@ -971,6 +987,7 @@ impl IOfflineFilesFileSysInfo_Vtbl {
         iid == &<IOfflineFilesFileSysInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesGhostInfo_Impl: Sized {
     fn IsGhosted(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -997,6 +1014,7 @@ impl IOfflineFilesGhostInfo_Vtbl {
         iid == &<IOfflineFilesGhostInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesItem_Impl: Sized {
     fn GetItemType(&self) -> ::windows::core::Result<OFFLINEFILES_ITEM_TYPE>;
@@ -1072,6 +1090,7 @@ impl IOfflineFilesItem_Vtbl {
         iid == &<IOfflineFilesItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"implement\"`*"]
 pub trait IOfflineFilesItemContainer_Impl: Sized {
     fn EnumItems(&self, dwqueryflags: u32) -> ::windows::core::Result<IEnumOfflineFilesItems>;
     fn EnumItemsEx(&self, pincludefilefilter: &::core::option::Option<IOfflineFilesItemFilter>, pincludedirfilter: &::core::option::Option<IOfflineFilesItemFilter>, pexcludefilefilter: &::core::option::Option<IOfflineFilesItemFilter>, pexcludedirfilter: &::core::option::Option<IOfflineFilesItemFilter>, dwenumflags: u32, dwqueryflags: u32) -> ::windows::core::Result<IEnumOfflineFilesItems>;
@@ -1111,6 +1130,7 @@ impl IOfflineFilesItemContainer_Vtbl {
         iid == &<IOfflineFilesItemContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesItemFilter_Impl: Sized {
     fn GetFilterFlags(&self, pullflags: *mut u64, pullmask: *mut u64) -> ::windows::core::Result<()>;
@@ -1148,6 +1168,7 @@ impl IOfflineFilesItemFilter_Vtbl {
         iid == &<IOfflineFilesItemFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesPinInfo_Impl: Sized {
     fn IsPinned(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -1205,6 +1226,7 @@ impl IOfflineFilesPinInfo_Vtbl {
         iid == &<IOfflineFilesPinInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesPinInfo2_Impl: Sized + IOfflineFilesPinInfo_Impl {
     fn IsPartlyPinned(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -1231,6 +1253,7 @@ impl IOfflineFilesPinInfo2_Vtbl {
         iid == &<IOfflineFilesPinInfo2 as ::windows::core::Interface>::IID || iid == &<IOfflineFilesPinInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesProgress_Impl: Sized {
     fn Begin(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -1280,6 +1303,7 @@ impl IOfflineFilesProgress_Vtbl {
         iid == &<IOfflineFilesProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesServerItem_Impl: Sized + IOfflineFilesItem_Impl {}
 #[cfg(feature = "Win32_Foundation")]
@@ -1293,6 +1317,7 @@ impl IOfflineFilesServerItem_Vtbl {
         iid == &<IOfflineFilesServerItem as ::windows::core::Interface>::IID || iid == &<IOfflineFilesItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IOfflineFilesSetting_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1396,6 +1421,7 @@ impl IOfflineFilesSetting_Vtbl {
         iid == &<IOfflineFilesSetting as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesShareInfo_Impl: Sized {
     fn GetShareItem(&self) -> ::windows::core::Result<IOfflineFilesShareItem>;
@@ -1451,6 +1477,7 @@ impl IOfflineFilesShareInfo_Vtbl {
         iid == &<IOfflineFilesShareInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesShareItem_Impl: Sized + IOfflineFilesItem_Impl {}
 #[cfg(feature = "Win32_Foundation")]
@@ -1464,6 +1491,7 @@ impl IOfflineFilesShareItem_Vtbl {
         iid == &<IOfflineFilesShareItem as ::windows::core::Interface>::IID || iid == &<IOfflineFilesItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesSimpleProgress_Impl: Sized + IOfflineFilesProgress_Impl {
     fn ItemBegin(&self, pszfile: &::windows::core::PCWSTR) -> ::windows::core::Result<OFFLINEFILES_OP_RESPONSE>;
@@ -1506,6 +1534,7 @@ impl IOfflineFilesSimpleProgress_Vtbl {
         iid == &<IOfflineFilesSimpleProgress as ::windows::core::Interface>::IID || iid == &<IOfflineFilesProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesSuspend_Impl: Sized {
     fn SuspendRoot(&self, bsuspend: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1526,6 +1555,7 @@ impl IOfflineFilesSuspend_Vtbl {
         iid == &<IOfflineFilesSuspend as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesSuspendInfo_Impl: Sized {
     fn IsSuspended(&self, pbsuspended: *mut super::super::Foundation::BOOL, pbsuspendedroot: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1546,6 +1576,7 @@ impl IOfflineFilesSuspendInfo_Vtbl {
         iid == &<IOfflineFilesSuspendInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"implement\"`*"]
 pub trait IOfflineFilesSyncConflictHandler_Impl: Sized {
     fn ResolveConflict(&self, pszpath: &::windows::core::PCWSTR, fstateknown: u32, state: OFFLINEFILES_SYNC_STATE, fchangedetails: u32, pconflictresolution: *mut OFFLINEFILES_SYNC_CONFLICT_RESOLVE, ppsznewname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
@@ -1563,6 +1594,7 @@ impl IOfflineFilesSyncConflictHandler_Vtbl {
         iid == &<IOfflineFilesSyncConflictHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOfflineFilesSyncErrorInfo_Impl: Sized + IOfflineFilesErrorInfo_Impl {
     fn GetSyncOperation(&self) -> ::windows::core::Result<OFFLINEFILES_SYNC_OPERATION>;
@@ -1658,6 +1690,7 @@ impl IOfflineFilesSyncErrorInfo_Vtbl {
         iid == &<IOfflineFilesSyncErrorInfo as ::windows::core::Interface>::IID || iid == &<IOfflineFilesErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesSyncErrorItemInfo_Impl: Sized {
     fn GetFileAttributes(&self) -> ::windows::core::Result<u32>;
@@ -1707,6 +1740,7 @@ impl IOfflineFilesSyncErrorItemInfo_Vtbl {
         iid == &<IOfflineFilesSyncErrorItemInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesSyncProgress_Impl: Sized + IOfflineFilesProgress_Impl {
     fn SyncItemBegin(&self, pszfile: &::windows::core::PCWSTR) -> ::windows::core::Result<OFFLINEFILES_OP_RESPONSE>;
@@ -1749,6 +1783,7 @@ impl IOfflineFilesSyncProgress_Vtbl {
         iid == &<IOfflineFilesSyncProgress as ::windows::core::Interface>::IID || iid == &<IOfflineFilesProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_OfflineFiles\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOfflineFilesTransparentCacheInfo_Impl: Sized {
     fn IsTransparentlyCached(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxBlockMapBlock_Impl: Sized {
     fn GetHash(&self, buffersize: *mut u32, buffer: *mut *mut u8) -> ::windows::core::Result<()>;
     fn GetCompressedSize(&self) -> ::windows::core::Result<u32>;
@@ -31,6 +32,7 @@ impl IAppxBlockMapBlock_Vtbl {
         iid == &<IAppxBlockMapBlock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxBlockMapBlocksEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxBlockMapBlock>;
@@ -86,6 +88,7 @@ impl IAppxBlockMapBlocksEnumerator_Vtbl {
         iid == &<IAppxBlockMapBlocksEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAppxBlockMapFile_Impl: Sized {
     fn GetBlocks(&self) -> ::windows::core::Result<IAppxBlockMapBlocksEnumerator>;
@@ -167,6 +170,7 @@ impl IAppxBlockMapFile_Vtbl {
         iid == &<IAppxBlockMapFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxBlockMapFilesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxBlockMapFile>;
@@ -222,6 +226,7 @@ impl IAppxBlockMapFilesEnumerator_Vtbl {
         iid == &<IAppxBlockMapFilesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxBlockMapReader_Impl: Sized {
     fn GetFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<IAppxBlockMapFile>;
@@ -290,6 +295,7 @@ impl IAppxBlockMapReader_Vtbl {
         iid == &<IAppxBlockMapReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxBundleFactory_Impl: Sized {
     fn CreateBundleWriter(&self, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, bundleversion: u64) -> ::windows::core::Result<IAppxBundleWriter>;
@@ -345,6 +351,7 @@ impl IAppxBundleFactory_Vtbl {
         iid == &<IAppxBundleFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxBundleManifestOptionalBundleInfo_Impl: Sized {
     fn GetPackageId(&self) -> ::windows::core::Result<IAppxManifestPackageId>;
     fn GetFileName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -397,6 +404,7 @@ impl IAppxBundleManifestOptionalBundleInfo_Vtbl {
         iid == &<IAppxBundleManifestOptionalBundleInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxBundleManifestOptionalBundleInfoEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxBundleManifestOptionalBundleInfo>;
@@ -452,6 +460,7 @@ impl IAppxBundleManifestOptionalBundleInfoEnumerator_Vtbl {
         iid == &<IAppxBundleManifestOptionalBundleInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxBundleManifestPackageInfo_Impl: Sized {
     fn GetPackageType(&self) -> ::windows::core::Result<APPX_BUNDLE_PAYLOAD_PACKAGE_TYPE>;
     fn GetPackageId(&self) -> ::windows::core::Result<IAppxManifestPackageId>;
@@ -543,6 +552,7 @@ impl IAppxBundleManifestPackageInfo_Vtbl {
         iid == &<IAppxBundleManifestPackageInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxBundleManifestPackageInfo2_Impl: Sized {
     fn GetIsPackageReference(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -598,6 +608,7 @@ impl IAppxBundleManifestPackageInfo2_Vtbl {
         iid == &<IAppxBundleManifestPackageInfo2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxBundleManifestPackageInfo3_Impl: Sized {
     fn GetTargetDeviceFamilies(&self) -> ::windows::core::Result<IAppxManifestTargetDeviceFamiliesEnumerator>;
 }
@@ -621,6 +632,7 @@ impl IAppxBundleManifestPackageInfo3_Vtbl {
         iid == &<IAppxBundleManifestPackageInfo3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxBundleManifestPackageInfo4_Impl: Sized {
     fn GetIsStub(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -647,6 +659,7 @@ impl IAppxBundleManifestPackageInfo4_Vtbl {
         iid == &<IAppxBundleManifestPackageInfo4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxBundleManifestPackageInfoEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxBundleManifestPackageInfo>;
@@ -702,6 +715,7 @@ impl IAppxBundleManifestPackageInfoEnumerator_Vtbl {
         iid == &<IAppxBundleManifestPackageInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxBundleManifestReader_Impl: Sized {
     fn GetPackageId(&self) -> ::windows::core::Result<IAppxManifestPackageId>;
@@ -757,6 +771,7 @@ impl IAppxBundleManifestReader_Vtbl {
         iid == &<IAppxBundleManifestReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxBundleManifestReader2_Impl: Sized {
     fn GetOptionalBundles(&self) -> ::windows::core::Result<IAppxBundleManifestOptionalBundleInfoEnumerator>;
 }
@@ -780,6 +795,7 @@ impl IAppxBundleManifestReader2_Vtbl {
         iid == &<IAppxBundleManifestReader2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxBundleReader_Impl: Sized {
     fn GetFootprintFile(&self, filetype: APPX_BUNDLE_FOOTPRINT_FILE_TYPE) -> ::windows::core::Result<IAppxFile>;
     fn GetBlockMap(&self) -> ::windows::core::Result<IAppxBlockMapReader>;
@@ -858,6 +874,7 @@ impl IAppxBundleReader_Vtbl {
         iid == &<IAppxBundleReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxBundleWriter_Impl: Sized {
     fn AddPayloadPackage(&self, filename: &::windows::core::PCWSTR, packagestream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -888,6 +905,7 @@ impl IAppxBundleWriter_Vtbl {
         iid == &<IAppxBundleWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxBundleWriter2_Impl: Sized {
     fn AddExternalPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -911,6 +929,7 @@ impl IAppxBundleWriter2_Vtbl {
         iid == &<IAppxBundleWriter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxBundleWriter3_Impl: Sized {
     fn AddPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -941,6 +960,7 @@ impl IAppxBundleWriter3_Vtbl {
         iid == &<IAppxBundleWriter3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAppxBundleWriter4_Impl: Sized {
     fn AddPayloadPackage(&self, filename: &::windows::core::PCWSTR, packagestream: &::core::option::Option<super::super::super::System::Com::IStream>, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -978,6 +998,7 @@ impl IAppxBundleWriter4_Vtbl {
         iid == &<IAppxBundleWriter4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxContentGroup_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetFiles(&self) -> ::windows::core::Result<IAppxContentGroupFilesEnumerator>;
@@ -1017,6 +1038,7 @@ impl IAppxContentGroup_Vtbl {
         iid == &<IAppxContentGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxContentGroupFilesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1072,6 +1094,7 @@ impl IAppxContentGroupFilesEnumerator_Vtbl {
         iid == &<IAppxContentGroupFilesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxContentGroupMapReader_Impl: Sized {
     fn GetRequiredGroup(&self) -> ::windows::core::Result<IAppxContentGroup>;
     fn GetAutomaticGroups(&self) -> ::windows::core::Result<IAppxContentGroupsEnumerator>;
@@ -1111,6 +1134,7 @@ impl IAppxContentGroupMapReader_Vtbl {
         iid == &<IAppxContentGroupMapReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxContentGroupMapWriter_Impl: Sized {
     fn AddAutomaticGroup(&self, groupname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn AddAutomaticFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1145,6 +1169,7 @@ impl IAppxContentGroupMapWriter_Vtbl {
         iid == &<IAppxContentGroupMapWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxContentGroupsEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxContentGroup>;
@@ -1200,6 +1225,7 @@ impl IAppxContentGroupsEnumerator_Vtbl {
         iid == &<IAppxContentGroupsEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxEncryptedBundleWriter_Impl: Sized {
     fn AddPayloadPackageEncrypted(&self, filename: &::windows::core::PCWSTR, packagestream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -1230,6 +1256,7 @@ impl IAppxEncryptedBundleWriter_Vtbl {
         iid == &<IAppxEncryptedBundleWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxEncryptedBundleWriter2_Impl: Sized {
     fn AddExternalPackageReference(&self, filename: &::windows::core::PCWSTR, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -1253,6 +1280,7 @@ impl IAppxEncryptedBundleWriter2_Vtbl {
         iid == &<IAppxEncryptedBundleWriter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAppxEncryptedBundleWriter3_Impl: Sized {
     fn AddPayloadPackageEncrypted(&self, filename: &::windows::core::PCWSTR, packagestream: &::core::option::Option<super::super::super::System::Com::IStream>, isdefaultapplicablepackage: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1283,6 +1311,7 @@ impl IAppxEncryptedBundleWriter3_Vtbl {
         iid == &<IAppxEncryptedBundleWriter3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxEncryptedPackageWriter_Impl: Sized {
     fn AddPayloadFileEncrypted(&self, filename: &::windows::core::PCWSTR, compressionoption: APPX_COMPRESSION_OPTION, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -1313,6 +1342,7 @@ impl IAppxEncryptedPackageWriter_Vtbl {
         iid == &<IAppxEncryptedPackageWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxEncryptedPackageWriter2_Impl: Sized {
     fn AddPayloadFilesEncrypted(&self, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::Result<()>;
@@ -1333,6 +1363,7 @@ impl IAppxEncryptedPackageWriter2_Vtbl {
         iid == &<IAppxEncryptedPackageWriter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAppxEncryptionFactory_Impl: Sized {
     fn EncryptPackage(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::Result<()>;
@@ -1429,6 +1460,7 @@ impl IAppxEncryptionFactory_Vtbl {
         iid == &<IAppxEncryptionFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAppxEncryptionFactory2_Impl: Sized {
     fn CreateEncryptedPackageWriter(&self, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, manifeststream: &::core::option::Option<super::super::super::System::Com::IStream>, contentgroupmapstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::Result<IAppxEncryptedPackageWriter>;
@@ -1458,6 +1490,7 @@ impl IAppxEncryptionFactory2_Vtbl {
         iid == &<IAppxEncryptionFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxEncryptionFactory3_Impl: Sized {
     fn EncryptPackage(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS) -> ::windows::core::Result<()>;
@@ -1514,6 +1547,7 @@ impl IAppxEncryptionFactory3_Vtbl {
         iid == &<IAppxEncryptionFactory3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxEncryptionFactory4_Impl: Sized {
     fn EncryptPackage(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_ENCRYPTED_PACKAGE_SETTINGS2, keyinfo: *const APPX_KEY_INFO, exemptedfiles: *const APPX_ENCRYPTED_EXEMPTIONS, memorylimit: u64) -> ::windows::core::Result<()>;
@@ -1534,6 +1568,7 @@ impl IAppxEncryptionFactory4_Vtbl {
         iid == &<IAppxEncryptionFactory4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAppxFactory_Impl: Sized {
     fn CreatePackageWriter(&self, outputstream: &::core::option::Option<super::super::super::System::Com::IStream>, settings: *const APPX_PACKAGE_SETTINGS) -> ::windows::core::Result<IAppxPackageWriter>;
@@ -1615,6 +1650,7 @@ impl IAppxFactory_Vtbl {
         iid == &<IAppxFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxFactory2_Impl: Sized {
     fn CreateContentGroupMapReader(&self, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<IAppxContentGroupMapReader>;
@@ -1670,6 +1706,7 @@ impl IAppxFactory2_Vtbl {
         iid == &<IAppxFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxFile_Impl: Sized {
     fn GetCompressionOption(&self) -> ::windows::core::Result<APPX_COMPRESSION_OPTION>;
@@ -1751,6 +1788,7 @@ impl IAppxFile_Vtbl {
         iid == &<IAppxFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxFilesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxFile>;
@@ -1806,6 +1844,7 @@ impl IAppxFilesEnumerator_Vtbl {
         iid == &<IAppxFilesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestApplication_Impl: Sized {
     fn GetStringValue(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetAppUserModelId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1845,6 +1884,7 @@ impl IAppxManifestApplication_Vtbl {
         iid == &<IAppxManifestApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestApplicationsEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestApplication>;
@@ -1900,6 +1940,7 @@ impl IAppxManifestApplicationsEnumerator_Vtbl {
         iid == &<IAppxManifestApplicationsEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestCapabilitiesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1955,6 +1996,7 @@ impl IAppxManifestCapabilitiesEnumerator_Vtbl {
         iid == &<IAppxManifestCapabilitiesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestDeviceCapabilitiesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2010,6 +2052,7 @@ impl IAppxManifestDeviceCapabilitiesEnumerator_Vtbl {
         iid == &<IAppxManifestDeviceCapabilitiesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestDriverConstraint_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetMinVersion(&self) -> ::windows::core::Result<u64>;
@@ -2062,6 +2105,7 @@ impl IAppxManifestDriverConstraint_Vtbl {
         iid == &<IAppxManifestDriverConstraint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestDriverConstraintsEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestDriverConstraint>;
@@ -2117,6 +2161,7 @@ impl IAppxManifestDriverConstraintsEnumerator_Vtbl {
         iid == &<IAppxManifestDriverConstraintsEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestDriverDependenciesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestDriverDependency>;
@@ -2172,6 +2217,7 @@ impl IAppxManifestDriverDependenciesEnumerator_Vtbl {
         iid == &<IAppxManifestDriverDependenciesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestDriverDependency_Impl: Sized {
     fn GetDriverConstraints(&self) -> ::windows::core::Result<IAppxManifestDriverConstraintsEnumerator>;
 }
@@ -2195,6 +2241,7 @@ impl IAppxManifestDriverDependency_Vtbl {
         iid == &<IAppxManifestDriverDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestHostRuntimeDependenciesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestHostRuntimeDependency>;
@@ -2250,6 +2297,7 @@ impl IAppxManifestHostRuntimeDependenciesEnumerator_Vtbl {
         iid == &<IAppxManifestHostRuntimeDependenciesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestHostRuntimeDependency_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2302,6 +2350,7 @@ impl IAppxManifestHostRuntimeDependency_Vtbl {
         iid == &<IAppxManifestHostRuntimeDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestHostRuntimeDependency2_Impl: Sized {
     fn GetPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -2325,6 +2374,7 @@ impl IAppxManifestHostRuntimeDependency2_Vtbl {
         iid == &<IAppxManifestHostRuntimeDependency2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestMainPackageDependenciesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestMainPackageDependency>;
@@ -2380,6 +2430,7 @@ impl IAppxManifestMainPackageDependenciesEnumerator_Vtbl {
         iid == &<IAppxManifestMainPackageDependenciesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestMainPackageDependency_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2432,6 +2483,7 @@ impl IAppxManifestMainPackageDependency_Vtbl {
         iid == &<IAppxManifestMainPackageDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestOSPackageDependenciesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestOSPackageDependency>;
@@ -2487,6 +2539,7 @@ impl IAppxManifestOSPackageDependenciesEnumerator_Vtbl {
         iid == &<IAppxManifestOSPackageDependenciesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestOSPackageDependency_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetVersion(&self) -> ::windows::core::Result<u64>;
@@ -2526,6 +2579,7 @@ impl IAppxManifestOSPackageDependency_Vtbl {
         iid == &<IAppxManifestOSPackageDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestOptionalPackageInfo_Impl: Sized {
     fn GetIsOptionalPackage(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -2568,6 +2622,7 @@ impl IAppxManifestOptionalPackageInfo_Vtbl {
         iid == &<IAppxManifestOptionalPackageInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestPackageDependenciesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestPackageDependency>;
@@ -2623,6 +2678,7 @@ impl IAppxManifestPackageDependenciesEnumerator_Vtbl {
         iid == &<IAppxManifestPackageDependenciesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestPackageDependency_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2675,6 +2731,7 @@ impl IAppxManifestPackageDependency_Vtbl {
         iid == &<IAppxManifestPackageDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestPackageDependency2_Impl: Sized + IAppxManifestPackageDependency_Impl {
     fn GetMaxMajorVersionTested(&self) -> ::windows::core::Result<u16>;
 }
@@ -2701,6 +2758,7 @@ impl IAppxManifestPackageDependency2_Vtbl {
         iid == &<IAppxManifestPackageDependency2 as ::windows::core::Interface>::IID || iid == &<IAppxManifestPackageDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestPackageDependency3_Impl: Sized {
     fn GetIsOptional(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -2727,6 +2785,7 @@ impl IAppxManifestPackageDependency3_Vtbl {
         iid == &<IAppxManifestPackageDependency3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestPackageId_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2847,6 +2906,7 @@ impl IAppxManifestPackageId_Vtbl {
         iid == &<IAppxManifestPackageId as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestPackageId2_Impl: Sized + IAppxManifestPackageId_Impl {
     fn GetArchitecture2(&self) -> ::windows::core::Result<APPX_PACKAGE_ARCHITECTURE2>;
@@ -2873,6 +2933,7 @@ impl IAppxManifestPackageId2_Vtbl {
         iid == &<IAppxManifestPackageId2 as ::windows::core::Interface>::IID || iid == &<IAppxManifestPackageId as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestProperties_Impl: Sized {
     fn GetBoolValue(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -2915,6 +2976,7 @@ impl IAppxManifestProperties_Vtbl {
         iid == &<IAppxManifestProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestQualifiedResource_Impl: Sized {
     fn GetLanguage(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetScale(&self) -> ::windows::core::Result<u32>;
@@ -2967,6 +3029,7 @@ impl IAppxManifestQualifiedResource_Vtbl {
         iid == &<IAppxManifestQualifiedResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestQualifiedResourcesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestQualifiedResource>;
@@ -3022,6 +3085,7 @@ impl IAppxManifestQualifiedResourcesEnumerator_Vtbl {
         iid == &<IAppxManifestQualifiedResourcesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxManifestReader_Impl: Sized {
     fn GetPackageId(&self) -> ::windows::core::Result<IAppxManifestPackageId>;
@@ -3155,6 +3219,7 @@ impl IAppxManifestReader_Vtbl {
         iid == &<IAppxManifestReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxManifestReader2_Impl: Sized + IAppxManifestReader_Impl {
     fn GetQualifiedResources(&self) -> ::windows::core::Result<IAppxManifestQualifiedResourcesEnumerator>;
@@ -3181,6 +3246,7 @@ impl IAppxManifestReader2_Vtbl {
         iid == &<IAppxManifestReader2 as ::windows::core::Interface>::IID || iid == &<IAppxManifestReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxManifestReader3_Impl: Sized + IAppxManifestReader2_Impl {
     fn GetCapabilitiesByCapabilityClass(&self, capabilityclass: APPX_CAPABILITY_CLASS_TYPE) -> ::windows::core::Result<IAppxManifestCapabilitiesEnumerator>;
@@ -3223,6 +3289,7 @@ impl IAppxManifestReader3_Vtbl {
         iid == &<IAppxManifestReader3 as ::windows::core::Interface>::IID || iid == &<IAppxManifestReader as ::windows::core::Interface>::IID || iid == &<IAppxManifestReader2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxManifestReader4_Impl: Sized + IAppxManifestReader3_Impl {
     fn GetOptionalPackageInfo(&self) -> ::windows::core::Result<IAppxManifestOptionalPackageInfo>;
@@ -3249,6 +3316,7 @@ impl IAppxManifestReader4_Vtbl {
         iid == &<IAppxManifestReader4 as ::windows::core::Interface>::IID || iid == &<IAppxManifestReader as ::windows::core::Interface>::IID || iid == &<IAppxManifestReader2 as ::windows::core::Interface>::IID || iid == &<IAppxManifestReader3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestReader5_Impl: Sized {
     fn GetMainPackageDependencies(&self) -> ::windows::core::Result<IAppxManifestMainPackageDependenciesEnumerator>;
 }
@@ -3275,6 +3343,7 @@ impl IAppxManifestReader5_Vtbl {
         iid == &<IAppxManifestReader5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestReader6_Impl: Sized {
     fn GetIsNonQualifiedResourcePackage(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -3304,6 +3373,7 @@ impl IAppxManifestReader6_Vtbl {
         iid == &<IAppxManifestReader6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestReader7_Impl: Sized {
     fn GetDriverDependencies(&self) -> ::windows::core::Result<IAppxManifestDriverDependenciesEnumerator>;
     fn GetOSPackageDependencies(&self) -> ::windows::core::Result<IAppxManifestOSPackageDependenciesEnumerator>;
@@ -3356,6 +3426,7 @@ impl IAppxManifestReader7_Vtbl {
         iid == &<IAppxManifestReader7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestResourcesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -3411,6 +3482,7 @@ impl IAppxManifestResourcesEnumerator_Vtbl {
         iid == &<IAppxManifestResourcesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAppxManifestTargetDeviceFamiliesEnumerator_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<IAppxManifestTargetDeviceFamily>;
@@ -3466,6 +3538,7 @@ impl IAppxManifestTargetDeviceFamiliesEnumerator_Vtbl {
         iid == &<IAppxManifestTargetDeviceFamiliesEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxManifestTargetDeviceFamily_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetMinVersion(&self) -> ::windows::core::Result<u64>;
@@ -3518,6 +3591,7 @@ impl IAppxManifestTargetDeviceFamily_Vtbl {
         iid == &<IAppxManifestTargetDeviceFamily as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAppxPackageEditor_Impl: Sized {
     fn SetWorkingDirectory(&self, workingdirectory: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -3576,6 +3650,7 @@ impl IAppxPackageEditor_Vtbl {
         iid == &<IAppxPackageEditor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxPackageReader_Impl: Sized {
     fn GetBlockMap(&self) -> ::windows::core::Result<IAppxBlockMapReader>;
     fn GetFootprintFile(&self, r#type: APPX_FOOTPRINT_FILE_TYPE) -> ::windows::core::Result<IAppxFile>;
@@ -3654,6 +3729,7 @@ impl IAppxPackageReader_Vtbl {
         iid == &<IAppxPackageReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxPackageWriter_Impl: Sized {
     fn AddPayloadFile(&self, filename: &::windows::core::PCWSTR, contenttype: &::windows::core::PCWSTR, compressionoption: APPX_COMPRESSION_OPTION, inputstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -3684,6 +3760,7 @@ impl IAppxPackageWriter_Vtbl {
         iid == &<IAppxPackageWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxPackageWriter2_Impl: Sized {
     fn Close(&self, manifest: &::core::option::Option<super::super::super::System::Com::IStream>, contentgroupmap: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -3704,6 +3781,7 @@ impl IAppxPackageWriter2_Vtbl {
         iid == &<IAppxPackageWriter2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAppxPackageWriter3_Impl: Sized {
     fn AddPayloadFiles(&self, filecount: u32, payloadfiles: *const APPX_PACKAGE_WRITER_PAYLOAD_STREAM, memorylimit: u64) -> ::windows::core::Result<()>;
@@ -3724,6 +3802,7 @@ impl IAppxPackageWriter3_Vtbl {
         iid == &<IAppxPackageWriter3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxPackagingDiagnosticEventSink_Impl: Sized {
     fn ReportContextChange(&self, changetype: APPX_PACKAGING_CONTEXT_CHANGE_TYPE, contextid: i32, contextname: &::windows::core::PCSTR, contextmessage: &::windows::core::PCWSTR, detailsmessage: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ReportError(&self, errormessage: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -3751,6 +3830,7 @@ impl IAppxPackagingDiagnosticEventSink_Vtbl {
         iid == &<IAppxPackagingDiagnosticEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxPackagingDiagnosticEventSinkManager_Impl: Sized {
     fn SetSinkForProcess(&self, sink: &::core::option::Option<IAppxPackagingDiagnosticEventSink>) -> ::windows::core::Result<()>;
 }
@@ -3768,6 +3848,7 @@ impl IAppxPackagingDiagnosticEventSinkManager_Vtbl {
         iid == &<IAppxPackagingDiagnosticEventSinkManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`, `\"implement\"`*"]
 pub trait IAppxSourceContentGroupMapReader_Impl: Sized {
     fn GetRequiredGroup(&self) -> ::windows::core::Result<IAppxContentGroup>;
     fn GetAutomaticGroups(&self) -> ::windows::core::Result<IAppxContentGroupsEnumerator>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Cryptography\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 pub trait IOpcCertificateEnumerator_Impl: Sized {
     fn MoveNext(&self, hasnext: *mut super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -48,6 +49,7 @@ impl IOpcCertificateEnumerator_Vtbl {
         iid == &<IOpcCertificateEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Cryptography\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography"))]
 pub trait IOpcCertificateSet_Impl: Sized {
     fn Add(&self, certificate: *const super::super::super::Security::Cryptography::CERT_CONTEXT) -> ::windows::core::Result<()>;
@@ -91,6 +93,7 @@ impl IOpcCertificateSet_Vtbl {
         iid == &<IOpcCertificateSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcDigitalSignature_Impl: Sized {
     fn GetNamespaces(&self, prefixes: *mut *mut ::windows::core::PWSTR, namespaces: *mut *mut ::windows::core::PWSTR, count: *mut u32) -> ::windows::core::Result<()>;
@@ -272,6 +275,7 @@ impl IOpcDigitalSignature_Vtbl {
         iid == &<IOpcDigitalSignature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcDigitalSignatureEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -340,6 +344,7 @@ impl IOpcDigitalSignatureEnumerator_Vtbl {
         iid == &<IOpcDigitalSignatureEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Cryptography\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_System_Com"))]
 pub trait IOpcDigitalSignatureManager_Impl: Sized {
     fn GetSignatureOriginPartName(&self) -> ::windows::core::Result<IOpcPartUri>;
@@ -442,6 +447,7 @@ impl IOpcDigitalSignatureManager_Vtbl {
         iid == &<IOpcDigitalSignatureManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_System_Com"))]
 pub trait IOpcFactory_Impl: Sized {
     fn CreatePackageRootUri(&self) -> ::windows::core::Result<IOpcUri>;
@@ -543,6 +549,7 @@ impl IOpcFactory_Vtbl {
         iid == &<IOpcFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"implement\"`*"]
 pub trait IOpcPackage_Impl: Sized {
     fn GetPartSet(&self) -> ::windows::core::Result<IOpcPartSet>;
     fn GetRelationshipSet(&self) -> ::windows::core::Result<IOpcRelationshipSet>;
@@ -582,6 +589,7 @@ impl IOpcPackage_Vtbl {
         iid == &<IOpcPackage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcPart_Impl: Sized {
     fn GetRelationshipSet(&self) -> ::windows::core::Result<IOpcRelationshipSet>;
@@ -663,6 +671,7 @@ impl IOpcPart_Vtbl {
         iid == &<IOpcPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcPartEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -731,6 +740,7 @@ impl IOpcPartEnumerator_Vtbl {
         iid == &<IOpcPartEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOpcPartSet_Impl: Sized {
     fn GetPart(&self, name: &::core::option::Option<IOpcPartUri>) -> ::windows::core::Result<IOpcPart>;
@@ -806,6 +816,7 @@ impl IOpcPartSet_Vtbl {
         iid == &<IOpcPartSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOpcPartUri_Impl: Sized + IOpcUri_Impl {
     fn ComparePartUri(&self, parturi: &::core::option::Option<IOpcPartUri>) -> ::windows::core::Result<i32>;
@@ -861,6 +872,7 @@ impl IOpcPartUri_Vtbl {
         iid == &<IOpcPartUri as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IUri as ::windows::core::Interface>::IID || iid == &<IOpcUri as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcRelationship_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -942,6 +954,7 @@ impl IOpcRelationship_Vtbl {
         iid == &<IOpcRelationship as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcRelationshipEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -1010,6 +1023,7 @@ impl IOpcRelationshipEnumerator_Vtbl {
         iid == &<IOpcRelationshipEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"implement\"`*"]
 pub trait IOpcRelationshipSelector_Impl: Sized {
     fn GetSelectorType(&self) -> ::windows::core::Result<OPC_RELATIONSHIP_SELECTOR>;
     fn GetSelectionCriterion(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1049,6 +1063,7 @@ impl IOpcRelationshipSelector_Vtbl {
         iid == &<IOpcRelationshipSelector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcRelationshipSelectorEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -1117,6 +1132,7 @@ impl IOpcRelationshipSelectorEnumerator_Vtbl {
         iid == &<IOpcRelationshipSelectorEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"implement\"`*"]
 pub trait IOpcRelationshipSelectorSet_Impl: Sized {
     fn Create(&self, selector: OPC_RELATIONSHIP_SELECTOR, selectioncriterion: &::windows::core::PCWSTR) -> ::windows::core::Result<IOpcRelationshipSelector>;
     fn Delete(&self, relationshipselector: &::core::option::Option<IOpcRelationshipSelector>) -> ::windows::core::Result<()>;
@@ -1163,6 +1179,7 @@ impl IOpcRelationshipSelectorSet_Vtbl {
         iid == &<IOpcRelationshipSelectorSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOpcRelationshipSet_Impl: Sized {
     fn GetRelationship(&self, relationshipidentifier: &::windows::core::PCWSTR) -> ::windows::core::Result<IOpcRelationship>;
@@ -1264,6 +1281,7 @@ impl IOpcRelationshipSet_Vtbl {
         iid == &<IOpcRelationshipSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"implement\"`*"]
 pub trait IOpcSignatureCustomObject_Impl: Sized {
     fn GetXml(&self, xmlmarkup: *mut *mut u8, count: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -1281,6 +1299,7 @@ impl IOpcSignatureCustomObject_Vtbl {
         iid == &<IOpcSignatureCustomObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcSignatureCustomObjectEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -1349,6 +1368,7 @@ impl IOpcSignatureCustomObjectEnumerator_Vtbl {
         iid == &<IOpcSignatureCustomObjectEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"implement\"`*"]
 pub trait IOpcSignatureCustomObjectSet_Impl: Sized {
     fn Create(&self, xmlmarkup: *const u8, count: u32) -> ::windows::core::Result<IOpcSignatureCustomObject>;
     fn Delete(&self, customobject: &::core::option::Option<IOpcSignatureCustomObject>) -> ::windows::core::Result<()>;
@@ -1395,6 +1415,7 @@ impl IOpcSignatureCustomObjectSet_Vtbl {
         iid == &<IOpcSignatureCustomObjectSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcSignaturePartReference_Impl: Sized {
     fn GetPartName(&self) -> ::windows::core::Result<IOpcPartUri>;
@@ -1470,6 +1491,7 @@ impl IOpcSignaturePartReference_Vtbl {
         iid == &<IOpcSignaturePartReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcSignaturePartReferenceEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -1538,6 +1560,7 @@ impl IOpcSignaturePartReferenceEnumerator_Vtbl {
         iid == &<IOpcSignaturePartReferenceEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcSignaturePartReferenceSet_Impl: Sized {
     fn Create(&self, parturi: &::core::option::Option<IOpcPartUri>, digestmethod: &::windows::core::PCWSTR, transformmethod: OPC_CANONICALIZATION_METHOD) -> ::windows::core::Result<IOpcSignaturePartReference>;
@@ -1587,6 +1610,7 @@ impl IOpcSignaturePartReferenceSet_Vtbl {
         iid == &<IOpcSignaturePartReferenceSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcSignatureReference_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1675,6 +1699,7 @@ impl IOpcSignatureReference_Vtbl {
         iid == &<IOpcSignatureReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcSignatureReferenceEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -1743,6 +1768,7 @@ impl IOpcSignatureReferenceEnumerator_Vtbl {
         iid == &<IOpcSignatureReferenceEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcSignatureReferenceSet_Impl: Sized {
     fn Create(&self, referenceuri: &::core::option::Option<super::super::super::System::Com::IUri>, referenceid: &::windows::core::PCWSTR, r#type: &::windows::core::PCWSTR, digestmethod: &::windows::core::PCWSTR, transformmethod: OPC_CANONICALIZATION_METHOD) -> ::windows::core::Result<IOpcSignatureReference>;
@@ -1792,6 +1818,7 @@ impl IOpcSignatureReferenceSet_Vtbl {
         iid == &<IOpcSignatureReferenceSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcSignatureRelationshipReference_Impl: Sized {
     fn GetSourceUri(&self) -> ::windows::core::Result<IOpcUri>;
@@ -1880,6 +1907,7 @@ impl IOpcSignatureRelationshipReference_Vtbl {
         iid == &<IOpcSignatureRelationshipReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpcSignatureRelationshipReferenceEnumerator_Impl: Sized {
     fn MoveNext(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -1948,6 +1976,7 @@ impl IOpcSignatureRelationshipReferenceEnumerator_Vtbl {
         iid == &<IOpcSignatureRelationshipReferenceEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcSignatureRelationshipReferenceSet_Impl: Sized {
     fn Create(&self, sourceuri: &::core::option::Option<IOpcUri>, digestmethod: &::windows::core::PCWSTR, relationshipsigningoption: OPC_RELATIONSHIPS_SIGNING_OPTION, selectorset: &::core::option::Option<IOpcRelationshipSelectorSet>, transformmethod: OPC_CANONICALIZATION_METHOD) -> ::windows::core::Result<IOpcSignatureRelationshipReference>;
@@ -2010,6 +2039,7 @@ impl IOpcSignatureRelationshipReferenceSet_Vtbl {
         iid == &<IOpcSignatureRelationshipReferenceSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOpcSigningOptions_Impl: Sized {
     fn GetSignatureId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2211,6 +2241,7 @@ impl IOpcSigningOptions_Vtbl {
         iid == &<IOpcSigningOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOpcUri_Impl: Sized + super::super::super::System::Com::IUri_Impl {
     fn GetRelationshipsPartUri(&self) -> ::windows::core::Result<IOpcPartUri>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IEnumVdsObject_Impl: Sized {
     fn Next(&self, celt: u32, ppobjectarray: *mut ::core::option::Option<::windows::core::IUnknown>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -45,6 +46,7 @@ impl IEnumVdsObject_Vtbl {
         iid == &<IEnumVdsObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsAdmin_Impl: Sized {
     fn RegisterProvider(&self, providerid: &::windows::core::GUID, providerclsid: &::windows::core::GUID, pwszname: &::windows::core::PCWSTR, r#type: VDS_PROVIDER_TYPE, pwszmachinename: &::windows::core::PCWSTR, pwszversion: &::windows::core::PCWSTR, guidversionid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn UnregisterProvider(&self, providerid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -72,6 +74,7 @@ impl IVdsAdmin_Vtbl {
         iid == &<IVdsAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsAdviseSink_Impl: Sized {
     fn OnNotify(&self, lnumberofnotifications: i32, pnotificationarray: *const VDS_NOTIFICATION) -> ::windows::core::Result<()>;
 }
@@ -89,6 +92,7 @@ impl IVdsAdviseSink_Vtbl {
         iid == &<IVdsAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsAsync_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn Wait(&self, phrresult: *mut ::windows::core::HRESULT, pasyncout: *mut VDS_ASYNC_OUTPUT) -> ::windows::core::Result<()>;
@@ -123,6 +127,7 @@ impl IVdsAsync_Vtbl {
         iid == &<IVdsAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsController_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_CONTROLLER_PROP>;
     fn GetSubSystem(&self) -> ::windows::core::Result<IVdsSubSystem>;
@@ -216,6 +221,7 @@ impl IVdsController_Vtbl {
         iid == &<IVdsController as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsControllerControllerPort_Impl: Sized {
     fn QueryControllerPorts(&self) -> ::windows::core::Result<IEnumVdsObject>;
 }
@@ -239,6 +245,7 @@ impl IVdsControllerControllerPort_Vtbl {
         iid == &<IVdsControllerControllerPort as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsControllerPort_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_PORT_PROP>;
     fn GetController(&self) -> ::windows::core::Result<IVdsController>;
@@ -305,6 +312,7 @@ impl IVdsControllerPort_Vtbl {
         iid == &<IVdsControllerPort as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsDrive_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_DRIVE_PROP>;
@@ -375,6 +383,7 @@ impl IVdsDrive_Vtbl {
         iid == &<IVdsDrive as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsDrive2_Impl: Sized {
     fn GetProperties2(&self) -> ::windows::core::Result<VDS_DRIVE_PROP2>;
 }
@@ -398,6 +407,7 @@ impl IVdsDrive2_Vtbl {
         iid == &<IVdsDrive2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsHwProvider_Impl: Sized {
     fn QuerySubSystems(&self) -> ::windows::core::Result<IEnumVdsObject>;
     fn Reenumerate(&self) -> ::windows::core::Result<()>;
@@ -438,6 +448,7 @@ impl IVdsHwProvider_Vtbl {
         iid == &<IVdsHwProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsHwProviderPrivate_Impl: Sized {
     fn QueryIfCreatedLun(&self, pwszdevicepath: &::windows::core::PCWSTR, pvdsluninformation: *const VDS_LUN_INFORMATION) -> ::windows::core::Result<::windows::core::GUID>;
@@ -464,6 +475,7 @@ impl IVdsHwProviderPrivate_Vtbl {
         iid == &<IVdsHwProviderPrivate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsHwProviderPrivateMpio_Impl: Sized {
     fn SetAllPathStatusesFromHbaPort(&self, hbaportprop: &VDS_HBAPORT_PROP, status: VDS_PATH_STATUS) -> ::windows::core::Result<()>;
 }
@@ -484,6 +496,7 @@ impl IVdsHwProviderPrivateMpio_Vtbl {
         iid == &<IVdsHwProviderPrivateMpio as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsHwProviderStoragePools_Impl: Sized {
     fn QueryStoragePools(&self, ulflags: u32, ullremainingfreespace: u64, ppoolattributes: *const VDS_POOL_ATTRIBUTES) -> ::windows::core::Result<IEnumVdsObject>;
@@ -539,6 +552,7 @@ impl IVdsHwProviderStoragePools_Vtbl {
         iid == &<IVdsHwProviderStoragePools as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsHwProviderType_Impl: Sized {
     fn GetProviderType(&self) -> ::windows::core::Result<VDS_HWPROVIDER_TYPE>;
 }
@@ -562,6 +576,7 @@ impl IVdsHwProviderType_Vtbl {
         iid == &<IVdsHwProviderType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsHwProviderType2_Impl: Sized {
     fn GetProviderType2(&self) -> ::windows::core::Result<VDS_HWPROVIDER_TYPE>;
 }
@@ -585,6 +600,7 @@ impl IVdsHwProviderType2_Vtbl {
         iid == &<IVdsHwProviderType2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsIscsiPortal_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_ISCSI_PORTAL_PROP>;
     fn GetSubSystem(&self) -> ::windows::core::Result<IVdsSubSystem>;
@@ -671,6 +687,7 @@ impl IVdsIscsiPortal_Vtbl {
         iid == &<IVdsIscsiPortal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsIscsiPortalGroup_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_ISCSI_PORTALGROUP_PROP>;
     fn GetTarget(&self) -> ::windows::core::Result<IVdsIscsiTarget>;
@@ -762,6 +779,7 @@ impl IVdsIscsiPortalGroup_Vtbl {
         iid == &<IVdsIscsiPortalGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsIscsiTarget_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_ISCSI_TARGET_PROP>;
@@ -884,6 +902,7 @@ impl IVdsIscsiTarget_Vtbl {
         iid == &<IVdsIscsiTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsLun_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_LUN_PROP>;
@@ -1091,6 +1110,7 @@ impl IVdsLun_Vtbl {
         iid == &<IVdsLun as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsLun2_Impl: Sized {
     fn QueryHints2(&self) -> ::windows::core::Result<VDS_HINTS2>;
@@ -1127,6 +1147,7 @@ impl IVdsLun2_Vtbl {
         iid == &<IVdsLun2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsLunControllerPorts_Impl: Sized {
     fn AssociateControllerPorts(&self, pactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofactivecontrollerports: i32, pinactivecontrollerportidarray: *const ::windows::core::GUID, lnumberofinactivecontrollerports: i32) -> ::windows::core::Result<()>;
     fn QueryActiveControllerPorts(&self) -> ::windows::core::Result<IEnumVdsObject>;
@@ -1160,6 +1181,7 @@ impl IVdsLunControllerPorts_Vtbl {
         iid == &<IVdsLunControllerPorts as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsLunIscsi_Impl: Sized {
     fn AssociateTargets(&self, ptargetidarray: *const ::windows::core::GUID, lnumberoftargets: i32) -> ::windows::core::Result<()>;
     fn QueryAssociatedTargets(&self) -> ::windows::core::Result<IEnumVdsObject>;
@@ -1193,6 +1215,7 @@ impl IVdsLunIscsi_Vtbl {
         iid == &<IVdsLunIscsi as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsLunMpio_Impl: Sized {
     fn GetPathInfo(&self, pppaths: *mut *mut VDS_PATH_INFO, plnumberofpaths: *mut i32) -> ::windows::core::Result<()>;
@@ -1243,6 +1266,7 @@ impl IVdsLunMpio_Vtbl {
         iid == &<IVdsLunMpio as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsLunNaming_Impl: Sized {
     fn SetFriendlyName(&self, pwszfriendlyname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1260,6 +1284,7 @@ impl IVdsLunNaming_Vtbl {
         iid == &<IVdsLunNaming as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsLunNumber_Impl: Sized {
     fn GetLunNumber(&self) -> ::windows::core::Result<u32>;
 }
@@ -1283,6 +1308,7 @@ impl IVdsLunNumber_Vtbl {
         iid == &<IVdsLunNumber as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsLunPlex_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_LUN_PLEX_PROP>;
@@ -1352,6 +1378,7 @@ impl IVdsLunPlex_Vtbl {
         iid == &<IVdsLunPlex as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsMaintenance_Impl: Sized {
     fn StartMaintenance(&self, operation: VDS_MAINTENANCE_OPERATION) -> ::windows::core::Result<()>;
     fn StopMaintenance(&self, operation: VDS_MAINTENANCE_OPERATION) -> ::windows::core::Result<()>;
@@ -1386,6 +1413,7 @@ impl IVdsMaintenance_Vtbl {
         iid == &<IVdsMaintenance as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsProvider_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_PROVIDER_PROP>;
 }
@@ -1409,6 +1437,7 @@ impl IVdsProvider_Vtbl {
         iid == &<IVdsProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsProviderPrivate_Impl: Sized {
     fn GetObject(&self, objectid: &::windows::core::GUID, r#type: VDS_OBJECT_TYPE) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1452,6 +1481,7 @@ impl IVdsProviderPrivate_Vtbl {
         iid == &<IVdsProviderPrivate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsProviderSupport_Impl: Sized {
     fn GetVersionSupport(&self) -> ::windows::core::Result<u32>;
 }
@@ -1475,6 +1505,7 @@ impl IVdsProviderSupport_Vtbl {
         iid == &<IVdsProviderSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsStoragePool_Impl: Sized {
     fn GetProvider(&self) -> ::windows::core::Result<IVdsProvider>;
@@ -1563,6 +1594,7 @@ impl IVdsStoragePool_Vtbl {
         iid == &<IVdsStoragePool as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsSubSystem_Impl: Sized {
     fn GetProperties(&self) -> ::windows::core::Result<VDS_SUB_SYSTEM_PROP>;
@@ -1711,6 +1743,7 @@ impl IVdsSubSystem_Vtbl {
         iid == &<IVdsSubSystem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVdsSubSystem2_Impl: Sized {
     fn GetProperties2(&self) -> ::windows::core::Result<VDS_SUB_SYSTEM_PROP2>;
@@ -1779,6 +1812,7 @@ impl IVdsSubSystem2_Vtbl {
         iid == &<IVdsSubSystem2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsSubSystemInterconnect_Impl: Sized {
     fn GetSupportedInterconnects(&self) -> ::windows::core::Result<u32>;
 }
@@ -1805,6 +1839,7 @@ impl IVdsSubSystemInterconnect_Vtbl {
         iid == &<IVdsSubSystemInterconnect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsSubSystemIscsi_Impl: Sized {
     fn QueryTargets(&self) -> ::windows::core::Result<IEnumVdsObject>;
     fn QueryPortals(&self) -> ::windows::core::Result<IEnumVdsObject>;
@@ -1864,6 +1899,7 @@ impl IVdsSubSystemIscsi_Vtbl {
         iid == &<IVdsSubSystemIscsi as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 pub trait IVdsSubSystemNaming_Impl: Sized {
     fn SetFriendlyName(&self, pwszfriendlyname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssAdmin_Impl: Sized {
     fn RegisterProvider(&self, pproviderid: &::windows::core::GUID, classid: &::windows::core::GUID, pwszprovidername: *const u16, eprovidertype: VSS_PROVIDER_TYPE, pwszproviderversion: *const u16, providerversionid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn UnregisterProvider(&self, providerid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -45,6 +46,7 @@ impl IVssAdmin_Vtbl {
         iid == &<IVssAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssAdminEx_Impl: Sized + IVssAdmin_Impl {
     fn GetProviderCapability(&self, pproviderid: &::windows::core::GUID) -> ::windows::core::Result<u64>;
     fn GetProviderContext(&self, providerid: &::windows::core::GUID) -> ::windows::core::Result<i32>;
@@ -91,6 +93,7 @@ impl IVssAdminEx_Vtbl {
         iid == &<IVssAdminEx as ::windows::core::Interface>::IID || iid == &<IVssAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssAsync_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn Wait(&self, dwmilliseconds: u32) -> ::windows::core::Result<()>;
@@ -125,6 +128,7 @@ impl IVssAsync_Vtbl {
         iid == &<IVssAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVssComponent_Impl: Sized {
     fn GetLogicalPath(&self, pbstrpath: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -419,6 +423,7 @@ impl IVssComponent_Vtbl {
         iid == &<IVssComponent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVssComponentEx_Impl: Sized + IVssComponent_Impl {
     fn SetPrepareForBackupFailureMsg(&self, wszfailuremsg: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -490,6 +495,7 @@ impl IVssComponentEx_Vtbl {
         iid == &<IVssComponentEx as ::windows::core::Interface>::IID || iid == &<IVssComponent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVssComponentEx2_Impl: Sized + IVssComponentEx_Impl {
     fn SetFailure(&self, hr: ::windows::core::HRESULT, hrapplication: ::windows::core::HRESULT, wszapplicationmessage: &::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::Result<()>;
@@ -520,6 +526,7 @@ impl IVssComponentEx2_Vtbl {
         iid == &<IVssComponentEx2 as ::windows::core::Interface>::IID || iid == &<IVssComponent as ::windows::core::Interface>::IID || iid == &<IVssComponentEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssCreateExpressWriterMetadata_Impl: Sized {
     fn AddExcludeFiles(&self, wszpath: &::windows::core::PCWSTR, wszfilespec: &::windows::core::PCWSTR, brecursive: u8) -> ::windows::core::Result<()>;
     fn AddComponent(&self, ct: VSS_COMPONENT_TYPE, wszlogicalpath: &::windows::core::PCWSTR, wszcomponentname: &::windows::core::PCWSTR, wszcaption: &::windows::core::PCWSTR, pbicon: *const u8, cbicon: u32, brestoremetadata: u8, bnotifyonbackupcomplete: u8, bselectable: u8, bselectableforrestore: u8, dwcomponentflags: u32) -> ::windows::core::Result<()>;
@@ -589,6 +596,7 @@ impl IVssCreateExpressWriterMetadata_Vtbl {
         iid == &<IVssCreateExpressWriterMetadata as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com"))]
 pub trait IVssCreateWriterMetadata_Impl: Sized {
     fn AddIncludeFiles(&self, wszpath: &::windows::core::PCWSTR, wszfilespec: &::windows::core::PCWSTR, brecursive: u8, wszalternatelocation: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -705,6 +713,7 @@ impl IVssCreateWriterMetadata {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssDifferentialSoftwareSnapshotMgmt_Impl: Sized {
     fn AddDiffArea(&self, pwszvolumename: *const u16, pwszdiffareavolumename: *const u16, llmaximumdiffspace: i64) -> ::windows::core::Result<()>;
     fn ChangeDiffAreaMaximumSize(&self, pwszvolumename: *const u16, pwszdiffareavolumename: *const u16, llmaximumdiffspace: i64) -> ::windows::core::Result<()>;
@@ -784,6 +793,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt_Vtbl {
         iid == &<IVssDifferentialSoftwareSnapshotMgmt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVssDifferentialSoftwareSnapshotMgmt2_Impl: Sized + IVssDifferentialSoftwareSnapshotMgmt_Impl {
     fn ChangeDiffAreaMaximumSizeEx(&self, pwszvolumename: *const u16, pwszdiffareavolumename: *const u16, llmaximumdiffspace: i64, bvolatile: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -834,6 +844,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt2_Vtbl {
         iid == &<IVssDifferentialSoftwareSnapshotMgmt2 as ::windows::core::Interface>::IID || iid == &<IVssDifferentialSoftwareSnapshotMgmt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVssDifferentialSoftwareSnapshotMgmt3_Impl: Sized + IVssDifferentialSoftwareSnapshotMgmt2_Impl {
     fn SetVolumeProtectLevel(&self, pwszvolumename: *const u16, protectionlevel: VSS_PROTECTION_LEVEL) -> ::windows::core::Result<()>;
@@ -891,6 +902,7 @@ impl IVssDifferentialSoftwareSnapshotMgmt3_Vtbl {
         iid == &<IVssDifferentialSoftwareSnapshotMgmt3 as ::windows::core::Interface>::IID || iid == &<IVssDifferentialSoftwareSnapshotMgmt as ::windows::core::Interface>::IID || iid == &<IVssDifferentialSoftwareSnapshotMgmt2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssEnumMgmtObject_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut VSS_MGMT_OBJECT_PROP, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -932,6 +944,7 @@ impl IVssEnumMgmtObject_Vtbl {
         iid == &<IVssEnumMgmtObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssEnumObject_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut VSS_OBJECT_PROP, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -973,6 +986,7 @@ impl IVssEnumObject_Vtbl {
         iid == &<IVssEnumObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssExpressWriter_Impl: Sized {
     fn CreateMetadata(&self, writerid: &::windows::core::GUID, writername: &::windows::core::PCWSTR, usagetype: VSS_USAGE_TYPE, versionmajor: u32, versionminor: u32, reserved: u32) -> ::windows::core::Result<IVssCreateExpressWriterMetadata>;
     fn LoadMetadata(&self, metadata: &::windows::core::PCWSTR, reserved: u32) -> ::windows::core::Result<()>;
@@ -1020,6 +1034,7 @@ impl IVssExpressWriter_Vtbl {
         iid == &<IVssExpressWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVssFileShareSnapshotProvider_Impl: Sized {
     fn SetContext(&self, lcontext: i32) -> ::windows::core::Result<()>;
@@ -1110,6 +1125,7 @@ impl IVssFileShareSnapshotProvider_Vtbl {
         iid == &<IVssFileShareSnapshotProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
 pub trait IVssHardwareSnapshotProvider_Impl: Sized {
     fn AreLunsSupported(&self, lluncount: i32, lcontext: i32, rgwszdevices: *const *const u16, pluninformation: *mut super::VirtualDiskService::VDS_LUN_INFORMATION, pbissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1168,6 +1184,7 @@ impl IVssHardwareSnapshotProvider_Vtbl {
         iid == &<IVssHardwareSnapshotProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
 pub trait IVssHardwareSnapshotProviderEx_Impl: Sized + IVssHardwareSnapshotProvider_Impl {
     fn GetProviderCapabilities(&self) -> ::windows::core::Result<u64>;
@@ -1224,6 +1241,7 @@ impl IVssHardwareSnapshotProviderEx_Vtbl {
         iid == &<IVssHardwareSnapshotProviderEx as ::windows::core::Interface>::IID || iid == &<IVssHardwareSnapshotProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssProviderCreateSnapshotSet_Impl: Sized {
     fn EndPrepareSnapshots(&self, snapshotsetid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn PreCommitSnapshots(&self, snapshotsetid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1286,6 +1304,7 @@ impl IVssProviderCreateSnapshotSet_Vtbl {
         iid == &<IVssProviderCreateSnapshotSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVssProviderNotifications_Impl: Sized {
     fn OnLoad(&self, pcallback: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1316,6 +1335,7 @@ impl IVssProviderNotifications_Vtbl {
         iid == &<IVssProviderNotifications as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssSnapshotMgmt_Impl: Sized {
     fn GetProviderMgmtInterface(&self, providerid: &::windows::core::GUID, interfaceid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn QueryVolumesSupportedForSnapshots(&self, providerid: &::windows::core::GUID, lcontext: i32) -> ::windows::core::Result<IVssEnumMgmtObject>;
@@ -1368,6 +1388,7 @@ impl IVssSnapshotMgmt_Vtbl {
         iid == &<IVssSnapshotMgmt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssSnapshotMgmt2_Impl: Sized {
     fn GetMinDiffAreaSize(&self) -> ::windows::core::Result<i64>;
 }
@@ -1391,6 +1412,7 @@ impl IVssSnapshotMgmt2_Vtbl {
         iid == &<IVssSnapshotMgmt2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IVssSoftwareSnapshotProvider_Impl: Sized {
     fn SetContext(&self, lcontext: i32) -> ::windows::core::Result<()>;
@@ -1501,6 +1523,7 @@ impl IVssSoftwareSnapshotProvider_Vtbl {
         iid == &<IVssSoftwareSnapshotProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssWMDependency_Impl: Sized {
     fn GetWriterId(&self, pwriterid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetLogicalPath(&self, pbstrlogicalpath: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1535,6 +1558,7 @@ impl IVssWMDependency_Vtbl {
         iid == &<IVssWMDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssWMFiledesc_Impl: Sized {
     fn GetPath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetFilespec(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1613,6 +1637,7 @@ impl IVssWMFiledesc_Vtbl {
         iid == &<IVssWMFiledesc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssWriterComponents_Impl: Sized {
     fn GetComponentCount(&self, pccomponents: *mut u32) -> ::windows::core::Result<()>;
     fn GetWriterInfo(&self, pidinstance: *mut ::windows::core::GUID, pidwriter: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1656,6 +1681,7 @@ impl IVssWriterComponents {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"implement\"`*"]
 pub trait IVssWriterImpl_Impl: Sized {
     fn Initialize(&self, writerid: &::windows::core::GUID, wszwritername: &::windows::core::PCWSTR, wszwriterinstancename: &::windows::core::PCWSTR, dwmajorversion: u32, dwminorversion: u32, ut: VSS_USAGE_TYPE, st: VSS_SOURCE_TYPE, nlevel: VSS_APPLICATION_LEVEL, dwtimeout: u32, aws: VSS_ALTERNATE_WRITER_STATE, biothrottlingonly: u8) -> ::windows::core::Result<()>;
     fn Subscribe(&self, dwsubscribetimeout: u32, dweventflags: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_Xps_Printing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrintDocumentPackageStatusEvent_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn PackageStatusUpdated(&self, packagestatus: *const PrintDocumentPackageStatus) -> ::windows::core::Result<()>;
@@ -21,6 +22,7 @@ impl IPrintDocumentPackageStatusEvent_Vtbl {
         iid == &<IPrintDocumentPackageStatusEvent as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 pub trait IPrintDocumentPackageTarget_Impl: Sized {
     fn GetPackageTargetTypes(&self, targetcount: *mut u32, targettypes: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetPackageTarget(&self, guidtargettype: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvtarget: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -55,6 +57,7 @@ impl IPrintDocumentPackageTarget_Vtbl {
         iid == &<IPrintDocumentPackageTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps_Printing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IPrintDocumentPackageTargetFactory_Impl: Sized {
     fn CreateDocumentPackageTargetForPrintJob(&self, printername: &::windows::core::PCWSTR, jobname: &::windows::core::PCWSTR, joboutputstream: &::core::option::Option<super::super::super::System::Com::IStream>, jobprintticketstream: &::core::option::Option<super::super::super::System::Com::IStream>) -> ::windows::core::Result<IPrintDocumentPackageTarget>;
@@ -84,6 +87,7 @@ impl IPrintDocumentPackageTargetFactory_Vtbl {
         iid == &<IPrintDocumentPackageTargetFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps_Printing\"`, `\"implement\"`*"]
 pub trait IXpsPrintJob_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn GetJobStatus(&self) -> ::windows::core::Result<XPS_JOB_STATUS>;
@@ -117,6 +121,7 @@ impl IXpsPrintJob_Vtbl {
         iid == &<IXpsPrintJob as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps_Printing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IXpsPrintJobStream_Impl: Sized + super::super::super::System::Com::ISequentialStream_Impl {
     fn Close(&self) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsDocumentPackageTarget_Impl: Sized {
     fn GetXpsOMPackageWriter(&self, documentsequencepartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, discardcontrolpartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMPackageWriter>;
@@ -53,6 +54,7 @@ impl IXpsDocumentPackageTarget_Vtbl {
         iid == &<IXpsDocumentPackageTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsDocumentPackageTarget3D_Impl: Sized {
     fn GetXpsOMPackageWriter3D(&self, documentsequencepartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, discardcontrolpartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, modelpartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, modeldata: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<IXpsOMPackageWriter3D>;
@@ -95,6 +97,7 @@ impl IXpsDocumentPackageTarget3D_Vtbl {
         iid == &<IXpsDocumentPackageTarget3D as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMBrush_Impl: Sized + IXpsOMShareable_Impl {
     fn GetOpacity(&self) -> ::windows::core::Result<f32>;
     fn SetOpacity(&self, opacity: f32) -> ::windows::core::Result<()>;
@@ -128,6 +131,7 @@ impl IXpsOMBrush_Vtbl {
         iid == &<IXpsOMBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXpsOMCanvas_Impl: Sized + IXpsOMVisual_Impl {
     fn GetVisuals(&self) -> ::windows::core::Result<IXpsOMVisualCollection>;
@@ -283,6 +287,7 @@ impl IXpsOMCanvas_Vtbl {
         iid == &<IXpsOMCanvas as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMVisual as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMColorProfileResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -319,6 +324,7 @@ impl IXpsOMColorProfileResource_Vtbl {
         iid == &<IXpsOMColorProfileResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMColorProfileResourceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -402,6 +408,7 @@ impl IXpsOMColorProfileResourceCollection_Vtbl {
         iid == &<IXpsOMColorProfileResourceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMCoreProperties_Impl: Sized + IXpsOMPart_Impl {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMPackage>;
@@ -764,6 +771,7 @@ impl IXpsOMCoreProperties_Vtbl {
         iid == &<IXpsOMCoreProperties as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMDashCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<XPS_DASH>;
@@ -831,6 +839,7 @@ impl IXpsOMDashCollection_Vtbl {
         iid == &<IXpsOMDashCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMDictionary_Impl: Sized {
     fn GetOwner(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -944,6 +953,7 @@ impl IXpsOMDictionary_Vtbl {
         iid == &<IXpsOMDictionary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMDocument_Impl: Sized + IXpsOMPart_Impl {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMDocumentSequence>;
@@ -1052,6 +1062,7 @@ impl IXpsOMDocument_Vtbl {
         iid == &<IXpsOMDocument as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMDocumentCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsOMDocument>;
@@ -1119,6 +1130,7 @@ impl IXpsOMDocumentCollection_Vtbl {
         iid == &<IXpsOMDocumentCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMDocumentSequence_Impl: Sized + IXpsOMPart_Impl {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMPackage>;
@@ -1181,6 +1193,7 @@ impl IXpsOMDocumentSequence_Vtbl {
         iid == &<IXpsOMDocumentSequence as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMDocumentStructureResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMDocument>;
@@ -1230,6 +1243,7 @@ impl IXpsOMDocumentStructureResource_Vtbl {
         iid == &<IXpsOMDocumentStructureResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMFontResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -1279,6 +1293,7 @@ impl IXpsOMFontResource_Vtbl {
         iid == &<IXpsOMFontResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMFontResourceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -1362,6 +1377,7 @@ impl IXpsOMFontResourceCollection_Vtbl {
         iid == &<IXpsOMFontResourceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMGeometry_Impl: Sized + IXpsOMShareable_Impl {
     fn GetFigures(&self) -> ::windows::core::Result<IXpsOMGeometryFigureCollection>;
     fn GetFillRule(&self) -> ::windows::core::Result<XPS_FILL_RULE>;
@@ -1474,6 +1490,7 @@ impl IXpsOMGeometry_Vtbl {
         iid == &<IXpsOMGeometry as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXpsOMGeometryFigure_Impl: Sized {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMGeometry>;
@@ -1643,6 +1660,7 @@ impl IXpsOMGeometryFigure_Vtbl {
         iid == &<IXpsOMGeometryFigure as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMGeometryFigureCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsOMGeometryFigure>;
@@ -1710,6 +1728,7 @@ impl IXpsOMGeometryFigureCollection_Vtbl {
         iid == &<IXpsOMGeometryFigureCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXpsOMGlyphs_Impl: Sized + IXpsOMVisual_Impl {
     fn GetUnicodeString(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2017,6 +2036,7 @@ impl IXpsOMGlyphs_Vtbl {
         iid == &<IXpsOMGlyphs as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMVisual as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXpsOMGlyphsEditor_Impl: Sized {
     fn ApplyEdits(&self) -> ::windows::core::Result<()>;
@@ -2201,6 +2221,7 @@ impl IXpsOMGlyphsEditor_Vtbl {
         iid == &<IXpsOMGlyphsEditor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMGradientBrush_Impl: Sized + IXpsOMBrush_Impl {
     fn GetGradientStops(&self) -> ::windows::core::Result<IXpsOMGradientStopCollection>;
     fn GetTransform(&self) -> ::windows::core::Result<IXpsOMMatrixTransform>;
@@ -2320,6 +2341,7 @@ impl IXpsOMGradientBrush_Vtbl {
         iid == &<IXpsOMGradientBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMGradientStop_Impl: Sized {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMGradientBrush>;
     fn GetOffset(&self) -> ::windows::core::Result<f32>;
@@ -2393,6 +2415,7 @@ impl IXpsOMGradientStop_Vtbl {
         iid == &<IXpsOMGradientStop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMGradientStopCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsOMGradientStop>;
@@ -2460,6 +2483,7 @@ impl IXpsOMGradientStopCollection_Vtbl {
         iid == &<IXpsOMGradientStopCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMImageBrush_Impl: Sized + IXpsOMTileBrush_Impl {
     fn GetImageResource(&self) -> ::windows::core::Result<IXpsOMImageResource>;
     fn SetImageResource(&self, imageresource: &::core::option::Option<IXpsOMImageResource>) -> ::windows::core::Result<()>;
@@ -2526,6 +2550,7 @@ impl IXpsOMImageBrush_Vtbl {
         iid == &<IXpsOMImageBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMTileBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMImageResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -2575,6 +2600,7 @@ impl IXpsOMImageResource_Vtbl {
         iid == &<IXpsOMImageResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMImageResourceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -2658,6 +2684,7 @@ impl IXpsOMImageResourceCollection_Vtbl {
         iid == &<IXpsOMImageResourceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMLinearGradientBrush_Impl: Sized + IXpsOMGradientBrush_Impl {
     fn GetStartPoint(&self) -> ::windows::core::Result<XPS_POINT>;
     fn SetStartPoint(&self, startpoint: *const XPS_POINT) -> ::windows::core::Result<()>;
@@ -2724,6 +2751,7 @@ impl IXpsOMLinearGradientBrush_Vtbl {
         iid == &<IXpsOMLinearGradientBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMGradientBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMMatrixTransform_Impl: Sized + IXpsOMShareable_Impl {
     fn GetMatrix(&self) -> ::windows::core::Result<XPS_MATRIX>;
     fn SetMatrix(&self, matrix: *const XPS_MATRIX) -> ::windows::core::Result<()>;
@@ -2770,6 +2798,7 @@ impl IXpsOMMatrixTransform_Vtbl {
         iid == &<IXpsOMMatrixTransform as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMNameCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2809,6 +2838,7 @@ impl IXpsOMNameCollection_Vtbl {
         iid == &<IXpsOMNameCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMObjectFactory_Impl: Sized {
     fn CreatePackage(&self) -> ::windows::core::Result<IXpsOMPackage>;
@@ -3306,6 +3336,7 @@ impl IXpsOMObjectFactory_Vtbl {
         iid == &<IXpsOMObjectFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMObjectFactory1_Impl: Sized + IXpsOMObjectFactory_Impl {
     fn GetDocumentTypeFromFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<XPS_DOCUMENT_TYPE>;
@@ -3478,6 +3509,7 @@ impl IXpsOMObjectFactory1_Vtbl {
         iid == &<IXpsOMObjectFactory1 as ::windows::core::Interface>::IID || iid == &<IXpsOMObjectFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPackage_Impl: Sized {
     fn GetDocumentSequence(&self) -> ::windows::core::Result<IXpsOMDocumentSequence>;
@@ -3588,6 +3620,7 @@ impl IXpsOMPackage_Vtbl {
         iid == &<IXpsOMPackage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPackage1_Impl: Sized + IXpsOMPackage_Impl {
     fn GetDocumentType(&self) -> ::windows::core::Result<XPS_DOCUMENT_TYPE>;
@@ -3631,6 +3664,7 @@ impl IXpsOMPackage1_Vtbl {
         iid == &<IXpsOMPackage1 as ::windows::core::Interface>::IID || iid == &<IXpsOMPackage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPackageTarget_Impl: Sized {
     fn CreateXpsOMPackageWriter(&self, documentsequencepartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, documentsequenceprintticket: &::core::option::Option<IXpsOMPrintTicketResource>, discardcontrolpartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMPackageWriter>;
@@ -3657,6 +3691,7 @@ impl IXpsOMPackageTarget_Vtbl {
         iid == &<IXpsOMPackageTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPackageWriter_Impl: Sized {
     fn StartNewDocument(&self, documentpartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, documentprintticket: &::core::option::Option<IXpsOMPrintTicketResource>, documentstructure: &::core::option::Option<IXpsOMDocumentStructureResource>, signatureblockresources: &::core::option::Option<IXpsOMSignatureBlockResourceCollection>, restrictedfonts: &::core::option::Option<IXpsOMPartUriCollection>) -> ::windows::core::Result<()>;
@@ -3714,6 +3749,7 @@ impl IXpsOMPackageWriter_Vtbl {
         iid == &<IXpsOMPackageWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPackageWriter3D_Impl: Sized + IXpsOMPackageWriter_Impl {
     fn AddModelTexture(&self, texturepartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>, texturedata: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -3744,6 +3780,7 @@ impl IXpsOMPackageWriter3D_Vtbl {
         iid == &<IXpsOMPackageWriter3D as ::windows::core::Interface>::IID || iid == &<IXpsOMPackageWriter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPage_Impl: Sized + IXpsOMPart_Impl {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMPageReference>;
@@ -3992,6 +4029,7 @@ impl IXpsOMPage_Vtbl {
         iid == &<IXpsOMPage as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPage1_Impl: Sized + IXpsOMPage_Impl {
     fn GetDocumentType(&self) -> ::windows::core::Result<XPS_DOCUMENT_TYPE>;
@@ -4028,6 +4066,7 @@ impl IXpsOMPage1_Vtbl {
         iid == &<IXpsOMPage1 as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMPage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXpsOMPageReference_Impl: Sized {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMDocument>;
@@ -4229,6 +4268,7 @@ impl IXpsOMPageReference_Vtbl {
         iid == &<IXpsOMPageReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMPageReferenceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsOMPageReference>;
@@ -4296,6 +4336,7 @@ impl IXpsOMPageReferenceCollection_Vtbl {
         iid == &<IXpsOMPageReferenceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPart_Impl: Sized {
     fn GetPartName(&self) -> ::windows::core::Result<super::Packaging::Opc::IOpcPartUri>;
@@ -4332,6 +4373,7 @@ impl IXpsOMPart_Vtbl {
         iid == &<IXpsOMPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMPartResources_Impl: Sized {
     fn GetFontResources(&self) -> ::windows::core::Result<IXpsOMFontResourceCollection>;
     fn GetImageResources(&self) -> ::windows::core::Result<IXpsOMImageResourceCollection>;
@@ -4397,6 +4439,7 @@ impl IXpsOMPartResources_Vtbl {
         iid == &<IXpsOMPartResources as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPartUriCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -4467,6 +4510,7 @@ impl IXpsOMPartUriCollection_Vtbl {
         iid == &<IXpsOMPartUriCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXpsOMPath_Impl: Sized + IXpsOMVisual_Impl {
     fn GetGeometry(&self) -> ::windows::core::Result<IXpsOMGeometry>;
@@ -4868,6 +4912,7 @@ impl IXpsOMPath_Vtbl {
         iid == &<IXpsOMPath as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMVisual as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMPrintTicketResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -4904,6 +4949,7 @@ impl IXpsOMPrintTicketResource_Vtbl {
         iid == &<IXpsOMPrintTicketResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMRadialGradientBrush_Impl: Sized + IXpsOMGradientBrush_Impl {
     fn GetCenter(&self) -> ::windows::core::Result<XPS_POINT>;
     fn SetCenter(&self, center: *const XPS_POINT) -> ::windows::core::Result<()>;
@@ -4990,6 +5036,7 @@ impl IXpsOMRadialGradientBrush_Vtbl {
         iid == &<IXpsOMRadialGradientBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMGradientBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMRemoteDictionaryResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetDictionary(&self) -> ::windows::core::Result<IXpsOMDictionary>;
@@ -5026,6 +5073,7 @@ impl IXpsOMRemoteDictionaryResource_Vtbl {
         iid == &<IXpsOMRemoteDictionaryResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMRemoteDictionaryResource1_Impl: Sized + IXpsOMRemoteDictionaryResource_Impl {
     fn GetDocumentType(&self) -> ::windows::core::Result<XPS_DOCUMENT_TYPE>;
@@ -5062,6 +5110,7 @@ impl IXpsOMRemoteDictionaryResource1_Vtbl {
         iid == &<IXpsOMRemoteDictionaryResource1 as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID || iid == &<IXpsOMRemoteDictionaryResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMRemoteDictionaryResourceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -5145,6 +5194,7 @@ impl IXpsOMRemoteDictionaryResourceCollection_Vtbl {
         iid == &<IXpsOMRemoteDictionaryResourceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMResource_Impl: Sized + IXpsOMPart_Impl {}
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
@@ -5158,6 +5208,7 @@ impl IXpsOMResource_Vtbl {
         iid == &<IXpsOMResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMShareable_Impl: Sized {
     fn GetOwner(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetType(&self) -> ::windows::core::Result<XPS_OBJECT_TYPE>;
@@ -5197,6 +5248,7 @@ impl IXpsOMShareable_Vtbl {
         iid == &<IXpsOMShareable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMSignatureBlockResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMDocument>;
@@ -5246,6 +5298,7 @@ impl IXpsOMSignatureBlockResource_Vtbl {
         iid == &<IXpsOMSignatureBlockResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMSignatureBlockResourceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -5329,6 +5382,7 @@ impl IXpsOMSignatureBlockResourceCollection_Vtbl {
         iid == &<IXpsOMSignatureBlockResourceCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMSolidColorBrush_Impl: Sized + IXpsOMBrush_Impl {
     fn GetColor(&self, color: *mut XPS_COLOR, colorprofile: *mut ::core::option::Option<IXpsOMColorProfileResource>) -> ::windows::core::Result<()>;
     fn SetColor(&self, color: *const XPS_COLOR, colorprofile: &::core::option::Option<IXpsOMColorProfileResource>) -> ::windows::core::Result<()>;
@@ -5369,6 +5423,7 @@ impl IXpsOMSolidColorBrush_Vtbl {
         iid == &<IXpsOMSolidColorBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMStoryFragmentsResource_Impl: Sized + IXpsOMResource_Impl {
     fn GetOwner(&self) -> ::windows::core::Result<IXpsOMPageReference>;
@@ -5418,6 +5473,7 @@ impl IXpsOMStoryFragmentsResource_Vtbl {
         iid == &<IXpsOMStoryFragmentsResource as ::windows::core::Interface>::IID || iid == &<IXpsOMPart as ::windows::core::Interface>::IID || iid == &<IXpsOMResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsOMThumbnailGenerator_Impl: Sized {
     fn GenerateThumbnail(&self, page: &::core::option::Option<IXpsOMPage>, thumbnailtype: XPS_IMAGE_TYPE, thumbnailsize: XPS_THUMBNAIL_SIZE, imageresourcepartname: &::core::option::Option<super::Packaging::Opc::IOpcPartUri>) -> ::windows::core::Result<IXpsOMImageResource>;
@@ -5444,6 +5500,7 @@ impl IXpsOMThumbnailGenerator_Vtbl {
         iid == &<IXpsOMThumbnailGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMTileBrush_Impl: Sized + IXpsOMBrush_Impl {
     fn GetTransform(&self) -> ::windows::core::Result<IXpsOMMatrixTransform>;
     fn GetTransformLocal(&self) -> ::windows::core::Result<IXpsOMMatrixTransform>;
@@ -5570,6 +5627,7 @@ impl IXpsOMTileBrush_Vtbl {
         iid == &<IXpsOMTileBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IXpsOMVisual_Impl: Sized + IXpsOMShareable_Impl {
     fn GetTransform(&self) -> ::windows::core::Result<IXpsOMMatrixTransform>;
@@ -5845,6 +5903,7 @@ impl IXpsOMVisual_Vtbl {
         iid == &<IXpsOMVisual as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMVisualBrush_Impl: Sized + IXpsOMTileBrush_Impl {
     fn GetVisual(&self) -> ::windows::core::Result<IXpsOMVisual>;
     fn GetVisualLocal(&self) -> ::windows::core::Result<IXpsOMVisual>;
@@ -5924,6 +5983,7 @@ impl IXpsOMVisualBrush_Vtbl {
         iid == &<IXpsOMVisualBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMShareable as ::windows::core::Interface>::IID || iid == &<IXpsOMBrush as ::windows::core::Interface>::IID || iid == &<IXpsOMTileBrush as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsOMVisualCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsOMVisual>;
@@ -5991,6 +6051,7 @@ impl IXpsOMVisualCollection_Vtbl {
         iid == &<IXpsOMVisualCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Cryptography\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsSignature_Impl: Sized {
     fn GetSignatureId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -6145,6 +6206,7 @@ impl IXpsSignature_Vtbl {
         iid == &<IXpsSignature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsSignatureBlock_Impl: Sized {
     fn GetRequests(&self) -> ::windows::core::Result<IXpsSignatureRequestCollection>;
@@ -6226,6 +6288,7 @@ impl IXpsSignatureBlock_Vtbl {
         iid == &<IXpsSignatureBlock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsSignatureBlockCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsSignatureBlock>;
@@ -6272,6 +6335,7 @@ impl IXpsSignatureBlockCollection_Vtbl {
         iid == &<IXpsSignatureBlockCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsSignatureCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsSignature>;
@@ -6318,6 +6382,7 @@ impl IXpsSignatureCollection_Vtbl {
         iid == &<IXpsSignatureCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Cryptography\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Cryptography", feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsSignatureManager_Impl: Sized {
     fn LoadPackageFile(&self, filename: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -6447,6 +6512,7 @@ impl IXpsSignatureManager_Vtbl {
         iid == &<IXpsSignatureManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsSignatureRequest_Impl: Sized {
     fn GetIntent(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -6583,6 +6649,7 @@ impl IXpsSignatureRequest_Vtbl {
         iid == &<IXpsSignatureRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 pub trait IXpsSignatureRequestCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, index: u32) -> ::windows::core::Result<IXpsSignatureRequest>;
@@ -6629,6 +6696,7 @@ impl IXpsSignatureRequestCollection_Vtbl {
         iid == &<IXpsSignatureRequestCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_Storage_Xps\"`, `\"Win32_Storage_Packaging_Opc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Packaging_Opc", feature = "Win32_System_Com"))]
 pub trait IXpsSigningOptions_Impl: Sized {
     fn GetSignatureId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IABContainer_Impl: Sized + IMAPIContainer_Impl {
     fn CreateEntry(&self, cbentryid: u32, lpentryid: *const ENTRYID, ulcreateflags: u32) -> ::windows::core::Result<IMAPIProp>;
@@ -54,6 +55,7 @@ impl IABContainer_Vtbl {
         iid == &<IABContainer as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID || iid == &<IMAPIContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAddrBook_Impl: Sized + IMAPIProp_Impl {
     fn OpenEntry(&self, cbentryid: u32, lpentryid: *mut ENTRYID, lpinterface: *mut ::windows::core::GUID, ulflags: u32, lpulobjtype: *mut u32, lppunk: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -196,6 +198,7 @@ impl IAddrBook_Vtbl {
         iid == &<IAddrBook as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAttach_Impl: Sized + IMAPIProp_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -209,6 +212,7 @@ impl IAttach_Vtbl {
         iid == &<IAttach as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDistList_Impl: Sized + IMAPIContainer_Impl {
     fn CreateEntry(&self, cbentryid: u32, lpentryid: *const ENTRYID, ulcreateflags: u32) -> ::windows::core::Result<IMAPIProp>;
@@ -265,6 +269,7 @@ impl IDistList_Vtbl {
         iid == &<IDistList as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID || iid == &<IMAPIContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMAPIAdviseSink_Impl: Sized {
     fn OnNotify(&self, cnotif: u32, lpnotifications: *mut NOTIFICATION) -> u32;
@@ -285,6 +290,7 @@ impl IMAPIAdviseSink_Vtbl {
         iid == &<IMAPIAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMAPIContainer_Impl: Sized + IMAPIProp_Impl {
     fn GetContentsTable(&self, ulflags: u32) -> ::windows::core::Result<IMAPITable>;
@@ -348,6 +354,7 @@ impl IMAPIContainer_Vtbl {
         iid == &<IMAPIContainer as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"implement\"`*"]
 pub trait IMAPIControl_Impl: Sized {
     fn GetLastError(&self, hresult: ::windows::core::HRESULT, ulflags: u32) -> ::windows::core::Result<*mut MAPIERROR>;
     fn Activate(&self, ulflags: u32, uluiparam: usize) -> ::windows::core::Result<()>;
@@ -388,6 +395,7 @@ impl IMAPIControl_Vtbl {
         iid == &<IMAPIControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMAPIFolder_Impl: Sized + IMAPIContainer_Impl {
     fn CreateMessage(&self, lpinterface: *mut ::windows::core::GUID, ulflags: u32, lppmessage: *mut ::core::option::Option<IMessage>) -> ::windows::core::Result<()>;
@@ -499,6 +507,7 @@ impl IMAPIFolder_Vtbl {
         iid == &<IMAPIFolder as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID || iid == &<IMAPIContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"implement\"`*"]
 pub trait IMAPIProgress_Impl: Sized {
     fn Progress(&self, ulvalue: u32, ulcount: u32, ultotal: u32) -> ::windows::core::Result<()>;
     fn GetFlags(&self, lpulflags: *mut u32) -> ::windows::core::Result<()>;
@@ -547,6 +556,7 @@ impl IMAPIProgress_Vtbl {
         iid == &<IMAPIProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMAPIProp_Impl: Sized {
     fn GetLastError(&self, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::Result<()>;
@@ -640,6 +650,7 @@ impl IMAPIProp_Vtbl {
         iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMAPIStatus_Impl: Sized + IMAPIProp_Impl {
     fn ValidateState(&self, uluiparam: usize, ulflags: u32) -> ::windows::core::Result<()>;
@@ -684,6 +695,7 @@ impl IMAPIStatus_Vtbl {
         iid == &<IMAPIStatus as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMAPITable_Impl: Sized {
     fn GetLastError(&self, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::Result<()>;
@@ -861,6 +873,7 @@ impl IMAPITable_Vtbl {
         iid == &<IMAPITable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMailUser_Impl: Sized + IMAPIProp_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -874,6 +887,7 @@ impl IMailUser_Vtbl {
         iid == &<IMailUser as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMessage_Impl: Sized + IMAPIProp_Impl {
     fn GetAttachmentTable(&self, ulflags: u32) -> ::windows::core::Result<IMAPITable>;
@@ -964,6 +978,7 @@ impl IMessage_Vtbl {
         iid == &<IMessage as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IMsgStore_Impl: Sized + IMAPIProp_Impl {
     fn Advise(&self, cbentryid: u32, lpentryid: *const ENTRYID, uleventmask: u32, lpadvisesink: &::core::option::Option<IMAPIAdviseSink>) -> ::windows::core::Result<u32>;
@@ -1095,6 +1110,7 @@ impl IMsgStore_Vtbl {
         iid == &<IMsgStore as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IProfSect_Impl: Sized + IMAPIProp_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -1108,6 +1124,7 @@ impl IProfSect_Vtbl {
         iid == &<IProfSect as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPropData_Impl: Sized + IMAPIProp_Impl {
     fn HrSetObjAccess(&self, ulaccess: u32) -> ::windows::core::Result<()>;
@@ -1152,6 +1169,7 @@ impl IPropData_Vtbl {
         iid == &<IPropData as ::windows::core::Interface>::IID || iid == &<IMAPIProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IProviderAdmin_Impl: Sized {
     fn GetLastError(&self, hresult: ::windows::core::HRESULT, ulflags: u32) -> ::windows::core::Result<*mut MAPIERROR>;
@@ -1227,6 +1245,7 @@ impl IProviderAdmin_Vtbl {
         iid == &<IProviderAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITableData_Impl: Sized {
     fn HrGetView(&self, lpssortorderset: *mut SSortOrderSet, lpfcallerrelease: *mut CALLERRELEASE, ulcallerdata: u32, lppmapitable: *mut ::core::option::Option<IMAPITable>) -> ::windows::core::Result<()>;
@@ -1306,6 +1325,7 @@ impl ITableData_Vtbl {
         iid == &<ITableData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWABExtInit_Impl: Sized {
     fn Initialize(&self, lpwabextdisplay: *mut WABEXTDISPLAY) -> ::windows::core::Result<()>;
@@ -1326,6 +1346,7 @@ impl IWABExtInit_Vtbl {
         iid == &<IWABExtInit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWABObject_Impl: Sized {
     fn GetLastError(&self, hresult: ::windows::core::HRESULT, ulflags: u32, lppmapierror: *mut *mut MAPIERROR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Antimalware/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Antimalware\"`, `\"implement\"`*"]
 pub trait IAmsiStream_Impl: Sized {
     fn GetAttribute(&self, attribute: AMSI_ATTRIBUTE, datasize: u32, data: *mut u8, retdata: *mut u32) -> ::windows::core::Result<()>;
     fn Read(&self, position: u64, size: u32, buffer: *mut u8, readsize: *mut u32) -> ::windows::core::Result<()>;
@@ -25,6 +26,7 @@ impl IAmsiStream_Vtbl {
         iid == &<IAmsiStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Antimalware\"`, `\"implement\"`*"]
 pub trait IAntimalware_Impl: Sized {
     fn Scan(&self, stream: &::core::option::Option<IAmsiStream>, result: *mut AMSI_RESULT, provider: *mut ::core::option::Option<IAntimalwareProvider>) -> ::windows::core::Result<()>;
     fn CloseSession(&self, session: u64);
@@ -52,6 +54,7 @@ impl IAntimalware_Vtbl {
         iid == &<IAntimalware as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Antimalware\"`, `\"implement\"`*"]
 pub trait IAntimalware2_Impl: Sized + IAntimalware_Impl {
     fn Notify(&self, buffer: *const ::core::ffi::c_void, length: u32, contentname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR) -> ::windows::core::Result<AMSI_RESULT>;
 }
@@ -75,6 +78,7 @@ impl IAntimalware2_Vtbl {
         iid == &<IAntimalware2 as ::windows::core::Interface>::IID || iid == &<IAntimalware as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Antimalware\"`, `\"implement\"`*"]
 pub trait IAntimalwareProvider_Impl: Sized {
     fn Scan(&self, stream: &::core::option::Option<IAmsiStream>) -> ::windows::core::Result<AMSI_RESULT>;
     fn CloseSession(&self, session: u64);
@@ -121,6 +125,7 @@ impl IAntimalwareProvider_Vtbl {
         iid == &<IAntimalwareProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Antimalware\"`, `\"implement\"`*"]
 pub trait IAntimalwareProvider2_Impl: Sized + IAntimalwareProvider_Impl {
     fn Notify(&self, buffer: *const ::core::ffi::c_void, length: u32, contentname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR) -> ::windows::core::Result<AMSI_RESULT>;
 }
@@ -144,6 +149,7 @@ impl IAntimalwareProvider2_Vtbl {
         iid == &<IAntimalwareProvider2 as ::windows::core::Interface>::IID || iid == &<IAntimalwareProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Antimalware\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAntimalwareUacProvider_Impl: Sized {
     fn UacScan(&self, context: *const AMSI_UAC_REQUEST_CONTEXT) -> ::windows::core::Result<AMSI_RESULT>;

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IAssemblyCache_Impl: Sized {
     fn UninstallAssembly(&self, dwflags: u32, pszassemblyname: &::windows::core::PCWSTR, prefdata: *mut FUSION_INSTALL_REFERENCE, puldisposition: *mut IASSEMBLYCACHE_UNINSTALL_DISPOSITION) -> ::windows::core::Result<()>;
     fn QueryAssemblyInfo(&self, dwflags: QUERYASMINFO_FLAGS, pszassemblyname: &::windows::core::PCWSTR, pasminfo: *mut ASSEMBLY_INFO) -> ::windows::core::Result<()>;
@@ -52,6 +53,7 @@ impl IAssemblyCache_Vtbl {
         iid == &<IAssemblyCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAssemblyCacheItem_Impl: Sized {
     fn CreateStream(&self, dwflags: u32, pszstreamname: &::windows::core::PCWSTR, dwformat: u32, dwformatflags: u32, ppistream: *mut ::core::option::Option<super::Com::IStream>, pulimaxsize: *mut u64) -> ::windows::core::Result<()>;
@@ -89,6 +91,7 @@ impl IAssemblyCacheItem_Vtbl {
         iid == &<IAssemblyCacheItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IAssemblyName_Impl: Sized {
     fn SetProperty(&self, propertyid: u32, pvproperty: *mut ::core::ffi::c_void, cbproperty: u32) -> ::windows::core::Result<()>;
     fn GetProperty(&self, propertyid: u32, pvproperty: *mut ::core::ffi::c_void, pcbproperty: *mut u32) -> ::windows::core::Result<()>;
@@ -171,6 +174,7 @@ impl IAssemblyName_Vtbl {
         iid == &<IAssemblyName as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumMsmDependency_Impl: Sized {
     fn Next(&self, cfetch: u32, rgmsmdependencies: *mut ::core::option::Option<IMsmDependency>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -221,6 +225,7 @@ impl IEnumMsmDependency_Vtbl {
         iid == &<IEnumMsmDependency as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumMsmError_Impl: Sized {
     fn Next(&self, cfetch: u32, rgmsmerrors: *mut ::core::option::Option<IMsmError>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -271,6 +276,7 @@ impl IEnumMsmError_Vtbl {
         iid == &<IEnumMsmError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IEnumMsmString_Impl: Sized {
     fn Next(&self, cfetch: u32, rgbstrstrings: *mut ::windows::core::BSTR, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cskip: u32) -> ::windows::core::Result<()>;
@@ -318,6 +324,7 @@ impl IEnumMsmString_Vtbl {
         iid == &<IEnumMsmString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMsmDependencies_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, item: i32) -> ::windows::core::Result<IMsmDependency>;
@@ -367,6 +374,7 @@ impl IMsmDependencies_Vtbl {
         iid == &<IMsmDependencies as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMsmDependency_Impl: Sized + super::Com::IDispatch_Impl {
     fn Module(&self, module: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -404,6 +412,7 @@ impl IMsmDependency_Vtbl {
         iid == &<IMsmDependency as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMsmError_Impl: Sized + super::Com::IDispatch_Impl {
     fn Type(&self, errortype: *mut msmErrorType) -> ::windows::core::Result<()>;
@@ -481,6 +490,7 @@ impl IMsmError_Vtbl {
         iid == &<IMsmError as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMsmErrors_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, item: i32) -> ::windows::core::Result<IMsmError>;
@@ -530,6 +540,7 @@ impl IMsmErrors_Vtbl {
         iid == &<IMsmErrors as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMsmGetFiles_Impl: Sized + super::Com::IDispatch_Impl {
     fn ModuleFiles(&self) -> ::windows::core::Result<IMsmStrings>;
@@ -556,6 +567,7 @@ impl IMsmGetFiles_Vtbl {
         iid == &<IMsmGetFiles as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMsmMerge_Impl: Sized + super::Com::IDispatch_Impl {
     fn OpenDatabase(&self, path: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -675,6 +687,7 @@ impl IMsmMerge_Vtbl {
         iid == &<IMsmMerge as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMsmStrings_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, item: i32, r#return: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -718,6 +731,7 @@ impl IMsmStrings_Vtbl {
         iid == &<IMsmStrings as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMApplicationInfo_Impl: Sized {
     fn ProductID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1329,6 +1343,7 @@ impl IPMApplicationInfo_Vtbl {
         iid == &<IPMApplicationInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMApplicationInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMApplicationInfo>;
 }
@@ -1352,6 +1367,7 @@ impl IPMApplicationInfoEnumerator_Vtbl {
         iid == &<IPMApplicationInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMBackgroundServiceAgentInfo_Impl: Sized {
     fn ProductID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1502,6 +1518,7 @@ impl IPMBackgroundServiceAgentInfo_Vtbl {
         iid == &<IPMBackgroundServiceAgentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMBackgroundServiceAgentInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMBackgroundServiceAgentInfo>;
 }
@@ -1525,6 +1542,7 @@ impl IPMBackgroundServiceAgentInfoEnumerator_Vtbl {
         iid == &<IPMBackgroundServiceAgentInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMBackgroundWorkerInfo_Impl: Sized {
     fn ProductID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1607,6 +1625,7 @@ impl IPMBackgroundWorkerInfo_Vtbl {
         iid == &<IPMBackgroundWorkerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMBackgroundWorkerInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMBackgroundWorkerInfo>;
 }
@@ -1630,6 +1649,7 @@ impl IPMBackgroundWorkerInfoEnumerator_Vtbl {
         iid == &<IPMBackgroundWorkerInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPMDeploymentManager_Impl: Sized {
     fn ReportDownloadBegin(&self, productid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1905,6 +1925,7 @@ impl IPMDeploymentManager_Vtbl {
         iid == &<IPMDeploymentManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMEnumerationManager_Impl: Sized {
     fn get_AllApplications(&self, ppappenum: *mut ::core::option::Option<IPMApplicationInfoEnumerator>, filter: &PM_ENUM_FILTER) -> ::windows::core::Result<()>;
@@ -2101,6 +2122,7 @@ impl IPMEnumerationManager_Vtbl {
         iid == &<IPMEnumerationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMExtensionCachedFileUpdaterInfo_Impl: Sized {
     fn SupportsUpdates(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2127,6 +2149,7 @@ impl IPMExtensionCachedFileUpdaterInfo_Vtbl {
         iid == &<IPMExtensionCachedFileUpdaterInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMExtensionContractInfo_Impl: Sized {
     fn get_InvocationInfo(&self, paumid: *mut ::windows::core::BSTR, pargs: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -2144,6 +2167,7 @@ impl IPMExtensionContractInfo_Vtbl {
         iid == &<IPMExtensionContractInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMExtensionFileExtensionInfo_Impl: Sized {
     fn Name(&self, pname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn DisplayName(&self, pdisplayname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2206,6 +2230,7 @@ impl IPMExtensionFileExtensionInfo_Vtbl {
         iid == &<IPMExtensionFileExtensionInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMExtensionFileOpenPickerInfo_Impl: Sized {
     fn get_AllFileTypes(&self, pctypes: *mut u32, pptypes: *mut *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2242,6 +2267,7 @@ impl IPMExtensionFileOpenPickerInfo_Vtbl {
         iid == &<IPMExtensionFileOpenPickerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMExtensionFileSavePickerInfo_Impl: Sized {
     fn get_AllFileTypes(&self, pctypes: *mut u32, pptypes: *mut *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2278,6 +2304,7 @@ impl IPMExtensionFileSavePickerInfo_Vtbl {
         iid == &<IPMExtensionFileSavePickerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMExtensionInfo_Impl: Sized {
     fn SupplierPID(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn SupplierTaskID(&self, psuppliertid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2339,6 +2366,7 @@ impl IPMExtensionInfo_Vtbl {
         iid == &<IPMExtensionInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMExtensionInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMExtensionInfo>;
 }
@@ -2362,6 +2390,7 @@ impl IPMExtensionInfoEnumerator_Vtbl {
         iid == &<IPMExtensionInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMExtensionProtocolInfo_Impl: Sized {
     fn Protocol(&self, pprotocol: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn get_InvocationInfo(&self, pimageurn: *mut ::windows::core::BSTR, pparameters: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2389,6 +2418,7 @@ impl IPMExtensionProtocolInfo_Vtbl {
         iid == &<IPMExtensionProtocolInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMExtensionShareTargetInfo_Impl: Sized {
     fn get_AllFileTypes(&self, pctypes: *mut u32, pptypes: *mut *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2432,6 +2462,7 @@ impl IPMExtensionShareTargetInfo_Vtbl {
         iid == &<IPMExtensionShareTargetInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMLiveTileJobInfo_Impl: Sized {
     fn ProductID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2676,6 +2707,7 @@ impl IPMLiveTileJobInfo_Vtbl {
         iid == &<IPMLiveTileJobInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMLiveTileJobInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMLiveTileJobInfo>;
 }
@@ -2699,6 +2731,7 @@ impl IPMLiveTileJobInfoEnumerator_Vtbl {
         iid == &<IPMLiveTileJobInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMTaskInfo_Impl: Sized {
     fn ProductID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2934,6 +2967,7 @@ impl IPMTaskInfo_Vtbl {
         iid == &<IPMTaskInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMTaskInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMTaskInfo>;
 }
@@ -2957,6 +2991,7 @@ impl IPMTaskInfoEnumerator_Vtbl {
         iid == &<IPMTaskInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPMTileInfo_Impl: Sized {
     fn ProductID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3219,6 +3254,7 @@ impl IPMTileInfo_Vtbl {
         iid == &<IPMTileInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMTileInfoEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMTileInfo>;
 }
@@ -3242,6 +3278,7 @@ impl IPMTileInfoEnumerator_Vtbl {
         iid == &<IPMTileInfoEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMTilePropertyEnumerator_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPMTilePropertyInfo>;
 }
@@ -3265,6 +3302,7 @@ impl IPMTilePropertyEnumerator_Vtbl {
         iid == &<IPMTilePropertyEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"implement\"`*"]
 pub trait IPMTilePropertyInfo_Impl: Sized {
     fn PropertyID(&self) -> ::windows::core::Result<u32>;
     fn PropertyValue(&self, ppropvalue: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3305,6 +3343,7 @@ impl IPMTilePropertyInfo_Vtbl {
         iid == &<IPMTilePropertyInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ApplicationInstallationAndServicing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IValidate_Impl: Sized {
     fn OpenDatabase(&self, szdatabase: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Accessibility"))]
 pub trait IAccessibleWinSAT_Impl: Sized + super::super::UI::Accessibility::IAccessible_Impl {
     fn SetAccessiblityData(&self, wsname: &::windows::core::PCWSTR, wsvalue: &::windows::core::PCWSTR, wsdesc: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -21,6 +22,7 @@ impl IAccessibleWinSAT_Vtbl {
         iid == &<IAccessibleWinSAT as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<super::super::UI::Accessibility::IAccessible as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInitiateWinSATAssessment_Impl: Sized {
     fn InitiateAssessment(&self, cmdline: &::windows::core::PCWSTR, pcallbacks: &::core::option::Option<IWinSATInitiateEvents>, callerhwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -58,6 +60,7 @@ impl IInitiateWinSATAssessment_Vtbl {
         iid == &<IInitiateWinSATAssessment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IProvideWinSATAssessmentInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Score(&self) -> ::windows::core::Result<f32>;
@@ -113,6 +116,7 @@ impl IProvideWinSATAssessmentInfo_Vtbl {
         iid == &<IProvideWinSATAssessmentInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IProvideWinSATResultsInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetAssessmentInfo(&self, assessment: WINSAT_ASSESSMENT_TYPE) -> ::windows::core::Result<IProvideWinSATAssessmentInfo>;
@@ -194,6 +198,7 @@ impl IProvideWinSATResultsInfo_Vtbl {
         iid == &<IProvideWinSATResultsInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IProvideWinSATVisuals_Impl: Sized {
     fn get_Bitmap(&self, bitmapsize: WINSAT_BITMAP_SIZE, state: WINSAT_ASSESSMENT_STATE, rating: f32) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
@@ -220,6 +225,7 @@ impl IProvideWinSATVisuals_Vtbl {
         iid == &<IProvideWinSATVisuals as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IQueryAllWinSATAssessments_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_AllXML(&self, xpath: &::windows::core::BSTR, namespaces: &::windows::core::BSTR) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMNodeList>;
@@ -246,6 +252,7 @@ impl IQueryAllWinSATAssessments_Vtbl {
         iid == &<IQueryAllWinSATAssessments as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"implement\"`*"]
 pub trait IQueryOEMWinSATCustomization_Impl: Sized {
     fn GetOEMPrePopulationInfo(&self) -> ::windows::core::Result<WINSAT_OEM_CUSTOMIZATION_STATE>;
 }
@@ -269,6 +276,7 @@ impl IQueryOEMWinSATCustomization_Vtbl {
         iid == &<IQueryOEMWinSATCustomization as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IQueryRecentWinSATAssessment_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_XML(&self, xpath: &::windows::core::BSTR, namespaces: &::windows::core::BSTR) -> ::windows::core::Result<super::super::Data::Xml::MsXml::IXMLDOMNodeList>;
@@ -311,6 +319,7 @@ impl IQueryRecentWinSATAssessment_Vtbl {
         iid == &<IQueryRecentWinSATAssessment as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_AssessmentTool\"`, `\"implement\"`*"]
 pub trait IWinSATInitiateEvents_Impl: Sized {
     fn WinSATComplete(&self, hresult: ::windows::core::HRESULT, strdescription: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn WinSATUpdate(&self, ucurrenttick: u32, uticktotal: u32, strcurrentstate: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/CallObj/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com_CallObj\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait ICallFrame_Impl: Sized {
     fn GetInfo(&self) -> ::windows::core::Result<CALLFRAMEINFO>;
@@ -183,6 +184,7 @@ impl ICallFrame_Vtbl {
         iid == &<ICallFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_CallObj\"`, `\"implement\"`*"]
 pub trait ICallFrameEvents_Impl: Sized {
     fn OnCall(&self, pframe: &::core::option::Option<ICallFrame>) -> ::windows::core::Result<()>;
 }
@@ -200,6 +202,7 @@ impl ICallFrameEvents_Vtbl {
         iid == &<ICallFrameEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_CallObj\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICallFrameWalker_Impl: Sized {
     fn OnWalkInterface(&self, iid: *const ::windows::core::GUID, ppvinterface: *const *const ::core::ffi::c_void, fin: super::super::super::Foundation::BOOL, fout: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -220,6 +223,7 @@ impl ICallFrameWalker_Vtbl {
         iid == &<ICallFrameWalker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_CallObj\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICallIndirect_Impl: Sized {
     fn CallIndirect(&self, phrreturn: *mut ::windows::core::HRESULT, imethod: u32, pvargs: *const ::core::ffi::c_void, cbargs: *mut u32) -> ::windows::core::Result<()>;
@@ -270,6 +274,7 @@ impl ICallIndirect_Vtbl {
         iid == &<ICallIndirect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_CallObj\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICallInterceptor_Impl: Sized + ICallIndirect_Impl {
     fn RegisterSink(&self, psink: &::core::option::Option<ICallFrameEvents>) -> ::windows::core::Result<()>;
@@ -306,6 +311,7 @@ impl ICallInterceptor_Vtbl {
         iid == &<ICallInterceptor as ::windows::core::Interface>::IID || iid == &<ICallIndirect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_CallObj\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICallUnmarshal_Impl: Sized {
     fn Unmarshal(&self, imethod: u32, pbuffer: *const ::core::ffi::c_void, cbbuffer: u32, fforcebuffercopy: super::super::super::Foundation::BOOL, datarep: u32, pcontext: *const CALLFRAME_MARSHALCONTEXT, pcbunmarshalled: *mut u32, ppframe: *mut ::core::option::Option<ICallFrame>) -> ::windows::core::Result<()>;
@@ -336,6 +342,7 @@ impl ICallUnmarshal_Vtbl {
         iid == &<ICallUnmarshal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_CallObj\"`, `\"implement\"`*"]
 pub trait IInterfaceRelated_Impl: Sized {
     fn SetIID(&self, iid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetIID(&self) -> ::windows::core::Result<::windows::core::GUID>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/ChannelCredentials/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/ChannelCredentials/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com_ChannelCredentials\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IChannelCredentials_Impl: Sized + super::IDispatch_Impl {
     fn SetWindowsCredential(&self, domain: &::windows::core::BSTR, username: &::windows::core::BSTR, password: &::windows::core::BSTR, impersonationlevel: i32, allowntlm: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"implement\"`*"]
 pub trait IDontSupportEventSubscription_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDontSupportEventSubscription {}
 impl IDontSupportEventSubscription_Vtbl {
@@ -8,6 +9,7 @@ impl IDontSupportEventSubscription_Vtbl {
         iid == &<IDontSupportEventSubscription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"implement\"`*"]
 pub trait IEnumEventObject_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumEventObject>;
     fn Next(&self, creqelem: u32, ppinterface: *mut ::core::option::Option<::windows::core::IUnknown>, cretelem: *mut u32) -> ::windows::core::Result<()>;
@@ -55,6 +57,7 @@ impl IEnumEventObject_Vtbl {
         iid == &<IEnumEventObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventClass_Impl: Sized + super::IDispatch_Impl {
     fn EventClassID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -211,6 +214,7 @@ impl IEventClass_Vtbl {
         iid == &<IEventClass as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventClass2_Impl: Sized + IEventClass_Impl {
     fn PublisherID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -307,6 +311,7 @@ impl IEventClass2_Vtbl {
         iid == &<IEventClass2 as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID || iid == &<IEventClass as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventControl_Impl: Sized + super::IDispatch_Impl {
     fn SetPublisherFilter(&self, methodname: &::windows::core::BSTR, ppublisherfilter: &::core::option::Option<IPublisherFilter>) -> ::windows::core::Result<()>;
@@ -376,6 +381,7 @@ impl IEventControl_Vtbl {
         iid == &<IEventControl as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"implement\"`*"]
 pub trait IEventObjectChange_Impl: Sized {
     fn ChangedSubscription(&self, changetype: EOC_ChangeType, bstrsubscriptionid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn ChangedEventClass(&self, changetype: EOC_ChangeType, bstreventclassid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -410,6 +416,7 @@ impl IEventObjectChange_Vtbl {
         iid == &<IEventObjectChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"implement\"`*"]
 pub trait IEventObjectChange2_Impl: Sized {
     fn ChangedSubscription(&self, pinfo: *const COMEVENTSYSCHANGEINFO) -> ::windows::core::Result<()>;
     fn ChangedEventClass(&self, pinfo: *const COMEVENTSYSCHANGEINFO) -> ::windows::core::Result<()>;
@@ -437,6 +444,7 @@ impl IEventObjectChange2_Vtbl {
         iid == &<IEventObjectChange2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventObjectCollection_Impl: Sized + super::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -519,6 +527,7 @@ impl IEventObjectCollection_Vtbl {
         iid == &<IEventObjectCollection as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventProperty_Impl: Sized + super::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -575,6 +584,7 @@ impl IEventProperty_Vtbl {
         iid == &<IEventProperty as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventPublisher_Impl: Sized + super::IDispatch_Impl {
     fn PublisherID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -731,6 +741,7 @@ impl IEventPublisher_Vtbl {
         iid == &<IEventPublisher as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventSubscription_Impl: Sized + super::IDispatch_Impl {
     fn SubscriptionID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1087,6 +1098,7 @@ impl IEventSubscription_Vtbl {
         iid == &<IEventSubscription as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IEventSystem_Impl: Sized + super::IDispatch_Impl {
     fn Query(&self, progid: &::windows::core::BSTR, querycriteria: &::windows::core::BSTR, errorindex: *mut i32, ppinterface: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1163,6 +1175,7 @@ impl IEventSystem_Vtbl {
         iid == &<IEventSystem as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IFiringControl_Impl: Sized + super::IDispatch_Impl {
     fn FireSubscription(&self, subscription: &::core::option::Option<IEventSubscription>) -> ::windows::core::Result<()>;
@@ -1183,6 +1196,7 @@ impl IFiringControl_Vtbl {
         iid == &<IFiringControl as ::windows::core::Interface>::IID || iid == &<super::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMultiInterfaceEventControl_Impl: Sized {
     fn SetMultiInterfacePublisherFilter(&self, classfilter: &::core::option::Option<IMultiInterfacePublisherFilter>) -> ::windows::core::Result<()>;
@@ -1272,6 +1286,7 @@ impl IMultiInterfaceEventControl_Vtbl {
         iid == &<IMultiInterfaceEventControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"implement\"`*"]
 pub trait IMultiInterfacePublisherFilter_Impl: Sized {
     fn Initialize(&self, peic: &::core::option::Option<IMultiInterfaceEventControl>) -> ::windows::core::Result<()>;
     fn PrepareToFire(&self, iid: *const ::windows::core::GUID, methodname: &::windows::core::BSTR, firingcontrol: &::core::option::Option<IFiringControl>) -> ::windows::core::Result<()>;
@@ -1299,6 +1314,7 @@ impl IMultiInterfacePublisherFilter_Vtbl {
         iid == &<IMultiInterfacePublisherFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Events\"`, `\"implement\"`*"]
 pub trait IPublisherFilter_Impl: Sized {
     fn Initialize(&self, methodname: &::windows::core::BSTR, dispuserdefined: &::core::option::Option<super::IDispatch>) -> ::windows::core::Result<()>;
     fn PrepareToFire(&self, methodname: &::windows::core::BSTR, firingcontrol: &::core::option::Option<IFiringControl>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Marshal/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com_Marshal\"`, `\"implement\"`*"]
 pub trait IMarshal_Impl: Sized {
     fn GetUnmarshalClass(&self, riid: *const ::windows::core::GUID, pv: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, mshlflags: u32, pcid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetMarshalSizeMax(&self, riid: *const ::windows::core::GUID, pv: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, mshlflags: u32, psize: *mut u32) -> ::windows::core::Result<()>;
@@ -53,6 +54,7 @@ impl IMarshal_Vtbl {
         iid == &<IMarshal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Marshal\"`, `\"implement\"`*"]
 pub trait IMarshal2_Impl: Sized + IMarshal_Impl {}
 impl ::windows::core::RuntimeName for IMarshal2 {}
 impl IMarshal2_Vtbl {
@@ -63,6 +65,7 @@ impl IMarshal2_Vtbl {
         iid == &<IMarshal2 as ::windows::core::Interface>::IID || iid == &<IMarshal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Marshal\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMarshalingStream_Impl: Sized + super::IStream_Impl {
     fn GetMarshalingContextAttribute(&self, attribute: super::CO_MARSHALING_CONTEXT_ATTRIBUTES) -> ::windows::core::Result<usize>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 pub trait IDirectWriterLock_Impl: Sized {
     fn WaitForWriteAccess(&self, dwtimeout: u32) -> ::windows::core::Result<()>;
     fn ReleaseWriteAccess(&self) -> ::windows::core::Result<()>;
@@ -32,6 +33,7 @@ impl IDirectWriterLock_Vtbl {
         iid == &<IDirectWriterLock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnumSTATPROPSETSTG_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut STATPROPSETSTG, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
@@ -82,6 +84,7 @@ impl IEnumSTATPROPSETSTG_Vtbl {
         iid == &<IEnumSTATPROPSETSTG as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 pub trait IEnumSTATPROPSTG_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut STATPROPSTG, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
     fn Skip(&self, celt: u32) -> ::windows::core::HRESULT;
@@ -129,6 +132,7 @@ impl IEnumSTATPROPSTG_Vtbl {
         iid == &<IEnumSTATPROPSTG as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnumSTATSTG_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut super::STATSTG, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -179,6 +183,7 @@ impl IEnumSTATSTG_Vtbl {
         iid == &<IEnumSTATSTG as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFillLockBytes_Impl: Sized {
     fn FillAppend(&self, pv: *const ::core::ffi::c_void, cb: u32) -> ::windows::core::Result<u32>;
@@ -235,6 +240,7 @@ impl IFillLockBytes_Vtbl {
         iid == &<IFillLockBytes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 pub trait ILayoutStorage_Impl: Sized {
     fn LayoutScript(&self, pstoragelayout: *const super::StorageLayout, nentries: u32, glfinterleavedflag: u32) -> ::windows::core::Result<()>;
     fn BeginMonitor(&self) -> ::windows::core::Result<()>;
@@ -283,6 +289,7 @@ impl ILayoutStorage_Vtbl {
         iid == &<ILayoutStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ILockBytes_Impl: Sized {
     fn ReadAt(&self, uloffset: u64, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32) -> ::windows::core::Result<()>;
@@ -348,6 +355,7 @@ impl ILockBytes_Vtbl {
         iid == &<ILockBytes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPersistStorage_Impl: Sized + super::IPersist_Impl {
     fn IsDirty(&self) -> ::windows::core::HRESULT;
@@ -406,6 +414,7 @@ impl IPersistStorage_Vtbl {
         iid == &<IPersistStorage as ::windows::core::Interface>::IID || iid == &<super::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IPropertyBag_Impl: Sized {
     fn Read(&self, pszpropname: &::windows::core::PCWSTR, pvar: *mut super::VARIANT, perrorlog: &::core::option::Option<super::IErrorLog>) -> ::windows::core::Result<()>;
@@ -432,6 +441,7 @@ impl IPropertyBag_Vtbl {
         iid == &<IPropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IPropertyBag2_Impl: Sized {
     fn Read(&self, cproperties: u32, ppropbag: *const PROPBAG2, perrlog: &::core::option::Option<super::IErrorLog>, pvarvalue: *mut super::VARIANT, phrerror: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -489,6 +499,7 @@ impl IPropertyBag2_Vtbl {
         iid == &<IPropertyBag2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 pub trait IPropertySetStorage_Impl: Sized {
     fn Create(&self, rfmtid: *const ::windows::core::GUID, pclsid: *const ::windows::core::GUID, grfflags: u32, grfmode: u32) -> ::windows::core::Result<IPropertyStorage>;
     fn Open(&self, rfmtid: *const ::windows::core::GUID, grfmode: u32) -> ::windows::core::Result<IPropertyStorage>;
@@ -548,6 +559,7 @@ impl IPropertySetStorage_Vtbl {
         iid == &<IPropertySetStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPropertyStorage_Impl: Sized {
     fn ReadMultiple(&self, cpspec: u32, rgpspec: *const PROPSPEC, rgpropvar: *mut PROPVARIANT) -> ::windows::core::Result<()>;
@@ -660,6 +672,7 @@ impl IPropertyStorage_Vtbl {
         iid == &<IPropertyStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 pub trait IRootStorage_Impl: Sized {
     fn SwitchToFile(&self, pszfile: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -677,6 +690,7 @@ impl IRootStorage_Vtbl {
         iid == &<IRootStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStorage_Impl: Sized {
     fn CreateStream(&self, pwcsname: &::windows::core::PCWSTR, grfmode: super::STGM, reserved1: u32, reserved2: u32) -> ::windows::core::Result<super::IStream>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/UI/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/UI/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com_UI\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IDummyHICONIncluder_Impl: Sized {
     fn Dummy(&self, h1: super::super::super::UI::WindowsAndMessaging::HICON, h2: super::super::super::Graphics::Gdi::HDC) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl IDummyHICONIncluder_Vtbl {
         iid == &<IDummyHICONIncluder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_UI\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IThumbnailExtractor_Impl: Sized {
     fn ExtractThumbnail(&self, pstg: &::core::option::Option<super::StructuredStorage::IStorage>, ullength: u32, ulheight: u32, puloutputlength: *mut u32, puloutputheight: *mut u32, phoutputbitmap: *mut super::super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBindCallbackRedirect_Impl: Sized {
     fn Redirect(&self, lpcurl: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;
@@ -24,6 +25,7 @@ impl IBindCallbackRedirect_Vtbl {
         iid == &<IBindCallbackRedirect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IBindHttpSecurity_Impl: Sized {
     fn GetIgnoreCertMask(&self) -> ::windows::core::Result<u32>;
 }
@@ -47,6 +49,7 @@ impl IBindHttpSecurity_Vtbl {
         iid == &<IBindHttpSecurity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IBindProtocol_Impl: Sized {
     fn CreateBinding(&self, szurl: &::windows::core::PCWSTR, pbc: &::core::option::Option<super::IBindCtx>) -> ::windows::core::Result<super::IBinding>;
 }
@@ -70,6 +73,7 @@ impl IBindProtocol_Vtbl {
         iid == &<IBindProtocol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait ICatalogFileInfo_Impl: Sized {
     fn GetCatalogFile(&self) -> ::windows::core::Result<::windows::core::PSTR>;
     fn GetJavaTrust(&self, ppjavatrust: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -103,6 +107,7 @@ impl ICatalogFileInfo_Vtbl {
         iid == &<ICatalogFileInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICodeInstall_Impl: Sized + IWindowForBindingUI_Impl {
     fn OnCodeInstallProblem(&self, ulstatuscode: u32, szdestination: &::windows::core::PCWSTR, szsource: &::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::Result<()>;
@@ -123,6 +128,7 @@ impl ICodeInstall_Vtbl {
         iid == &<ICodeInstall as ::windows::core::Interface>::IID || iid == &<IWindowForBindingUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IDataFilter_Impl: Sized {
     fn DoEncode(&self, dwflags: u32, linbuffersize: i32, pbinbuffer: *const u8, loutbuffersize: i32, pboutbuffer: *mut u8, linbytesavailable: i32, plinbytesread: *mut i32, ploutbyteswritten: *mut i32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn DoDecode(&self, dwflags: u32, linbuffersize: i32, pbinbuffer: *const u8, loutbuffersize: i32, pboutbuffer: *mut u8, linbytesavailable: i32, plinbytesread: *mut i32, ploutbyteswritten: *mut i32, dwreserved: u32) -> ::windows::core::Result<()>;
@@ -157,6 +163,7 @@ impl IDataFilter_Vtbl {
         iid == &<IDataFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IEncodingFilterFactory_Impl: Sized {
     fn FindBestFilter(&self, pwzcodein: &::windows::core::PCWSTR, pwzcodeout: &::windows::core::PCWSTR, info: &DATAINFO) -> ::windows::core::Result<IDataFilter>;
     fn GetDefaultFilter(&self, pwzcodein: &::windows::core::PCWSTR, pwzcodeout: &::windows::core::PCWSTR) -> ::windows::core::Result<IDataFilter>;
@@ -196,6 +203,7 @@ impl IEncodingFilterFactory_Vtbl {
         iid == &<IEncodingFilterFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IGetBindHandle_Impl: Sized {
     fn GetBindHandle(&self, enumrequestedhandle: BINDHANDLETYPES) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
@@ -222,6 +230,7 @@ impl IGetBindHandle_Vtbl {
         iid == &<IGetBindHandle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IHttpNegotiate_Impl: Sized {
     fn BeginningTransaction(&self, szurl: &::windows::core::PCWSTR, szheaders: &::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn OnResponse(&self, dwresponsecode: u32, szresponseheaders: &::windows::core::PCWSTR, szrequestheaders: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -261,6 +270,7 @@ impl IHttpNegotiate_Vtbl {
         iid == &<IHttpNegotiate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IHttpNegotiate2_Impl: Sized + IHttpNegotiate_Impl {
     fn GetRootSecurityId(&self, pbsecurityid: *mut u8, pcbsecurityid: *mut u32, dwreserved: usize) -> ::windows::core::Result<()>;
 }
@@ -278,6 +288,7 @@ impl IHttpNegotiate2_Vtbl {
         iid == &<IHttpNegotiate2 as ::windows::core::Interface>::IID || iid == &<IHttpNegotiate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IHttpNegotiate3_Impl: Sized + IHttpNegotiate2_Impl {
     fn GetSerializedClientCertContext(&self, ppbcert: *mut *mut u8, pcbcert: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -298,6 +309,7 @@ impl IHttpNegotiate3_Vtbl {
         iid == &<IHttpNegotiate3 as ::windows::core::Interface>::IID || iid == &<IHttpNegotiate as ::windows::core::Interface>::IID || iid == &<IHttpNegotiate2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IHttpSecurity_Impl: Sized + IWindowForBindingUI_Impl {
     fn OnSecurityProblem(&self, dwproblem: u32) -> ::windows::core::Result<()>;
@@ -318,6 +330,7 @@ impl IHttpSecurity_Vtbl {
         iid == &<IHttpSecurity as ::windows::core::Interface>::IID || iid == &<IWindowForBindingUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternet_Impl: Sized {}
 impl ::windows::core::RuntimeName for IInternet {}
 impl IInternet_Vtbl {
@@ -328,6 +341,7 @@ impl IInternet_Vtbl {
         iid == &<IInternet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Security\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IInternetBindInfo_Impl: Sized {
     fn GetBindInfo(&self, grfbindf: *mut u32, pbindinfo: *mut super::BINDINFO) -> ::windows::core::Result<()>;
@@ -358,6 +372,7 @@ impl IInternetBindInfo_Vtbl {
         iid == &<IInternetBindInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Security\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IInternetBindInfoEx_Impl: Sized + IInternetBindInfo_Impl {
     fn GetBindInfoEx(&self, grfbindf: *mut u32, pbindinfo: *mut super::BINDINFO, grfbindf2: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
@@ -378,6 +393,7 @@ impl IInternetBindInfoEx_Vtbl {
         iid == &<IInternetBindInfoEx as ::windows::core::Interface>::IID || iid == &<IInternetBindInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetHostSecurityManager_Impl: Sized {
     fn GetSecurityId(&self, pbsecurityid: *mut u8, pcbsecurityid: *mut u32, dwreserved: usize) -> ::windows::core::Result<()>;
     fn ProcessUrlAction(&self, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, pcontext: *const u8, cbcontext: u32, dwflags: u32, dwreserved: u32) -> ::windows::core::Result<()>;
@@ -412,6 +428,7 @@ impl IInternetHostSecurityManager_Vtbl {
         iid == &<IInternetHostSecurityManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetPriority_Impl: Sized {
     fn SetPriority(&self, npriority: i32) -> ::windows::core::Result<()>;
     fn GetPriority(&self) -> ::windows::core::Result<i32>;
@@ -445,6 +462,7 @@ impl IInternetPriority_Vtbl {
         iid == &<IInternetPriority as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInternetProtocol_Impl: Sized + IInternetProtocolRoot_Impl {
     fn Read(&self, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32) -> ::windows::core::Result<()>;
@@ -495,6 +513,7 @@ impl IInternetProtocol_Vtbl {
         iid == &<IInternetProtocol as ::windows::core::Interface>::IID || iid == &<IInternetProtocolRoot as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInternetProtocolEx_Impl: Sized + IInternetProtocol_Impl {
     fn StartEx(&self, puri: &::core::option::Option<super::IUri>, poiprotsink: &::core::option::Option<IInternetProtocolSink>, poibindinfo: &::core::option::Option<IInternetBindInfo>, grfpi: u32, dwreserved: super::super::super::Foundation::HANDLE_PTR) -> ::windows::core::Result<()>;
@@ -515,6 +534,7 @@ impl IInternetProtocolEx_Vtbl {
         iid == &<IInternetProtocolEx as ::windows::core::Interface>::IID || iid == &<IInternetProtocolRoot as ::windows::core::Interface>::IID || iid == &<IInternetProtocol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetProtocolInfo_Impl: Sized {
     fn ParseUrl(&self, pwzurl: &::windows::core::PCWSTR, parseaction: PARSEACTION, dwparseflags: u32, pwzresult: ::windows::core::PWSTR, cchresult: u32, pcchresult: *mut u32, dwreserved: u32) -> ::windows::core::Result<()>;
     fn CombineUrl(&self, pwzbaseurl: &::windows::core::PCWSTR, pwzrelativeurl: &::windows::core::PCWSTR, dwcombineflags: u32, pwzresult: &::windows::core::PCWSTR, cchresult: u32, pcchresult: *mut u32, dwreserved: u32) -> ::windows::core::Result<()>;
@@ -556,6 +576,7 @@ impl IInternetProtocolInfo_Vtbl {
         iid == &<IInternetProtocolInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInternetProtocolRoot_Impl: Sized {
     fn Start(&self, szurl: &::windows::core::PCWSTR, poiprotsink: &::core::option::Option<IInternetProtocolSink>, poibindinfo: &::core::option::Option<IInternetBindInfo>, grfpi: u32, dwreserved: super::super::super::Foundation::HANDLE_PTR) -> ::windows::core::Result<()>;
@@ -614,6 +635,7 @@ impl IInternetProtocolRoot_Vtbl {
         iid == &<IInternetProtocolRoot as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetProtocolSink_Impl: Sized {
     fn Switch(&self, pprotocoldata: *const PROTOCOLDATA) -> ::windows::core::Result<()>;
     fn ReportProgress(&self, ulstatuscode: u32, szstatustext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -655,6 +677,7 @@ impl IInternetProtocolSink_Vtbl {
         iid == &<IInternetProtocolSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetProtocolSinkStackable_Impl: Sized {
     fn SwitchSink(&self, poiprotsink: &::core::option::Option<IInternetProtocolSink>) -> ::windows::core::Result<()>;
     fn CommitSwitch(&self) -> ::windows::core::Result<()>;
@@ -689,6 +712,7 @@ impl IInternetProtocolSinkStackable_Vtbl {
         iid == &<IInternetProtocolSinkStackable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetSecurityManager_Impl: Sized {
     fn SetSecuritySite(&self, psite: &::core::option::Option<IInternetSecurityMgrSite>) -> ::windows::core::Result<()>;
     fn GetSecuritySite(&self) -> ::windows::core::Result<IInternetSecurityMgrSite>;
@@ -764,6 +788,7 @@ impl IInternetSecurityManager_Vtbl {
         iid == &<IInternetSecurityManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetSecurityManagerEx_Impl: Sized + IInternetSecurityManager_Impl {
     fn ProcessUrlActionEx(&self, pwszurl: &::windows::core::PCWSTR, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, pcontext: *const u8, cbcontext: u32, dwflags: u32, dwreserved: u32, pdwoutflags: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -781,6 +806,7 @@ impl IInternetSecurityManagerEx_Vtbl {
         iid == &<IInternetSecurityManagerEx as ::windows::core::Interface>::IID || iid == &<IInternetSecurityManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetSecurityManagerEx2_Impl: Sized + IInternetSecurityManagerEx_Impl {
     fn MapUrlToZoneEx2(&self, puri: &::core::option::Option<super::IUri>, pdwzone: *mut u32, dwflags: u32, ppwszmappedurl: *mut ::windows::core::PWSTR, pdwoutflags: *mut u32) -> ::windows::core::Result<()>;
     fn ProcessUrlActionEx2(&self, puri: &::core::option::Option<super::IUri>, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, pcontext: *const u8, cbcontext: u32, dwflags: u32, dwreserved: usize, pdwoutflags: *mut u32) -> ::windows::core::Result<()>;
@@ -822,6 +848,7 @@ impl IInternetSecurityManagerEx2_Vtbl {
         iid == &<IInternetSecurityManagerEx2 as ::windows::core::Interface>::IID || iid == &<IInternetSecurityManager as ::windows::core::Interface>::IID || iid == &<IInternetSecurityManagerEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInternetSecurityMgrSite_Impl: Sized {
     fn GetWindow(&self) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
@@ -858,6 +885,7 @@ impl IInternetSecurityMgrSite_Vtbl {
         iid == &<IInternetSecurityMgrSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetSession_Impl: Sized {
     fn RegisterNameSpace(&self, pcf: &::core::option::Option<super::IClassFactory>, rclsid: *const ::windows::core::GUID, pwzprotocol: &::windows::core::PCWSTR, cpatterns: u32, ppwzpatterns: *const ::windows::core::PCWSTR, dwreserved: u32) -> ::windows::core::Result<()>;
     fn UnregisterNameSpace(&self, pcf: &::core::option::Option<super::IClassFactory>, pszprotocol: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -920,6 +948,7 @@ impl IInternetSession_Vtbl {
         iid == &<IInternetSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IInternetThreadSwitch_Impl: Sized {
     fn Prepare(&self) -> ::windows::core::Result<()>;
     fn Continue(&self) -> ::windows::core::Result<()>;
@@ -947,6 +976,7 @@ impl IInternetThreadSwitch_Vtbl {
         iid == &<IInternetThreadSwitch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInternetZoneManager_Impl: Sized {
     fn GetZoneAttributes(&self, dwzone: u32, pzoneattributes: *mut ZONEATTRIBUTES) -> ::windows::core::Result<()>;
@@ -1053,6 +1083,7 @@ impl IInternetZoneManager_Vtbl {
         iid == &<IInternetZoneManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInternetZoneManagerEx_Impl: Sized + IInternetZoneManager_Impl {
     fn GetZoneActionPolicyEx(&self, dwzone: u32, dwaction: u32, ppolicy: *mut u8, cbpolicy: u32, urlzonereg: URLZONEREG, dwflags: u32) -> ::windows::core::Result<()>;
@@ -1083,6 +1114,7 @@ impl IInternetZoneManagerEx_Vtbl {
         iid == &<IInternetZoneManagerEx as ::windows::core::Interface>::IID || iid == &<IInternetZoneManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInternetZoneManagerEx2_Impl: Sized + IInternetZoneManagerEx_Impl {
     fn GetZoneAttributesEx(&self, dwzone: u32, pzoneattributes: *mut ZONEATTRIBUTES, dwflags: u32) -> ::windows::core::Result<()>;
@@ -1127,6 +1159,7 @@ impl IInternetZoneManagerEx2_Vtbl {
         iid == &<IInternetZoneManagerEx2 as ::windows::core::Interface>::IID || iid == &<IInternetZoneManager as ::windows::core::Interface>::IID || iid == &<IInternetZoneManagerEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IMonikerProp_Impl: Sized {
     fn PutProperty(&self, mkp: MONIKERPROPERTY, val: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1144,6 +1177,7 @@ impl IMonikerProp_Vtbl {
         iid == &<IMonikerProp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPersistMoniker_Impl: Sized {
     fn GetClassID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -1214,6 +1248,7 @@ impl IPersistMoniker_Vtbl {
         iid == &<IPersistMoniker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Data_Xml_MsXml\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Data_Xml_MsXml")]
 pub trait ISoftDistExt_Impl: Sized {
     fn ProcessSoftDist(&self, szcdfurl: &::windows::core::PCWSTR, psoftdistelement: &::core::option::Option<super::super::super::Data::Xml::MsXml::IXMLElement>, lpsdi: *mut SOFTDISTINFO) -> ::windows::core::Result<()>;
@@ -1258,6 +1293,7 @@ impl ISoftDistExt_Vtbl {
         iid == &<ISoftDistExt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IUriBuilderFactory_Impl: Sized {
     fn CreateIUriBuilder(&self, dwflags: u32, dwreserved: usize) -> ::windows::core::Result<super::IUriBuilder>;
     fn CreateInitializedIUriBuilder(&self, dwflags: u32, dwreserved: usize) -> ::windows::core::Result<super::IUriBuilder>;
@@ -1297,6 +1333,7 @@ impl IUriBuilderFactory_Vtbl {
         iid == &<IUriBuilderFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IUriContainer_Impl: Sized {
     fn GetIUri(&self) -> ::windows::core::Result<super::IUri>;
 }
@@ -1320,6 +1357,7 @@ impl IUriContainer_Vtbl {
         iid == &<IUriContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IWinInetCacheHints_Impl: Sized {
     fn SetCacheExtension(&self, pwzext: &::windows::core::PCWSTR, pszcachefile: *mut ::core::ffi::c_void, pcbcachefile: *mut u32, pdwwinineterror: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -1337,6 +1375,7 @@ impl IWinInetCacheHints_Vtbl {
         iid == &<IWinInetCacheHints as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IWinInetCacheHints2_Impl: Sized + IWinInetCacheHints_Impl {
     fn SetCacheExtension2(&self, pwzext: &::windows::core::PCWSTR, pwzcachefile: ::windows::core::PWSTR, pcchcachefile: *mut u32, pdwwinineterror: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -1354,6 +1393,7 @@ impl IWinInetCacheHints2_Vtbl {
         iid == &<IWinInetCacheHints2 as ::windows::core::Interface>::IID || iid == &<IWinInetCacheHints as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IWinInetFileStream_Impl: Sized {
     fn SetHandleForUnlock(&self, hwininetlockhandle: usize, dwreserved: usize) -> ::windows::core::Result<()>;
     fn SetDeleteFile(&self, dwreserved: usize) -> ::windows::core::Result<()>;
@@ -1381,6 +1421,7 @@ impl IWinInetFileStream_Vtbl {
         iid == &<IWinInetFileStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IWinInetHttpInfo_Impl: Sized + IWinInetInfo_Impl {
     fn QueryInfo(&self, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pcbbuf: *mut u32, pdwflags: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -1398,6 +1439,7 @@ impl IWinInetHttpInfo_Vtbl {
         iid == &<IWinInetHttpInfo as ::windows::core::Interface>::IID || iid == &<IWinInetInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IWinInetHttpTimeouts_Impl: Sized {
     fn GetRequestTimeouts(&self, pdwconnecttimeout: *mut u32, pdwsendtimeout: *mut u32, pdwreceivetimeout: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -1415,6 +1457,7 @@ impl IWinInetHttpTimeouts_Vtbl {
         iid == &<IWinInetHttpTimeouts as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IWinInetInfo_Impl: Sized {
     fn QueryOption(&self, dwoption: u32, pbuffer: *mut ::core::ffi::c_void, pcbbuf: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -1432,6 +1475,7 @@ impl IWinInetInfo_Vtbl {
         iid == &<IWinInetInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWindowForBindingUI_Impl: Sized {
     fn GetWindow(&self, rguidreason: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
@@ -1458,6 +1502,7 @@ impl IWindowForBindingUI_Vtbl {
         iid == &<IWindowForBindingUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IWrappedProtocol_Impl: Sized {
     fn GetWrapperCode(&self, pncode: *mut i32, dwreserved: usize) -> ::windows::core::Result<()>;
 }
@@ -1475,6 +1520,7 @@ impl IWrappedProtocol_Vtbl {
         iid == &<IWrappedProtocol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IZoneIdentifier_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<u32>;
     fn SetId(&self, dwzone: u32) -> ::windows::core::Result<()>;
@@ -1515,6 +1561,7 @@ impl IZoneIdentifier_Vtbl {
         iid == &<IZoneIdentifier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`, `\"implement\"`*"]
 pub trait IZoneIdentifier2_Impl: Sized + IZoneIdentifier_Impl {
     fn GetLastWriterPackageFamilyName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn SetLastWriterPackageFamilyName(&self, packagefamilyname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait AsyncIAdviseSink_Impl: Sized {
     fn Begin_OnDataChange(&self, pformatetc: *const FORMATETC, pstgmed: *const STGMEDIUM);
@@ -84,6 +85,7 @@ impl AsyncIAdviseSink_Vtbl {
         iid == &<AsyncIAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait AsyncIAdviseSink2_Impl: Sized + AsyncIAdviseSink_Impl {
     fn Begin_OnLinkSrcChange(&self, pmk: &::core::option::Option<IMoniker>);
@@ -114,6 +116,7 @@ impl AsyncIAdviseSink2_Vtbl {
         iid == &<AsyncIAdviseSink2 as ::windows::core::Interface>::IID || iid == &<AsyncIAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait AsyncIMultiQI_Impl: Sized {
     fn Begin_QueryMultipleInterfaces(&self, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::Result<()>;
     fn Finish_QueryMultipleInterfaces(&self, pmqis: *mut MULTI_QI) -> ::windows::core::Result<()>;
@@ -141,6 +144,7 @@ impl AsyncIMultiQI_Vtbl {
         iid == &<AsyncIMultiQI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait AsyncIPipeByte_Impl: Sized {
     fn Begin_Pull(&self, crequest: u32) -> ::windows::core::Result<()>;
     fn Finish_Pull(&self, buf: *mut u8, pcreturned: *mut u32) -> ::windows::core::Result<()>;
@@ -182,6 +186,7 @@ impl AsyncIPipeByte_Vtbl {
         iid == &<AsyncIPipeByte as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait AsyncIPipeDouble_Impl: Sized {
     fn Begin_Pull(&self, crequest: u32) -> ::windows::core::Result<()>;
     fn Finish_Pull(&self, buf: *mut f64, pcreturned: *mut u32) -> ::windows::core::Result<()>;
@@ -223,6 +228,7 @@ impl AsyncIPipeDouble_Vtbl {
         iid == &<AsyncIPipeDouble as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait AsyncIPipeLong_Impl: Sized {
     fn Begin_Pull(&self, crequest: u32) -> ::windows::core::Result<()>;
     fn Finish_Pull(&self, buf: *mut i32, pcreturned: *mut u32) -> ::windows::core::Result<()>;
@@ -264,6 +270,7 @@ impl AsyncIPipeLong_Vtbl {
         iid == &<AsyncIPipeLong as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait AsyncIUnknown_Impl: Sized {
     fn Begin_QueryInterface(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Finish_QueryInterface(&self, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -319,6 +326,7 @@ impl AsyncIUnknown_Vtbl {
         iid == &<AsyncIUnknown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IActivationFilter_Impl: Sized {
     fn HandleActivation(&self, dwactivationtype: u32, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -342,6 +350,7 @@ impl IActivationFilter_Vtbl {
         iid == &<IActivationFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IAddrExclusionControl_Impl: Sized {
     fn GetCurrentAddrExclusionList(&self, riid: *const ::windows::core::GUID, ppenumerator: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn UpdateAddrExclusionList(&self, penumerator: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -369,6 +378,7 @@ impl IAddrExclusionControl_Vtbl {
         iid == &<IAddrExclusionControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IAddrTrackingControl_Impl: Sized {
     fn EnableCOMDynamicAddrTracking(&self) -> ::windows::core::Result<()>;
     fn DisableCOMDynamicAddrTracking(&self) -> ::windows::core::Result<()>;
@@ -396,6 +406,7 @@ impl IAddrTrackingControl_Vtbl {
         iid == &<IAddrTrackingControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IAdviseSink_Impl: Sized {
     fn OnDataChange(&self, pformatetc: *const FORMATETC, pstgmed: *const STGMEDIUM);
@@ -447,6 +458,7 @@ impl IAdviseSink_Vtbl {
         iid == &<IAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IAdviseSink2_Impl: Sized + IAdviseSink_Impl {
     fn OnLinkSrcChange(&self, pmk: &::core::option::Option<IMoniker>);
@@ -467,6 +479,7 @@ impl IAdviseSink2_Vtbl {
         iid == &<IAdviseSink2 as ::windows::core::Interface>::IID || iid == &<IAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IAgileObject_Impl: Sized {}
 impl ::windows::core::RuntimeName for IAgileObject {}
 impl IAgileObject_Vtbl {
@@ -477,6 +490,7 @@ impl IAgileObject_Vtbl {
         iid == &<IAgileObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IAsyncManager_Impl: Sized {
     fn CompleteCall(&self, result: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn GetCallContext(&self, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -517,6 +531,7 @@ impl IAsyncManager_Vtbl {
         iid == &<IAsyncManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IAsyncRpcChannelBuffer_Impl: Sized + IRpcChannelBuffer2_Impl {
     fn Send(&self, pmsg: *mut RPCOLEMESSAGE, psync: &::core::option::Option<ISynchronize>, pulstatus: *mut u32) -> ::windows::core::Result<()>;
     fn Receive(&self, pmsg: *mut RPCOLEMESSAGE, pulstatus: *mut u32) -> ::windows::core::Result<()>;
@@ -551,6 +566,7 @@ impl IAsyncRpcChannelBuffer_Vtbl {
         iid == &<IAsyncRpcChannelBuffer as ::windows::core::Interface>::IID || iid == &<IRpcChannelBuffer as ::windows::core::Interface>::IID || iid == &<IRpcChannelBuffer2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAuthenticate_Impl: Sized {
     fn Authenticate(&self, phwnd: *mut super::super::Foundation::HWND, pszusername: *mut ::windows::core::PWSTR, pszpassword: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -571,6 +587,7 @@ impl IAuthenticate_Vtbl {
         iid == &<IAuthenticate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAuthenticateEx_Impl: Sized + IAuthenticate_Impl {
     fn AuthenticateEx(&self, phwnd: *mut super::super::Foundation::HWND, pszusername: *mut ::windows::core::PWSTR, pszpassword: *mut ::windows::core::PWSTR, pauthinfo: *const AUTHENTICATEINFO) -> ::windows::core::Result<()>;
@@ -591,6 +608,7 @@ impl IAuthenticateEx_Vtbl {
         iid == &<IAuthenticateEx as ::windows::core::Interface>::IID || iid == &<IAuthenticate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IBindCtx_Impl: Sized {
     fn RegisterObjectBound(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn RevokeObjectBound(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -692,6 +710,7 @@ impl IBindCtx_Vtbl {
         iid == &<IBindCtx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IBindHost_Impl: Sized {
     fn CreateMoniker(&self, szname: &::windows::core::PCWSTR, pbc: &::core::option::Option<IBindCtx>, ppmk: *mut ::core::option::Option<IMoniker>, dwreserved: u32) -> ::windows::core::Result<()>;
     fn MonikerBindToStorage(&self, pmk: &::core::option::Option<IMoniker>, pbc: &::core::option::Option<IBindCtx>, pbsc: &::core::option::Option<IBindStatusCallback>, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -726,6 +745,7 @@ impl IBindHost_Vtbl {
         iid == &<IBindHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Security\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IBindStatusCallback_Impl: Sized {
     fn OnStartBinding(&self, dwreserved: u32, pib: &::core::option::Option<IBinding>) -> ::windows::core::Result<()>;
@@ -804,6 +824,7 @@ impl IBindStatusCallback_Vtbl {
         iid == &<IBindStatusCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_Security\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_Security", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IBindStatusCallbackEx_Impl: Sized + IBindStatusCallback_Impl {
     fn GetBindInfoEx(&self, grfbindf: *mut u32, pbindinfo: *mut BINDINFO, grfbindf2: *mut u32, pdwreserved: *mut u32) -> ::windows::core::Result<()>;
@@ -824,6 +845,7 @@ impl IBindStatusCallbackEx_Vtbl {
         iid == &<IBindStatusCallbackEx as ::windows::core::Interface>::IID || iid == &<IBindStatusCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IBinding_Impl: Sized {
     fn Abort(&self) -> ::windows::core::Result<()>;
     fn Suspend(&self) -> ::windows::core::Result<()>;
@@ -885,6 +907,7 @@ impl IBinding_Vtbl {
         iid == &<IBinding as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IBlockingLock_Impl: Sized {
     fn Lock(&self, dwtimeout: u32) -> ::windows::core::Result<()>;
     fn Unlock(&self) -> ::windows::core::Result<()>;
@@ -912,6 +935,7 @@ impl IBlockingLock_Vtbl {
         iid == &<IBlockingLock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ICallFactory_Impl: Sized {
     fn CreateCall(&self, riid: *const ::windows::core::GUID, pctrlunk: &::core::option::Option<::windows::core::IUnknown>, riid2: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -935,6 +959,7 @@ impl ICallFactory_Vtbl {
         iid == &<ICallFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ICancelMethodCalls_Impl: Sized {
     fn Cancel(&self, ulseconds: u32) -> ::windows::core::Result<()>;
     fn TestCancel(&self) -> ::windows::core::Result<()>;
@@ -962,6 +987,7 @@ impl ICancelMethodCalls_Vtbl {
         iid == &<ICancelMethodCalls as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ICatInformation_Impl: Sized {
     fn EnumCategories(&self, lcid: u32) -> ::windows::core::Result<IEnumCATEGORYINFO>;
     fn GetCategoryDesc(&self, rcatid: *const ::windows::core::GUID, lcid: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1047,6 +1073,7 @@ impl ICatInformation_Vtbl {
         iid == &<ICatInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ICatRegister_Impl: Sized {
     fn RegisterCategories(&self, ccategories: u32, rgcategoryinfo: *const CATEGORYINFO) -> ::windows::core::Result<()>;
     fn UnRegisterCategories(&self, ccategories: u32, rgcatid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1102,6 +1129,7 @@ impl ICatRegister_Vtbl {
         iid == &<ICatRegister as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IChannelHook_Impl: Sized {
     fn ClientGetSize(&self, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pdatasize: *mut u32);
     fn ClientFillBuffer(&self, uextent: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pdatasize: *mut u32, pdatabuffer: *const ::core::ffi::c_void);
@@ -1157,6 +1185,7 @@ impl IChannelHook_Vtbl {
         iid == &<IChannelHook as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IClassActivator_Impl: Sized {
     fn GetClassObject(&self, rclsid: *const ::windows::core::GUID, dwclasscontext: u32, locale: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1174,6 +1203,7 @@ impl IClassActivator_Vtbl {
         iid == &<IClassActivator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IClassFactory_Impl: Sized {
     fn CreateInstance(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1204,6 +1234,7 @@ impl IClassFactory_Vtbl {
         iid == &<IClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IClientSecurity_Impl: Sized {
     fn QueryBlanket(&self, pproxy: &::core::option::Option<::windows::core::IUnknown>, pauthnsvc: *mut u32, pauthzsvc: *mut u32, pserverprincname: *mut *mut u16, pauthnlevel: *mut RPC_C_AUTHN_LEVEL, pimplevel: *mut RPC_C_IMP_LEVEL, pauthinfo: *mut *mut ::core::ffi::c_void, pcapabilites: *mut EOLE_AUTHENTICATION_CAPABILITIES) -> ::windows::core::Result<()>;
     fn SetBlanket(&self, pproxy: &::core::option::Option<::windows::core::IUnknown>, dwauthnsvc: u32, dwauthzsvc: u32, pserverprincname: &::windows::core::PCWSTR, dwauthnlevel: RPC_C_AUTHN_LEVEL, dwimplevel: RPC_C_IMP_LEVEL, pauthinfo: *const ::core::ffi::c_void, dwcapabilities: EOLE_AUTHENTICATION_CAPABILITIES) -> ::windows::core::Result<()>;
@@ -1244,6 +1275,7 @@ impl IClientSecurity_Vtbl {
         iid == &<IClientSecurity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IComThreadingInfo_Impl: Sized {
     fn GetCurrentApartmentType(&self) -> ::windows::core::Result<APTTYPE>;
     fn GetCurrentThreadType(&self) -> ::windows::core::Result<THDTYPE>;
@@ -1303,6 +1335,7 @@ impl IComThreadingInfo_Vtbl {
         iid == &<IComThreadingInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IConnectionPoint_Impl: Sized {
     fn GetConnectionInterface(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetConnectionPointContainer(&self) -> ::windows::core::Result<IConnectionPointContainer>;
@@ -1375,6 +1408,7 @@ impl IConnectionPoint_Vtbl {
         iid == &<IConnectionPoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IConnectionPointContainer_Impl: Sized {
     fn EnumConnectionPoints(&self) -> ::windows::core::Result<IEnumConnectionPoints>;
     fn FindConnectionPoint(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<IConnectionPoint>;
@@ -1414,6 +1448,7 @@ impl IConnectionPointContainer_Vtbl {
         iid == &<IConnectionPointContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IContextCallback_Impl: Sized {
     fn ContextCallback(&self, pfncallback: PFNCONTEXTCALL, pparam: *const ComCallData, riid: *const ::windows::core::GUID, imethod: i32, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -1431,6 +1466,7 @@ impl IContextCallback_Vtbl {
         iid == &<IContextCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IDataAdviseHolder_Impl: Sized {
     fn Advise(&self, pdataobject: &::core::option::Option<IDataObject>, pfetc: *const FORMATETC, advf: u32, padvise: &::core::option::Option<IAdviseSink>) -> ::windows::core::Result<u32>;
     fn Unadvise(&self, dwconnection: u32) -> ::windows::core::Result<()>;
@@ -1484,6 +1520,7 @@ impl IDataAdviseHolder_Vtbl {
         iid == &<IDataAdviseHolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IDataObject_Impl: Sized {
     fn GetData(&self, pformatetcin: *const FORMATETC) -> ::windows::core::Result<STGMEDIUM>;
@@ -1587,6 +1624,7 @@ impl IDataObject_Vtbl {
         iid == &<IDataObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDispatch_Impl: Sized {
     fn GetTypeInfoCount(&self) -> ::windows::core::Result<u32>;
@@ -1643,6 +1681,7 @@ impl IDispatch_Vtbl {
         iid == &<IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumCATEGORYINFO_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut CATEGORYINFO, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1690,6 +1729,7 @@ impl IEnumCATEGORYINFO_Vtbl {
         iid == &<IEnumCATEGORYINFO as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumConnectionPoints_Impl: Sized {
     fn Next(&self, cconnections: u32, ppcp: *mut ::core::option::Option<IConnectionPoint>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cconnections: u32) -> ::windows::core::Result<()>;
@@ -1737,6 +1777,7 @@ impl IEnumConnectionPoints_Vtbl {
         iid == &<IEnumConnectionPoints as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumConnections_Impl: Sized {
     fn Next(&self, cconnections: u32, rgcd: *mut CONNECTDATA, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cconnections: u32) -> ::windows::core::Result<()>;
@@ -1784,6 +1825,7 @@ impl IEnumConnections_Vtbl {
         iid == &<IEnumConnections as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumFORMATETC_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut FORMATETC, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1831,6 +1873,7 @@ impl IEnumFORMATETC_Vtbl {
         iid == &<IEnumFORMATETC as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumGUID_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
     fn Skip(&self, celt: u32) -> ::windows::core::HRESULT;
@@ -1878,6 +1921,7 @@ impl IEnumGUID_Vtbl {
         iid == &<IEnumGUID as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumMoniker_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IMoniker>, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
     fn Skip(&self, celt: u32) -> ::windows::core::HRESULT;
@@ -1925,6 +1969,7 @@ impl IEnumMoniker_Vtbl {
         iid == &<IEnumMoniker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumSTATDATA_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut STATDATA, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1972,6 +2017,7 @@ impl IEnumSTATDATA_Vtbl {
         iid == &<IEnumSTATDATA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumString_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::windows::core::PWSTR, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
     fn Skip(&self, celt: u32) -> ::windows::core::HRESULT;
@@ -2019,6 +2065,7 @@ impl IEnumString_Vtbl {
         iid == &<IEnumString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IEnumUnknown_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<::windows::core::IUnknown>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -2066,6 +2113,7 @@ impl IEnumUnknown_Vtbl {
         iid == &<IEnumUnknown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IErrorInfo_Impl: Sized {
     fn GetGUID(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetSource(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2144,6 +2192,7 @@ impl IErrorInfo_Vtbl {
         iid == &<IErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IErrorLog_Impl: Sized {
     fn AddError(&self, pszpropname: &::windows::core::PCWSTR, pexcepinfo: *const EXCEPINFO) -> ::windows::core::Result<()>;
 }
@@ -2161,6 +2210,7 @@ impl IErrorLog_Vtbl {
         iid == &<IErrorLog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IExternalConnection_Impl: Sized {
     fn AddConnection(&self, extconn: u32, reserved: u32) -> u32;
@@ -2191,6 +2241,7 @@ impl IExternalConnection_Vtbl {
         iid == &<IExternalConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IFastRundown_Impl: Sized {}
 impl ::windows::core::RuntimeName for IFastRundown {}
 impl IFastRundown_Vtbl {
@@ -2201,6 +2252,7 @@ impl IFastRundown_Vtbl {
         iid == &<IFastRundown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IForegroundTransfer_Impl: Sized {
     fn AllowForegroundTransfer(&self, lpvreserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -2218,6 +2270,7 @@ impl IForegroundTransfer_Vtbl {
         iid == &<IForegroundTransfer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IGlobalInterfaceTable_Impl: Sized {
     fn RegisterInterfaceInGlobal(&self, punk: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
     fn RevokeInterfaceFromGlobal(&self, dwcookie: u32) -> ::windows::core::Result<()>;
@@ -2258,6 +2311,7 @@ impl IGlobalInterfaceTable_Vtbl {
         iid == &<IGlobalInterfaceTable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IGlobalOptions_Impl: Sized {
     fn Set(&self, dwproperty: GLOBALOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::Result<()>;
     fn Query(&self, dwproperty: GLOBALOPT_PROPERTIES) -> ::windows::core::Result<usize>;
@@ -2287,6 +2341,7 @@ impl IGlobalOptions_Vtbl {
         iid == &<IGlobalOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IInitializeSpy_Impl: Sized {
     fn PreInitialize(&self, dwcoinit: u32, dwcurthreadaptrefs: u32) -> ::windows::core::Result<()>;
     fn PostInitialize(&self, hrcoinit: ::windows::core::HRESULT, dwcoinit: u32, dwnewthreadaptrefs: u32) -> ::windows::core::Result<()>;
@@ -2328,6 +2383,7 @@ impl IInitializeSpy_Vtbl {
         iid == &<IInitializeSpy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IInternalUnknown_Impl: Sized {
     fn QueryInternalInterface(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -2345,6 +2401,7 @@ impl IInternalUnknown_Vtbl {
         iid == &<IInternalUnknown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IMachineGlobalObjectTable_Impl: Sized {
     fn RegisterObject(&self, clsid: *const ::windows::core::GUID, identifier: &::windows::core::PCWSTR, object: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<*mut MachineGlobalObjectTableRegistrationToken__>;
     fn GetObject(&self, clsid: *const ::windows::core::GUID, identifier: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2385,6 +2442,7 @@ impl IMachineGlobalObjectTable_Vtbl {
         iid == &<IMachineGlobalObjectTable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IMalloc_Impl: Sized {
     fn Alloc(&self, cb: usize) -> *mut ::core::ffi::c_void;
     fn Realloc(&self, pv: *const ::core::ffi::c_void, cb: usize) -> *mut ::core::ffi::c_void;
@@ -2440,6 +2498,7 @@ impl IMalloc_Vtbl {
         iid == &<IMalloc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMallocSpy_Impl: Sized {
     fn PreAlloc(&self, cbrequest: usize) -> usize;
@@ -2540,6 +2599,7 @@ impl IMallocSpy_Vtbl {
         iid == &<IMallocSpy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMoniker_Impl: Sized + IPersistStream_Impl {
     fn BindToObject(&self, pbc: &::core::option::Option<IBindCtx>, pmktoleft: &::core::option::Option<IMoniker>, riidresult: *const ::windows::core::GUID, ppvresult: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2715,6 +2775,7 @@ impl IMoniker_Vtbl {
         iid == &<IMoniker as ::windows::core::Interface>::IID || iid == &<IPersist as ::windows::core::Interface>::IID || iid == &<IPersistStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IMultiQI_Impl: Sized {
     fn QueryMultipleInterfaces(&self, cmqis: u32, pmqis: *mut MULTI_QI) -> ::windows::core::Result<()>;
 }
@@ -2732,6 +2793,7 @@ impl IMultiQI_Vtbl {
         iid == &<IMultiQI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait INoMarshal_Impl: Sized {}
 impl ::windows::core::RuntimeName for INoMarshal {}
 impl INoMarshal_Vtbl {
@@ -2742,6 +2804,7 @@ impl INoMarshal_Vtbl {
         iid == &<INoMarshal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IOplockStorage_Impl: Sized {
     fn CreateStorageEx(&self, pwcsname: &::windows::core::PCWSTR, grfmode: u32, stgfmt: u32, grfattrs: u32, riid: *const ::windows::core::GUID, ppstgopen: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn OpenStorageEx(&self, pwcsname: &::windows::core::PCWSTR, grfmode: u32, stgfmt: u32, grfattrs: u32, riid: *const ::windows::core::GUID, ppstgopen: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2769,6 +2832,7 @@ impl IOplockStorage_Vtbl {
         iid == &<IOplockStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IPSFactoryBuffer_Impl: Sized {
     fn CreateProxy(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppproxy: *mut ::core::option::Option<IRpcProxyBuffer>, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CreateStub(&self, riid: *const ::windows::core::GUID, punkserver: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<IRpcStubBuffer>;
@@ -2802,6 +2866,7 @@ impl IPSFactoryBuffer_Vtbl {
         iid == &<IPSFactoryBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IPersist_Impl: Sized {
     fn GetClassID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -2825,6 +2890,7 @@ impl IPersist_Vtbl {
         iid == &<IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPersistFile_Impl: Sized + IPersist_Impl {
     fn IsDirty(&self) -> ::windows::core::HRESULT;
@@ -2882,6 +2948,7 @@ impl IPersistFile_Vtbl {
         iid == &<IPersistFile as ::windows::core::Interface>::IID || iid == &<IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPersistMemory_Impl: Sized + IPersist_Impl {
     fn IsDirty(&self) -> ::windows::core::HRESULT;
@@ -2939,6 +3006,7 @@ impl IPersistMemory_Vtbl {
         iid == &<IPersistMemory as ::windows::core::Interface>::IID || iid == &<IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPersistStream_Impl: Sized + IPersist_Impl {
     fn IsDirty(&self) -> ::windows::core::HRESULT;
@@ -2989,6 +3057,7 @@ impl IPersistStream_Vtbl {
         iid == &<IPersistStream as ::windows::core::Interface>::IID || iid == &<IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPersistStreamInit_Impl: Sized + IPersist_Impl {
     fn IsDirty(&self) -> ::windows::core::HRESULT;
@@ -3046,6 +3115,7 @@ impl IPersistStreamInit_Vtbl {
         iid == &<IPersistStreamInit as ::windows::core::Interface>::IID || iid == &<IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IPipeByte_Impl: Sized {
     fn Pull(&self, buf: *mut u8, crequest: u32, pcreturned: *mut u32) -> ::windows::core::Result<()>;
     fn Push(&self, buf: *const u8, csent: u32) -> ::windows::core::Result<()>;
@@ -3069,6 +3139,7 @@ impl IPipeByte_Vtbl {
         iid == &<IPipeByte as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IPipeDouble_Impl: Sized {
     fn Pull(&self, buf: *mut f64, crequest: u32, pcreturned: *mut u32) -> ::windows::core::Result<()>;
     fn Push(&self, buf: *const f64, csent: u32) -> ::windows::core::Result<()>;
@@ -3092,6 +3163,7 @@ impl IPipeDouble_Vtbl {
         iid == &<IPipeDouble as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IPipeLong_Impl: Sized {
     fn Pull(&self, buf: *mut i32, crequest: u32, pcreturned: *mut u32) -> ::windows::core::Result<()>;
     fn Push(&self, buf: *const i32, csent: u32) -> ::windows::core::Result<()>;
@@ -3115,6 +3187,7 @@ impl IPipeLong_Vtbl {
         iid == &<IPipeLong as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IProcessInitControl_Impl: Sized {
     fn ResetInitializerTimeout(&self, dwsecondsremaining: u32) -> ::windows::core::Result<()>;
 }
@@ -3132,6 +3205,7 @@ impl IProcessInitControl_Vtbl {
         iid == &<IProcessInitControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IProcessLock_Impl: Sized {
     fn AddRefOnProcess(&self) -> u32;
     fn ReleaseRefOnProcess(&self) -> u32;
@@ -3159,6 +3233,7 @@ impl IProcessLock_Vtbl {
         iid == &<IProcessLock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProgressNotify_Impl: Sized {
     fn OnProgress(&self, dwprogresscurrent: u32, dwprogressmaximum: u32, faccurate: super::super::Foundation::BOOL, fowner: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3179,6 +3254,7 @@ impl IProgressNotify_Vtbl {
         iid == &<IProgressNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IROTData_Impl: Sized {
     fn GetComparisonData(&self, pbdata: *mut u8, cbmax: u32, pcbdata: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -3196,6 +3272,7 @@ impl IROTData_Vtbl {
         iid == &<IROTData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IReleaseMarshalBuffers_Impl: Sized {
     fn ReleaseMarshalBuffer(&self, pmsg: *mut RPCOLEMESSAGE, dwflags: u32, pchnl: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -3213,6 +3290,7 @@ impl IReleaseMarshalBuffers_Vtbl {
         iid == &<IReleaseMarshalBuffers as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcChannelBuffer_Impl: Sized {
     fn GetBuffer(&self, pmessage: *mut RPCOLEMESSAGE, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SendReceive(&self, pmessage: *mut RPCOLEMESSAGE, pstatus: *mut u32) -> ::windows::core::Result<()>;
@@ -3261,6 +3339,7 @@ impl IRpcChannelBuffer_Vtbl {
         iid == &<IRpcChannelBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcChannelBuffer2_Impl: Sized + IRpcChannelBuffer_Impl {
     fn GetProtocolVersion(&self) -> ::windows::core::Result<u32>;
 }
@@ -3284,6 +3363,7 @@ impl IRpcChannelBuffer2_Vtbl {
         iid == &<IRpcChannelBuffer2 as ::windows::core::Interface>::IID || iid == &<IRpcChannelBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcChannelBuffer3_Impl: Sized + IRpcChannelBuffer2_Impl {
     fn Send(&self, pmsg: *mut RPCOLEMESSAGE, pulstatus: *mut u32) -> ::windows::core::Result<()>;
     fn Receive(&self, pmsg: *mut RPCOLEMESSAGE, ulsize: u32, pulstatus: *mut u32) -> ::windows::core::Result<()>;
@@ -3352,6 +3432,7 @@ impl IRpcChannelBuffer3_Vtbl {
         iid == &<IRpcChannelBuffer3 as ::windows::core::Interface>::IID || iid == &<IRpcChannelBuffer as ::windows::core::Interface>::IID || iid == &<IRpcChannelBuffer2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcHelper_Impl: Sized {
     fn GetDCOMProtocolVersion(&self) -> ::windows::core::Result<u32>;
     fn GetIIDFromOBJREF(&self, pobjref: *const ::core::ffi::c_void) -> ::windows::core::Result<*mut ::windows::core::GUID>;
@@ -3391,6 +3472,7 @@ impl IRpcHelper_Vtbl {
         iid == &<IRpcHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcOptions_Impl: Sized {
     fn Set(&self, pprx: &::core::option::Option<::windows::core::IUnknown>, dwproperty: RPCOPT_PROPERTIES, dwvalue: usize) -> ::windows::core::Result<()>;
     fn Query(&self, pprx: &::core::option::Option<::windows::core::IUnknown>, dwproperty: RPCOPT_PROPERTIES) -> ::windows::core::Result<usize>;
@@ -3420,6 +3502,7 @@ impl IRpcOptions_Vtbl {
         iid == &<IRpcOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcProxyBuffer_Impl: Sized {
     fn Connect(&self, prpcchannelbuffer: &::core::option::Option<IRpcChannelBuffer>) -> ::windows::core::Result<()>;
     fn Disconnect(&self);
@@ -3447,6 +3530,7 @@ impl IRpcProxyBuffer_Vtbl {
         iid == &<IRpcProxyBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcStubBuffer_Impl: Sized {
     fn Connect(&self, punkserver: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Disconnect(&self);
@@ -3509,6 +3593,7 @@ impl IRpcStubBuffer_Vtbl {
         iid == &<IRpcStubBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IRpcSyntaxNegotiate_Impl: Sized {
     fn NegotiateSyntax(&self, pmsg: *mut RPCOLEMESSAGE) -> ::windows::core::Result<()>;
 }
@@ -3526,6 +3611,7 @@ impl IRpcSyntaxNegotiate_Vtbl {
         iid == &<IRpcSyntaxNegotiate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRunnableObject_Impl: Sized {
     fn GetRunningClass(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3583,6 +3669,7 @@ impl IRunnableObject_Vtbl {
         iid == &<IRunnableObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRunningObjectTable_Impl: Sized {
     fn Register(&self, grfflags: ROT_FLAGS, punkobject: &::core::option::Option<::windows::core::IUnknown>, pmkobjectname: &::core::option::Option<IMoniker>) -> ::windows::core::Result<u32>;
@@ -3672,6 +3759,7 @@ impl IRunningObjectTable_Vtbl {
         iid == &<IRunningObjectTable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ISequentialStream_Impl: Sized {
     fn Read(&self, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32) -> ::windows::core::HRESULT;
     fn Write(&self, pv: *const ::core::ffi::c_void, cb: u32, pcbwritten: *mut u32) -> ::windows::core::HRESULT;
@@ -3695,6 +3783,7 @@ impl ISequentialStream_Vtbl {
         iid == &<ISequentialStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IServerSecurity_Impl: Sized {
     fn QueryBlanket(&self, pauthnsvc: *mut u32, pauthzsvc: *mut u32, pserverprincname: *mut *mut u16, pauthnlevel: *mut u32, pimplevel: *mut u32, pprivs: *mut *mut ::core::ffi::c_void, pcapabilities: *mut u32) -> ::windows::core::Result<()>;
@@ -3739,6 +3828,7 @@ impl IServerSecurity_Vtbl {
         iid == &<IServerSecurity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IServiceProvider_Impl: Sized {
     fn QueryService(&self, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -3756,6 +3846,7 @@ impl IServiceProvider_Vtbl {
         iid == &<IServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IStdMarshalInfo_Impl: Sized {
     fn GetClassForHandler(&self, dwdestcontext: u32, pvdestcontext: *mut ::core::ffi::c_void, pclsid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -3773,6 +3864,7 @@ impl IStdMarshalInfo_Vtbl {
         iid == &<IStdMarshalInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStream_Impl: Sized + ISequentialStream_Impl {
     fn Seek(&self, dlibmove: i64, dworigin: STREAM_SEEK, plibnewposition: *mut u64) -> ::windows::core::Result<()>;
@@ -3858,6 +3950,7 @@ impl IStream_Vtbl {
         iid == &<IStream as ::windows::core::Interface>::IID || iid == &<ISequentialStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ISupportErrorInfo_Impl: Sized {
     fn InterfaceSupportsErrorInfo(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -3878,6 +3971,7 @@ impl ISupportErrorInfo_Vtbl {
         iid == &<ISupportErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ISurrogate_Impl: Sized {
     fn LoadDllServer(&self, clsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn FreeSurrogate(&self) -> ::windows::core::Result<()>;
@@ -3905,6 +3999,7 @@ impl ISurrogate_Vtbl {
         iid == &<ISurrogate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISurrogateService_Impl: Sized {
     fn Init(&self, rguidprocessid: *const ::windows::core::GUID, pprocesslock: &::core::option::Option<IProcessLock>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3962,6 +4057,7 @@ impl ISurrogateService_Vtbl {
         iid == &<ISurrogateService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ISynchronize_Impl: Sized {
     fn Wait(&self, dwflags: u32, dwmilliseconds: u32) -> ::windows::core::Result<()>;
     fn Signal(&self) -> ::windows::core::Result<()>;
@@ -3996,6 +4092,7 @@ impl ISynchronize_Vtbl {
         iid == &<ISynchronize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ISynchronizeContainer_Impl: Sized {
     fn AddSynchronize(&self, psync: &::core::option::Option<ISynchronize>) -> ::windows::core::Result<()>;
     fn WaitMultiple(&self, dwflags: u32, dwtimeout: u32) -> ::windows::core::Result<ISynchronize>;
@@ -4029,6 +4126,7 @@ impl ISynchronizeContainer_Vtbl {
         iid == &<ISynchronizeContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISynchronizeEvent_Impl: Sized + ISynchronizeHandle_Impl {
     fn SetEventHandle(&self, ph: *const super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -4049,6 +4147,7 @@ impl ISynchronizeEvent_Vtbl {
         iid == &<ISynchronizeEvent as ::windows::core::Interface>::IID || iid == &<ISynchronizeHandle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISynchronizeHandle_Impl: Sized {
     fn GetHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -4075,6 +4174,7 @@ impl ISynchronizeHandle_Vtbl {
         iid == &<ISynchronizeHandle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ISynchronizeMutex_Impl: Sized + ISynchronize_Impl {
     fn ReleaseMutex(&self) -> ::windows::core::Result<()>;
 }
@@ -4092,6 +4192,7 @@ impl ISynchronizeMutex_Vtbl {
         iid == &<ISynchronizeMutex as ::windows::core::Interface>::IID || iid == &<ISynchronize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ITimeAndNoticeControl_Impl: Sized {
     fn SuppressChanges(&self, res1: u32, res2: u32) -> ::windows::core::Result<()>;
 }
@@ -4109,6 +4210,7 @@ impl ITimeAndNoticeControl_Vtbl {
         iid == &<ITimeAndNoticeControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait ITypeComp_Impl: Sized {
     fn Bind(&self, szname: &::windows::core::PCWSTR, lhashval: u32, wflags: u16, pptinfo: *mut ::core::option::Option<ITypeInfo>, pdesckind: *mut DESCKIND, pbindptr: *mut BINDPTR) -> ::windows::core::Result<()>;
@@ -4139,6 +4241,7 @@ impl ITypeComp_Vtbl {
         iid == &<ITypeComp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait ITypeInfo_Impl: Sized {
     fn GetTypeAttr(&self) -> ::windows::core::Result<*mut TYPEATTR>;
@@ -4336,6 +4439,7 @@ impl ITypeInfo_Vtbl {
         iid == &<ITypeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait ITypeInfo2_Impl: Sized + ITypeInfo_Impl {
     fn GetTypeKind(&self) -> ::windows::core::Result<TYPEKIND>;
@@ -4541,6 +4645,7 @@ impl ITypeInfo2_Vtbl {
         iid == &<ITypeInfo2 as ::windows::core::Interface>::IID || iid == &<ITypeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITypeLib_Impl: Sized {
     fn GetTypeInfoCount(&self) -> u32;
@@ -4657,6 +4762,7 @@ impl ITypeLib_Vtbl {
         iid == &<ITypeLib as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait ITypeLib2_Impl: Sized + ITypeLib_Impl {
     fn GetCustData(&self, guid: *const ::windows::core::GUID) -> ::windows::core::Result<VARIANT>;
@@ -4713,6 +4819,7 @@ impl ITypeLib2_Vtbl {
         iid == &<ITypeLib2 as ::windows::core::Interface>::IID || iid == &<ITypeLib as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ITypeLibRegistration_Impl: Sized {
     fn GetGuid(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetVersion(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4830,6 +4937,7 @@ impl ITypeLibRegistration_Vtbl {
         iid == &<ITypeLibRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait ITypeLibRegistrationReader_Impl: Sized {
     fn EnumTypeLibRegistrations(&self) -> ::windows::core::Result<IEnumUnknown>;
 }
@@ -4853,6 +4961,7 @@ impl ITypeLibRegistrationReader_Vtbl {
         iid == &<ITypeLibRegistrationReader as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUri_Impl: Sized {
     fn GetPropertyBSTR(&self, uriprop: Uri_PROPERTY, pbstrproperty: *mut ::windows::core::BSTR, dwflags: u32) -> ::windows::core::Result<()>;
@@ -5176,6 +5285,7 @@ impl IUri_Vtbl {
         iid == &<IUri as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUriBuilder_Impl: Sized {
     fn CreateUriSimple(&self, dwallowencodingpropertymask: u32, dwreserved: usize) -> ::windows::core::Result<IUri>;
@@ -5377,6 +5487,7 @@ impl IUriBuilder_Vtbl {
         iid == &<IUriBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IUrlMon_Impl: Sized {
     fn AsyncGetClassBits(&self, rclsid: *const ::windows::core::GUID, psztype: &::windows::core::PCWSTR, pszext: &::windows::core::PCWSTR, dwfileversionms: u32, dwfileversionls: u32, pszcodebase: &::windows::core::PCWSTR, pbc: &::core::option::Option<IBindCtx>, dwclasscontext: u32, riid: *const ::windows::core::GUID, flags: u32) -> ::windows::core::Result<()>;
 }
@@ -5394,6 +5505,7 @@ impl IUrlMon_Vtbl {
         iid == &<IUrlMon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Com\"`, `\"implement\"`*"]
 pub trait IWaitMultiple_Impl: Sized {
     fn WaitMultiple(&self, timeout: u32) -> ::windows::core::Result<ISynchronize>;
     fn AddSynchronize(&self, psync: &::core::option::Option<ISynchronize>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ComponentServices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ContextInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsInTransaction(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -79,6 +80,7 @@ impl ContextInfo_Vtbl {
         iid == &<ContextInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ContextInfo2_Impl: Sized + ContextInfo_Impl {
     fn GetPartitionId(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -134,6 +136,7 @@ impl ContextInfo2_Vtbl {
         iid == &<ContextInfo2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ContextInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAppDomainHelper_Impl: Sized + super::Com::IDispatch_Impl {
     fn Initialize(&self, punkad: &::core::option::Option<::windows::core::IUnknown>, __midl__iappdomainhelper0000: isize, ppool: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -164,6 +167,7 @@ impl IAppDomainHelper_Vtbl {
         iid == &<IAppDomainHelper as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAssemblyLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetModules(&self, applicationdir: &::windows::core::BSTR, applicationname: &::windows::core::BSTR, assemblyname: &::windows::core::BSTR) -> ::windows::core::Result<*mut super::Com::SAFEARRAY>;
@@ -190,6 +194,7 @@ impl IAssemblyLocator_Vtbl {
         iid == &<IAssemblyLocator as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IAsyncErrorNotify_Impl: Sized {
     fn OnError(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -207,6 +212,7 @@ impl IAsyncErrorNotify_Vtbl {
         iid == &<IAsyncErrorNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICOMAdminCatalog_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetCollection(&self, bstrcollname: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -441,6 +447,7 @@ impl ICOMAdminCatalog_Vtbl {
         iid == &<ICOMAdminCatalog as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICOMAdminCatalog2_Impl: Sized + ICOMAdminCatalog_Impl {
     fn GetCollectionByQuery2(&self, bstrcollectionname: &::windows::core::BSTR, pvarquerystrings: *const super::Com::VARIANT) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -758,6 +765,7 @@ impl ICOMAdminCatalog2_Vtbl {
         iid == &<ICOMAdminCatalog2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ICOMAdminCatalog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ICOMLBArguments_Impl: Sized {
     fn GetCLSID(&self, pclsid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SetCLSID(&self, pclsid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -799,6 +807,7 @@ impl ICOMLBArguments_Vtbl {
         iid == &<ICOMLBArguments as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICatalogCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -999,6 +1008,7 @@ impl ICatalogCollection_Vtbl {
         iid == &<ICatalogCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICatalogObject_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Value(&self, bstrpropname: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -1100,6 +1110,7 @@ impl ICatalogObject_Vtbl {
         iid == &<ICatalogObject as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ICheckSxsConfig_Impl: Sized {
     fn IsSameSxsConfig(&self, wszsxsname: &::windows::core::PCWSTR, wszsxsdirectory: &::windows::core::PCWSTR, wszsxsappname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1117,6 +1128,7 @@ impl ICheckSxsConfig_Vtbl {
         iid == &<ICheckSxsConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComActivityEvents_Impl: Sized {
     fn OnActivityCreate(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnActivityDestroy(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1179,6 +1191,7 @@ impl IComActivityEvents_Vtbl {
         iid == &<IComActivityEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComApp2Events_Impl: Sized {
     fn OnAppActivation2(&self, pinfo: *const COMSVCSEVENTINFO, guidapp: &::windows::core::GUID, guidprocess: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1230,6 +1243,7 @@ impl IComApp2Events_Vtbl {
         iid == &<IComApp2Events as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComAppEvents_Impl: Sized {
     fn OnAppActivation(&self, pinfo: *const COMSVCSEVENTINFO, guidapp: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnAppShutdown(&self, pinfo: *const COMSVCSEVENTINFO, guidapp: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1264,6 +1278,7 @@ impl IComAppEvents_Vtbl {
         iid == &<IComAppEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComCRMEvents_Impl: Sized {
     fn OnCRMRecoveryStart(&self, pinfo: *const COMSVCSEVENTINFO, guidapp: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1385,6 +1400,7 @@ impl IComCRMEvents_Vtbl {
         iid == &<IComCRMEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComExceptionEvents_Impl: Sized {
     fn OnExceptionUser(&self, pinfo: *const COMSVCSEVENTINFO, code: u32, address: u64, pszstacktrace: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1402,6 +1418,7 @@ impl IComExceptionEvents_Vtbl {
         iid == &<IComExceptionEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComIdentityEvents_Impl: Sized {
     fn OnIISRequestInfo(&self, pinfo: *const COMSVCSEVENTINFO, objid: u64, pszclientip: &::windows::core::PCWSTR, pszserverip: &::windows::core::PCWSTR, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1419,6 +1436,7 @@ impl IComIdentityEvents_Vtbl {
         iid == &<IComIdentityEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComInstance2Events_Impl: Sized {
     fn OnObjectCreate2(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn OnObjectDestroy2(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::Result<()>;
@@ -1446,6 +1464,7 @@ impl IComInstance2Events_Vtbl {
         iid == &<IComInstance2Events as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComInstanceEvents_Impl: Sized {
     fn OnObjectCreate(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, clsid: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, ctxtid: u64, objectid: u64) -> ::windows::core::Result<()>;
     fn OnObjectDestroy(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64) -> ::windows::core::Result<()>;
@@ -1473,6 +1492,7 @@ impl IComInstanceEvents_Vtbl {
         iid == &<IComInstanceEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComLTxEvents_Impl: Sized {
     fn OnLtxTransactionStart(&self, pinfo: *const COMSVCSEVENTINFO, guidltx: &::windows::core::GUID, tsid: &::windows::core::GUID, froot: super::super::Foundation::BOOL, nisolationlevel: i32) -> ::windows::core::Result<()>;
@@ -1524,6 +1544,7 @@ impl IComLTxEvents_Vtbl {
         iid == &<IComLTxEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComMethod2Events_Impl: Sized {
     fn OnMethodCall2(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32) -> ::windows::core::Result<()>;
     fn OnMethodReturn2(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, dwthread: u32, imeth: u32, hresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1558,6 +1579,7 @@ impl IComMethod2Events_Vtbl {
         iid == &<IComMethod2Events as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComMethodEvents_Impl: Sized {
     fn OnMethodCall(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32) -> ::windows::core::Result<()>;
     fn OnMethodReturn(&self, pinfo: *const COMSVCSEVENTINFO, oid: u64, guidcid: *const ::windows::core::GUID, guidrid: *const ::windows::core::GUID, imeth: u32, hresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1592,6 +1614,7 @@ impl IComMethodEvents_Vtbl {
         iid == &<IComMethodEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComMtaThreadPoolKnobs_Impl: Sized {
     fn MTASetMaxThreadCount(&self, dwmaxthreads: u32) -> ::windows::core::Result<()>;
     fn MTAGetMaxThreadCount(&self) -> ::windows::core::Result<u32>;
@@ -1645,6 +1668,7 @@ impl IComMtaThreadPoolKnobs_Vtbl {
         iid == &<IComMtaThreadPoolKnobs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComObjectConstruction2Events_Impl: Sized {
     fn OnObjectConstruct2(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: &::windows::core::PCWSTR, oid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -1662,6 +1686,7 @@ impl IComObjectConstruction2Events_Vtbl {
         iid == &<IComObjectConstruction2Events as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComObjectConstructionEvents_Impl: Sized {
     fn OnObjectConstruct(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, sconstructstring: &::windows::core::PCWSTR, oid: u64) -> ::windows::core::Result<()>;
 }
@@ -1679,6 +1704,7 @@ impl IComObjectConstructionEvents_Vtbl {
         iid == &<IComObjectConstructionEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComObjectEvents_Impl: Sized {
     fn OnObjectActivate(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64, objectid: u64) -> ::windows::core::Result<()>;
     fn OnObjectDeactivate(&self, pinfo: *const COMSVCSEVENTINFO, ctxtid: u64, objectid: u64) -> ::windows::core::Result<()>;
@@ -1734,6 +1760,7 @@ impl IComObjectEvents_Vtbl {
         iid == &<IComObjectEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComObjectPool2Events_Impl: Sized {
     fn OnObjPoolPutObject2(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, nreason: i32, dwavailable: u32, oid: u64) -> ::windows::core::Result<()>;
     fn OnObjPoolGetObject2(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, dwavailable: u32, oid: u64, guidpartition: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1775,6 +1802,7 @@ impl IComObjectPool2Events_Vtbl {
         iid == &<IComObjectPool2Events as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComObjectPoolEvents_Impl: Sized {
     fn OnObjPoolPutObject(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, nreason: i32, dwavailable: u32, oid: u64) -> ::windows::core::Result<()>;
     fn OnObjPoolGetObject(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, guidobject: *const ::windows::core::GUID, dwavailable: u32, oid: u64) -> ::windows::core::Result<()>;
@@ -1816,6 +1844,7 @@ impl IComObjectPoolEvents_Vtbl {
         iid == &<IComObjectPoolEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComObjectPoolEvents2_Impl: Sized {
     fn OnObjPoolCreateObject(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, dwobjscreated: u32, oid: u64) -> ::windows::core::Result<()>;
     fn OnObjPoolDestroyObject(&self, pinfo: *const COMSVCSEVENTINFO, guidobject: *const ::windows::core::GUID, dwobjscreated: u32, oid: u64) -> ::windows::core::Result<()>;
@@ -1864,6 +1893,7 @@ impl IComObjectPoolEvents2_Vtbl {
         iid == &<IComObjectPoolEvents2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComQCEvents_Impl: Sized {
     fn OnQCRecord(&self, pinfo: *const COMSVCSEVENTINFO, objid: u64, szqueue: &::windows::core::PCWSTR, guidmsgid: *const ::windows::core::GUID, guidworkflowid: *const ::windows::core::GUID, msmqhr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnQCQueueOpen(&self, pinfo: *const COMSVCSEVENTINFO, szqueue: &::windows::core::PCWSTR, queueid: u64, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1926,6 +1956,7 @@ impl IComQCEvents_Vtbl {
         iid == &<IComQCEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComResourceEvents_Impl: Sized {
     fn OnResourceCreate(&self, pinfo: *const COMSVCSEVENTINFO, objectid: u64, psztype: &::windows::core::PCWSTR, resid: u64, enlisted: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1977,6 +2008,7 @@ impl IComResourceEvents_Vtbl {
         iid == &<IComResourceEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComSecurityEvents_Impl: Sized {
     fn OnAuthenticate(&self, pinfo: *const COMSVCSEVENTINFO, guidactivity: *const ::windows::core::GUID, objectid: u64, guidiid: *const ::windows::core::GUID, imeth: u32, cbbyteorig: u32, psidoriginaluser: *const u8, cbbytecur: u32, psidcurrentuser: *const u8, bcurrentuserinpersonatinginproc: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2007,6 +2039,7 @@ impl IComSecurityEvents_Vtbl {
         iid == &<IComSecurityEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComStaThreadPoolKnobs_Impl: Sized {
     fn SetMinThreadCount(&self, minthreads: u32) -> ::windows::core::Result<()>;
     fn GetMinThreadCount(&self) -> ::windows::core::Result<u32>;
@@ -2133,6 +2166,7 @@ impl IComStaThreadPoolKnobs_Vtbl {
         iid == &<IComStaThreadPoolKnobs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComStaThreadPoolKnobs2_Impl: Sized + IComStaThreadPoolKnobs_Impl {
     fn GetMaxCPULoad(&self) -> ::windows::core::Result<u32>;
@@ -2249,6 +2283,7 @@ impl IComStaThreadPoolKnobs2_Vtbl {
         iid == &<IComStaThreadPoolKnobs2 as ::windows::core::Interface>::IID || iid == &<IComStaThreadPoolKnobs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComThreadEvents_Impl: Sized {
     fn OnThreadStart(&self, pinfo: *const COMSVCSEVENTINFO, threadid: u64, dwthread: u32, dwtheadcnt: u32) -> ::windows::core::Result<()>;
     fn OnThreadTerminate(&self, pinfo: *const COMSVCSEVENTINFO, threadid: u64, dwthread: u32, dwtheadcnt: u32) -> ::windows::core::Result<()>;
@@ -2339,6 +2374,7 @@ impl IComThreadEvents_Vtbl {
         iid == &<IComThreadEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComTrackingInfoCollection_Impl: Sized {
     fn Type(&self) -> ::windows::core::Result<TRACKING_COLL_TYPE>;
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -2385,6 +2421,7 @@ impl IComTrackingInfoCollection_Vtbl {
         iid == &<IComTrackingInfoCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComTrackingInfoEvents_Impl: Sized {
     fn OnNewTrackingInfo(&self, ptoplevelcollection: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -2402,6 +2439,7 @@ impl IComTrackingInfoEvents_Vtbl {
         iid == &<IComTrackingInfoEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComTrackingInfoObject_Impl: Sized {
     fn GetValue(&self, szpropertyname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -2428,6 +2466,7 @@ impl IComTrackingInfoObject_Vtbl {
         iid == &<IComTrackingInfoObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IComTrackingInfoProperties_Impl: Sized {
     fn PropCount(&self) -> ::windows::core::Result<u32>;
     fn GetPropName(&self, ulindex: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2467,6 +2506,7 @@ impl IComTrackingInfoProperties_Vtbl {
         iid == &<IComTrackingInfoProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComTransaction2Events_Impl: Sized {
     fn OnTransactionStart2(&self, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, froot: super::super::Foundation::BOOL, nisolationlevel: i32) -> ::windows::core::Result<()>;
@@ -2511,6 +2551,7 @@ impl IComTransaction2Events_Vtbl {
         iid == &<IComTransaction2Events as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IComTransactionEvents_Impl: Sized {
     fn OnTransactionStart(&self, pinfo: *const COMSVCSEVENTINFO, guidtx: *const ::windows::core::GUID, tsid: *const ::windows::core::GUID, froot: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2555,6 +2596,7 @@ impl IComTransactionEvents_Vtbl {
         iid == &<IComTransactionEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComUserEvent_Impl: Sized {
     fn OnUserEvent(&self, pinfo: *const COMSVCSEVENTINFO, pvarevent: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2575,6 +2617,7 @@ impl IComUserEvent_Vtbl {
         iid == &<IComUserEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IContextProperties_Impl: Sized {
     fn Count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -2632,6 +2675,7 @@ impl IContextProperties_Vtbl {
         iid == &<IContextProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContextSecurityPerimeter_Impl: Sized {
     fn GetPerimeterFlag(&self, pflag: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2662,6 +2706,7 @@ impl IContextSecurityPerimeter_Vtbl {
         iid == &<IContextSecurityPerimeter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContextState_Impl: Sized {
     fn SetDeactivateOnReturn(&self, bdeactivate: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -2706,6 +2751,7 @@ impl IContextState_Vtbl {
         iid == &<IContextState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ICreateWithLocalTransaction_Impl: Sized {
     fn CreateInstanceWithSysTx(&self, ptransaction: &::core::option::Option<::windows::core::IUnknown>, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -2723,6 +2769,7 @@ impl ICreateWithLocalTransaction_Vtbl {
         iid == &<ICreateWithLocalTransaction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ICreateWithTipTransactionEx_Impl: Sized {
     fn CreateInstance(&self, bstrtipurl: &::windows::core::BSTR, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -2740,6 +2787,7 @@ impl ICreateWithTipTransactionEx_Vtbl {
         iid == &<ICreateWithTipTransactionEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 pub trait ICreateWithTransactionEx_Impl: Sized {
     fn CreateInstance(&self, ptransaction: &::core::option::Option<super::DistributedTransactionCoordinator::ITransaction>, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2760,6 +2808,7 @@ impl ICreateWithTransactionEx_Vtbl {
         iid == &<ICreateWithTransactionEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ICrmCompensator_Impl: Sized {
     fn SetLogControl(&self, plogcontrol: &::core::option::Option<ICrmLogControl>) -> ::windows::core::Result<()>;
@@ -2870,6 +2919,7 @@ impl ICrmCompensator_Vtbl {
         iid == &<ICrmCompensator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICrmCompensatorVariants_Impl: Sized {
     fn SetLogControlVariants(&self, plogcontrol: &::core::option::Option<ICrmLogControl>) -> ::windows::core::Result<()>;
@@ -2980,6 +3030,7 @@ impl ICrmCompensatorVariants_Vtbl {
         iid == &<ICrmCompensatorVariants as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICrmFormatLogRecords_Impl: Sized {
     fn GetColumnCount(&self) -> ::windows::core::Result<i32>;
@@ -3048,6 +3099,7 @@ impl ICrmFormatLogRecords_Vtbl {
         iid == &<ICrmFormatLogRecords as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICrmLogControl_Impl: Sized {
     fn TransactionUOW(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3119,6 +3171,7 @@ impl ICrmLogControl_Vtbl {
         iid == &<ICrmLogControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICrmMonitor_Impl: Sized {
     fn GetClerks(&self) -> ::windows::core::Result<ICrmMonitorClerks>;
@@ -3161,6 +3214,7 @@ impl ICrmMonitor_Vtbl {
         iid == &<ICrmMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICrmMonitorClerks_Impl: Sized + super::Com::IDispatch_Impl {
     fn Item(&self, index: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -3268,6 +3322,7 @@ impl ICrmMonitorClerks_Vtbl {
         iid == &<ICrmMonitorClerks as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICrmMonitorLogRecords_Impl: Sized {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3343,6 +3398,7 @@ impl ICrmMonitorLogRecords_Vtbl {
         iid == &<ICrmMonitorLogRecords as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDispenserDriver_Impl: Sized {
     fn CreateResource(&self, restypid: usize, presid: *mut usize, psecsfreebeforedestroy: *mut i32) -> ::windows::core::Result<()>;
@@ -3401,6 +3457,7 @@ impl IDispenserDriver_Vtbl {
         iid == &<IDispenserDriver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IDispenserManager_Impl: Sized {
     fn RegisterDispenser(&self, __midl__idispensermanager0000: &::core::option::Option<IDispenserDriver>, szdispensername: &::windows::core::PCWSTR) -> ::windows::core::Result<IHolder>;
     fn GetContext(&self, __midl__idispensermanager0002: *mut usize, __midl__idispensermanager0003: *mut usize) -> ::windows::core::Result<()>;
@@ -3434,6 +3491,7 @@ impl IDispenserManager_Vtbl {
         iid == &<IDispenserManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IEnumNames_Impl: Sized {
     fn Next(&self, celt: u32, rgname: *mut ::windows::core::BSTR, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -3481,6 +3539,7 @@ impl IEnumNames_Vtbl {
         iid == &<IEnumNames as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEventServerTrace_Impl: Sized + super::Com::IDispatch_Impl {
     fn StartTraceGuid(&self, bstrguidevent: &::windows::core::BSTR, bstrguidfilter: &::windows::core::BSTR, lpidfilter: i32) -> ::windows::core::Result<()>;
@@ -3518,6 +3577,7 @@ impl IEventServerTrace_Vtbl {
         iid == &<IEventServerTrace as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IGetAppTrackerData_Impl: Sized {
     fn GetApplicationProcesses(&self, partitionid: *const ::windows::core::GUID, applicationid: *const ::windows::core::GUID, flags: u32, numapplicationprocesses: *mut u32, applicationprocesses: *mut *mut ApplicationProcessSummary) -> ::windows::core::Result<()>;
@@ -3595,6 +3655,7 @@ impl IGetAppTrackerData_Vtbl {
         iid == &<IGetAppTrackerData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGetContextProperties_Impl: Sized {
     fn Count(&self, plcount: *mut i32) -> ::windows::core::Result<()>;
@@ -3638,6 +3699,7 @@ impl IGetContextProperties_Vtbl {
         iid == &<IGetContextProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGetSecurityCallContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSecurityCallContext(&self) -> ::windows::core::Result<ISecurityCallContext>;
@@ -3664,6 +3726,7 @@ impl IGetSecurityCallContext_Vtbl {
         iid == &<IGetSecurityCallContext as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IHolder_Impl: Sized {
     fn AllocResource(&self, __midl__iholder0000: usize, __midl__iholder0001: *mut usize) -> ::windows::core::Result<()>;
@@ -3736,6 +3799,7 @@ impl IHolder_Vtbl {
         iid == &<IHolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ILBEvents_Impl: Sized {
     fn TargetUp(&self, bstrservername: &::windows::core::BSTR, bstrclsideng: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3773,6 +3837,7 @@ impl ILBEvents_Vtbl {
         iid == &<ILBEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IMTSActivity_Impl: Sized {
     fn SynchronousCall(&self, pcall: &::core::option::Option<IMTSCall>) -> ::windows::core::Result<()>;
     fn AsyncCall(&self, pcall: &::core::option::Option<IMTSCall>) -> ::windows::core::Result<()>;
@@ -3821,6 +3886,7 @@ impl IMTSActivity_Vtbl {
         iid == &<IMTSActivity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IMTSCall_Impl: Sized {
     fn OnCall(&self) -> ::windows::core::Result<()>;
 }
@@ -3838,6 +3904,7 @@ impl IMTSCall_Vtbl {
         iid == &<IMTSCall as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMTSLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetEventDispatcher(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3864,6 +3931,7 @@ impl IMTSLocator_Vtbl {
         iid == &<IMTSLocator as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IManagedActivationEvents_Impl: Sized {
     fn CreateManagedStub(&self, pinfo: &::core::option::Option<IManagedObjectInfo>, fdist: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3894,6 +3962,7 @@ impl IManagedActivationEvents_Vtbl {
         iid == &<IManagedActivationEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IManagedObjectInfo_Impl: Sized {
     fn GetIUnknown(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3950,6 +4019,7 @@ impl IManagedObjectInfo_Vtbl {
         iid == &<IManagedObjectInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IManagedPoolAction_Impl: Sized {
     fn LastRelease(&self) -> ::windows::core::Result<()>;
 }
@@ -3967,6 +4037,7 @@ impl IManagedPoolAction_Vtbl {
         iid == &<IManagedPoolAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IManagedPooledObj_Impl: Sized {
     fn SetHeld(&self, m_bheld: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3987,6 +4058,7 @@ impl IManagedPooledObj_Vtbl {
         iid == &<IManagedPooledObj as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMessageMover_Impl: Sized + super::Com::IDispatch_Impl {
     fn SourcePath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4076,6 +4148,7 @@ impl IMessageMover_Vtbl {
         iid == &<IMessageMover as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMtsEventInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Names(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -4157,6 +4230,7 @@ impl IMtsEventInfo_Vtbl {
         iid == &<IMtsEventInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMtsEvents_Impl: Sized + super::Com::IDispatch_Impl {
     fn PackageName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4232,6 +4306,7 @@ impl IMtsEvents_Vtbl {
         iid == &<IMtsEvents as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMtsGrp_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4281,6 +4356,7 @@ impl IMtsGrp_Vtbl {
         iid == &<IMtsGrp as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IObjPool_Impl: Sized {
     fn Reserved1(&self);
     fn Reserved2(&self);
@@ -4343,6 +4419,7 @@ impl IObjPool_Vtbl {
         iid == &<IObjPool as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IObjectConstruct_Impl: Sized {
     fn Construct(&self, pctorobj: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -4363,6 +4440,7 @@ impl IObjectConstruct_Vtbl {
         iid == &<IObjectConstruct as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IObjectConstructString_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConstructString(&self, pval: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4383,6 +4461,7 @@ impl IObjectConstructString_Vtbl {
         iid == &<IObjectConstructString as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IObjectContext_Impl: Sized {
     fn CreateInstance(&self, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -4455,6 +4534,7 @@ impl IObjectContext_Vtbl {
         iid == &<IObjectContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IObjectContextActivity_Impl: Sized {
     fn GetActivityId(&self, pguid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -4472,6 +4552,7 @@ impl IObjectContextActivity_Vtbl {
         iid == &<IObjectContextActivity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IObjectContextInfo_Impl: Sized {
     fn IsInTransaction(&self) -> super::super::Foundation::BOOL;
@@ -4529,6 +4610,7 @@ impl IObjectContextInfo_Vtbl {
         iid == &<IObjectContextInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IObjectContextInfo2_Impl: Sized + IObjectContextInfo_Impl {
     fn GetPartitionId(&self, pguid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -4566,6 +4648,7 @@ impl IObjectContextInfo2_Vtbl {
         iid == &<IObjectContextInfo2 as ::windows::core::Interface>::IID || iid == &<IObjectContextInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IObjectContextTip_Impl: Sized {
     fn GetTipUrl(&self, ptipurl: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -4583,6 +4666,7 @@ impl IObjectContextTip_Vtbl {
         iid == &<IObjectContextTip as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IObjectControl_Impl: Sized {
     fn Activate(&self) -> ::windows::core::Result<()>;
@@ -4620,6 +4704,7 @@ impl IObjectControl_Vtbl {
         iid == &<IObjectControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IPlaybackControl_Impl: Sized {
     fn FinalClientRetry(&self) -> ::windows::core::Result<()>;
     fn FinalServerRetry(&self) -> ::windows::core::Result<()>;
@@ -4647,6 +4732,7 @@ impl IPlaybackControl_Vtbl {
         iid == &<IPlaybackControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPoolManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn ShutdownPool(&self, clsidorprogid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4667,6 +4753,7 @@ impl IPoolManager_Vtbl {
         iid == &<IPoolManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IProcessInitializer_Impl: Sized {
     fn Startup(&self, punkprocesscontrol: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Shutdown(&self) -> ::windows::core::Result<()>;
@@ -4694,6 +4781,7 @@ impl IProcessInitializer_Vtbl {
         iid == &<IProcessInitializer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISecurityCallContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4788,6 +4876,7 @@ impl ISecurityCallContext_Vtbl {
         iid == &<ISecurityCallContext as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISecurityCallersColl_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4843,6 +4932,7 @@ impl ISecurityCallersColl_Vtbl {
         iid == &<ISecurityCallersColl as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISecurityIdentityColl_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4898,6 +4988,7 @@ impl ISecurityIdentityColl_Vtbl {
         iid == &<ISecurityIdentityColl as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISecurityProperty_Impl: Sized {
     fn GetDirectCreatorSID(&self, psid: *mut super::super::Foundation::PSID) -> ::windows::core::Result<()>;
@@ -4949,6 +5040,7 @@ impl ISecurityProperty_Vtbl {
         iid == &<ISecurityProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ISelectCOMLBServer_Impl: Sized {
     fn Init(&self) -> ::windows::core::Result<()>;
     fn GetLBServer(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -4976,6 +5068,7 @@ impl ISelectCOMLBServer_Vtbl {
         iid == &<ISelectCOMLBServer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ISendMethodEvents_Impl: Sized {
     fn SendMethodCall(&self, pidentity: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwmeth: u32) -> ::windows::core::Result<()>;
     fn SendMethodReturn(&self, pidentity: *const ::core::ffi::c_void, riid: *const ::windows::core::GUID, dwmeth: u32, hrcall: ::windows::core::HRESULT, hrserver: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -5003,6 +5096,7 @@ impl ISendMethodEvents_Vtbl {
         iid == &<ISendMethodEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceActivity_Impl: Sized {
     fn SynchronousCall(&self, piservicecall: &::core::option::Option<IServiceCall>) -> ::windows::core::Result<()>;
     fn AsynchronousCall(&self, piservicecall: &::core::option::Option<IServiceCall>) -> ::windows::core::Result<()>;
@@ -5044,6 +5138,7 @@ impl IServiceActivity_Vtbl {
         iid == &<IServiceActivity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceCall_Impl: Sized {
     fn OnCall(&self) -> ::windows::core::Result<()>;
 }
@@ -5061,6 +5156,7 @@ impl IServiceCall_Vtbl {
         iid == &<IServiceCall as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceComTIIntrinsicsConfig_Impl: Sized {
     fn ComTIIntrinsicsConfig(&self, comtiintrinsicsconfig: CSC_COMTIIntrinsicsConfig) -> ::windows::core::Result<()>;
 }
@@ -5078,6 +5174,7 @@ impl IServiceComTIIntrinsicsConfig_Vtbl {
         iid == &<IServiceComTIIntrinsicsConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceIISIntrinsicsConfig_Impl: Sized {
     fn IISIntrinsicsConfig(&self, iisintrinsicsconfig: CSC_IISIntrinsicsConfig) -> ::windows::core::Result<()>;
 }
@@ -5095,6 +5192,7 @@ impl IServiceIISIntrinsicsConfig_Vtbl {
         iid == &<IServiceIISIntrinsicsConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceInheritanceConfig_Impl: Sized {
     fn ContainingContextTreatment(&self, inheritanceconfig: CSC_InheritanceConfig) -> ::windows::core::Result<()>;
 }
@@ -5115,6 +5213,7 @@ impl IServiceInheritanceConfig_Vtbl {
         iid == &<IServiceInheritanceConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServicePartitionConfig_Impl: Sized {
     fn PartitionConfig(&self, partitionconfig: CSC_PartitionConfig) -> ::windows::core::Result<()>;
     fn PartitionID(&self, guidpartitionid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -5142,6 +5241,7 @@ impl IServicePartitionConfig_Vtbl {
         iid == &<IServicePartitionConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServicePool_Impl: Sized {
     fn Initialize(&self, ppoolconfig: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetObject(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -5176,6 +5276,7 @@ impl IServicePool_Vtbl {
         iid == &<IServicePool as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IServicePoolConfig_Impl: Sized {
     fn SetMaxPoolSize(&self, dwmaxpool: u32) -> ::windows::core::Result<()>;
@@ -5268,6 +5369,7 @@ impl IServicePoolConfig_Vtbl {
         iid == &<IServicePoolConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceSxsConfig_Impl: Sized {
     fn SxsConfig(&self, scsconfig: CSC_SxsConfig) -> ::windows::core::Result<()>;
     fn SxsName(&self, szsxsname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -5302,6 +5404,7 @@ impl IServiceSxsConfig_Vtbl {
         iid == &<IServiceSxsConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceSynchronizationConfig_Impl: Sized {
     fn ConfigureSynchronization(&self, synchconfig: CSC_SynchronizationConfig) -> ::windows::core::Result<()>;
 }
@@ -5319,6 +5422,7 @@ impl IServiceSynchronizationConfig_Vtbl {
         iid == &<IServiceSynchronizationConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 pub trait IServiceSysTxnConfig_Impl: Sized + IServiceTransactionConfig_Impl {
     fn ConfigureBYOTSysTxn(&self, ptxproxy: &::core::option::Option<ITransactionProxy>) -> ::windows::core::Result<()>;
@@ -5339,6 +5443,7 @@ impl IServiceSysTxnConfig_Vtbl {
         iid == &<IServiceSysTxnConfig as ::windows::core::Interface>::IID || iid == &<IServiceTransactionConfigBase as ::windows::core::Interface>::IID || iid == &<IServiceTransactionConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceThreadPoolConfig_Impl: Sized {
     fn SelectThreadPool(&self, threadpool: CSC_ThreadPool) -> ::windows::core::Result<()>;
     fn SetBindingInfo(&self, binding: CSC_Binding) -> ::windows::core::Result<()>;
@@ -5366,6 +5471,7 @@ impl IServiceThreadPoolConfig_Vtbl {
         iid == &<IServiceThreadPoolConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceTrackerConfig_Impl: Sized {
     fn TrackerConfig(&self, trackerconfig: CSC_TrackerConfig, sztrackerappname: &::windows::core::PCWSTR, sztrackerctxname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -5383,6 +5489,7 @@ impl IServiceTrackerConfig_Vtbl {
         iid == &<IServiceTrackerConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 pub trait IServiceTransactionConfig_Impl: Sized + IServiceTransactionConfigBase_Impl {
     fn ConfigureBYOT(&self, pitxbyot: &::core::option::Option<super::DistributedTransactionCoordinator::ITransaction>) -> ::windows::core::Result<()>;
@@ -5403,6 +5510,7 @@ impl IServiceTransactionConfig_Vtbl {
         iid == &<IServiceTransactionConfig as ::windows::core::Interface>::IID || iid == &<IServiceTransactionConfigBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IServiceTransactionConfigBase_Impl: Sized {
     fn ConfigureTransaction(&self, transactionconfig: CSC_TransactionConfig) -> ::windows::core::Result<()>;
     fn IsolationLevel(&self, option: COMAdminTxIsolationLevelOptions) -> ::windows::core::Result<()>;
@@ -5451,6 +5559,7 @@ impl IServiceTransactionConfigBase_Vtbl {
         iid == &<IServiceTransactionConfigBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISharedProperty_Impl: Sized + super::Com::IDispatch_Impl {
     fn Value(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -5487,6 +5596,7 @@ impl ISharedProperty_Vtbl {
         iid == &<ISharedProperty as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISharedPropertyGroup_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreatePropertyByPosition(&self, index: i32, fexists: *mut super::super::Foundation::VARIANT_BOOL, ppprop: *mut ::core::option::Option<ISharedProperty>) -> ::windows::core::Result<()>;
@@ -5543,6 +5653,7 @@ impl ISharedPropertyGroup_Vtbl {
         iid == &<ISharedPropertyGroup as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISharedPropertyGroupManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreatePropertyGroup(&self, name: &::windows::core::BSTR, dwisomode: *mut i32, dwrelmode: *mut i32, fexists: *mut super::super::Foundation::VARIANT_BOOL, ppgroup: *mut ::core::option::Option<ISharedPropertyGroup>) -> ::windows::core::Result<()>;
@@ -5592,6 +5703,7 @@ impl ISharedPropertyGroupManager_Vtbl {
         iid == &<ISharedPropertyGroupManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ISystemAppEventData_Impl: Sized {
     fn Startup(&self) -> ::windows::core::Result<()>;
     fn OnDataChanged(&self, dwpid: u32, dwmask: u32, dwnumbersinks: u32, bstrdwmethodmask: &::windows::core::BSTR, dwreason: u32, u64tracehandle: u64) -> ::windows::core::Result<()>;
@@ -5619,6 +5731,7 @@ impl ISystemAppEventData_Vtbl {
         iid == &<ISystemAppEventData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait IThreadPoolKnobs_Impl: Sized {
     fn GetMaxThreads(&self, plcmaxthreads: *mut i32) -> ::windows::core::Result<()>;
     fn GetCurrentThreads(&self, plccurrentthreads: *mut i32) -> ::windows::core::Result<()>;
@@ -5702,6 +5815,7 @@ impl IThreadPoolKnobs_Vtbl {
         iid == &<IThreadPoolKnobs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITransactionContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateInstance(&self, pszprogid: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -5745,6 +5859,7 @@ impl ITransactionContext_Vtbl {
         iid == &<ITransactionContext as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ITransactionContextEx_Impl: Sized {
     fn CreateInstance(&self, rclsid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn Commit(&self) -> ::windows::core::Result<()>;
@@ -5779,6 +5894,7 @@ impl ITransactionContextEx_Vtbl {
         iid == &<ITransactionContextEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ITransactionProperty_Impl: Sized {
     fn Reserved1(&self);
     fn Reserved2(&self);
@@ -5924,6 +6040,7 @@ impl ITransactionProperty_Vtbl {
         iid == &<ITransactionProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_DistributedTransactionCoordinator"))]
 pub trait ITransactionProxy_Impl: Sized {
     fn Commit(&self, guid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -6001,6 +6118,7 @@ impl ITransactionProxy_Vtbl {
         iid == &<ITransactionProxy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ITransactionResourcePool_Impl: Sized {
     fn PutResource(&self, ppool: &::core::option::Option<IObjPool>, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetResource(&self, ppool: &::core::option::Option<IObjPool>) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -6034,6 +6152,7 @@ impl ITransactionResourcePool_Vtbl {
         iid == &<ITransactionResourcePool as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ITransactionStatus_Impl: Sized {
     fn SetTransactionStatus(&self, hrstatus: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn GetTransactionStatus(&self, phrstatus: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -6061,6 +6180,7 @@ impl ITransactionStatus_Vtbl {
         iid == &<ITransactionStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"implement\"`*"]
 pub trait ITxProxyHolder_Impl: Sized {
     fn GetIdentifier(&self, pguidltx: *mut ::windows::core::GUID);
 }
@@ -6078,6 +6198,7 @@ impl ITxProxyHolder_Vtbl {
         iid == &<ITxProxyHolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ObjectContext_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateInstance(&self, bstrprogid: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -6239,6 +6360,7 @@ impl ObjectContext_Vtbl {
         iid == &<ObjectContext as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ObjectControl_Impl: Sized {
     fn Activate(&self) -> ::windows::core::Result<()>;
@@ -6276,6 +6398,7 @@ impl ObjectControl_Vtbl {
         iid == &<ObjectControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ComponentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait SecurityProperty_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetDirectCallerName(&self) -> ::windows::core::Result<::windows::core::BSTR>;

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContact_Impl: Sized {
     fn GetContactID(&self, pszcontactid: &::windows::core::PWSTR, cchcontactid: u32, pdwcchcontactidrequired: *mut u32) -> ::windows::core::Result<()>;
     fn GetPath(&self, pszpath: &::windows::core::PWSTR, cchpath: u32, pdwcchpathrequired: *mut u32) -> ::windows::core::Result<()>;
@@ -32,6 +33,7 @@ impl IContact_Vtbl {
         iid == &<IContact as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactAggregationAggregate_Impl: Sized {
     fn Save(&self) -> ::windows::core::Result<()>;
     fn GetComponentItems(&self) -> ::windows::core::Result<IContactAggregationContactCollection>;
@@ -138,6 +140,7 @@ impl IContactAggregationAggregate_Vtbl {
         iid == &<IContactAggregationAggregate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactAggregationAggregateCollection_Impl: Sized {
     fn FindFirst(&self) -> ::windows::core::Result<IContactAggregationAggregate>;
     fn FindFirstByAntiLinkId(&self, pantilinkid: &::windows::core::PCWSTR) -> ::windows::core::Result<IContactAggregationAggregate>;
@@ -203,6 +206,7 @@ impl IContactAggregationAggregateCollection_Vtbl {
         iid == &<IContactAggregationAggregateCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContactAggregationContact_Impl: Sized {
     fn Delete(&self) -> ::windows::core::Result<()>;
@@ -399,6 +403,7 @@ impl IContactAggregationContact_Vtbl {
         iid == &<IContactAggregationContact as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactAggregationContactCollection_Impl: Sized {
     fn FindFirst(&self) -> ::windows::core::Result<IContactAggregationContact>;
     fn FindNext(&self) -> ::windows::core::Result<IContactAggregationContact>;
@@ -477,6 +482,7 @@ impl IContactAggregationContactCollection_Vtbl {
         iid == &<IContactAggregationContactCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactAggregationGroup_Impl: Sized {
     fn Delete(&self) -> ::windows::core::Result<()>;
     fn Save(&self) -> ::windows::core::Result<()>;
@@ -584,6 +590,7 @@ impl IContactAggregationGroup_Vtbl {
         iid == &<IContactAggregationGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactAggregationGroupCollection_Impl: Sized {
     fn FindFirst(&self) -> ::windows::core::Result<IContactAggregationGroup>;
     fn FindFirstByGlobalObjectId(&self, pglobalobjectid: *const ::windows::core::GUID) -> ::windows::core::Result<IContactAggregationGroup>;
@@ -649,6 +656,7 @@ impl IContactAggregationGroupCollection_Vtbl {
         iid == &<IContactAggregationGroupCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContactAggregationLink_Impl: Sized {
     fn Delete(&self) -> ::windows::core::Result<()>;
@@ -832,6 +840,7 @@ impl IContactAggregationLink_Vtbl {
         iid == &<IContactAggregationLink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactAggregationLinkCollection_Impl: Sized {
     fn FindFirst(&self) -> ::windows::core::Result<IContactAggregationLink>;
     fn FindFirstByRemoteId(&self, psourcetype: &::windows::core::PCWSTR, paccountid: &::windows::core::PCWSTR, premoteid: *const CONTACT_AGGREGATION_BLOB) -> ::windows::core::Result<IContactAggregationLink>;
@@ -897,6 +906,7 @@ impl IContactAggregationLinkCollection_Vtbl {
         iid == &<IContactAggregationLinkCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContactAggregationManager_Impl: Sized {
     fn GetVersionInfo(&self, plmajorversion: *mut i32, plminorversion: *mut i32) -> ::windows::core::Result<()>;
@@ -1090,6 +1100,7 @@ impl IContactAggregationManager_Vtbl {
         iid == &<IContactAggregationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContactAggregationServerPerson_Impl: Sized {
     fn Delete(&self) -> ::windows::core::Result<()>;
@@ -1333,6 +1344,7 @@ impl IContactAggregationServerPerson_Vtbl {
         iid == &<IContactAggregationServerPerson as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactAggregationServerPersonCollection_Impl: Sized {
     fn FindFirst(&self) -> ::windows::core::Result<IContactAggregationServerPerson>;
     fn FindFirstByServerId(&self, pserverid: &::windows::core::PCWSTR) -> ::windows::core::Result<IContactAggregationServerPerson>;
@@ -1424,6 +1436,7 @@ impl IContactAggregationServerPersonCollection_Vtbl {
         iid == &<IContactAggregationServerPersonCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactCollection_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Next(&self) -> ::windows::core::Result<()>;
@@ -1464,6 +1477,7 @@ impl IContactCollection_Vtbl {
         iid == &<IContactCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"implement\"`*"]
 pub trait IContactManager_Impl: Sized {
     fn Initialize(&self, pszappname: &::windows::core::PCWSTR, pszappversion: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Load(&self, pszcontactid: &::windows::core::PCWSTR) -> ::windows::core::Result<IContact>;
@@ -1537,6 +1551,7 @@ impl IContactManager_Vtbl {
         iid == &<IContactManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IContactProperties_Impl: Sized {
     fn GetString(&self, pszpropertyname: &::windows::core::PCWSTR, dwflags: u32, pszvalue: &::windows::core::PWSTR, cchvalue: u32, pdwcchpropertyvaluerequired: *mut u32) -> ::windows::core::Result<()>;
@@ -1644,6 +1659,7 @@ impl IContactProperties_Vtbl {
         iid == &<IContactProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Contacts\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContactPropertyCollection_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DeploymentServices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportCacheable_Impl: Sized + super::Com::IDispatch_Impl {
     fn Dirty(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -48,6 +49,7 @@ impl IWdsTransportCacheable_Vtbl {
         iid == &<IWdsTransportCacheable as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportClient_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IWdsTransportSession>;
@@ -214,6 +216,7 @@ impl IWdsTransportClient_Vtbl {
         iid == &<IWdsTransportClient as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -269,6 +272,7 @@ impl IWdsTransportCollection_Vtbl {
         iid == &<IWdsTransportCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportConfigurationManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn ServicePolicy(&self) -> ::windows::core::Result<IWdsTransportServicePolicy>;
@@ -366,6 +370,7 @@ impl IWdsTransportConfigurationManager_Vtbl {
         iid == &<IWdsTransportConfigurationManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportConfigurationManager2_Impl: Sized + IWdsTransportConfigurationManager_Impl {
     fn MulticastSessionPolicy(&self) -> ::windows::core::Result<IWdsTransportMulticastSessionPolicy>;
@@ -395,6 +400,7 @@ impl IWdsTransportConfigurationManager2_Vtbl {
         iid == &<IWdsTransportConfigurationManager2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportConfigurationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportContent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Namespace(&self) -> ::windows::core::Result<IWdsTransportNamespace>;
@@ -470,6 +476,7 @@ impl IWdsTransportContent_Vtbl {
         iid == &<IWdsTransportContent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportContentProvider_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -538,6 +545,7 @@ impl IWdsTransportContentProvider_Vtbl {
         iid == &<IWdsTransportContentProvider as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportDiagnosticsPolicy_Impl: Sized + IWdsTransportCacheable_Impl {
     fn Enabled(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -594,6 +602,7 @@ impl IWdsTransportDiagnosticsPolicy_Vtbl {
         iid == &<IWdsTransportDiagnosticsPolicy as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportCacheable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetWdsTransportServer(&self, bszservername: &::windows::core::BSTR) -> ::windows::core::Result<IWdsTransportServer>;
@@ -620,6 +629,7 @@ impl IWdsTransportManager_Vtbl {
         iid == &<IWdsTransportManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportMulticastSessionPolicy_Impl: Sized + IWdsTransportCacheable_Impl {
     fn SlowClientHandling(&self) -> ::windows::core::Result<WDSTRANSPORT_SLOW_CLIENT_HANDLING_TYPE>;
@@ -716,6 +726,7 @@ impl IWdsTransportMulticastSessionPolicy_Vtbl {
         iid == &<IWdsTransportMulticastSessionPolicy as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportCacheable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespace_Impl: Sized + super::Com::IDispatch_Impl {
     fn Type(&self) -> ::windows::core::Result<WDSTRANSPORT_NAMESPACE_TYPE>;
@@ -957,6 +968,7 @@ impl IWdsTransportNamespace_Vtbl {
         iid == &<IWdsTransportNamespace as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespaceAutoCast_Impl: Sized + IWdsTransportNamespace_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -970,6 +982,7 @@ impl IWdsTransportNamespaceAutoCast_Vtbl {
         iid == &<IWdsTransportNamespaceAutoCast as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportNamespace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespaceManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateNamespace(&self, namespacetype: WDSTRANSPORT_NAMESPACE_TYPE, bsznamespacename: &::windows::core::BSTR, bszcontentprovider: &::windows::core::BSTR, bszconfiguration: &::windows::core::BSTR) -> ::windows::core::Result<IWdsTransportNamespace>;
@@ -1025,6 +1038,7 @@ impl IWdsTransportNamespaceManager_Vtbl {
         iid == &<IWdsTransportNamespaceManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespaceScheduledCast_Impl: Sized + IWdsTransportNamespace_Impl {
     fn StartTransmission(&self) -> ::windows::core::Result<()>;
@@ -1045,6 +1059,7 @@ impl IWdsTransportNamespaceScheduledCast_Vtbl {
         iid == &<IWdsTransportNamespaceScheduledCast as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportNamespace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespaceScheduledCastAutoStart_Impl: Sized + IWdsTransportNamespaceScheduledCast_Impl {
     fn MinimumClients(&self) -> ::windows::core::Result<u32>;
@@ -1101,6 +1116,7 @@ impl IWdsTransportNamespaceScheduledCastAutoStart_Vtbl {
         iid == &<IWdsTransportNamespaceScheduledCastAutoStart as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportNamespace as ::windows::core::Interface>::IID || iid == &<IWdsTransportNamespaceScheduledCast as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportNamespaceScheduledCastManualStart_Impl: Sized + IWdsTransportNamespaceScheduledCast_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -1114,6 +1130,7 @@ impl IWdsTransportNamespaceScheduledCastManualStart_Vtbl {
         iid == &<IWdsTransportNamespaceScheduledCastManualStart as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportNamespace as ::windows::core::Interface>::IID || iid == &<IWdsTransportNamespaceScheduledCast as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportServer_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1189,6 +1206,7 @@ impl IWdsTransportServer_Vtbl {
         iid == &<IWdsTransportServer as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportServer2_Impl: Sized + IWdsTransportServer_Impl {
     fn TftpManager(&self) -> ::windows::core::Result<IWdsTransportTftpManager>;
@@ -1215,6 +1233,7 @@ impl IWdsTransportServer2_Vtbl {
         iid == &<IWdsTransportServer2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportServer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportServicePolicy_Impl: Sized + IWdsTransportCacheable_Impl {
     fn get_IpAddressSource(&self, addresstype: WDSTRANSPORT_IP_ADDRESS_TYPE) -> ::windows::core::Result<WDSTRANSPORT_IP_ADDRESS_SOURCE_TYPE>;
@@ -1351,6 +1370,7 @@ impl IWdsTransportServicePolicy_Vtbl {
         iid == &<IWdsTransportServicePolicy as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportCacheable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportServicePolicy2_Impl: Sized + IWdsTransportServicePolicy_Impl {
     fn UdpPortPolicy(&self) -> ::windows::core::Result<WDSTRANSPORT_UDP_PORT_POLICY>;
@@ -1427,6 +1447,7 @@ impl IWdsTransportServicePolicy2_Vtbl {
         iid == &<IWdsTransportServicePolicy2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportCacheable as ::windows::core::Interface>::IID || iid == &<IWdsTransportServicePolicy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn Content(&self) -> ::windows::core::Result<IWdsTransportContent>;
@@ -1541,6 +1562,7 @@ impl IWdsTransportSession_Vtbl {
         iid == &<IWdsTransportSession as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportSetupManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn Version(&self) -> ::windows::core::Result<u64>;
@@ -1610,6 +1632,7 @@ impl IWdsTransportSetupManager_Vtbl {
         iid == &<IWdsTransportSetupManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportSetupManager2_Impl: Sized + IWdsTransportSetupManager_Impl {
     fn TftpCapabilities(&self) -> ::windows::core::Result<u32>;
@@ -1652,6 +1675,7 @@ impl IWdsTransportSetupManager2_Vtbl {
         iid == &<IWdsTransportSetupManager2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWdsTransportSetupManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportTftpClient_Impl: Sized + super::Com::IDispatch_Impl {
     fn FileName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1759,6 +1783,7 @@ impl IWdsTransportTftpClient_Vtbl {
         iid == &<IWdsTransportTftpClient as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DeploymentServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWdsTransportTftpManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn RetrieveTftpClients(&self) -> ::windows::core::Result<IWdsTransportCollection>;

--- a/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DesktopSharing/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIApplication_Impl: Sized + super::Com::IDispatch_Impl {
     fn Windows(&self) -> ::windows::core::Result<IRDPSRAPIWindowList>;
@@ -86,6 +87,7 @@ impl IRDPSRAPIApplication_Vtbl {
         iid == &<IRDPSRAPIApplication as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIApplicationFilter_Impl: Sized + super::Com::IDispatch_Impl {
     fn Applications(&self) -> ::windows::core::Result<IRDPSRAPIApplicationList>;
@@ -148,6 +150,7 @@ impl IRDPSRAPIApplicationFilter_Vtbl {
         iid == &<IRDPSRAPIApplicationFilter as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIApplicationList_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -190,6 +193,7 @@ impl IRDPSRAPIApplicationList_Vtbl {
         iid == &<IRDPSRAPIApplicationList as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIAttendee_Impl: Sized + super::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<i32>;
@@ -298,6 +302,7 @@ impl IRDPSRAPIAttendee_Vtbl {
         iid == &<IRDPSRAPIAttendee as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIAttendeeDisconnectInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Attendee(&self) -> ::windows::core::Result<IRDPSRAPIAttendee>;
@@ -353,6 +358,7 @@ impl IRDPSRAPIAttendeeDisconnectInfo_Vtbl {
         iid == &<IRDPSRAPIAttendeeDisconnectInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIAttendeeManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -395,6 +401,7 @@ impl IRDPSRAPIAttendeeManager_Vtbl {
         iid == &<IRDPSRAPIAttendeeManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"implement\"`*"]
 pub trait IRDPSRAPIAudioStream_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<i64>;
     fn Start(&self) -> ::windows::core::Result<()>;
@@ -449,6 +456,7 @@ impl IRDPSRAPIAudioStream_Vtbl {
         iid == &<IRDPSRAPIAudioStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IRDPSRAPIClipboardUseEvents_Impl: Sized {
     fn OnPasteFromClipboard(&self, clipboardformat: u32, pattendee: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -475,6 +483,7 @@ impl IRDPSRAPIClipboardUseEvents_Vtbl {
         iid == &<IRDPSRAPIClipboardUseEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"implement\"`*"]
 pub trait IRDPSRAPIDebug_Impl: Sized {
     fn SetCLXCmdLine(&self, clxcmdline: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn CLXCmdLine(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -508,6 +517,7 @@ impl IRDPSRAPIDebug_Vtbl {
         iid == &<IRDPSRAPIDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIFrameBuffer_Impl: Sized + super::Com::IDispatch_Impl {
     fn Width(&self) -> ::windows::core::Result<i32>;
@@ -576,6 +586,7 @@ impl IRDPSRAPIFrameBuffer_Vtbl {
         iid == &<IRDPSRAPIFrameBuffer as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIInvitation_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConnectionString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -671,6 +682,7 @@ impl IRDPSRAPIInvitation_Vtbl {
         iid == &<IRDPSRAPIInvitation as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIInvitationManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -739,6 +751,7 @@ impl IRDPSRAPIInvitationManager_Vtbl {
         iid == &<IRDPSRAPIInvitationManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"implement\"`*"]
 pub trait IRDPSRAPIPerfCounterLogger_Impl: Sized {
     fn LogValue(&self, lvalue: i64) -> ::windows::core::Result<()>;
 }
@@ -756,6 +769,7 @@ impl IRDPSRAPIPerfCounterLogger_Vtbl {
         iid == &<IRDPSRAPIPerfCounterLogger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"implement\"`*"]
 pub trait IRDPSRAPIPerfCounterLoggingManager_Impl: Sized {
     fn CreateLogger(&self, bstrcountername: &::windows::core::BSTR) -> ::windows::core::Result<IRDPSRAPIPerfCounterLogger>;
 }
@@ -779,6 +793,7 @@ impl IRDPSRAPIPerfCounterLoggingManager_Vtbl {
         iid == &<IRDPSRAPIPerfCounterLoggingManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPISessionProperties_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Property(&self, propertyname: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -815,6 +830,7 @@ impl IRDPSRAPISessionProperties_Vtbl {
         iid == &<IRDPSRAPISessionProperties as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPISharingSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn Open(&self) -> ::windows::core::Result<()>;
@@ -965,6 +981,7 @@ impl IRDPSRAPISharingSession_Vtbl {
         iid == &<IRDPSRAPISharingSession as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPISharingSession2_Impl: Sized + IRDPSRAPISharingSession_Impl {
     fn ConnectUsingTransportStream(&self, pstream: &::core::option::Option<IRDPSRAPITransportStream>, bstrgroup: &::windows::core::BSTR, bstrauthenticatedattendeename: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1008,6 +1025,7 @@ impl IRDPSRAPISharingSession2_Vtbl {
         iid == &<IRDPSRAPISharingSession2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IRDPSRAPISharingSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPITcpConnectionInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Protocol(&self) -> ::windows::core::Result<i32>;
@@ -1089,6 +1107,7 @@ impl IRDPSRAPITcpConnectionInfo_Vtbl {
         iid == &<IRDPSRAPITcpConnectionInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"implement\"`*"]
 pub trait IRDPSRAPITransportStream_Impl: Sized {
     fn AllocBuffer(&self, maxpayload: i32) -> ::windows::core::Result<IRDPSRAPITransportStreamBuffer>;
     fn FreeBuffer(&self, pbuffer: &::core::option::Option<IRDPSRAPITransportStreamBuffer>) -> ::windows::core::Result<()>;
@@ -1150,6 +1169,7 @@ impl IRDPSRAPITransportStream_Vtbl {
         iid == &<IRDPSRAPITransportStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"implement\"`*"]
 pub trait IRDPSRAPITransportStreamBuffer_Impl: Sized {
     fn Storage(&self) -> ::windows::core::Result<*mut u8>;
     fn StorageSize(&self) -> ::windows::core::Result<i32>;
@@ -1269,6 +1289,7 @@ impl IRDPSRAPITransportStreamBuffer_Vtbl {
         iid == &<IRDPSRAPITransportStreamBuffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"implement\"`*"]
 pub trait IRDPSRAPITransportStreamEvents_Impl: Sized {
     fn OnWriteCompleted(&self, pbuffer: &::core::option::Option<IRDPSRAPITransportStreamBuffer>);
     fn OnReadCompleted(&self, pbuffer: &::core::option::Option<IRDPSRAPITransportStreamBuffer>);
@@ -1303,6 +1324,7 @@ impl IRDPSRAPITransportStreamEvents_Vtbl {
         iid == &<IRDPSRAPITransportStreamEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIViewer_Impl: Sized + super::Com::IDispatch_Impl {
     fn Connect(&self, bstrconnectionstring: &::windows::core::BSTR, bstrname: &::windows::core::BSTR, bstrpassword: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1465,6 +1487,7 @@ impl IRDPSRAPIViewer_Vtbl {
         iid == &<IRDPSRAPIViewer as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIVirtualChannel_Impl: Sized + super::Com::IDispatch_Impl {
     fn SendData(&self, bstrdata: &::windows::core::BSTR, lattendeeid: i32, channelsendflags: u32) -> ::windows::core::Result<()>;
@@ -1534,6 +1557,7 @@ impl IRDPSRAPIVirtualChannel_Vtbl {
         iid == &<IRDPSRAPIVirtualChannel as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIVirtualChannelManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1589,6 +1613,7 @@ impl IRDPSRAPIVirtualChannelManager_Vtbl {
         iid == &<IRDPSRAPIVirtualChannelManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIWindow_Impl: Sized + super::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<i32>;
@@ -1684,6 +1709,7 @@ impl IRDPSRAPIWindow_Vtbl {
         iid == &<IRDPSRAPIWindow as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRDPSRAPIWindowList_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1726,6 +1752,7 @@ impl IRDPSRAPIWindowList_Vtbl {
         iid == &<IRDPSRAPIWindowList as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRDPViewerInputSink_Impl: Sized {
     fn SendMouseButtonEvent(&self, buttontype: RDPSRAPI_MOUSE_BUTTON_TYPE, vbbuttondown: super::super::Foundation::VARIANT_BOOL, xpos: u32, ypos: u32) -> ::windows::core::Result<()>;
@@ -1798,6 +1825,7 @@ impl IRDPViewerInputSink_Vtbl {
         iid == &<IRDPViewerInputSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DesktopSharing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IRDPSessionEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait AsyncIDebugApplicationNodeEvents_Impl: Sized {
     fn Begin_onAddChild(&self, prddpchild: &::core::option::Option<IDebugApplicationNode>) -> ::windows::core::Result<()>;
     fn Finish_onAddChild(&self) -> ::windows::core::Result<()>;
@@ -67,6 +68,7 @@ impl AsyncIDebugApplicationNodeEvents_Vtbl {
         iid == &<AsyncIDebugApplicationNodeEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait DebugBaseEventCallbacks_Impl: Sized + IDebugEventCallbacks_Impl {}
 #[cfg(feature = "Win32_Foundation")]
@@ -80,6 +82,7 @@ impl DebugBaseEventCallbacks_Vtbl {
         iid == &<DebugBaseEventCallbacks as ::windows::core::Interface>::IID || iid == &<IDebugEventCallbacks as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait DebugBaseEventCallbacksWide_Impl: Sized + IDebugEventCallbacksWide_Impl {}
 #[cfg(feature = "Win32_Foundation")]
@@ -93,6 +96,7 @@ impl DebugBaseEventCallbacksWide_Vtbl {
         iid == &<DebugBaseEventCallbacksWide as ::windows::core::Interface>::IID || iid == &<IDebugEventCallbacksWide as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScript_Impl: Sized {
     fn SetScriptSite(&self, pass: &::core::option::Option<IActiveScriptSite>) -> ::windows::core::Result<()>;
@@ -236,6 +240,7 @@ impl IActiveScript_Vtbl {
         iid == &<IActiveScript as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IActiveScriptAuthor_Impl: Sized {
     fn AddNamedItem(&self, pszname: &::windows::core::PCWSTR, dwflags: u32, pdisp: &::core::option::Option<super::super::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -381,6 +386,7 @@ impl IActiveScriptAuthor_Vtbl {
         iid == &<IActiveScriptAuthor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptAuthorProcedure_Impl: Sized {
     fn ParseProcedureText(&self, pszcode: &::windows::core::PCWSTR, pszformalparams: &::windows::core::PCWSTR, pszprocedurename: &::windows::core::PCWSTR, pszitemname: &::windows::core::PCWSTR, pszdelimiter: &::windows::core::PCWSTR, dwcookie: u32, dwflags: u32, pdispfor: &::core::option::Option<super::super::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -401,6 +407,7 @@ impl IActiveScriptAuthorProcedure_Vtbl {
         iid == &<IActiveScriptAuthorProcedure as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptDebug32_Impl: Sized {
     fn GetScriptTextAttributes(&self, pstrcode: &::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::Result<()>;
     fn GetScriptletTextAttributes(&self, pstrcode: &::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::Result<()>;
@@ -441,6 +448,7 @@ impl IActiveScriptDebug32_Vtbl {
         iid == &<IActiveScriptDebug32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptDebug64_Impl: Sized {
     fn GetScriptTextAttributes(&self, pstrcode: &::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::Result<()>;
     fn GetScriptletTextAttributes(&self, pstrcode: &::windows::core::PCWSTR, unumcodechars: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32, pattr: *mut u16) -> ::windows::core::Result<()>;
@@ -481,6 +489,7 @@ impl IActiveScriptDebug64_Vtbl {
         iid == &<IActiveScriptDebug64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptEncode_Impl: Sized {
     fn EncodeSection(&self, pchin: &::windows::core::PCWSTR, cchin: u32, pchout: &::windows::core::PWSTR, cchout: u32, pcchret: *mut u32) -> ::windows::core::Result<()>;
     fn DecodeScript(&self, pchin: &::windows::core::PCWSTR, cchin: u32, pchout: &::windows::core::PWSTR, cchout: u32, pcchret: *mut u32) -> ::windows::core::Result<()>;
@@ -515,6 +524,7 @@ impl IActiveScriptEncode_Vtbl {
         iid == &<IActiveScriptEncode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptError_Impl: Sized {
     fn GetExceptionInfo(&self) -> ::windows::core::Result<super::super::Com::EXCEPINFO>;
@@ -564,6 +574,7 @@ impl IActiveScriptError_Vtbl {
         iid == &<IActiveScriptError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptError64_Impl: Sized + IActiveScriptError_Impl {
     fn GetSourcePosition64(&self, pdwsourcecontext: *mut u64, pullinenumber: *mut u32, plcharacterposition: *mut i32) -> ::windows::core::Result<()>;
@@ -584,6 +595,7 @@ impl IActiveScriptError64_Vtbl {
         iid == &<IActiveScriptError64 as ::windows::core::Interface>::IID || iid == &<IActiveScriptError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptErrorDebug_Impl: Sized + IActiveScriptError_Impl {
     fn GetDocumentContext(&self) -> ::windows::core::Result<IDebugDocumentContext>;
@@ -626,6 +638,7 @@ impl IActiveScriptErrorDebug_Vtbl {
         iid == &<IActiveScriptErrorDebug as ::windows::core::Interface>::IID || iid == &<IActiveScriptError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptErrorDebug110_Impl: Sized {
     fn GetExceptionThrownKind(&self) -> ::windows::core::Result<SCRIPT_ERROR_DEBUG_EXCEPTION_THROWN_KIND>;
 }
@@ -649,6 +662,7 @@ impl IActiveScriptErrorDebug110_Vtbl {
         iid == &<IActiveScriptErrorDebug110 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptGarbageCollector_Impl: Sized {
     fn CollectGarbage(&self, scriptgctype: SCRIPTGCTYPE) -> ::windows::core::Result<()>;
 }
@@ -666,6 +680,7 @@ impl IActiveScriptGarbageCollector_Vtbl {
         iid == &<IActiveScriptGarbageCollector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptHostEncode_Impl: Sized {
     fn EncodeScriptHostFile(&self, bstrinfile: &::windows::core::BSTR, pbstroutfile: *mut ::windows::core::BSTR, cflags: u32, bstrdefaultlang: &::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -683,6 +698,7 @@ impl IActiveScriptHostEncode_Vtbl {
         iid == &<IActiveScriptHostEncode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IActiveScriptParse32_Impl: Sized {
     fn InitNew(&self) -> ::windows::core::Result<()>;
@@ -721,6 +737,7 @@ impl IActiveScriptParse32_Vtbl {
         iid == &<IActiveScriptParse32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IActiveScriptParse64_Impl: Sized {
     fn InitNew(&self) -> ::windows::core::Result<()>;
@@ -759,6 +776,7 @@ impl IActiveScriptParse64_Vtbl {
         iid == &<IActiveScriptParse64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedure2_32_Impl: Sized + IActiveScriptParseProcedure32_Impl {}
 #[cfg(feature = "Win32_System_Com")]
@@ -772,6 +790,7 @@ impl IActiveScriptParseProcedure2_32_Vtbl {
         iid == &<IActiveScriptParseProcedure2_32 as ::windows::core::Interface>::IID || iid == &<IActiveScriptParseProcedure32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedure2_64_Impl: Sized + IActiveScriptParseProcedure64_Impl {}
 #[cfg(feature = "Win32_System_Com")]
@@ -785,6 +804,7 @@ impl IActiveScriptParseProcedure2_64_Vtbl {
         iid == &<IActiveScriptParseProcedure2_64 as ::windows::core::Interface>::IID || iid == &<IActiveScriptParseProcedure64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedure32_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstrprocedurename: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
@@ -811,6 +831,7 @@ impl IActiveScriptParseProcedure32_Vtbl {
         iid == &<IActiveScriptParseProcedure32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedure64_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstrprocedurename: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
@@ -837,6 +858,7 @@ impl IActiveScriptParseProcedure64_Vtbl {
         iid == &<IActiveScriptParseProcedure64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedureOld32_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u32, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
@@ -863,6 +885,7 @@ impl IActiveScriptParseProcedureOld32_Vtbl {
         iid == &<IActiveScriptParseProcedureOld32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptParseProcedureOld64_Impl: Sized {
     fn ParseProcedureText(&self, pstrcode: &::windows::core::PCWSTR, pstrformalparams: &::windows::core::PCWSTR, pstritemname: &::windows::core::PCWSTR, punkcontext: &::core::option::Option<::windows::core::IUnknown>, pstrdelimiter: &::windows::core::PCWSTR, dwsourcecontextcookie: u64, ulstartinglinenumber: u32, dwflags: u32) -> ::windows::core::Result<super::super::Com::IDispatch>;
@@ -889,6 +912,7 @@ impl IActiveScriptParseProcedureOld64_Vtbl {
         iid == &<IActiveScriptParseProcedureOld64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerCallback_Impl: Sized {
     fn Initialize(&self, dwcontext: u32) -> ::windows::core::Result<()>;
     fn Shutdown(&self, hrreason: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -944,6 +968,7 @@ impl IActiveScriptProfilerCallback_Vtbl {
         iid == &<IActiveScriptProfilerCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerCallback2_Impl: Sized + IActiveScriptProfilerCallback_Impl {
     fn OnFunctionEnterByName(&self, pwszfunctionname: &::windows::core::PCWSTR, r#type: PROFILER_SCRIPT_TYPE) -> ::windows::core::Result<()>;
     fn OnFunctionExitByName(&self, pwszfunctionname: &::windows::core::PCWSTR, r#type: PROFILER_SCRIPT_TYPE) -> ::windows::core::Result<()>;
@@ -971,6 +996,7 @@ impl IActiveScriptProfilerCallback2_Vtbl {
         iid == &<IActiveScriptProfilerCallback2 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerCallback3_Impl: Sized + IActiveScriptProfilerCallback2_Impl {
     fn SetWebWorkerId(&self, webworkerid: u32) -> ::windows::core::Result<()>;
 }
@@ -988,6 +1014,7 @@ impl IActiveScriptProfilerCallback3_Vtbl {
         iid == &<IActiveScriptProfilerCallback3 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerCallback as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerCallback2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerControl_Impl: Sized {
     fn StartProfiling(&self, clsidprofilerobject: *const ::windows::core::GUID, dweventmask: u32, dwcontext: u32) -> ::windows::core::Result<()>;
     fn SetProfilerEventMask(&self, dweventmask: u32) -> ::windows::core::Result<()>;
@@ -1022,6 +1049,7 @@ impl IActiveScriptProfilerControl_Vtbl {
         iid == &<IActiveScriptProfilerControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerControl2_Impl: Sized + IActiveScriptProfilerControl_Impl {
     fn CompleteProfilerStart(&self) -> ::windows::core::Result<()>;
     fn PrepareProfilerStop(&self) -> ::windows::core::Result<()>;
@@ -1049,6 +1077,7 @@ impl IActiveScriptProfilerControl2_Vtbl {
         iid == &<IActiveScriptProfilerControl2 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerControl3_Impl: Sized + IActiveScriptProfilerControl2_Impl {
     fn EnumHeap(&self) -> ::windows::core::Result<IActiveScriptProfilerHeapEnum>;
 }
@@ -1072,6 +1101,7 @@ impl IActiveScriptProfilerControl3_Vtbl {
         iid == &<IActiveScriptProfilerControl3 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerControl4_Impl: Sized + IActiveScriptProfilerControl3_Impl {
     fn SummarizeHeap(&self, heapsummary: *mut PROFILER_HEAP_SUMMARY) -> ::windows::core::Result<()>;
 }
@@ -1089,6 +1119,7 @@ impl IActiveScriptProfilerControl4_Vtbl {
         iid == &<IActiveScriptProfilerControl4 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl2 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerControl5_Impl: Sized + IActiveScriptProfilerControl4_Impl {
     fn EnumHeap2(&self, enumflags: PROFILER_HEAP_ENUM_FLAGS) -> ::windows::core::Result<IActiveScriptProfilerHeapEnum>;
 }
@@ -1112,6 +1143,7 @@ impl IActiveScriptProfilerControl5_Vtbl {
         iid == &<IActiveScriptProfilerControl5 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl2 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl3 as ::windows::core::Interface>::IID || iid == &<IActiveScriptProfilerControl4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptProfilerHeapEnum_Impl: Sized {
     fn Next(&self, celt: u32, heapobjects: *mut *mut PROFILER_HEAP_OBJECT, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn GetOptionalInfo(&self, heapobject: *const PROFILER_HEAP_OBJECT, celt: u32, optionalinfo: *mut PROFILER_HEAP_OBJECT_OPTIONAL_INFO) -> ::windows::core::Result<()>;
@@ -1153,6 +1185,7 @@ impl IActiveScriptProfilerHeapEnum_Vtbl {
         iid == &<IActiveScriptProfilerHeapEnum as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IActiveScriptProperty_Impl: Sized {
     fn GetProperty(&self, dwproperty: u32, pvarindex: *const super::super::Com::VARIANT) -> ::windows::core::Result<super::super::Com::VARIANT>;
@@ -1189,6 +1222,7 @@ impl IActiveScriptProperty_Vtbl {
         iid == &<IActiveScriptProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptSIPInfo_Impl: Sized {
     fn GetSIPOID(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -1212,6 +1246,7 @@ impl IActiveScriptSIPInfo_Vtbl {
         iid == &<IActiveScriptSIPInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IActiveScriptSite_Impl: Sized {
     fn GetLCID(&self) -> ::windows::core::Result<u32>;
@@ -1296,6 +1331,7 @@ impl IActiveScriptSite_Vtbl {
         iid == &<IActiveScriptSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IActiveScriptSiteDebug32_Impl: Sized {
     fn GetDocumentContextFromPosition(&self, dwsourcecontext: u32, ucharacteroffset: u32, unumchars: u32) -> ::windows::core::Result<IDebugDocumentContext>;
@@ -1358,6 +1394,7 @@ impl IActiveScriptSiteDebug32_Vtbl {
         iid == &<IActiveScriptSiteDebug32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IActiveScriptSiteDebug64_Impl: Sized {
     fn GetDocumentContextFromPosition(&self, dwsourcecontext: u64, ucharacteroffset: u32, unumchars: u32) -> ::windows::core::Result<IDebugDocumentContext>;
@@ -1420,6 +1457,7 @@ impl IActiveScriptSiteDebug64_Vtbl {
         iid == &<IActiveScriptSiteDebug64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IActiveScriptSiteDebugEx_Impl: Sized {
     fn OnCanNotJITScriptErrorDebug(&self, perrordebug: &::core::option::Option<IActiveScriptErrorDebug>) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -1449,6 +1487,7 @@ impl IActiveScriptSiteDebugEx_Vtbl {
         iid == &<IActiveScriptSiteDebugEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptSiteInterruptPoll_Impl: Sized {
     fn QueryContinue(&self) -> ::windows::core::Result<()>;
 }
@@ -1466,6 +1505,7 @@ impl IActiveScriptSiteInterruptPoll_Vtbl {
         iid == &<IActiveScriptSiteInterruptPoll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptSiteTraceInfo_Impl: Sized {
     fn SendScriptTraceInfo(&self, stieventtype: SCRIPTTRACEINFO, guidcontextid: &::windows::core::GUID, dwscriptcontextcookie: u32, lscriptstatementstart: i32, lscriptstatementend: i32, dwreserved: u64) -> ::windows::core::Result<()>;
 }
@@ -1483,6 +1523,7 @@ impl IActiveScriptSiteTraceInfo_Vtbl {
         iid == &<IActiveScriptSiteTraceInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptSiteUIControl_Impl: Sized {
     fn GetUIBehavior(&self, uicitem: SCRIPTUICITEM) -> ::windows::core::Result<SCRIPTUICHANDLING>;
 }
@@ -1506,6 +1547,7 @@ impl IActiveScriptSiteUIControl_Vtbl {
         iid == &<IActiveScriptSiteUIControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IActiveScriptSiteWindow_Impl: Sized {
     fn GetWindow(&self) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
@@ -1542,6 +1584,7 @@ impl IActiveScriptSiteWindow_Vtbl {
         iid == &<IActiveScriptSiteWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptStats_Impl: Sized {
     fn GetStat(&self, stid: u32, pluhi: *mut u32, plulo: *mut u32) -> ::windows::core::Result<()>;
     fn GetStatEx(&self, guid: *const ::windows::core::GUID, pluhi: *mut u32, plulo: *mut u32) -> ::windows::core::Result<()>;
@@ -1576,6 +1619,7 @@ impl IActiveScriptStats_Vtbl {
         iid == &<IActiveScriptStats as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptStringCompare_Impl: Sized {
     fn StrComp(&self, bszstr1: &::windows::core::BSTR, bszstr2: &::windows::core::BSTR) -> ::windows::core::Result<i32>;
 }
@@ -1599,6 +1643,7 @@ impl IActiveScriptStringCompare_Vtbl {
         iid == &<IActiveScriptStringCompare as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IActiveScriptTraceInfo_Impl: Sized {
     fn StartScriptTracing(&self, psitetraceinfo: &::core::option::Option<IActiveScriptSiteTraceInfo>, guidcontextid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn StopScriptTracing(&self) -> ::windows::core::Result<()>;
@@ -1626,6 +1671,7 @@ impl IActiveScriptTraceInfo_Vtbl {
         iid == &<IActiveScriptTraceInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IActiveScriptWinRTErrorDebug_Impl: Sized + IActiveScriptError_Impl {
     fn GetRestrictedErrorString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1681,6 +1727,7 @@ impl IActiveScriptWinRTErrorDebug_Vtbl {
         iid == &<IActiveScriptWinRTErrorDebug as ::windows::core::Interface>::IID || iid == &<IActiveScriptError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IApplicationDebugger_Impl: Sized {
     fn QueryAlive(&self) -> ::windows::core::Result<()>;
     fn CreateInstanceAtDebugger(&self, rclsid: *const ::windows::core::GUID, punkouter: &::core::option::Option<::windows::core::IUnknown>, dwclscontext: u32, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1742,6 +1789,7 @@ impl IApplicationDebugger_Vtbl {
         iid == &<IApplicationDebugger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IApplicationDebuggerUI_Impl: Sized {
     fn BringDocumentToTop(&self, pddt: &::core::option::Option<IDebugDocumentText>) -> ::windows::core::Result<()>;
     fn BringDocumentContextToTop(&self, pddc: &::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
@@ -1769,6 +1817,7 @@ impl IApplicationDebuggerUI_Vtbl {
         iid == &<IApplicationDebuggerUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBindEventHandler_Impl: Sized {
     fn BindHandler(&self, pstrevent: &::windows::core::PCWSTR, pdisp: &::core::option::Option<super::super::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -1789,6 +1838,7 @@ impl IBindEventHandler_Vtbl {
         iid == &<IBindEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait ICodeAddressConcept_Impl: Sized {
     fn GetContainingSymbol(&self, pcontextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IDebugHostSymbol>;
 }
@@ -1812,6 +1862,7 @@ impl ICodeAddressConcept_Vtbl {
         iid == &<ICodeAddressConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IComparableConcept_Impl: Sized {
     fn CompareObjects(&self, contextobject: &::core::option::Option<IModelObject>, otherobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<i32>;
 }
@@ -1835,6 +1886,7 @@ impl IComparableConcept_Vtbl {
         iid == &<IComparableConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelConcept_Impl: Sized {
     fn InitializeObject(&self, modelobject: &::core::option::Option<IModelObject>, matchingtypesignature: &::core::option::Option<IDebugHostTypeSignature>, wildcardmatches: &::core::option::Option<IDebugHostSymbolEnumerator>) -> ::windows::core::Result<()>;
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1868,6 +1920,7 @@ impl IDataModelConcept_Vtbl {
         iid == &<IDataModelConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataModelManager_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -2096,6 +2149,7 @@ impl IDataModelManager_Vtbl {
         iid == &<IDataModelManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataModelManager2_Impl: Sized + IDataModelManager_Impl {
     fn AcquireSubNamespace(&self, modelname: &::windows::core::PCWSTR, subnamespacemodelname: &::windows::core::PCWSTR, accessname: &::windows::core::PCWSTR, metadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<IModelObject>;
@@ -2138,6 +2192,7 @@ impl IDataModelManager2_Vtbl {
         iid == &<IDataModelManager2 as ::windows::core::Interface>::IID || iid == &<IDataModelManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelNameBinder_Impl: Sized {
     fn BindValue(&self, contextobject: &::core::option::Option<IModelObject>, name: &::windows::core::PCWSTR, value: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
     fn BindReference(&self, contextobject: &::core::option::Option<IModelObject>, name: &::windows::core::PCWSTR, reference: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -2191,6 +2246,7 @@ impl IDataModelNameBinder_Vtbl {
         iid == &<IDataModelNameBinder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDataModelScript_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2268,6 +2324,7 @@ impl IDataModelScript_Vtbl {
         iid == &<IDataModelScript as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptClient_Impl: Sized {
     fn ReportError(&self, errclass: ErrorClass, hrfail: ::windows::core::HRESULT, message: &::windows::core::PCWSTR, line: u32, position: u32) -> ::windows::core::Result<()>;
 }
@@ -2285,6 +2342,7 @@ impl IDataModelScriptClient_Vtbl {
         iid == &<IDataModelScriptClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebug_Impl: Sized {
     fn GetDebugState(&self) -> ScriptDebugState;
     fn GetCurrentPosition(&self, currentposition: *mut ScriptDebugPosition, positionspanend: *mut ScriptDebugPosition, linetext: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2398,6 +2456,7 @@ impl IDataModelScriptDebug_Vtbl {
         iid == &<IDataModelScriptDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebug2_Impl: Sized + IDataModelScriptDebug_Impl {
     fn SetBreakpointAtFunction(&self, functionname: &::windows::core::PCWSTR) -> ::windows::core::Result<IDataModelScriptDebugBreakpoint>;
 }
@@ -2421,6 +2480,7 @@ impl IDataModelScriptDebug2_Vtbl {
         iid == &<IDataModelScriptDebug2 as ::windows::core::Interface>::IID || iid == &<IDataModelScriptDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebugBreakpoint_Impl: Sized {
     fn GetId(&self) -> u64;
     fn IsEnabled(&self) -> bool;
@@ -2476,6 +2536,7 @@ impl IDataModelScriptDebugBreakpoint_Vtbl {
         iid == &<IDataModelScriptDebugBreakpoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebugBreakpointEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDataModelScriptDebugBreakpoint>;
@@ -2509,6 +2570,7 @@ impl IDataModelScriptDebugBreakpointEnumerator_Vtbl {
         iid == &<IDataModelScriptDebugBreakpointEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebugClient_Impl: Sized {
     fn NotifyDebugEvent(&self, peventinfo: *const ScriptDebugEventInformation, pscript: &::core::option::Option<IDataModelScript>, peventdataobject: &::core::option::Option<IModelObject>, resumeeventkind: *mut ScriptExecutionKind) -> ::windows::core::Result<()>;
 }
@@ -2526,6 +2588,7 @@ impl IDataModelScriptDebugClient_Vtbl {
         iid == &<IDataModelScriptDebugClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebugStack_Impl: Sized {
     fn GetFrameCount(&self) -> u64;
     fn GetStackFrame(&self, framenumber: u64) -> ::windows::core::Result<IDataModelScriptDebugStackFrame>;
@@ -2559,6 +2622,7 @@ impl IDataModelScriptDebugStack_Vtbl {
         iid == &<IDataModelScriptDebugStack as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebugStackFrame_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetPosition(&self, position: *mut ScriptDebugPosition, positionspanend: *mut ScriptDebugPosition, linetext: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2651,6 +2715,7 @@ impl IDataModelScriptDebugStackFrame_Vtbl {
         iid == &<IDataModelScriptDebugStackFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptDebugVariableSetEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self, variablename: *mut ::windows::core::BSTR, variablevalue: *mut ::core::option::Option<IModelObject>, variablemetadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -2678,6 +2743,7 @@ impl IDataModelScriptDebugVariableSetEnumerator_Vtbl {
         iid == &<IDataModelScriptDebugVariableSetEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptHostContext_Impl: Sized {
     fn NotifyScriptChange(&self, script: &::core::option::Option<IDataModelScript>, changekind: ScriptChangeKind) -> ::windows::core::Result<()>;
     fn GetNamespaceObject(&self) -> ::windows::core::Result<IModelObject>;
@@ -2711,6 +2777,7 @@ impl IDataModelScriptHostContext_Vtbl {
         iid == &<IDataModelScriptHostContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptManager_Impl: Sized {
     fn GetDefaultNameBinder(&self) -> ::windows::core::Result<IDataModelNameBinder>;
     fn RegisterScriptProvider(&self, provider: &::core::option::Option<IDataModelScriptProvider>) -> ::windows::core::Result<()>;
@@ -2790,6 +2857,7 @@ impl IDataModelScriptManager_Vtbl {
         iid == &<IDataModelScriptManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptProvider_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetExtension(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2868,6 +2936,7 @@ impl IDataModelScriptProvider_Vtbl {
         iid == &<IDataModelScriptProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptProviderEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDataModelScriptProvider>;
@@ -2901,6 +2970,7 @@ impl IDataModelScriptProviderEnumerator_Vtbl {
         iid == &<IDataModelScriptProviderEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDataModelScriptTemplate_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2956,6 +3026,7 @@ impl IDataModelScriptTemplate_Vtbl {
         iid == &<IDataModelScriptTemplate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDataModelScriptTemplateEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDataModelScriptTemplate>;
@@ -2989,6 +3060,7 @@ impl IDataModelScriptTemplateEnumerator_Vtbl {
         iid == &<IDataModelScriptTemplateEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugAdvanced_Impl: Sized {
     fn GetThreadContext(&self, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
     fn SetThreadContext(&self, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
@@ -3016,6 +3088,7 @@ impl IDebugAdvanced_Vtbl {
         iid == &<IDebugAdvanced as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugAdvanced2_Impl: Sized {
     fn GetThreadContext(&self, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
     fn SetThreadContext(&self, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
@@ -3078,6 +3151,7 @@ impl IDebugAdvanced2_Vtbl {
         iid == &<IDebugAdvanced2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugAdvanced3_Impl: Sized {
     fn GetThreadContext(&self, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
     fn SetThreadContext(&self, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
@@ -3161,6 +3235,7 @@ impl IDebugAdvanced3_Vtbl {
         iid == &<IDebugAdvanced3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugAdvanced4_Impl: Sized {
     fn GetThreadContext(&self, context: *mut ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
     fn SetThreadContext(&self, context: *const ::core::ffi::c_void, contextsize: u32) -> ::windows::core::Result<()>;
@@ -3251,6 +3326,7 @@ impl IDebugAdvanced4_Vtbl {
         iid == &<IDebugAdvanced4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugApplication11032_Impl: Sized + IRemoteDebugApplication110_Impl {
     fn SynchronousCallInMainThread(&self, pptc: &::core::option::Option<IDebugThreadCall32>, dwparam1: usize, dwparam2: usize, dwparam3: usize) -> ::windows::core::Result<()>;
@@ -3294,6 +3370,7 @@ impl IDebugApplication11032_Vtbl {
         iid == &<IDebugApplication11032 as ::windows::core::Interface>::IID || iid == &<IRemoteDebugApplication110 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugApplication11064_Impl: Sized + IRemoteDebugApplication110_Impl {
     fn SynchronousCallInMainThread(&self, pptc: &::core::option::Option<IDebugThreadCall64>, dwparam1: usize, dwparam2: usize, dwparam3: usize) -> ::windows::core::Result<()>;
@@ -3337,6 +3414,7 @@ impl IDebugApplication11064_Vtbl {
         iid == &<IDebugApplication11064 as ::windows::core::Interface>::IID || iid == &<IRemoteDebugApplication110 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugApplication32_Impl: Sized + IRemoteDebugApplication_Impl {
     fn SetName(&self, pstrname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -3529,6 +3607,7 @@ impl IDebugApplication32_Vtbl {
         iid == &<IDebugApplication32 as ::windows::core::Interface>::IID || iid == &<IRemoteDebugApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugApplication64_Impl: Sized + IRemoteDebugApplication_Impl {
     fn SetName(&self, pstrname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -3721,6 +3800,7 @@ impl IDebugApplication64_Vtbl {
         iid == &<IDebugApplication64 as ::windows::core::Interface>::IID || iid == &<IRemoteDebugApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugApplicationNode_Impl: Sized + IDebugDocumentProvider_Impl {
     fn EnumChildren(&self) -> ::windows::core::Result<IEnumDebugApplicationNodes>;
     fn GetParent(&self) -> ::windows::core::Result<IDebugApplicationNode>;
@@ -3788,6 +3868,7 @@ impl IDebugApplicationNode_Vtbl {
         iid == &<IDebugApplicationNode as ::windows::core::Interface>::IID || iid == &<IDebugDocumentInfo as ::windows::core::Interface>::IID || iid == &<IDebugDocumentProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugApplicationNode100_Impl: Sized {
     fn SetFilterForEventSink(&self, dwcookie: u32, filter: APPLICATION_NODE_EVENT_FILTER) -> ::windows::core::Result<()>;
     fn GetExcludedDocuments(&self, filter: APPLICATION_NODE_EVENT_FILTER) -> ::windows::core::Result<TEXT_DOCUMENT_ARRAY>;
@@ -3828,6 +3909,7 @@ impl IDebugApplicationNode100_Vtbl {
         iid == &<IDebugApplicationNode100 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugApplicationNodeEvents_Impl: Sized {
     fn onAddChild(&self, prddpchild: &::core::option::Option<IDebugApplicationNode>) -> ::windows::core::Result<()>;
     fn onRemoveChild(&self, prddpchild: &::core::option::Option<IDebugApplicationNode>) -> ::windows::core::Result<()>;
@@ -3869,6 +3951,7 @@ impl IDebugApplicationNodeEvents_Vtbl {
         iid == &<IDebugApplicationNodeEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugApplicationThread_Impl: Sized + IRemoteDebugApplicationThread_Impl {
     fn SynchronousCallIntoThread32(&self, pstcb: &::core::option::Option<IDebugThreadCall32>, dwparam1: u32, dwparam2: u32, dwparam3: u32) -> ::windows::core::Result<()>;
     fn QueryIsCurrentThread(&self) -> ::windows::core::Result<()>;
@@ -3917,6 +4000,7 @@ impl IDebugApplicationThread_Vtbl {
         iid == &<IDebugApplicationThread as ::windows::core::Interface>::IID || iid == &<IRemoteDebugApplicationThread as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugApplicationThread11032_Impl: Sized {
     fn GetActiveThreadRequestCount(&self) -> ::windows::core::Result<u32>;
@@ -3979,6 +4063,7 @@ impl IDebugApplicationThread11032_Vtbl {
         iid == &<IDebugApplicationThread11032 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugApplicationThread11064_Impl: Sized {
     fn GetActiveThreadRequestCount(&self) -> ::windows::core::Result<u32>;
@@ -4041,6 +4126,7 @@ impl IDebugApplicationThread11064_Vtbl {
         iid == &<IDebugApplicationThread11064 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugApplicationThread64_Impl: Sized + IDebugApplicationThread_Impl {
     fn SynchronousCallIntoThread64(&self, pstcb: &::core::option::Option<IDebugThreadCall64>, dwparam1: u64, dwparam2: u64, dwparam3: u64) -> ::windows::core::Result<()>;
 }
@@ -4061,6 +4147,7 @@ impl IDebugApplicationThread64_Vtbl {
         iid == &<IDebugApplicationThread64 as ::windows::core::Interface>::IID || iid == &<IRemoteDebugApplicationThread as ::windows::core::Interface>::IID || iid == &<IDebugApplicationThread as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugApplicationThreadEvents110_Impl: Sized {
     fn OnSuspendForBreakPoint(&self) -> ::windows::core::Result<()>;
     fn OnResumeFromBreakPoint(&self) -> ::windows::core::Result<()>;
@@ -4102,6 +4189,7 @@ impl IDebugApplicationThreadEvents110_Vtbl {
         iid == &<IDebugApplicationThreadEvents110 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugAsyncOperation_Impl: Sized {
     fn GetSyncDebugOperation(&self) -> ::windows::core::Result<IDebugSyncOperation>;
     fn Start(&self, padocb: &::core::option::Option<IDebugAsyncOperationCallBack>) -> ::windows::core::Result<()>;
@@ -4156,6 +4244,7 @@ impl IDebugAsyncOperation_Vtbl {
         iid == &<IDebugAsyncOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugAsyncOperationCallBack_Impl: Sized {
     fn onComplete(&self) -> ::windows::core::Result<()>;
 }
@@ -4173,6 +4262,7 @@ impl IDebugAsyncOperationCallBack_Vtbl {
         iid == &<IDebugAsyncOperationCallBack as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugBreakpoint_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<u32>;
     fn GetType(&self, breaktype: *mut u32, proctype: *mut u32) -> ::windows::core::Result<()>;
@@ -4381,6 +4471,7 @@ impl IDebugBreakpoint_Vtbl {
         iid == &<IDebugBreakpoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugBreakpoint2_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<u32>;
     fn GetType(&self, breaktype: *mut u32, proctype: *mut u32) -> ::windows::core::Result<()>;
@@ -4617,6 +4708,7 @@ impl IDebugBreakpoint2_Vtbl {
         iid == &<IDebugBreakpoint2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugBreakpoint3_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<u32>;
     fn GetType(&self, breaktype: *mut u32, proctype: *mut u32) -> ::windows::core::Result<()>;
@@ -4866,6 +4958,7 @@ impl IDebugBreakpoint3_Vtbl {
         iid == &<IDebugBreakpoint3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -5260,6 +5353,7 @@ impl IDebugClient_Vtbl {
         iid == &<IDebugClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient2_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -5710,6 +5804,7 @@ impl IDebugClient2_Vtbl {
         iid == &<IDebugClient2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient3_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -6194,6 +6289,7 @@ impl IDebugClient3_Vtbl {
         iid == &<IDebugClient3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient4_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -6726,6 +6822,7 @@ impl IDebugClient4_Vtbl {
         iid == &<IDebugClient4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient5_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -7509,6 +7606,7 @@ impl IDebugClient5_Vtbl {
         iid == &<IDebugClient5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient6_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -8299,6 +8397,7 @@ impl IDebugClient6_Vtbl {
         iid == &<IDebugClient6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient7_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -9096,6 +9195,7 @@ impl IDebugClient7_Vtbl {
         iid == &<IDebugClient7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugClient8_Impl: Sized {
     fn AttachKernel(&self, flags: u32, connectoptions: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetKernelConnectionOptions(&self, buffer: ::windows::core::PSTR, buffersize: u32, optionssize: *mut u32) -> ::windows::core::Result<()>;
@@ -9900,6 +10000,7 @@ impl IDebugClient8_Vtbl {
         iid == &<IDebugClient8 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugCodeContext_Impl: Sized {
     fn GetDocumentContext(&self) -> ::windows::core::Result<IDebugDocumentContext>;
     fn SetBreakPoint(&self, bps: BREAKPOINT_STATE) -> ::windows::core::Result<()>;
@@ -9933,6 +10034,7 @@ impl IDebugCodeContext_Vtbl {
         iid == &<IDebugCodeContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub trait IDebugControl_Impl: Sized {
     fn GetInterrupt(&self) -> ::windows::core::Result<()>;
@@ -10750,6 +10852,7 @@ impl IDebugControl_Vtbl {
         iid == &<IDebugControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub trait IDebugControl2_Impl: Sized {
     fn GetInterrupt(&self) -> ::windows::core::Result<()>;
@@ -11647,6 +11750,7 @@ impl IDebugControl2_Vtbl {
         iid == &<IDebugControl2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub trait IDebugControl3_Impl: Sized {
     fn GetInterrupt(&self) -> ::windows::core::Result<()>;
@@ -12671,6 +12775,7 @@ impl IDebugControl3_Vtbl {
         iid == &<IDebugControl3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub trait IDebugControl4_Impl: Sized {
     fn GetInterrupt(&self) -> ::windows::core::Result<()>;
@@ -14102,6 +14207,7 @@ impl IDebugControl4_Vtbl {
         iid == &<IDebugControl4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub trait IDebugControl5_Impl: Sized {
     fn GetInterrupt(&self) -> ::windows::core::Result<()>;
@@ -15574,6 +15680,7 @@ impl IDebugControl5_Vtbl {
         iid == &<IDebugControl5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub trait IDebugControl6_Impl: Sized {
     fn GetInterrupt(&self) -> ::windows::core::Result<()>;
@@ -17066,6 +17173,7 @@ impl IDebugControl6_Vtbl {
         iid == &<IDebugControl6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub trait IDebugControl7_Impl: Sized {
     fn GetInterrupt(&self) -> ::windows::core::Result<()>;
@@ -18565,6 +18673,7 @@ impl IDebugControl7_Vtbl {
         iid == &<IDebugControl7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugCookie_Impl: Sized {
     fn SetDebugCookie(&self, dwdebugappcookie: u32) -> ::windows::core::Result<()>;
 }
@@ -18582,6 +18691,7 @@ impl IDebugCookie_Vtbl {
         iid == &<IDebugCookie as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDataSpaces_Impl: Sized {
     fn ReadVirtual(&self, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::Result<()>;
     fn WriteVirtual(&self, offset: u64, buffer: *const ::core::ffi::c_void, buffersize: u32, byteswritten: *mut u32) -> ::windows::core::Result<()>;
@@ -18747,6 +18857,7 @@ impl IDebugDataSpaces_Vtbl {
         iid == &<IDebugDataSpaces as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Memory\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Memory")]
 pub trait IDebugDataSpaces2_Impl: Sized {
     fn ReadVirtual(&self, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::Result<()>;
@@ -18969,6 +19080,7 @@ impl IDebugDataSpaces2_Vtbl {
         iid == &<IDebugDataSpaces2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Memory\"`, `\"Win32_System_SystemInformation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Memory", feature = "Win32_System_SystemInformation"))]
 pub trait IDebugDataSpaces3_Impl: Sized {
     fn ReadVirtual(&self, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::Result<()>;
@@ -19238,6 +19350,7 @@ impl IDebugDataSpaces3_Vtbl {
         iid == &<IDebugDataSpaces3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Memory\"`, `\"Win32_System_SystemInformation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Memory", feature = "Win32_System_SystemInformation"))]
 pub trait IDebugDataSpaces4_Impl: Sized {
     fn ReadVirtual(&self, offset: u64, buffer: *mut ::core::ffi::c_void, buffersize: u32, bytesread: *mut u32) -> ::windows::core::Result<()>;
@@ -19589,6 +19702,7 @@ impl IDebugDataSpaces4_Vtbl {
         iid == &<IDebugDataSpaces4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDocument_Impl: Sized + IDebugDocumentInfo_Impl {}
 impl ::windows::core::RuntimeName for IDebugDocument {}
 impl IDebugDocument_Vtbl {
@@ -19599,6 +19713,7 @@ impl IDebugDocument_Vtbl {
         iid == &<IDebugDocument as ::windows::core::Interface>::IID || iid == &<IDebugDocumentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDocumentContext_Impl: Sized {
     fn GetDocument(&self) -> ::windows::core::Result<IDebugDocument>;
     fn EnumCodeContexts(&self) -> ::windows::core::Result<IEnumDebugCodeContexts>;
@@ -19638,6 +19753,7 @@ impl IDebugDocumentContext_Vtbl {
         iid == &<IDebugDocumentContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugDocumentHelper32_Impl: Sized {
     fn Init(&self, pda: &::core::option::Option<IDebugApplication32>, pszshortname: &::windows::core::PCWSTR, pszlongname: &::windows::core::PCWSTR, docattr: u32) -> ::windows::core::Result<()>;
@@ -19798,6 +19914,7 @@ impl IDebugDocumentHelper32_Vtbl {
         iid == &<IDebugDocumentHelper32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugDocumentHelper64_Impl: Sized {
     fn Init(&self, pda: &::core::option::Option<IDebugApplication64>, pszshortname: &::windows::core::PCWSTR, pszlongname: &::windows::core::PCWSTR, docattr: u32) -> ::windows::core::Result<()>;
@@ -19958,6 +20075,7 @@ impl IDebugDocumentHelper64_Vtbl {
         iid == &<IDebugDocumentHelper64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugDocumentHost_Impl: Sized {
     fn GetDeferredText(&self, dwtextstartcookie: u32, pchartext: &::windows::core::PWSTR, pstatextattr: *mut u16, pcnumchars: *mut u32, cmaxchars: u32) -> ::windows::core::Result<()>;
@@ -20028,6 +20146,7 @@ impl IDebugDocumentHost_Vtbl {
         iid == &<IDebugDocumentHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDocumentInfo_Impl: Sized {
     fn GetName(&self, dnt: DOCUMENTNAMETYPE) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetDocumentClassId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -20067,6 +20186,7 @@ impl IDebugDocumentInfo_Vtbl {
         iid == &<IDebugDocumentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDocumentProvider_Impl: Sized + IDebugDocumentInfo_Impl {
     fn GetDocument(&self) -> ::windows::core::Result<IDebugDocument>;
 }
@@ -20090,6 +20210,7 @@ impl IDebugDocumentProvider_Vtbl {
         iid == &<IDebugDocumentProvider as ::windows::core::Interface>::IID || iid == &<IDebugDocumentInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDocumentText_Impl: Sized + IDebugDocument_Impl {
     fn GetDocumentAttributes(&self) -> ::windows::core::Result<u32>;
     fn GetSize(&self, pcnumlines: *mut u32, pcnumchars: *mut u32) -> ::windows::core::Result<()>;
@@ -20170,6 +20291,7 @@ impl IDebugDocumentText_Vtbl {
         iid == &<IDebugDocumentText as ::windows::core::Interface>::IID || iid == &<IDebugDocumentInfo as ::windows::core::Interface>::IID || iid == &<IDebugDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDocumentTextAuthor_Impl: Sized + IDebugDocumentText_Impl {
     fn InsertText(&self, ccharacterposition: u32, cnumtoinsert: u32, pchartext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn RemoveText(&self, ccharacterposition: u32, cnumtoremove: u32) -> ::windows::core::Result<()>;
@@ -20204,6 +20326,7 @@ impl IDebugDocumentTextAuthor_Vtbl {
         iid == &<IDebugDocumentTextAuthor as ::windows::core::Interface>::IID || iid == &<IDebugDocumentInfo as ::windows::core::Interface>::IID || iid == &<IDebugDocument as ::windows::core::Interface>::IID || iid == &<IDebugDocumentText as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugDocumentTextEvents_Impl: Sized {
     fn onDestroy(&self) -> ::windows::core::Result<()>;
     fn onInsertText(&self, ccharacterposition: u32, cnumtoinsert: u32) -> ::windows::core::Result<()>;
@@ -20259,6 +20382,7 @@ impl IDebugDocumentTextEvents_Vtbl {
         iid == &<IDebugDocumentTextEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugDocumentTextExternalAuthor_Impl: Sized {
     fn GetPathName(&self, pbstrlongname: *mut ::windows::core::BSTR, pfisoriginalfile: *mut super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -20302,6 +20426,7 @@ impl IDebugDocumentTextExternalAuthor_Vtbl {
         iid == &<IDebugDocumentTextExternalAuthor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugEventCallbacks_Impl: Sized {
     fn GetInterestMask(&self) -> ::windows::core::Result<u32>;
@@ -20423,6 +20548,7 @@ impl IDebugEventCallbacks_Vtbl {
         iid == &<IDebugEventCallbacks as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugEventCallbacksWide_Impl: Sized {
     fn GetInterestMask(&self) -> ::windows::core::Result<u32>;
@@ -20544,6 +20670,7 @@ impl IDebugEventCallbacksWide_Vtbl {
         iid == &<IDebugEventCallbacksWide as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugEventContextCallbacks_Impl: Sized {
     fn GetInterestMask(&self) -> ::windows::core::Result<u32>;
@@ -20679,6 +20806,7 @@ impl IDebugEventContextCallbacks_Vtbl {
         iid == &<IDebugEventContextCallbacks as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugExpression_Impl: Sized {
     fn Start(&self, pdecb: &::core::option::Option<IDebugExpressionCallBack>) -> ::windows::core::Result<()>;
     fn Abort(&self) -> ::windows::core::Result<()>;
@@ -20727,6 +20855,7 @@ impl IDebugExpression_Vtbl {
         iid == &<IDebugExpression as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugExpressionCallBack_Impl: Sized {
     fn onComplete(&self) -> ::windows::core::Result<()>;
 }
@@ -20744,6 +20873,7 @@ impl IDebugExpressionCallBack_Vtbl {
         iid == &<IDebugExpressionCallBack as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugExpressionContext_Impl: Sized {
     fn ParseLanguageText(&self, pstrcode: &::windows::core::PCWSTR, nradix: u32, pstrdelimiter: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<IDebugExpression>;
     fn GetLanguageInfo(&self, pbstrlanguagename: *mut ::windows::core::BSTR, planguageid: *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -20777,6 +20907,7 @@ impl IDebugExpressionContext_Vtbl {
         iid == &<IDebugExpressionContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IDebugExtendedProperty_Impl: Sized + IDebugProperty_Impl {
     fn GetExtendedPropertyInfo(&self, dwfieldspec: u32, nradix: u32) -> ::windows::core::Result<ExtendedDebugPropertyInfo>;
@@ -20819,6 +20950,7 @@ impl IDebugExtendedProperty_Vtbl {
         iid == &<IDebugExtendedProperty as ::windows::core::Interface>::IID || iid == &<IDebugProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDebugFormatter_Impl: Sized {
     fn GetStringForVariant(&self, pvar: *const super::super::Com::VARIANT, nradix: u32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -20874,6 +21006,7 @@ impl IDebugFormatter_Vtbl {
         iid == &<IDebugFormatter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDebugHelper_Impl: Sized {
     fn CreatePropertyBrowser(&self, pvar: *const super::super::Com::VARIANT, bstrname: &::windows::core::PCWSTR, pdat: &::core::option::Option<IDebugApplicationThread>) -> ::windows::core::Result<IDebugProperty>;
@@ -20929,6 +21062,7 @@ impl IDebugHelper_Vtbl {
         iid == &<IDebugHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHost_Impl: Sized {
     fn GetHostDefinedInterface(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetCurrentContext(&self) -> ::windows::core::Result<IDebugHostContext>;
@@ -20981,6 +21115,7 @@ impl IDebugHost_Vtbl {
         iid == &<IDebugHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostBaseClass_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetOffset(&self) -> ::windows::core::Result<u64>;
 }
@@ -21004,6 +21139,7 @@ impl IDebugHostBaseClass_Vtbl {
         iid == &<IDebugHostBaseClass as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDebugHostConstant_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetValue(&self) -> ::windows::core::Result<super::super::Com::VARIANT>;
@@ -21030,6 +21166,7 @@ impl IDebugHostConstant_Vtbl {
         iid == &<IDebugHostConstant as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostContext_Impl: Sized {
     fn IsEqualTo(&self, pcontext: &::core::option::Option<IDebugHostContext>) -> ::windows::core::Result<bool>;
 }
@@ -21053,6 +21190,7 @@ impl IDebugHostContext_Vtbl {
         iid == &<IDebugHostContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDebugHostData_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLocationKind(&self) -> ::windows::core::Result<LocationKind>;
@@ -21108,6 +21246,7 @@ impl IDebugHostData_Vtbl {
         iid == &<IDebugHostData as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostErrorSink_Impl: Sized {
     fn ReportError(&self, errclass: ErrorClass, hrerror: ::windows::core::HRESULT, message: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -21125,6 +21264,7 @@ impl IDebugHostErrorSink_Vtbl {
         iid == &<IDebugHostErrorSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostEvaluator_Impl: Sized {
     fn EvaluateExpression(&self, context: &::core::option::Option<IDebugHostContext>, expression: &::windows::core::PCWSTR, bindingcontext: &::core::option::Option<IModelObject>, result: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
     fn EvaluateExtendedExpression(&self, context: &::core::option::Option<IDebugHostContext>, expression: &::windows::core::PCWSTR, bindingcontext: &::core::option::Option<IModelObject>, result: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -21152,6 +21292,7 @@ impl IDebugHostEvaluator_Vtbl {
         iid == &<IDebugHostEvaluator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostEvaluator2_Impl: Sized + IDebugHostEvaluator_Impl {
     fn AssignTo(&self, assignmentreference: &::core::option::Option<IModelObject>, assignmentvalue: &::core::option::Option<IModelObject>, assignmentresult: *mut ::core::option::Option<IModelObject>, assignmentmetadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
@@ -21169,6 +21310,7 @@ impl IDebugHostEvaluator2_Vtbl {
         iid == &<IDebugHostEvaluator2 as ::windows::core::Interface>::IID || iid == &<IDebugHostEvaluator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostExtensibility_Impl: Sized {
     fn CreateFunctionAlias(&self, aliasname: &::windows::core::PCWSTR, functionobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
     fn DestroyFunctionAlias(&self, aliasname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -21196,6 +21338,7 @@ impl IDebugHostExtensibility_Vtbl {
         iid == &<IDebugHostExtensibility as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDebugHostField_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLocationKind(&self) -> ::windows::core::Result<LocationKind>;
@@ -21264,6 +21407,7 @@ impl IDebugHostField_Vtbl {
         iid == &<IDebugHostField as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostMemory_Impl: Sized {
     fn ReadBytes(&self, context: &::core::option::Option<IDebugHostContext>, location: &Location, buffer: *mut ::core::ffi::c_void, buffersize: u64, bytesread: *mut u64) -> ::windows::core::Result<()>;
     fn WriteBytes(&self, context: &::core::option::Option<IDebugHostContext>, location: &Location, buffer: *const ::core::ffi::c_void, buffersize: u64, byteswritten: *mut u64) -> ::windows::core::Result<()>;
@@ -21318,6 +21462,7 @@ impl IDebugHostMemory_Vtbl {
         iid == &<IDebugHostMemory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostMemory2_Impl: Sized + IDebugHostMemory_Impl {
     fn LinearizeLocation(&self, context: &::core::option::Option<IDebugHostContext>, location: &Location) -> ::windows::core::Result<Location>;
 }
@@ -21341,6 +21486,7 @@ impl IDebugHostMemory2_Vtbl {
         iid == &<IDebugHostMemory2 as ::windows::core::Interface>::IID || iid == &<IDebugHostMemory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostModule_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetImageName(&self, allowpath: u8) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetBaseLocation(&self) -> ::windows::core::Result<Location>;
@@ -21426,6 +21572,7 @@ impl IDebugHostModule_Vtbl {
         iid == &<IDebugHostModule as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostModule2_Impl: Sized + IDebugHostModule_Impl {
     fn FindContainingSymbolByRVA(&self, rva: u64, symbol: *mut ::core::option::Option<IDebugHostSymbol>, offset: *mut u64) -> ::windows::core::Result<()>;
 }
@@ -21443,6 +21590,7 @@ impl IDebugHostModule2_Vtbl {
         iid == &<IDebugHostModule2 as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID || iid == &<IDebugHostModule as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostModuleSignature_Impl: Sized {
     fn IsMatch(&self, pmodule: &::core::option::Option<IDebugHostModule>) -> ::windows::core::Result<bool>;
 }
@@ -21466,6 +21614,7 @@ impl IDebugHostModuleSignature_Vtbl {
         iid == &<IDebugHostModuleSignature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostPublic_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLocationKind(&self) -> ::windows::core::Result<LocationKind>;
     fn GetLocation(&self) -> ::windows::core::Result<Location>;
@@ -21505,6 +21654,7 @@ impl IDebugHostPublic_Vtbl {
         iid == &<IDebugHostPublic as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostScriptHost_Impl: Sized {
     fn CreateContext(&self, script: &::core::option::Option<IDataModelScript>) -> ::windows::core::Result<IDataModelScriptHostContext>;
 }
@@ -21528,6 +21678,7 @@ impl IDebugHostScriptHost_Vtbl {
         iid == &<IDebugHostScriptHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostStatus_Impl: Sized {
     fn PollUserInterrupt(&self) -> ::windows::core::Result<bool>;
 }
@@ -21551,6 +21702,7 @@ impl IDebugHostStatus_Vtbl {
         iid == &<IDebugHostStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostSymbol_Impl: Sized {
     fn GetContext(&self) -> ::windows::core::Result<IDebugHostContext>;
     fn EnumerateChildren(&self, kind: SymbolKind, name: &::windows::core::PCWSTR) -> ::windows::core::Result<IDebugHostSymbolEnumerator>;
@@ -21655,6 +21807,7 @@ impl IDebugHostSymbol_Vtbl {
         iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostSymbol2_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetLanguage(&self) -> ::windows::core::Result<LanguageKind>;
 }
@@ -21678,6 +21831,7 @@ impl IDebugHostSymbol2_Vtbl {
         iid == &<IDebugHostSymbol2 as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostSymbolEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self) -> ::windows::core::Result<IDebugHostSymbol>;
@@ -21711,6 +21865,7 @@ impl IDebugHostSymbolEnumerator_Vtbl {
         iid == &<IDebugHostSymbolEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostSymbols_Impl: Sized {
     fn CreateModuleSignature(&self, pwszmodulename: &::windows::core::PCWSTR, pwszminversion: &::windows::core::PCWSTR, pwszmaxversion: &::windows::core::PCWSTR) -> ::windows::core::Result<IDebugHostModuleSignature>;
     fn CreateTypeSignature(&self, signaturespecification: &::windows::core::PCWSTR, module: &::core::option::Option<IDebugHostModule>) -> ::windows::core::Result<IDebugHostTypeSignature>;
@@ -21809,6 +21964,7 @@ impl IDebugHostSymbols_Vtbl {
         iid == &<IDebugHostSymbols as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostType_Impl: Sized + IDebugHostSymbol_Impl {
     fn GetTypeKind(&self) -> ::windows::core::Result<TypeKind>;
     fn GetSize(&self) -> ::windows::core::Result<u64>;
@@ -22051,6 +22207,7 @@ impl IDebugHostType_Vtbl {
         iid == &<IDebugHostType as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostType2_Impl: Sized + IDebugHostType_Impl {
     fn IsTypedef(&self) -> ::windows::core::Result<bool>;
     fn GetTypedefBaseType(&self) -> ::windows::core::Result<IDebugHostType2>;
@@ -22129,6 +22286,7 @@ impl IDebugHostType2_Vtbl {
         iid == &<IDebugHostType2 as ::windows::core::Interface>::IID || iid == &<IDebugHostSymbol as ::windows::core::Interface>::IID || iid == &<IDebugHostType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugHostTypeSignature_Impl: Sized {
     fn GetHashCode(&self) -> ::windows::core::Result<u32>;
     fn IsMatch(&self, r#type: &::core::option::Option<IDebugHostType>, ismatch: *mut bool, wildcardmatches: *mut ::core::option::Option<IDebugHostSymbolEnumerator>) -> ::windows::core::Result<()>;
@@ -22175,6 +22333,7 @@ impl IDebugHostTypeSignature_Vtbl {
         iid == &<IDebugHostTypeSignature as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugInputCallbacks_Impl: Sized {
     fn StartInput(&self, buffersize: u32) -> ::windows::core::Result<()>;
     fn EndInput(&self) -> ::windows::core::Result<()>;
@@ -22202,6 +22361,7 @@ impl IDebugInputCallbacks_Vtbl {
         iid == &<IDebugInputCallbacks as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugOutputCallbacks_Impl: Sized {
     fn Output(&self, mask: u32, text: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
 }
@@ -22219,6 +22379,7 @@ impl IDebugOutputCallbacks_Vtbl {
         iid == &<IDebugOutputCallbacks as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugOutputCallbacks2_Impl: Sized {
     fn Output(&self, mask: u32, text: &::windows::core::PCSTR) -> ::windows::core::Result<()>;
     fn GetInterestMask(&self) -> ::windows::core::Result<u32>;
@@ -22259,6 +22420,7 @@ impl IDebugOutputCallbacks2_Vtbl {
         iid == &<IDebugOutputCallbacks2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugOutputCallbacksWide_Impl: Sized {
     fn Output(&self, mask: u32, text: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -22276,6 +22438,7 @@ impl IDebugOutputCallbacksWide_Vtbl {
         iid == &<IDebugOutputCallbacksWide as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugOutputStream_Impl: Sized {
     fn Write(&self, psz: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -22293,6 +22456,7 @@ impl IDebugOutputStream_Vtbl {
         iid == &<IDebugOutputStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPlmClient_Impl: Sized {
     fn LaunchPlmPackageForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -22313,6 +22477,7 @@ impl IDebugPlmClient_Vtbl {
         iid == &<IDebugPlmClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPlmClient2_Impl: Sized {
     fn LaunchPlmPackageForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
     fn LaunchPlmBgTaskForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, backgroundtaskid: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
@@ -22340,6 +22505,7 @@ impl IDebugPlmClient2_Vtbl {
         iid == &<IDebugPlmClient2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPlmClient3_Impl: Sized {
     fn LaunchPlmPackageForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, appname: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
     fn LaunchPlmBgTaskForDebugWide(&self, server: u64, timeout: u32, packagefullname: &::windows::core::PCWSTR, backgroundtaskid: &::windows::core::PCWSTR, processid: *mut u32, threadid: *mut u32) -> ::windows::core::Result<()>;
@@ -22430,6 +22596,7 @@ impl IDebugPlmClient3_Vtbl {
         iid == &<IDebugPlmClient3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDebugProperty_Impl: Sized {
     fn GetPropertyInfo(&self, dwfieldspec: u32, nradix: u32) -> ::windows::core::Result<DebugPropertyInfo>;
@@ -22499,6 +22666,7 @@ impl IDebugProperty_Vtbl {
         iid == &<IDebugProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPropertyEnumType_All_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -22522,6 +22690,7 @@ impl IDebugPropertyEnumType_All_Vtbl {
         iid == &<IDebugPropertyEnumType_All as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPropertyEnumType_Arguments_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
 impl ::windows::core::RuntimeName for IDebugPropertyEnumType_Arguments {}
 impl IDebugPropertyEnumType_Arguments_Vtbl {
@@ -22532,6 +22701,7 @@ impl IDebugPropertyEnumType_Arguments_Vtbl {
         iid == &<IDebugPropertyEnumType_Arguments as ::windows::core::Interface>::IID || iid == &<IDebugPropertyEnumType_All as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPropertyEnumType_Locals_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
 impl ::windows::core::RuntimeName for IDebugPropertyEnumType_Locals {}
 impl IDebugPropertyEnumType_Locals_Vtbl {
@@ -22542,6 +22712,7 @@ impl IDebugPropertyEnumType_Locals_Vtbl {
         iid == &<IDebugPropertyEnumType_Locals as ::windows::core::Interface>::IID || iid == &<IDebugPropertyEnumType_All as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPropertyEnumType_LocalsPlusArgs_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
 impl ::windows::core::RuntimeName for IDebugPropertyEnumType_LocalsPlusArgs {}
 impl IDebugPropertyEnumType_LocalsPlusArgs_Vtbl {
@@ -22552,6 +22723,7 @@ impl IDebugPropertyEnumType_LocalsPlusArgs_Vtbl {
         iid == &<IDebugPropertyEnumType_LocalsPlusArgs as ::windows::core::Interface>::IID || iid == &<IDebugPropertyEnumType_All as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugPropertyEnumType_Registers_Impl: Sized + IDebugPropertyEnumType_All_Impl {}
 impl ::windows::core::RuntimeName for IDebugPropertyEnumType_Registers {}
 impl IDebugPropertyEnumType_Registers_Vtbl {
@@ -22562,6 +22734,7 @@ impl IDebugPropertyEnumType_Registers_Vtbl {
         iid == &<IDebugPropertyEnumType_Registers as ::windows::core::Interface>::IID || iid == &<IDebugPropertyEnumType_All as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugRegisters_Impl: Sized {
     fn GetNumberRegisters(&self) -> ::windows::core::Result<u32>;
@@ -22691,6 +22864,7 @@ impl IDebugRegisters_Vtbl {
         iid == &<IDebugRegisters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugRegisters2_Impl: Sized {
     fn GetNumberRegisters(&self) -> ::windows::core::Result<u32>;
@@ -22967,6 +23141,7 @@ impl IDebugRegisters2_Vtbl {
         iid == &<IDebugRegisters2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugSessionProvider_Impl: Sized {
     fn StartDebugSession(&self, pda: &::core::option::Option<IRemoteDebugApplication>) -> ::windows::core::Result<()>;
 }
@@ -22984,6 +23159,7 @@ impl IDebugSessionProvider_Vtbl {
         iid == &<IDebugSessionProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugStackFrame_Impl: Sized {
     fn GetCodeContext(&self) -> ::windows::core::Result<IDebugCodeContext>;
@@ -23065,6 +23241,7 @@ impl IDebugStackFrame_Vtbl {
         iid == &<IDebugStackFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugStackFrame110_Impl: Sized + IDebugStackFrame_Impl {
     fn GetStackFrameType(&self) -> ::windows::core::Result<DEBUG_STACKFRAME_TYPE>;
@@ -23107,6 +23284,7 @@ impl IDebugStackFrame110_Vtbl {
         iid == &<IDebugStackFrame110 as ::windows::core::Interface>::IID || iid == &<IDebugStackFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugStackFrameSniffer_Impl: Sized {
     fn EnumStackFrames(&self) -> ::windows::core::Result<IEnumDebugStackFrames>;
 }
@@ -23130,6 +23308,7 @@ impl IDebugStackFrameSniffer_Vtbl {
         iid == &<IDebugStackFrameSniffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugStackFrameSnifferEx32_Impl: Sized + IDebugStackFrameSniffer_Impl {
     fn EnumStackFramesEx32(&self, dwspmin: u32) -> ::windows::core::Result<IEnumDebugStackFrames>;
 }
@@ -23153,6 +23332,7 @@ impl IDebugStackFrameSnifferEx32_Vtbl {
         iid == &<IDebugStackFrameSnifferEx32 as ::windows::core::Interface>::IID || iid == &<IDebugStackFrameSniffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugStackFrameSnifferEx64_Impl: Sized + IDebugStackFrameSniffer_Impl {
     fn EnumStackFramesEx64(&self, dwspmin: u64) -> ::windows::core::Result<IEnumDebugStackFrames64>;
 }
@@ -23176,6 +23356,7 @@ impl IDebugStackFrameSnifferEx64_Vtbl {
         iid == &<IDebugStackFrameSnifferEx64 as ::windows::core::Interface>::IID || iid == &<IDebugStackFrameSniffer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugSymbolGroup_Impl: Sized {
     fn GetNumberSymbols(&self) -> ::windows::core::Result<u32>;
@@ -23268,6 +23449,7 @@ impl IDebugSymbolGroup_Vtbl {
         iid == &<IDebugSymbolGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugSymbolGroup2_Impl: Sized {
     fn GetNumberSymbols(&self) -> ::windows::core::Result<u32>;
@@ -23475,6 +23657,7 @@ impl IDebugSymbolGroup2_Vtbl {
         iid == &<IDebugSymbolGroup2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugSymbols_Impl: Sized {
     fn GetSymbolOptions(&self) -> ::windows::core::Result<u32>;
@@ -23913,6 +24096,7 @@ impl IDebugSymbols_Vtbl {
         iid == &<IDebugSymbols as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugSymbols2_Impl: Sized {
     fn GetSymbolOptions(&self) -> ::windows::core::Result<u32>;
@@ -24413,6 +24597,7 @@ impl IDebugSymbols2_Vtbl {
         iid == &<IDebugSymbols2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugSymbols3_Impl: Sized {
     fn GetSymbolOptions(&self) -> ::windows::core::Result<u32>;
@@ -25453,6 +25638,7 @@ impl IDebugSymbols3_Vtbl {
         iid == &<IDebugSymbols3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugSymbols4_Impl: Sized {
     fn GetSymbolOptions(&self) -> ::windows::core::Result<u32>;
@@ -26542,6 +26728,7 @@ impl IDebugSymbols4_Vtbl {
         iid == &<IDebugSymbols4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDebugSymbols5_Impl: Sized {
     fn GetSymbolOptions(&self) -> ::windows::core::Result<u32>;
@@ -27651,6 +27838,7 @@ impl IDebugSymbols5_Vtbl {
         iid == &<IDebugSymbols5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugSyncOperation_Impl: Sized {
     fn GetTargetThread(&self) -> ::windows::core::Result<IDebugApplicationThread>;
     fn Execute(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -27697,6 +27885,7 @@ impl IDebugSyncOperation_Vtbl {
         iid == &<IDebugSyncOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugSystemObjects_Impl: Sized {
     fn GetEventThread(&self) -> ::windows::core::Result<u32>;
     fn GetEventProcess(&self) -> ::windows::core::Result<u32>;
@@ -28051,6 +28240,7 @@ impl IDebugSystemObjects_Vtbl {
         iid == &<IDebugSystemObjects as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugSystemObjects2_Impl: Sized {
     fn GetEventThread(&self) -> ::windows::core::Result<u32>;
     fn GetEventProcess(&self) -> ::windows::core::Result<u32>;
@@ -28458,6 +28648,7 @@ impl IDebugSystemObjects2_Vtbl {
         iid == &<IDebugSystemObjects2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugSystemObjects3_Impl: Sized {
     fn GetEventThread(&self) -> ::windows::core::Result<u32>;
     fn GetEventProcess(&self) -> ::windows::core::Result<u32>;
@@ -28958,6 +29149,7 @@ impl IDebugSystemObjects3_Vtbl {
         iid == &<IDebugSystemObjects3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugSystemObjects4_Impl: Sized {
     fn GetEventThread(&self) -> ::windows::core::Result<u32>;
     fn GetEventProcess(&self) -> ::windows::core::Result<u32>;
@@ -29472,6 +29664,7 @@ impl IDebugSystemObjects4_Vtbl {
         iid == &<IDebugSystemObjects4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugThreadCall32_Impl: Sized {
     fn ThreadCallHandler(&self, dwparam1: u32, dwparam2: u32, dwparam3: u32) -> ::windows::core::Result<()>;
 }
@@ -29489,6 +29682,7 @@ impl IDebugThreadCall32_Vtbl {
         iid == &<IDebugThreadCall32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDebugThreadCall64_Impl: Sized {
     fn ThreadCallHandler(&self, dwparam1: u64, dwparam2: u64, dwparam3: u64) -> ::windows::core::Result<()>;
 }
@@ -29506,6 +29700,7 @@ impl IDebugThreadCall64_Vtbl {
         iid == &<IDebugThreadCall64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDynamicConceptProviderConcept_Impl: Sized {
     fn GetConcept(&self, contextobject: &::core::option::Option<IModelObject>, conceptid: *const ::windows::core::GUID, conceptinterface: *mut ::core::option::Option<::windows::core::IUnknown>, conceptmetadata: *mut ::core::option::Option<IKeyStore>, hasconcept: *mut bool) -> ::windows::core::Result<()>;
     fn SetConcept(&self, contextobject: &::core::option::Option<IModelObject>, conceptid: *const ::windows::core::GUID, conceptinterface: &::core::option::Option<::windows::core::IUnknown>, conceptmetadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -29554,6 +29749,7 @@ impl IDynamicConceptProviderConcept_Vtbl {
         iid == &<IDynamicConceptProviderConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IDynamicKeyProviderConcept_Impl: Sized {
     fn GetKey(&self, contextobject: &::core::option::Option<IModelObject>, key: &::windows::core::PCWSTR, keyvalue: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>, haskey: *mut bool) -> ::windows::core::Result<()>;
     fn SetKey(&self, contextobject: &::core::option::Option<IModelObject>, key: &::windows::core::PCWSTR, keyvalue: &::core::option::Option<IModelObject>, metadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -29594,6 +29790,7 @@ impl IDynamicKeyProviderConcept_Vtbl {
         iid == &<IDynamicKeyProviderConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEnumDebugApplicationNodes_Impl: Sized {
     fn Next(&self, celt: u32, pprddp: *mut ::core::option::Option<IDebugApplicationNode>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -29641,6 +29838,7 @@ impl IEnumDebugApplicationNodes_Vtbl {
         iid == &<IEnumDebugApplicationNodes as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEnumDebugCodeContexts_Impl: Sized {
     fn Next(&self, celt: u32, pscc: *mut ::core::option::Option<IDebugCodeContext>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -29688,6 +29886,7 @@ impl IEnumDebugCodeContexts_Vtbl {
         iid == &<IEnumDebugCodeContexts as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEnumDebugExpressionContexts_Impl: Sized {
     fn Next(&self, celt: u32, ppdec: *mut ::core::option::Option<IDebugExpressionContext>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -29735,6 +29934,7 @@ impl IEnumDebugExpressionContexts_Vtbl {
         iid == &<IEnumDebugExpressionContexts as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IEnumDebugExtendedPropertyInfo_Impl: Sized {
     fn Next(&self, celt: u32, rgextendedpropertyinfo: *mut ExtendedDebugPropertyInfo, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -29798,6 +29998,7 @@ impl IEnumDebugExtendedPropertyInfo_Vtbl {
         iid == &<IEnumDebugExtendedPropertyInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEnumDebugPropertyInfo_Impl: Sized {
     fn Next(&self, celt: u32, pi: *mut DebugPropertyInfo, pceltsfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -29858,6 +30059,7 @@ impl IEnumDebugPropertyInfo_Vtbl {
         iid == &<IEnumDebugPropertyInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnumDebugStackFrames_Impl: Sized {
     fn Next(&self, celt: u32, prgdsfd: *mut DebugStackFrameDescriptor, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -29908,6 +30110,7 @@ impl IEnumDebugStackFrames_Vtbl {
         iid == &<IEnumDebugStackFrames as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnumDebugStackFrames64_Impl: Sized + IEnumDebugStackFrames_Impl {
     fn Next64(&self, celt: u32, prgdsfd: *mut DebugStackFrameDescriptor64, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -29928,6 +30131,7 @@ impl IEnumDebugStackFrames64_Vtbl {
         iid == &<IEnumDebugStackFrames64 as ::windows::core::Interface>::IID || iid == &<IEnumDebugStackFrames as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEnumJsStackFrames_Impl: Sized {
     fn Next(&self, cframecount: u32, pframes: *mut JS_NATIVE_FRAME, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -29951,6 +30155,7 @@ impl IEnumJsStackFrames_Vtbl {
         iid == &<IEnumJsStackFrames as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEnumRemoteDebugApplicationThreads_Impl: Sized {
     fn Next(&self, celt: u32, pprdat: *mut ::core::option::Option<IRemoteDebugApplicationThread>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -29998,6 +30203,7 @@ impl IEnumRemoteDebugApplicationThreads_Vtbl {
         iid == &<IEnumRemoteDebugApplicationThreads as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEnumRemoteDebugApplications_Impl: Sized {
     fn Next(&self, celt: u32, ppda: *mut ::core::option::Option<IRemoteDebugApplication>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -30045,6 +30251,7 @@ impl IEnumRemoteDebugApplications_Vtbl {
         iid == &<IEnumRemoteDebugApplications as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IEquatableConcept_Impl: Sized {
     fn AreObjectsEqual(&self, contextobject: &::core::option::Option<IModelObject>, otherobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<bool>;
 }
@@ -30068,6 +30275,7 @@ impl IEquatableConcept_Vtbl {
         iid == &<IEquatableConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IHostDataModelAccess_Impl: Sized {
     fn GetDataModel(&self, manager: *mut ::core::option::Option<IDataModelManager>, host: *mut ::core::option::Option<IDebugHost>) -> ::windows::core::Result<()>;
 }
@@ -30085,6 +30293,7 @@ impl IHostDataModelAccess_Vtbl {
         iid == &<IHostDataModelAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IIndexableConcept_Impl: Sized {
     fn GetDimensionality(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<u64>;
     fn GetAt(&self, contextobject: &::core::option::Option<IModelObject>, indexercount: u64, indexers: *const ::core::option::Option<IModelObject>, object: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -30125,6 +30334,7 @@ impl IIndexableConcept_Vtbl {
         iid == &<IIndexableConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IIterableConcept_Impl: Sized {
     fn GetDefaultIndexDimensionality(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<u64>;
     fn GetIterator(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IModelIterator>;
@@ -30164,6 +30374,7 @@ impl IIterableConcept_Vtbl {
         iid == &<IIterableConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IJsDebug_Impl: Sized {
     fn OpenVirtualProcess(&self, processid: u32, runtimejsbaseaddress: u64, pdatatarget: &::core::option::Option<IJsDebugDataTarget>) -> ::windows::core::Result<IJsDebugProcess>;
 }
@@ -30187,6 +30398,7 @@ impl IJsDebug_Vtbl {
         iid == &<IJsDebug as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IJsDebugBreakPoint_Impl: Sized {
     fn IsEnabled(&self) -> ::windows::core::Result<super::super::super::Foundation::BOOL>;
@@ -30244,6 +30456,7 @@ impl IJsDebugBreakPoint_Vtbl {
         iid == &<IJsDebugBreakPoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IJsDebugDataTarget_Impl: Sized {
     fn ReadMemory(&self, address: u64, flags: JsDebugReadMemoryFlags, pbuffer: *mut u8, size: u32, pbytesread: *mut u32) -> ::windows::core::Result<()>;
     fn WriteMemory(&self, address: u64, pmemory: *const u8, size: u32) -> ::windows::core::Result<()>;
@@ -30350,6 +30563,7 @@ impl IJsDebugDataTarget_Vtbl {
         iid == &<IJsDebugDataTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IJsDebugFrame_Impl: Sized {
     fn GetStackRange(&self, pstart: *mut u64, pend: *mut u64) -> ::windows::core::Result<()>;
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -30430,6 +30644,7 @@ impl IJsDebugFrame_Vtbl {
         iid == &<IJsDebugFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IJsDebugProcess_Impl: Sized {
     fn CreateStackWalker(&self, threadid: u32) -> ::windows::core::Result<IJsDebugStackWalker>;
@@ -30492,6 +30707,7 @@ impl IJsDebugProcess_Vtbl {
         iid == &<IJsDebugProcess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IJsDebugProperty_Impl: Sized {
     fn GetPropertyInfo(&self, nradix: u32) -> ::windows::core::Result<JsDebugPropertyInfo>;
     fn GetMembers(&self, members: JS_PROPERTY_MEMBERS) -> ::windows::core::Result<IJsEnumDebugProperty>;
@@ -30531,6 +30747,7 @@ impl IJsDebugProperty_Vtbl {
         iid == &<IJsDebugProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IJsDebugStackWalker_Impl: Sized {
     fn GetNext(&self) -> ::windows::core::Result<IJsDebugFrame>;
 }
@@ -30554,6 +30771,7 @@ impl IJsDebugStackWalker_Vtbl {
         iid == &<IJsDebugStackWalker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IJsEnumDebugProperty_Impl: Sized {
     fn Next(&self, count: u32, ppdebugproperty: *mut ::core::option::Option<IJsDebugProperty>, pactualcount: *mut u32) -> ::windows::core::Result<()>;
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -30587,6 +30805,7 @@ impl IJsEnumDebugProperty_Vtbl {
         iid == &<IJsEnumDebugProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IKeyEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self, key: *mut ::windows::core::BSTR, value: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -30614,6 +30833,7 @@ impl IKeyEnumerator_Vtbl {
         iid == &<IKeyEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IKeyStore_Impl: Sized {
     fn GetKey(&self, key: &::windows::core::PCWSTR, object: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
     fn SetKey(&self, key: &::windows::core::PCWSTR, object: &::core::option::Option<IModelObject>, metadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -30662,6 +30882,7 @@ impl IKeyStore_Vtbl {
         iid == &<IKeyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IMachineDebugManager_Impl: Sized {
     fn AddApplication(&self, pda: &::core::option::Option<IRemoteDebugApplication>) -> ::windows::core::Result<u32>;
     fn RemoveApplication(&self, dwappcookie: u32) -> ::windows::core::Result<()>;
@@ -30708,6 +30929,7 @@ impl IMachineDebugManager_Vtbl {
         iid == &<IMachineDebugManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IMachineDebugManagerCookie_Impl: Sized {
     fn AddApplication(&self, pda: &::core::option::Option<IRemoteDebugApplication>, dwdebugappcookie: u32) -> ::windows::core::Result<u32>;
     fn RemoveApplication(&self, dwdebugappcookie: u32, dwappcookie: u32) -> ::windows::core::Result<()>;
@@ -30754,6 +30976,7 @@ impl IMachineDebugManagerCookie_Vtbl {
         iid == &<IMachineDebugManagerCookie as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IMachineDebugManagerEvents_Impl: Sized {
     fn onAddApplication(&self, pda: &::core::option::Option<IRemoteDebugApplication>, dwappcookie: u32) -> ::windows::core::Result<()>;
     fn onRemoveApplication(&self, pda: &::core::option::Option<IRemoteDebugApplication>, dwappcookie: u32) -> ::windows::core::Result<()>;
@@ -30781,6 +31004,7 @@ impl IMachineDebugManagerEvents_Vtbl {
         iid == &<IMachineDebugManagerEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IModelIterator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self, object: *mut ::core::option::Option<IModelObject>, dimensions: u64, indexers: *mut ::core::option::Option<IModelObject>, metadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
@@ -30808,6 +31032,7 @@ impl IModelIterator_Vtbl {
         iid == &<IModelIterator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IModelKeyReference_Impl: Sized {
     fn GetKeyName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetOriginalObject(&self) -> ::windows::core::Result<IModelObject>;
@@ -30888,6 +31113,7 @@ impl IModelKeyReference_Vtbl {
         iid == &<IModelKeyReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IModelKeyReference2_Impl: Sized + IModelKeyReference_Impl {
     fn OverrideContextObject(&self, newcontextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
 }
@@ -30905,6 +31131,7 @@ impl IModelKeyReference2_Vtbl {
         iid == &<IModelKeyReference2 as ::windows::core::Interface>::IID || iid == &<IModelKeyReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IModelMethod_Impl: Sized {
     fn Call(&self, pcontextobject: &::core::option::Option<IModelObject>, argcount: u64, pparguments: *const ::core::option::Option<IModelObject>, ppresult: *mut ::core::option::Option<IModelObject>, ppmetadata: *mut ::core::option::Option<IKeyStore>) -> ::windows::core::Result<()>;
 }
@@ -30922,6 +31149,7 @@ impl IModelMethod_Vtbl {
         iid == &<IModelMethod as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IModelObject_Impl: Sized {
     fn GetContext(&self, context: *mut ::core::option::Option<IDebugHostContext>) -> ::windows::core::Result<()>;
@@ -31271,6 +31499,7 @@ impl IModelObject_Vtbl {
         iid == &<IModelObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IModelPropertyAccessor_Impl: Sized {
     fn GetValue(&self, key: &::windows::core::PCWSTR, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IModelObject>;
     fn SetValue(&self, key: &::windows::core::PCWSTR, contextobject: &::core::option::Option<IModelObject>, value: &::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
@@ -31304,6 +31533,7 @@ impl IModelPropertyAccessor_Vtbl {
         iid == &<IModelPropertyAccessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IObjectSafety_Impl: Sized {
     fn GetInterfaceSafetyOptions(&self, riid: *const ::windows::core::GUID, pdwsupportedoptions: *mut u32, pdwenabledoptions: *mut u32) -> ::windows::core::Result<()>;
     fn SetInterfaceSafetyOptions(&self, riid: *const ::windows::core::GUID, dwoptionsetmask: u32, dwenabledoptions: u32) -> ::windows::core::Result<()>;
@@ -31331,6 +31561,7 @@ impl IObjectSafety_Vtbl {
         iid == &<IObjectSafety as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Ole")]
 pub trait IPerPropertyBrowsing2_Impl: Sized {
     fn GetDisplayString(&self, dispid: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -31387,6 +31618,7 @@ impl IPerPropertyBrowsing2_Vtbl {
         iid == &<IPerPropertyBrowsing2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IPreferredRuntimeTypeConcept_Impl: Sized {
     fn CastToPreferredRuntimeType(&self, contextobject: &::core::option::Option<IModelObject>) -> ::windows::core::Result<IModelObject>;
 }
@@ -31413,6 +31645,7 @@ impl IPreferredRuntimeTypeConcept_Vtbl {
         iid == &<IPreferredRuntimeTypeConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IProcessDebugManager32_Impl: Sized {
     fn CreateApplication(&self) -> ::windows::core::Result<IDebugApplication32>;
     fn GetDefaultApplication(&self) -> ::windows::core::Result<IDebugApplication32>;
@@ -31485,6 +31718,7 @@ impl IProcessDebugManager32_Vtbl {
         iid == &<IProcessDebugManager32 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IProcessDebugManager64_Impl: Sized {
     fn CreateApplication(&self) -> ::windows::core::Result<IDebugApplication64>;
     fn GetDefaultApplication(&self) -> ::windows::core::Result<IDebugApplication64>;
@@ -31557,6 +31791,7 @@ impl IProcessDebugManager64_Vtbl {
         iid == &<IProcessDebugManager64 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IProvideExpressionContexts_Impl: Sized {
     fn EnumExpressionContexts(&self) -> ::windows::core::Result<IEnumDebugExpressionContexts>;
 }
@@ -31580,6 +31815,7 @@ impl IProvideExpressionContexts_Vtbl {
         iid == &<IProvideExpressionContexts as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IRawEnumerator_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn GetNext(&self, name: *mut ::windows::core::BSTR, kind: *mut SymbolKind, value: *mut ::core::option::Option<IModelObject>) -> ::windows::core::Result<()>;
@@ -31607,6 +31843,7 @@ impl IRawEnumerator_Vtbl {
         iid == &<IRawEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IRemoteDebugApplication_Impl: Sized {
     fn ResumeFromBreakPoint(&self, prptfocus: &::core::option::Option<IRemoteDebugApplicationThread>, bra: BREAKRESUMEACTION, era: ERRORRESUMEACTION) -> ::windows::core::Result<()>;
     fn CauseBreak(&self) -> ::windows::core::Result<()>;
@@ -31733,6 +31970,7 @@ impl IRemoteDebugApplication_Vtbl {
         iid == &<IRemoteDebugApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IRemoteDebugApplication110_Impl: Sized {
     fn SetDebuggerOptions(&self, mask: SCRIPT_DEBUGGER_OPTIONS, value: SCRIPT_DEBUGGER_OPTIONS) -> ::windows::core::Result<()>;
     fn GetCurrentDebuggerOptions(&self) -> ::windows::core::Result<SCRIPT_DEBUGGER_OPTIONS>;
@@ -31779,6 +32017,7 @@ impl IRemoteDebugApplication110_Vtbl {
         iid == &<IRemoteDebugApplication110 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IRemoteDebugApplicationEvents_Impl: Sized {
     fn OnConnectDebugger(&self, pad: &::core::option::Option<IApplicationDebugger>) -> ::windows::core::Result<()>;
     fn OnDisconnectDebugger(&self) -> ::windows::core::Result<()>;
@@ -31862,6 +32101,7 @@ impl IRemoteDebugApplicationEvents_Vtbl {
         iid == &<IRemoteDebugApplicationEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IRemoteDebugApplicationThread_Impl: Sized {
     fn GetSystemThreadId(&self) -> ::windows::core::Result<u32>;
     fn GetApplication(&self) -> ::windows::core::Result<IRemoteDebugApplication>;
@@ -31980,6 +32220,7 @@ impl IRemoteDebugApplicationThread_Vtbl {
         iid == &<IRemoteDebugApplicationThread as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IRemoteDebugCriticalErrorEvent110_Impl: Sized {
     fn GetErrorInfo(&self, pbstrsource: *mut ::windows::core::BSTR, pmessageid: *mut i32, pbstrmessage: *mut ::windows::core::BSTR, pplocation: *mut ::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
 }
@@ -31997,6 +32238,7 @@ impl IRemoteDebugCriticalErrorEvent110_Vtbl {
         iid == &<IRemoteDebugCriticalErrorEvent110 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IRemoteDebugInfoEvent110_Impl: Sized {
     fn GetEventInfo(&self, pmessagetype: *mut DEBUG_EVENT_INFO_TYPE, pbstrmessage: *mut ::windows::core::BSTR, pbstrurl: *mut ::windows::core::BSTR, pplocation: *mut ::core::option::Option<IDebugDocumentContext>) -> ::windows::core::Result<()>;
 }
@@ -32014,6 +32256,7 @@ impl IRemoteDebugInfoEvent110_Vtbl {
         iid == &<IRemoteDebugInfoEvent110 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IScriptEntry_Impl: Sized + IScriptNode_Impl {
     fn GetText(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -32131,6 +32374,7 @@ impl IScriptEntry_Vtbl {
         iid == &<IScriptEntry as ::windows::core::Interface>::IID || iid == &<IScriptNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IScriptInvocationContext_Impl: Sized {
     fn GetContextType(&self) -> ::windows::core::Result<SCRIPT_INVOCATION_CONTEXT_TYPE>;
     fn GetContextDescription(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -32183,6 +32427,7 @@ impl IScriptInvocationContext_Vtbl {
         iid == &<IScriptInvocationContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IScriptNode_Impl: Sized {
     fn Alive(&self) -> ::windows::core::Result<()>;
@@ -32317,6 +32562,7 @@ impl IScriptNode_Vtbl {
         iid == &<IScriptNode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IScriptScriptlet_Impl: Sized + IScriptEntry_Impl {
     fn GetSubItemName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -32393,6 +32639,7 @@ impl IScriptScriptlet_Vtbl {
         iid == &<IScriptScriptlet as ::windows::core::Interface>::IID || iid == &<IScriptNode as ::windows::core::Interface>::IID || iid == &<IScriptEntry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISimpleConnectionPoint_Impl: Sized {
     fn GetEventCount(&self) -> ::windows::core::Result<u32>;
@@ -32449,6 +32696,7 @@ impl ISimpleConnectionPoint_Vtbl {
         iid == &<ISimpleConnectionPoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"implement\"`*"]
 pub trait IStringDisplayableConcept_Impl: Sized {
     fn ToDisplayString(&self, contextobject: &::core::option::Option<IModelObject>, metadata: &::core::option::Option<IKeyStore>) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -32472,6 +32720,7 @@ impl IStringDisplayableConcept_Vtbl {
         iid == &<IStringDisplayableConcept as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITridentEventSink_Impl: Sized {
     fn FireEvent(&self, pstrevent: &::windows::core::PCWSTR, pdp: *const super::super::Com::DISPPARAMS, pvarres: *mut super::super::Com::VARIANT, pei: *mut super::super::Com::EXCEPINFO) -> ::windows::core::Result<()>;
@@ -32492,6 +32741,7 @@ impl ITridentEventSink_Vtbl {
         iid == &<ITridentEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWebAppDiagnosticsObjectInitialization_Impl: Sized {
     fn Initialize(&self, hpassedhandle: super::super::super::Foundation::HANDLE_PTR, pdebugapplication: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -32512,6 +32762,7 @@ impl IWebAppDiagnosticsObjectInitialization_Vtbl {
         iid == &<IWebAppDiagnosticsObjectInitialization as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWebAppDiagnosticsSetup_Impl: Sized {
     fn DiagnosticsSupported(&self) -> ::windows::core::Result<super::super::super::Foundation::VARIANT_BOOL>;

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Etw\"`, `\"implement\"`*"]
 pub trait ITraceEvent_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<ITraceEvent>;
     fn GetUserContext(&self) -> ::windows::core::Result<*mut ::core::ffi::c_void>;
@@ -113,6 +114,7 @@ impl ITraceEvent_Vtbl {
         iid == &<ITraceEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Etw\"`, `\"implement\"`*"]
 pub trait ITraceEventCallback_Impl: Sized {
     fn OnBeginProcessTrace(&self, headerevent: &::core::option::Option<ITraceEvent>, relogger: &::core::option::Option<ITraceRelogger>) -> ::windows::core::Result<()>;
     fn OnFinalizeProcessTrace(&self, relogger: &::core::option::Option<ITraceRelogger>) -> ::windows::core::Result<()>;
@@ -147,6 +149,7 @@ impl ITraceEventCallback_Vtbl {
         iid == &<ITraceEventCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Diagnostics_Etw\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITraceRelogger_Impl: Sized {
     fn AddLogfileTraceStream(&self, logfilename: &::windows::core::BSTR, usercontext: *const ::core::ffi::c_void) -> ::windows::core::Result<RELOGSTREAM_HANDLE>;

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuConfigure_Impl: Sized {
     fn Add(&self, puclupair: *const u8, cblupair: u32) -> ::windows::core::Result<()>;
     fn Delete(&self, puclupair: *const u8, cblupair: u32) -> ::windows::core::Result<()>;
@@ -21,6 +22,7 @@ impl IDtcLuConfigure_Vtbl {
         iid == &<IDtcLuConfigure as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRecovery_Impl: Sized {}
 impl ::windows::core::RuntimeName for IDtcLuRecovery {}
 impl IDtcLuRecovery_Vtbl {
@@ -31,6 +33,7 @@ impl IDtcLuRecovery_Vtbl {
         iid == &<IDtcLuRecovery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRecoveryFactory_Impl: Sized {
     fn Create(&self, puclupair: *const u8, cblupair: u32) -> ::windows::core::Result<IDtcLuRecovery>;
 }
@@ -54,6 +57,7 @@ impl IDtcLuRecoveryFactory_Vtbl {
         iid == &<IDtcLuRecoveryFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRecoveryInitiatedByDtc_Impl: Sized {
     fn GetWork(&self, pwork: *mut DTCINITIATEDRECOVERYWORK, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -71,6 +75,7 @@ impl IDtcLuRecoveryInitiatedByDtc_Vtbl {
         iid == &<IDtcLuRecoveryInitiatedByDtc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRecoveryInitiatedByDtcStatusWork_Impl: Sized {
     fn HandleCheckLuStatus(&self, lrecoveryseqnum: i32) -> ::windows::core::Result<()>;
 }
@@ -88,6 +93,7 @@ impl IDtcLuRecoveryInitiatedByDtcStatusWork_Vtbl {
         iid == &<IDtcLuRecoveryInitiatedByDtcStatusWork as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcLuRecoveryInitiatedByDtcTransWork_Impl: Sized {
     fn GetLogNameSizes(&self, pcbourlogname: *mut u32, pcbremotelogname: *mut u32) -> ::windows::core::Result<()>;
@@ -195,6 +201,7 @@ impl IDtcLuRecoveryInitiatedByDtcTransWork_Vtbl {
         iid == &<IDtcLuRecoveryInitiatedByDtcTransWork as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRecoveryInitiatedByLu_Impl: Sized {
     fn GetObjectToHandleWorkFromLu(&self) -> ::windows::core::Result<IDtcLuRecoveryInitiatedByLuWork>;
 }
@@ -221,6 +228,7 @@ impl IDtcLuRecoveryInitiatedByLu_Vtbl {
         iid == &<IDtcLuRecoveryInitiatedByLu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRecoveryInitiatedByLuWork_Impl: Sized {
     fn HandleTheirXln(&self, lrecoveryseqnum: i32, xln: DTCLUXLN, premotelogname: *mut u8, cbremotelogname: u32, pourlogname: *mut u8, cbourlogname: u32, dwprotocol: u32, presponse: *mut DTCLUXLNRESPONSE) -> ::windows::core::Result<()>;
     fn GetOurLogNameSize(&self, pcbourlogname: *mut u32) -> ::windows::core::Result<()>;
@@ -290,6 +298,7 @@ impl IDtcLuRecoveryInitiatedByLuWork_Vtbl {
         iid == &<IDtcLuRecoveryInitiatedByLuWork as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcLuRmEnlistment_Impl: Sized {
     fn Unplug(&self, fconversationlost: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -348,6 +357,7 @@ impl IDtcLuRmEnlistment_Vtbl {
         iid == &<IDtcLuRmEnlistment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRmEnlistmentFactory_Impl: Sized {
     fn Create(&self, puclupair: *mut u8, cblupair: u32, pitransaction: &::core::option::Option<ITransaction>, ptransid: *mut u8, cbtransid: u32, prmenlistmentsink: &::core::option::Option<IDtcLuRmEnlistmentSink>, pprmenlistment: *mut ::core::option::Option<IDtcLuRmEnlistment>) -> ::windows::core::Result<()>;
 }
@@ -365,6 +375,7 @@ impl IDtcLuRmEnlistmentFactory_Vtbl {
         iid == &<IDtcLuRmEnlistmentFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuRmEnlistmentSink_Impl: Sized {
     fn AckUnplug(&self) -> ::windows::core::Result<()>;
     fn TmDown(&self) -> ::windows::core::Result<()>;
@@ -441,6 +452,7 @@ impl IDtcLuRmEnlistmentSink_Vtbl {
         iid == &<IDtcLuRmEnlistmentSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcLuSubordinateDtc_Impl: Sized {
     fn Unplug(&self, fconversationlost: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -506,6 +518,7 @@ impl IDtcLuSubordinateDtc_Vtbl {
         iid == &<IDtcLuSubordinateDtc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuSubordinateDtcFactory_Impl: Sized {
     fn Create(&self, puclupair: *mut u8, cblupair: u32, punktransactionouter: &::core::option::Option<::windows::core::IUnknown>, isolevel: i32, isoflags: u32, poptions: &::core::option::Option<ITransactionOptions>, pptransaction: *mut ::core::option::Option<ITransaction>, ptransid: *mut u8, cbtransid: u32, psubordinatedtcsink: &::core::option::Option<IDtcLuSubordinateDtcSink>, ppsubordinatedtc: *mut ::core::option::Option<IDtcLuSubordinateDtc>) -> ::windows::core::Result<()>;
 }
@@ -524,6 +537,7 @@ impl IDtcLuSubordinateDtcFactory_Vtbl {
         iid == &<IDtcLuSubordinateDtcFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcLuSubordinateDtcSink_Impl: Sized {
     fn AckUnplug(&self) -> ::windows::core::Result<()>;
     fn TmDown(&self) -> ::windows::core::Result<()>;
@@ -593,6 +607,7 @@ impl IDtcLuSubordinateDtcSink_Vtbl {
         iid == &<IDtcLuSubordinateDtcSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcNetworkAccessConfig_Impl: Sized {
     fn GetAnyNetworkAccess(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -736,6 +751,7 @@ impl IDtcNetworkAccessConfig_Vtbl {
         iid == &<IDtcNetworkAccessConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcNetworkAccessConfig2_Impl: Sized + IDtcNetworkAccessConfig_Impl {
     fn GetNetworkInboundAccess(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -812,6 +828,7 @@ impl IDtcNetworkAccessConfig2_Vtbl {
         iid == &<IDtcNetworkAccessConfig2 as ::windows::core::Interface>::IID || iid == &<IDtcNetworkAccessConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcNetworkAccessConfig3_Impl: Sized + IDtcNetworkAccessConfig2_Impl {
     fn GetLUAccess(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -848,6 +865,7 @@ impl IDtcNetworkAccessConfig3_Vtbl {
         iid == &<IDtcNetworkAccessConfig3 as ::windows::core::Interface>::IID || iid == &<IDtcNetworkAccessConfig as ::windows::core::Interface>::IID || iid == &<IDtcNetworkAccessConfig2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcToXaHelper_Impl: Sized {
     fn Close(&self, i_fdorecovery: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -884,6 +902,7 @@ impl IDtcToXaHelper_Vtbl {
         iid == &<IDtcToXaHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IDtcToXaHelperFactory_Impl: Sized {
     fn Create(&self, pszdsn: &::windows::core::PCSTR, pszclientdllname: &::windows::core::PCSTR, pguidrm: *mut ::windows::core::GUID, ppxahelper: *mut ::core::option::Option<IDtcToXaHelper>) -> ::windows::core::Result<()>;
 }
@@ -901,6 +920,7 @@ impl IDtcToXaHelperFactory_Vtbl {
         iid == &<IDtcToXaHelperFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcToXaHelperSinglePipe_Impl: Sized {
     fn XARMCreate(&self, pszdsn: &::windows::core::PCSTR, pszclientdll: &::windows::core::PCSTR, pdwrmcookie: *mut u32) -> ::windows::core::Result<()>;
@@ -951,6 +971,7 @@ impl IDtcToXaHelperSinglePipe_Vtbl {
         iid == &<IDtcToXaHelperSinglePipe as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDtcToXaMapper_Impl: Sized {
     fn RequestNewResourceManager(&self, pszdsn: &::windows::core::PCSTR, pszclientdllname: &::windows::core::PCSTR, pdwrmcookie: *mut u32) -> ::windows::core::Result<()>;
@@ -995,6 +1016,7 @@ impl IDtcToXaMapper_Vtbl {
         iid == &<IDtcToXaMapper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IGetDispenser_Impl: Sized {
     fn GetDispenser(&self, iid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1012,6 +1034,7 @@ impl IGetDispenser_Vtbl {
         iid == &<IGetDispenser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IKernelTransaction_Impl: Sized {
     fn GetHandle(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -1038,6 +1061,7 @@ impl IKernelTransaction_Vtbl {
         iid == &<IKernelTransaction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ILastResourceManager_Impl: Sized {
     fn TransactionCommitted(&self, pprepinfo: *const u8, cbprepinfo: u32) -> ::windows::core::Result<()>;
     fn RecoveryDone(&self) -> ::windows::core::Result<()>;
@@ -1065,6 +1089,7 @@ impl ILastResourceManager_Vtbl {
         iid == &<ILastResourceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IPrepareInfo_Impl: Sized {
     fn GetPrepareInfoSize(&self, pcbprepinfo: *mut u32) -> ::windows::core::Result<()>;
     fn GetPrepareInfo(&self, pprepinfo: *mut u8) -> ::windows::core::Result<()>;
@@ -1092,6 +1117,7 @@ impl IPrepareInfo_Vtbl {
         iid == &<IPrepareInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IPrepareInfo2_Impl: Sized {
     fn GetPrepareInfoSize(&self) -> ::windows::core::Result<u32>;
     fn GetPrepareInfo(&self, cbprepareinfo: u32, pprepinfo: *mut u8) -> ::windows::core::Result<()>;
@@ -1125,6 +1151,7 @@ impl IPrepareInfo2_Vtbl {
         iid == &<IPrepareInfo2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRMHelper_Impl: Sized {
     fn RMCount(&self, dwctotalnumberofrms: u32) -> ::windows::core::Result<()>;
@@ -1155,6 +1182,7 @@ impl IRMHelper_Vtbl {
         iid == &<IRMHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IResourceManager_Impl: Sized {
     fn Enlist(&self, ptransaction: &::core::option::Option<ITransaction>, pres: &::core::option::Option<ITransactionResourceAsync>, puow: *mut BOID, pisolevel: *mut i32, ppenlist: *mut ::core::option::Option<ITransactionEnlistmentAsync>) -> ::windows::core::Result<()>;
     fn Reenlist(&self, pprepinfo: *const u8, cbprepinfo: u32, ltimeout: u32) -> ::windows::core::Result<XACTSTAT>;
@@ -1202,6 +1230,7 @@ impl IResourceManager_Vtbl {
         iid == &<IResourceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResourceManager2_Impl: Sized + IResourceManager_Impl {
     fn Enlist2(&self, ptransaction: &::core::option::Option<ITransaction>, presasync: &::core::option::Option<ITransactionResourceAsync>, puow: *mut BOID, pisolevel: *mut i32, pxid: *mut XID, ppenlist: *mut ::core::option::Option<ITransactionEnlistmentAsync>) -> ::windows::core::Result<()>;
@@ -1238,6 +1267,7 @@ impl IResourceManager2_Vtbl {
         iid == &<IResourceManager2 as ::windows::core::Interface>::IID || iid == &<IResourceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IResourceManagerFactory_Impl: Sized {
     fn Create(&self, pguidrm: *const ::windows::core::GUID, pszrmname: &::windows::core::PCSTR, piresmgrsink: &::core::option::Option<IResourceManagerSink>) -> ::windows::core::Result<IResourceManager>;
 }
@@ -1261,6 +1291,7 @@ impl IResourceManagerFactory_Vtbl {
         iid == &<IResourceManagerFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IResourceManagerFactory2_Impl: Sized + IResourceManagerFactory_Impl {
     fn CreateEx(&self, pguidrm: *const ::windows::core::GUID, pszrmname: &::windows::core::PCSTR, piresmgrsink: &::core::option::Option<IResourceManagerSink>, riidrequested: *const ::windows::core::GUID, ppvresmgr: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1278,6 +1309,7 @@ impl IResourceManagerFactory2_Vtbl {
         iid == &<IResourceManagerFactory2 as ::windows::core::Interface>::IID || iid == &<IResourceManagerFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResourceManagerRejoinable_Impl: Sized + IResourceManager2_Impl {
     fn Rejoin(&self, pprepinfo: *const u8, cbprepinfo: u32, ltimeout: u32) -> ::windows::core::Result<XACTSTAT>;
@@ -1304,6 +1336,7 @@ impl IResourceManagerRejoinable_Vtbl {
         iid == &<IResourceManagerRejoinable as ::windows::core::Interface>::IID || iid == &<IResourceManager as ::windows::core::Interface>::IID || iid == &<IResourceManager2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IResourceManagerSink_Impl: Sized {
     fn TMDown(&self) -> ::windows::core::Result<()>;
 }
@@ -1321,6 +1354,7 @@ impl IResourceManagerSink_Vtbl {
         iid == &<IResourceManagerSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITipHelper_Impl: Sized {
     fn Pull(&self, i_psztxurl: *const u8) -> ::windows::core::Result<ITransaction>;
     fn PullAsync(&self, i_psztxurl: *const u8, i_ptippullsink: &::core::option::Option<ITipPullSink>) -> ::windows::core::Result<ITransaction>;
@@ -1373,6 +1407,7 @@ impl ITipHelper_Vtbl {
         iid == &<ITipHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITipPullSink_Impl: Sized {
     fn PullComplete(&self, i_hrpull: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
 }
@@ -1390,6 +1425,7 @@ impl ITipPullSink_Vtbl {
         iid == &<ITipPullSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITipTransaction_Impl: Sized {
     fn Push(&self, i_pszremotetmurl: *const u8) -> ::windows::core::Result<::windows::core::PSTR>;
     fn GetTransactionUrl(&self) -> ::windows::core::Result<::windows::core::PSTR>;
@@ -1429,6 +1465,7 @@ impl ITipTransaction_Vtbl {
         iid == &<ITipTransaction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITmNodeName_Impl: Sized {
     fn GetNodeNameSize(&self) -> ::windows::core::Result<u32>;
     fn GetNodeName(&self, cbnodenamebuffersize: u32, pnodenamebuffer: &::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -1462,6 +1499,7 @@ impl ITmNodeName_Vtbl {
         iid == &<ITmNodeName as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransaction_Impl: Sized {
     fn Commit(&self, fretaining: super::super::Foundation::BOOL, grftc: u32, grfrm: u32) -> ::windows::core::Result<()>;
@@ -1505,6 +1543,7 @@ impl ITransaction_Vtbl {
         iid == &<ITransaction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransaction2_Impl: Sized + ITransactionCloner_Impl {
     fn GetTransactionInfo2(&self) -> ::windows::core::Result<XACTTRANSINFO>;
@@ -1531,6 +1570,7 @@ impl ITransaction2_Vtbl {
         iid == &<ITransaction2 as ::windows::core::Interface>::IID || iid == &<ITransaction as ::windows::core::Interface>::IID || iid == &<ITransactionCloner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransactionCloner_Impl: Sized + ITransaction_Impl {
     fn CloneWithCommitDisabled(&self) -> ::windows::core::Result<ITransaction>;
@@ -1557,6 +1597,7 @@ impl ITransactionCloner_Vtbl {
         iid == &<ITransactionCloner as ::windows::core::Interface>::IID || iid == &<ITransaction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionDispenser_Impl: Sized {
     fn GetOptionsObject(&self) -> ::windows::core::Result<ITransactionOptions>;
     fn BeginTransaction(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, isolevel: i32, isoflags: u32, poptions: &::core::option::Option<ITransactionOptions>) -> ::windows::core::Result<ITransaction>;
@@ -1596,6 +1637,7 @@ impl ITransactionDispenser_Vtbl {
         iid == &<ITransactionDispenser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITransactionEnlistmentAsync_Impl: Sized {
     fn PrepareRequestDone(&self, hr: ::windows::core::HRESULT, pmk: &::core::option::Option<super::Com::IMoniker>, pboidreason: *const BOID) -> ::windows::core::Result<()>;
@@ -1633,6 +1675,7 @@ impl ITransactionEnlistmentAsync_Vtbl {
         iid == &<ITransactionEnlistmentAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionExport_Impl: Sized {
     fn Export(&self, punktransaction: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
     fn GetTransactionCookie(&self, punktransaction: &::core::option::Option<::windows::core::IUnknown>, cbtransactioncookie: u32, rgbtransactioncookie: *mut u8, pcbused: *mut u32) -> ::windows::core::Result<()>;
@@ -1666,6 +1709,7 @@ impl ITransactionExport_Vtbl {
         iid == &<ITransactionExport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionExportFactory_Impl: Sized {
     fn GetRemoteClassId(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn Create(&self, cbwhereabouts: u32, rgbwhereabouts: *const u8) -> ::windows::core::Result<ITransactionExport>;
@@ -1705,6 +1749,7 @@ impl ITransactionExportFactory_Vtbl {
         iid == &<ITransactionExportFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionImport_Impl: Sized {
     fn Import(&self, cbtransactioncookie: u32, rgbtransactioncookie: *const u8, piid: *const ::windows::core::GUID, ppvtransaction: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1722,6 +1767,7 @@ impl ITransactionImport_Vtbl {
         iid == &<ITransactionImport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionImportWhereabouts_Impl: Sized {
     fn GetWhereaboutsSize(&self) -> ::windows::core::Result<u32>;
     fn GetWhereabouts(&self, cbwhereabouts: u32, rgbwhereabouts: *mut u8, pcbused: *mut u32) -> ::windows::core::Result<()>;
@@ -1755,6 +1801,7 @@ impl ITransactionImportWhereabouts_Vtbl {
         iid == &<ITransactionImportWhereabouts as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionLastEnlistmentAsync_Impl: Sized {
     fn TransactionOutcome(&self, xactstat: XACTSTAT, pboidreason: *const BOID) -> ::windows::core::Result<()>;
 }
@@ -1772,6 +1819,7 @@ impl ITransactionLastEnlistmentAsync_Vtbl {
         iid == &<ITransactionLastEnlistmentAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionLastResourceAsync_Impl: Sized {
     fn DelegateCommit(&self, grfrm: u32) -> ::windows::core::Result<()>;
     fn ForgetRequest(&self, pnewuow: *const BOID) -> ::windows::core::Result<()>;
@@ -1799,6 +1847,7 @@ impl ITransactionLastResourceAsync_Vtbl {
         iid == &<ITransactionLastResourceAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionOptions_Impl: Sized {
     fn SetOptions(&self, poptions: *const XACTOPT) -> ::windows::core::Result<()>;
     fn GetOptions(&self, poptions: *mut XACTOPT) -> ::windows::core::Result<()>;
@@ -1826,6 +1875,7 @@ impl ITransactionOptions_Vtbl {
         iid == &<ITransactionOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransactionOutcomeEvents_Impl: Sized {
     fn Committed(&self, fretaining: super::super::Foundation::BOOL, pnewuow: *const BOID, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1870,6 +1920,7 @@ impl ITransactionOutcomeEvents_Vtbl {
         iid == &<ITransactionOutcomeEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionPhase0EnlistmentAsync_Impl: Sized {
     fn Enable(&self) -> ::windows::core::Result<()>;
     fn WaitForEnlistment(&self) -> ::windows::core::Result<()>;
@@ -1924,6 +1975,7 @@ impl ITransactionPhase0EnlistmentAsync_Vtbl {
         iid == &<ITransactionPhase0EnlistmentAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionPhase0Factory_Impl: Sized {
     fn Create(&self, pphase0notify: &::core::option::Option<ITransactionPhase0NotifyAsync>) -> ::windows::core::Result<ITransactionPhase0EnlistmentAsync>;
 }
@@ -1947,6 +1999,7 @@ impl ITransactionPhase0Factory_Vtbl {
         iid == &<ITransactionPhase0Factory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransactionPhase0NotifyAsync_Impl: Sized {
     fn Phase0Request(&self, fabortinghint: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1977,6 +2030,7 @@ impl ITransactionPhase0NotifyAsync_Vtbl {
         iid == &<ITransactionPhase0NotifyAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionReceiver_Impl: Sized {
     fn UnmarshalPropagationToken(&self, cbtoken: u32, rgbtoken: *const u8) -> ::windows::core::Result<ITransaction>;
     fn GetReturnTokenSize(&self) -> ::windows::core::Result<u32>;
@@ -2030,6 +2084,7 @@ impl ITransactionReceiver_Vtbl {
         iid == &<ITransactionReceiver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionReceiverFactory_Impl: Sized {
     fn Create(&self) -> ::windows::core::Result<ITransactionReceiver>;
 }
@@ -2053,6 +2108,7 @@ impl ITransactionReceiverFactory_Vtbl {
         iid == &<ITransactionReceiverFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransactionResource_Impl: Sized {
     fn PrepareRequest(&self, fretaining: super::super::Foundation::BOOL, grfrm: u32, fwantmoniker: super::super::Foundation::BOOL, fsinglephase: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2097,6 +2153,7 @@ impl ITransactionResource_Vtbl {
         iid == &<ITransactionResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransactionResourceAsync_Impl: Sized {
     fn PrepareRequest(&self, fretaining: super::super::Foundation::BOOL, grfrm: u32, fwantmoniker: super::super::Foundation::BOOL, fsinglephase: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2141,6 +2198,7 @@ impl ITransactionResourceAsync_Vtbl {
         iid == &<ITransactionResourceAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionTransmitter_Impl: Sized {
     fn Set(&self, ptransaction: &::core::option::Option<ITransaction>) -> ::windows::core::Result<()>;
     fn GetPropagationTokenSize(&self) -> ::windows::core::Result<u32>;
@@ -2195,6 +2253,7 @@ impl ITransactionTransmitter_Vtbl {
         iid == &<ITransactionTransmitter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionTransmitterFactory_Impl: Sized {
     fn Create(&self) -> ::windows::core::Result<ITransactionTransmitter>;
 }
@@ -2218,6 +2277,7 @@ impl ITransactionTransmitterFactory_Vtbl {
         iid == &<ITransactionTransmitterFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionVoterBallotAsync2_Impl: Sized {
     fn VoteRequestDone(&self, hr: ::windows::core::HRESULT, pboidreason: *const BOID) -> ::windows::core::Result<()>;
 }
@@ -2235,6 +2295,7 @@ impl ITransactionVoterBallotAsync2_Vtbl {
         iid == &<ITransactionVoterBallotAsync2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait ITransactionVoterFactory2_Impl: Sized {
     fn Create(&self, ptransaction: &::core::option::Option<ITransaction>, pvoternotify: &::core::option::Option<ITransactionVoterNotifyAsync2>) -> ::windows::core::Result<ITransactionVoterBallotAsync2>;
 }
@@ -2258,6 +2319,7 @@ impl ITransactionVoterFactory2_Vtbl {
         iid == &<ITransactionVoterFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransactionVoterNotifyAsync2_Impl: Sized + ITransactionOutcomeEvents_Impl {
     fn VoteRequest(&self) -> ::windows::core::Result<()>;
@@ -2278,6 +2340,7 @@ impl ITransactionVoterNotifyAsync2_Vtbl {
         iid == &<ITransactionVoterNotifyAsync2 as ::windows::core::Interface>::IID || iid == &<ITransactionOutcomeEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IXAConfig_Impl: Sized {
     fn Initialize(&self, clsidhelperdll: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn Terminate(&self) -> ::windows::core::Result<()>;
@@ -2305,6 +2368,7 @@ impl IXAConfig_Vtbl {
         iid == &<IXAConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IXAObtainRMInfo_Impl: Sized {
     fn ObtainRMInfo(&self, pirmhelper: &::core::option::Option<IRMHelper>) -> ::windows::core::Result<()>;
 }
@@ -2322,6 +2386,7 @@ impl IXAObtainRMInfo_Vtbl {
         iid == &<IXAObtainRMInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 pub trait IXATransLookup_Impl: Sized {
     fn Lookup(&self) -> ::windows::core::Result<ITransaction>;
 }
@@ -2345,6 +2410,7 @@ impl IXATransLookup_Vtbl {
         iid == &<IXATransLookup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_DistributedTransactionCoordinator\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IXATransLookup2_Impl: Sized {
     fn Lookup(&self, pxid: *const XID) -> ::windows::core::Result<ITransaction>;

--- a/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_EventNotificationService\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISensLogon_Impl: Sized + super::Com::IDispatch_Impl {
     fn Logon(&self, bstrusername: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -63,6 +64,7 @@ impl ISensLogon_Vtbl {
         iid == &<ISensLogon as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_EventNotificationService\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISensLogon2_Impl: Sized + super::Com::IDispatch_Impl {
     fn Logon(&self, bstrusername: &::windows::core::BSTR, dwsessionid: u32) -> ::windows::core::Result<()>;
@@ -114,6 +116,7 @@ impl ISensLogon2_Vtbl {
         iid == &<ISensLogon2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_EventNotificationService\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISensNetwork_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConnectionMade(&self, bstrconnection: &::windows::core::BSTR, ultype: u32, lpqocinfo: *const SENS_QOCINFO) -> ::windows::core::Result<()>;
@@ -165,6 +168,7 @@ impl ISensNetwork_Vtbl {
         iid == &<ISensNetwork as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_EventNotificationService\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISensOnNow_Impl: Sized + super::Com::IDispatch_Impl {
     fn OnACPower(&self) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait IGPEInformation_Impl: Sized {
     fn GetName(&self, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::Result<()>;
@@ -77,6 +78,7 @@ impl IGPEInformation_Vtbl {
         iid == &<IGPEInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPM_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetDomain(&self, bstrdomain: &::windows::core::BSTR, bstrdomaincontroller: &::windows::core::BSTR, ldcflags: i32) -> ::windows::core::Result<IGPMDomain>;
@@ -243,6 +245,7 @@ impl IGPM_Vtbl {
         iid == &<IGPM as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPM2_Impl: Sized + IGPM_Impl {
     fn GetBackupDirEx(&self, bstrbackupdir: &::windows::core::BSTR, backupdirtype: GPMBackupType) -> ::windows::core::Result<IGPMBackupDirEx>;
@@ -279,6 +282,7 @@ impl IGPM2_Vtbl {
         iid == &<IGPM2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IGPM as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMAsyncCancel_Impl: Sized + super::Com::IDispatch_Impl {
     fn Cancel(&self) -> ::windows::core::Result<()>;
@@ -299,6 +303,7 @@ impl IGPMAsyncCancel_Vtbl {
         iid == &<IGPMAsyncCancel as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMAsyncProgress_Impl: Sized + super::Com::IDispatch_Impl {
     fn Status(&self, lprogressnumerator: i32, lprogressdenominator: i32, hrstatus: ::windows::core::HRESULT, presult: *const super::Com::VARIANT, ppigpmstatusmsgcollection: &::core::option::Option<IGPMStatusMsgCollection>) -> ::windows::core::Result<()>;
@@ -319,6 +324,7 @@ impl IGPMAsyncProgress_Vtbl {
         iid == &<IGPMAsyncProgress as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMBackup_Impl: Sized + super::Com::IDispatch_Impl {
     fn ID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -453,6 +459,7 @@ impl IGPMBackup_Vtbl {
         iid == &<IGPMBackup as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMBackupCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -508,6 +515,7 @@ impl IGPMBackupCollection_Vtbl {
         iid == &<IGPMBackupCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMBackupDir_Impl: Sized + super::Com::IDispatch_Impl {
     fn BackupDirectory(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -563,6 +571,7 @@ impl IGPMBackupDir_Vtbl {
         iid == &<IGPMBackupDir as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMBackupDirEx_Impl: Sized + super::Com::IDispatch_Impl {
     fn BackupDir(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -631,6 +640,7 @@ impl IGPMBackupDirEx_Vtbl {
         iid == &<IGPMBackupDirEx as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMCSECollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -686,6 +696,7 @@ impl IGPMCSECollection_Vtbl {
         iid == &<IGPMCSECollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMClientSideExtension_Impl: Sized + super::Com::IDispatch_Impl {
     fn ID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -754,6 +765,7 @@ impl IGPMClientSideExtension_Vtbl {
         iid == &<IGPMClientSideExtension as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMConstants_Impl: Sized + super::Com::IDispatch_Impl {
     fn PermGPOApply(&self) -> ::windows::core::Result<GPMPermissionType>;
@@ -1550,6 +1562,7 @@ impl IGPMConstants_Vtbl {
         iid == &<IGPMConstants as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMConstants2_Impl: Sized + IGPMConstants_Impl {
     fn BackupTypeGPO(&self) -> ::windows::core::Result<GPMBackupType>;
@@ -1761,6 +1774,7 @@ impl IGPMConstants2_Vtbl {
         iid == &<IGPMConstants2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IGPMConstants as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMDomain_Impl: Sized + super::Com::IDispatch_Impl {
     fn DomainController(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1901,6 +1915,7 @@ impl IGPMDomain_Vtbl {
         iid == &<IGPMDomain as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMDomain2_Impl: Sized + IGPMDomain_Impl {
     fn CreateStarterGPO(&self) -> ::windows::core::Result<IGPMStarterGPO>;
@@ -1983,6 +1998,7 @@ impl IGPMDomain2_Vtbl {
         iid == &<IGPMDomain2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IGPMDomain as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMDomain3_Impl: Sized + IGPMDomain2_Impl {
     fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const super::Com::VARIANT, pvargpmcancel: *mut super::Com::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows::core::Result<()>;
@@ -2033,6 +2049,7 @@ impl IGPMDomain3_Vtbl {
         iid == &<IGPMDomain3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IGPMDomain as ::windows::core::Interface>::IID || iid == &<IGPMDomain2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMGPO_Impl: Sized + super::Com::IDispatch_Impl {
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2354,6 +2371,7 @@ impl IGPMGPO_Vtbl {
         iid == &<IGPMGPO as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMGPO2_Impl: Sized + IGPMGPO_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2390,6 +2408,7 @@ impl IGPMGPO2_Vtbl {
         iid == &<IGPMGPO2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IGPMGPO as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMGPO3_Impl: Sized + IGPMGPO2_Impl {
     fn InfrastructureDC(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2433,6 +2452,7 @@ impl IGPMGPO3_Vtbl {
         iid == &<IGPMGPO3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IGPMGPO as ::windows::core::Interface>::IID || iid == &<IGPMGPO2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMGPOCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2488,6 +2508,7 @@ impl IGPMGPOCollection_Vtbl {
         iid == &<IGPMGPOCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMGPOLink_Impl: Sized + super::Com::IDispatch_Impl {
     fn GPOID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2603,6 +2624,7 @@ impl IGPMGPOLink_Vtbl {
         iid == &<IGPMGPOLink as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMGPOLinksCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2658,6 +2680,7 @@ impl IGPMGPOLinksCollection_Vtbl {
         iid == &<IGPMGPOLinksCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMMapEntry_Impl: Sized + super::Com::IDispatch_Impl {
     fn Source(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2726,6 +2749,7 @@ impl IGPMMapEntry_Vtbl {
         iid == &<IGPMMapEntry as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMMapEntryCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2781,6 +2805,7 @@ impl IGPMMapEntryCollection_Vtbl {
         iid == &<IGPMMapEntryCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMMigrationTable_Impl: Sized + super::Com::IDispatch_Impl {
     fn Save(&self, bstrmigrationtablepath: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2883,6 +2908,7 @@ impl IGPMMigrationTable_Vtbl {
         iid == &<IGPMMigrationTable as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMPermission_Impl: Sized + super::Com::IDispatch_Impl {
     fn Inherited(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2964,6 +2990,7 @@ impl IGPMPermission_Vtbl {
         iid == &<IGPMPermission as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMRSOP_Impl: Sized + super::Com::IDispatch_Impl {
     fn Mode(&self) -> ::windows::core::Result<GPMRSOPMode>;
@@ -3333,6 +3360,7 @@ impl IGPMRSOP_Vtbl {
         iid == &<IGPMRSOP as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn Status(&self) -> ::windows::core::Result<IGPMStatusMsgCollection>;
@@ -3382,6 +3410,7 @@ impl IGPMResult_Vtbl {
         iid == &<IGPMResult as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMSOM_Impl: Sized + super::Com::IDispatch_Impl {
     fn GPOInheritanceBlocked(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3516,6 +3545,7 @@ impl IGPMSOM_Vtbl {
         iid == &<IGPMSOM as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMSOMCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3571,6 +3601,7 @@ impl IGPMSOMCollection_Vtbl {
         iid == &<IGPMSOMCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMSearchCriteria_Impl: Sized + super::Com::IDispatch_Impl {
     fn Add(&self, searchproperty: GPMSearchProperty, searchoperation: GPMSearchOperation, varvalue: &super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -3591,6 +3622,7 @@ impl IGPMSearchCriteria_Vtbl {
         iid == &<IGPMSearchCriteria as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMSecurityInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -3667,6 +3699,7 @@ impl IGPMSecurityInfo_Vtbl {
         iid == &<IGPMSecurityInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMSitesContainer_Impl: Sized + super::Com::IDispatch_Impl {
     fn DomainController(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3748,6 +3781,7 @@ impl IGPMSitesContainer_Vtbl {
         iid == &<IGPMSitesContainer as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMStarterGPO_Impl: Sized + super::Com::IDispatch_Impl {
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4002,6 +4036,7 @@ impl IGPMStarterGPO_Vtbl {
         iid == &<IGPMStarterGPO as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMStarterGPOBackup_Impl: Sized + super::Com::IDispatch_Impl {
     fn BackupDir(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4149,6 +4184,7 @@ impl IGPMStarterGPOBackup_Vtbl {
         iid == &<IGPMStarterGPOBackup as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMStarterGPOBackupCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4204,6 +4240,7 @@ impl IGPMStarterGPOBackupCollection_Vtbl {
         iid == &<IGPMStarterGPOBackupCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMStarterGPOCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4259,6 +4296,7 @@ impl IGPMStarterGPOCollection_Vtbl {
         iid == &<IGPMStarterGPOCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMStatusMessage_Impl: Sized + super::Com::IDispatch_Impl {
     fn ObjectPath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4341,6 +4379,7 @@ impl IGPMStatusMessage_Vtbl {
         iid == &<IGPMStatusMessage as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMStatusMsgCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4396,6 +4435,7 @@ impl IGPMStatusMsgCollection_Vtbl {
         iid == &<IGPMStatusMsgCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMTrustee_Impl: Sized + super::Com::IDispatch_Impl {
     fn TrusteeSid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4477,6 +4517,7 @@ impl IGPMTrustee_Vtbl {
         iid == &<IGPMTrustee as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMWMIFilter_Impl: Sized + super::Com::IDispatch_Impl {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4579,6 +4620,7 @@ impl IGPMWMIFilter_Vtbl {
         iid == &<IGPMWMIFilter as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IGPMWMIFilterCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4634,6 +4676,7 @@ impl IGPMWMIFilterCollection_Vtbl {
         iid == &<IGPMWMIFilterCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Controls"))]
 pub trait IGroupPolicyObject_Impl: Sized {
     fn New(&self, pszdomainname: &::windows::core::PCWSTR, pszdisplayname: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
@@ -4776,6 +4819,7 @@ impl IGroupPolicyObject_Vtbl {
         iid == &<IGroupPolicyObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_GroupPolicy\"`, `\"implement\"`*"]
 pub trait IRSOPInformation_Impl: Sized {
     fn GetNamespace(&self, dwsection: u32, pszname: ::windows::core::PWSTR, cchmaxlength: i32) -> ::windows::core::Result<()>;
     fn GetFlags(&self, pdwflags: *mut u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait AsyncIFtpAuthenticationProvider_Impl: Sized {
     fn Begin_AuthenticateUser(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszpassword: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -28,6 +29,7 @@ impl AsyncIFtpAuthenticationProvider_Vtbl {
         iid == &<AsyncIFtpAuthenticationProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait AsyncIFtpAuthorizationProvider_Impl: Sized {
     fn Begin_GetUserAccessPermission(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszvirtualpath: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Finish_GetUserAccessPermission(&self) -> ::windows::core::Result<FTP_ACCESS>;
@@ -61,6 +63,7 @@ impl AsyncIFtpAuthorizationProvider_Vtbl {
         iid == &<AsyncIFtpAuthorizationProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait AsyncIFtpHomeDirectoryProvider_Impl: Sized {
     fn Begin_GetUserHomeDirectoryData(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Finish_GetUserHomeDirectoryData(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -94,6 +97,7 @@ impl AsyncIFtpHomeDirectoryProvider_Vtbl {
         iid == &<AsyncIFtpHomeDirectoryProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait AsyncIFtpLogProvider_Impl: Sized {
     fn Begin_Log(&self, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::Result<()>;
     fn Finish_Log(&self) -> ::windows::core::Result<()>;
@@ -121,6 +125,7 @@ impl AsyncIFtpLogProvider_Vtbl {
         iid == &<AsyncIFtpLogProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait AsyncIFtpPostprocessProvider_Impl: Sized {
     fn Begin_HandlePostprocess(&self, ppostprocessparameters: *const POST_PROCESS_PARAMETERS) -> ::windows::core::Result<()>;
@@ -157,6 +162,7 @@ impl AsyncIFtpPostprocessProvider_Vtbl {
         iid == &<AsyncIFtpPostprocessProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait AsyncIFtpPreprocessProvider_Impl: Sized {
     fn Begin_HandlePreprocess(&self, ppreprocessparameters: *const PRE_PROCESS_PARAMETERS) -> ::windows::core::Result<()>;
@@ -193,6 +199,7 @@ impl AsyncIFtpPreprocessProvider_Vtbl {
         iid == &<AsyncIFtpPreprocessProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait AsyncIFtpRoleProvider_Impl: Sized {
     fn Begin_IsUserInRole(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszrole: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -229,6 +236,7 @@ impl AsyncIFtpRoleProvider_Vtbl {
         iid == &<AsyncIFtpRoleProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait AsyncIMSAdminBaseSinkW_Impl: Sized {
     fn Begin_SinkNotify(&self, dwmdnumelements: u32, pcochangelist: *const MD_CHANGE_OBJECT_W) -> ::windows::core::Result<()>;
     fn Finish_SinkNotify(&self) -> ::windows::core::Result<()>;
@@ -270,6 +278,7 @@ impl AsyncIMSAdminBaseSinkW_Vtbl {
         iid == &<AsyncIMSAdminBaseSinkW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait IADMEXT_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
     fn EnumDcomCLSIDs(&self, pclsiddcom: *mut ::windows::core::GUID, dwenumindex: u32) -> ::windows::core::Result<()>;
@@ -304,6 +313,7 @@ impl IADMEXT_Vtbl {
         iid == &<IADMEXT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFtpAuthenticationProvider_Impl: Sized {
     fn AuthenticateUser(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszpassword: &::windows::core::PCWSTR, ppszcanonicalusername: *mut ::windows::core::PWSTR, pfauthenticated: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -324,6 +334,7 @@ impl IFtpAuthenticationProvider_Vtbl {
         iid == &<IFtpAuthenticationProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait IFtpAuthorizationProvider_Impl: Sized {
     fn GetUserAccessPermission(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszvirtualpath: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<FTP_ACCESS>;
 }
@@ -347,6 +358,7 @@ impl IFtpAuthorizationProvider_Vtbl {
         iid == &<IFtpAuthorizationProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait IFtpHomeDirectoryProvider_Impl: Sized {
     fn GetUserHomeDirectoryData(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -370,6 +382,7 @@ impl IFtpHomeDirectoryProvider_Vtbl {
         iid == &<IFtpHomeDirectoryProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait IFtpLogProvider_Impl: Sized {
     fn Log(&self, ploggingparameters: *const LOGGING_PARAMETERS) -> ::windows::core::Result<()>;
 }
@@ -387,6 +400,7 @@ impl IFtpLogProvider_Vtbl {
         iid == &<IFtpLogProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFtpPostprocessProvider_Impl: Sized {
     fn HandlePostprocess(&self, ppostprocessparameters: *const POST_PROCESS_PARAMETERS) -> ::windows::core::Result<FTP_PROCESS_STATUS>;
@@ -413,6 +427,7 @@ impl IFtpPostprocessProvider_Vtbl {
         iid == &<IFtpPostprocessProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFtpPreprocessProvider_Impl: Sized {
     fn HandlePreprocess(&self, ppreprocessparameters: *const PRE_PROCESS_PARAMETERS) -> ::windows::core::Result<FTP_PROCESS_STATUS>;
@@ -439,6 +454,7 @@ impl IFtpPreprocessProvider_Vtbl {
         iid == &<IFtpPreprocessProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IFtpProviderConstruct_Impl: Sized {
     fn Construct(&self, configurationentries: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -459,6 +475,7 @@ impl IFtpProviderConstruct_Vtbl {
         iid == &<IFtpProviderConstruct as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFtpRoleProvider_Impl: Sized {
     fn IsUserInRole(&self, pszsessionid: &::windows::core::PCWSTR, pszsitename: &::windows::core::PCWSTR, pszusername: &::windows::core::PCWSTR, pszrole: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -485,6 +502,7 @@ impl IFtpRoleProvider_Vtbl {
         iid == &<IFtpRoleProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMSAdminBase2W_Impl: Sized + IMSAdminBaseW_Impl {
     fn BackupWithPasswd(&self, pszmdbackuplocation: &::windows::core::PCWSTR, dwmdversion: u32, dwmdflags: u32, pszpasswd: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -543,6 +561,7 @@ impl IMSAdminBase2W_Vtbl {
         iid == &<IMSAdminBase2W as ::windows::core::Interface>::IID || iid == &<IMSAdminBaseW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMSAdminBase3W_Impl: Sized + IMSAdminBase2W_Impl {
     fn GetChildPaths(&self, hmdhandle: u32, pszmdpath: &::windows::core::PCWSTR, cchmdbuffersize: u32, pszbuffer: &::windows::core::PWSTR, pcchmdrequiredbuffersize: *mut u32) -> ::windows::core::Result<()>;
@@ -563,6 +582,7 @@ impl IMSAdminBase3W_Vtbl {
         iid == &<IMSAdminBase3W as ::windows::core::Interface>::IID || iid == &<IMSAdminBaseW as ::windows::core::Interface>::IID || iid == &<IMSAdminBase2W as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait IMSAdminBaseSinkW_Impl: Sized {
     fn SinkNotify(&self, dwmdnumelements: u32, pcochangelist: *const MD_CHANGE_OBJECT_W) -> ::windows::core::Result<()>;
     fn ShutdownNotify(&self) -> ::windows::core::Result<()>;
@@ -590,6 +610,7 @@ impl IMSAdminBaseSinkW_Vtbl {
         iid == &<IMSAdminBaseSinkW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMSAdminBaseW_Impl: Sized {
     fn AddKey(&self, hmdhandle: u32, pszmdpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -853,6 +874,7 @@ impl IMSAdminBaseW_Vtbl {
         iid == &<IMSAdminBaseW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Iis\"`, `\"implement\"`*"]
 pub trait IMSImpExpHelpW_Impl: Sized {
     fn EnumeratePathsInFile(&self, pszfilename: &::windows::core::PCWSTR, pszkeytype: &::windows::core::PCWSTR, dwmdbuffersize: u32, pszbuffer: &::windows::core::PWSTR, pdwmdrequiredbuffersize: *mut u32) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MessageQueuing/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQApplication_Impl: Sized + super::Com::IDispatch_Impl {
     fn MachineIdOfMachineName(&self, machinename: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -24,6 +25,7 @@ impl IMSMQApplication_Vtbl {
         iid == &<IMSMQApplication as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQApplication2_Impl: Sized + IMSMQApplication_Impl {
     fn RegisterCertificate(&self, flags: *const super::Com::VARIANT, externalcertificate: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -125,6 +127,7 @@ impl IMSMQApplication2_Vtbl {
         iid == &<IMSMQApplication2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQApplication3_Impl: Sized + IMSMQApplication2_Impl {
     fn ActiveQueues(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -247,6 +250,7 @@ impl IMSMQApplication3_Vtbl {
         iid == &<IMSMQApplication3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQApplication as ::windows::core::Interface>::IID || iid == &<IMSMQApplication2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Item(&self, index: *const super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -302,6 +306,7 @@ impl IMSMQCollection_Vtbl {
         iid == &<IMSMQCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQCoordinatedTransactionDispenser_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction>;
@@ -328,6 +333,7 @@ impl IMSMQCoordinatedTransactionDispenser_Vtbl {
         iid == &<IMSMQCoordinatedTransactionDispenser as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQCoordinatedTransactionDispenser2_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction2>;
@@ -370,6 +376,7 @@ impl IMSMQCoordinatedTransactionDispenser2_Vtbl {
         iid == &<IMSMQCoordinatedTransactionDispenser2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQCoordinatedTransactionDispenser3_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction3>;
@@ -412,6 +419,7 @@ impl IMSMQCoordinatedTransactionDispenser3_Vtbl {
         iid == &<IMSMQCoordinatedTransactionDispenser3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQDestination_Impl: Sized + super::Com::IDispatch_Impl {
     fn Open(&self) -> ::windows::core::Result<()>;
@@ -568,6 +576,7 @@ impl IMSMQDestination_Vtbl {
         iid == &<IMSMQDestination as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQEvent_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -581,6 +590,7 @@ impl IMSMQEvent_Vtbl {
         iid == &<IMSMQEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQEvent2_Impl: Sized + IMSMQEvent_Impl {
     fn Properties(&self) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -607,6 +617,7 @@ impl IMSMQEvent2_Vtbl {
         iid == &<IMSMQEvent2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQEvent3_Impl: Sized + IMSMQEvent2_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -620,6 +631,7 @@ impl IMSMQEvent3_Vtbl {
         iid == &<IMSMQEvent3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQEvent as ::windows::core::Interface>::IID || iid == &<IMSMQEvent2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQManagement_Impl: Sized + super::Com::IDispatch_Impl {
     fn Init(&self, machine: *const super::Com::VARIANT, pathname: *const super::Com::VARIANT, formatname: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -747,6 +759,7 @@ impl IMSMQManagement_Vtbl {
         iid == &<IMSMQManagement as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQMessage_Impl: Sized + super::Com::IDispatch_Impl {
     fn Class(&self) -> ::windows::core::Result<i32>;
@@ -1274,6 +1287,7 @@ impl IMSMQMessage_Vtbl {
         iid == &<IMSMQMessage as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQMessage2_Impl: Sized + super::Com::IDispatch_Impl {
     fn Class(&self) -> ::windows::core::Result<i32>;
@@ -2079,6 +2093,7 @@ impl IMSMQMessage2_Vtbl {
         iid == &<IMSMQMessage2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQMessage3_Impl: Sized + super::Com::IDispatch_Impl {
     fn Class(&self) -> ::windows::core::Result<i32>;
@@ -3056,6 +3071,7 @@ impl IMSMQMessage3_Vtbl {
         iid == &<IMSMQMessage3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQMessage4_Impl: Sized + super::Com::IDispatch_Impl {
     fn Class(&self) -> ::windows::core::Result<i32>;
@@ -4033,6 +4049,7 @@ impl IMSMQMessage4_Vtbl {
         iid == &<IMSMQMessage4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQOutgoingQueueManagement_Impl: Sized + IMSMQManagement_Impl {
     fn State(&self) -> ::windows::core::Result<i32>;
@@ -4109,6 +4126,7 @@ impl IMSMQOutgoingQueueManagement_Vtbl {
         iid == &<IMSMQOutgoingQueueManagement as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQManagement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQPrivateDestination_Impl: Sized + super::Com::IDispatch_Impl {
     fn Handle(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -4145,6 +4163,7 @@ impl IMSMQPrivateDestination_Vtbl {
         iid == &<IMSMQPrivateDestination as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQPrivateEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Hwnd(&self) -> ::windows::core::Result<i32>;
@@ -4188,6 +4207,7 @@ impl IMSMQPrivateEvent_Vtbl {
         iid == &<IMSMQPrivateEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQuery_Impl: Sized + super::Com::IDispatch_Impl {
     fn LookupQueue(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos>;
@@ -4214,6 +4234,7 @@ impl IMSMQQuery_Vtbl {
         iid == &<IMSMQQuery as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQuery2_Impl: Sized + super::Com::IDispatch_Impl {
     fn LookupQueue(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos2>;
@@ -4256,6 +4277,7 @@ impl IMSMQQuery2_Vtbl {
         iid == &<IMSMQQuery2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQuery3_Impl: Sized + super::Com::IDispatch_Impl {
     fn LookupQueue_v2(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos3>;
@@ -4323,6 +4345,7 @@ impl IMSMQQuery3_Vtbl {
         iid == &<IMSMQQuery3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQuery4_Impl: Sized + super::Com::IDispatch_Impl {
     fn LookupQueue_v2(&self, queueguid: *const super::Com::VARIANT, servicetypeguid: *const super::Com::VARIANT, label: *const super::Com::VARIANT, createtime: *const super::Com::VARIANT, modifytime: *const super::Com::VARIANT, relservicetype: *const super::Com::VARIANT, rellabel: *const super::Com::VARIANT, relcreatetime: *const super::Com::VARIANT, relmodifytime: *const super::Com::VARIANT) -> ::windows::core::Result<IMSMQQueueInfos4>;
@@ -4390,6 +4413,7 @@ impl IMSMQQuery4_Vtbl {
         iid == &<IMSMQQuery4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueue_Impl: Sized + super::Com::IDispatch_Impl {
     fn Access(&self) -> ::windows::core::Result<i32>;
@@ -4557,6 +4581,7 @@ impl IMSMQQueue_Vtbl {
         iid == &<IMSMQQueue as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueue2_Impl: Sized + super::Com::IDispatch_Impl {
     fn Access(&self) -> ::windows::core::Result<i32>;
@@ -4802,6 +4827,7 @@ impl IMSMQQueue2_Vtbl {
         iid == &<IMSMQQueue2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueue3_Impl: Sized + super::Com::IDispatch_Impl {
     fn Access(&self) -> ::windows::core::Result<i32>;
@@ -5210,6 +5236,7 @@ impl IMSMQQueue3_Vtbl {
         iid == &<IMSMQQueue3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueue4_Impl: Sized + super::Com::IDispatch_Impl {
     fn Access(&self) -> ::windows::core::Result<i32>;
@@ -5631,6 +5658,7 @@ impl IMSMQQueue4_Vtbl {
         iid == &<IMSMQQueue4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn QueueGuid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5953,6 +5981,7 @@ impl IMSMQQueueInfo_Vtbl {
         iid == &<IMSMQQueueInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfo2_Impl: Sized + super::Com::IDispatch_Impl {
     fn QueueGuid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6321,6 +6350,7 @@ impl IMSMQQueueInfo2_Vtbl {
         iid == &<IMSMQQueueInfo2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfo3_Impl: Sized + super::Com::IDispatch_Impl {
     fn QueueGuid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6748,6 +6778,7 @@ impl IMSMQQueueInfo3_Vtbl {
         iid == &<IMSMQQueueInfo3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfo4_Impl: Sized + super::Com::IDispatch_Impl {
     fn QueueGuid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7175,6 +7206,7 @@ impl IMSMQQueueInfo4_Vtbl {
         iid == &<IMSMQQueueInfo4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfos_Impl: Sized + super::Com::IDispatch_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -7211,6 +7243,7 @@ impl IMSMQQueueInfos_Vtbl {
         iid == &<IMSMQQueueInfos as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfos2_Impl: Sized + super::Com::IDispatch_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -7260,6 +7293,7 @@ impl IMSMQQueueInfos2_Vtbl {
         iid == &<IMSMQQueueInfos2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfos3_Impl: Sized + super::Com::IDispatch_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -7309,6 +7343,7 @@ impl IMSMQQueueInfos3_Vtbl {
         iid == &<IMSMQQueueInfos3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueInfos4_Impl: Sized + super::Com::IDispatch_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -7358,6 +7393,7 @@ impl IMSMQQueueInfos4_Vtbl {
         iid == &<IMSMQQueueInfos4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQQueueManagement_Impl: Sized + IMSMQManagement_Impl {
     fn JournalMessageCount(&self) -> ::windows::core::Result<i32>;
@@ -7413,6 +7449,7 @@ impl IMSMQQueueManagement_Vtbl {
         iid == &<IMSMQQueueManagement as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQManagement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQTransaction_Impl: Sized + super::Com::IDispatch_Impl {
     fn Transaction(&self) -> ::windows::core::Result<i32>;
@@ -7456,6 +7493,7 @@ impl IMSMQTransaction_Vtbl {
         iid == &<IMSMQTransaction as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQTransaction2_Impl: Sized + IMSMQTransaction_Impl {
     fn InitNew(&self, vartransaction: &super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -7492,6 +7530,7 @@ impl IMSMQTransaction2_Vtbl {
         iid == &<IMSMQTransaction2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQTransaction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQTransaction3_Impl: Sized + IMSMQTransaction2_Impl {
     fn ITransaction(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -7518,6 +7557,7 @@ impl IMSMQTransaction3_Vtbl {
         iid == &<IMSMQTransaction3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IMSMQTransaction as ::windows::core::Interface>::IID || iid == &<IMSMQTransaction2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQTransactionDispenser_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction>;
@@ -7544,6 +7584,7 @@ impl IMSMQTransactionDispenser_Vtbl {
         iid == &<IMSMQTransactionDispenser as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQTransactionDispenser2_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction2>;
@@ -7586,6 +7627,7 @@ impl IMSMQTransactionDispenser2_Vtbl {
         iid == &<IMSMQTransactionDispenser2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMSMQTransactionDispenser3_Impl: Sized + super::Com::IDispatch_Impl {
     fn BeginTransaction(&self) -> ::windows::core::Result<IMSMQTransaction3>;
@@ -7628,6 +7670,7 @@ impl IMSMQTransactionDispenser3_Vtbl {
         iid == &<IMSMQTransactionDispenser3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_MessageQueuing\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _DMSMQEventEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Mmc/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait AppEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -11,6 +12,7 @@ impl AppEvents_Vtbl {
         iid == &<AppEvents as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Column_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -120,6 +122,7 @@ impl Column_Vtbl {
         iid == &<Column as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Columns_Impl: Sized + super::Com::IDispatch_Impl {
     fn Item(&self, index: i32) -> ::windows::core::Result<Column>;
@@ -175,6 +178,7 @@ impl Columns_Vtbl {
         iid == &<Columns as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ContextMenu_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -230,6 +234,7 @@ impl ContextMenu_Vtbl {
         iid == &<ContextMenu as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Document_Impl: Sized + super::Com::IDispatch_Impl {
     fn Save(&self) -> ::windows::core::Result<()>;
@@ -424,6 +429,7 @@ impl Document_Vtbl {
         iid == &<Document as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Extension_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<*mut u16>;
@@ -519,6 +525,7 @@ impl Extension_Vtbl {
         iid == &<Extension as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Extensions_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -574,6 +581,7 @@ impl Extensions_Vtbl {
         iid == &<Extensions as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Frame_Impl: Sized + super::Com::IDispatch_Impl {
     fn Maximize(&self) -> ::windows::core::Result<()>;
@@ -691,6 +699,7 @@ impl Frame_Vtbl {
         iid == &<Frame as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IColumnData_Impl: Sized {
     fn SetColumnConfigData(&self, pcolid: *const SColumnSetID, pcolsetdata: *const MMC_COLUMN_SET_DATA) -> ::windows::core::Result<()>;
     fn GetColumnConfigData(&self, pcolid: *const SColumnSetID) -> ::windows::core::Result<*mut MMC_COLUMN_SET_DATA>;
@@ -744,6 +753,7 @@ impl IColumnData_Vtbl {
         iid == &<IColumnData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IComponent_Impl: Sized {
     fn Initialize(&self, lpconsole: &::core::option::Option<IConsole>) -> ::windows::core::Result<()>;
@@ -815,6 +825,7 @@ impl IComponent_Vtbl {
         iid == &<IComponent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IComponent2_Impl: Sized + IComponent_Impl {
     fn QueryDispatch(&self, cookie: isize, r#type: DATA_OBJECT_TYPES) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -858,6 +869,7 @@ impl IComponent2_Vtbl {
         iid == &<IComponent2 as ::windows::core::Interface>::IID || iid == &<IComponent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IComponentData_Impl: Sized {
     fn Initialize(&self, punknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -935,6 +947,7 @@ impl IComponentData_Vtbl {
         iid == &<IComponentData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IComponentData2_Impl: Sized + IComponentData_Impl {
     fn QueryDispatch(&self, cookie: isize, r#type: DATA_OBJECT_TYPES) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -961,6 +974,7 @@ impl IComponentData2_Vtbl {
         iid == &<IComponentData2 as ::windows::core::Interface>::IID || iid == &<IComponentData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IConsole_Impl: Sized {
     fn SetHeader(&self, pheader: &::core::option::Option<IHeaderCtrl>) -> ::windows::core::Result<()>;
@@ -1090,6 +1104,7 @@ impl IConsole_Vtbl {
         iid == &<IConsole as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IConsole2_Impl: Sized + IConsole_Impl {
     fn Expand(&self, hitem: isize, bexpand: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1127,6 +1142,7 @@ impl IConsole2_Vtbl {
         iid == &<IConsole2 as ::windows::core::Interface>::IID || iid == &<IConsole as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IConsole3_Impl: Sized + IConsole2_Impl {
     fn RenameScopeItem(&self, hscopeitem: isize) -> ::windows::core::Result<()>;
@@ -1147,6 +1163,7 @@ impl IConsole3_Vtbl {
         iid == &<IConsole3 as ::windows::core::Interface>::IID || iid == &<IConsole as ::windows::core::Interface>::IID || iid == &<IConsole2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IConsoleNameSpace_Impl: Sized {
     fn InsertItem(&self, item: *mut SCOPEDATAITEM) -> ::windows::core::Result<()>;
@@ -1212,6 +1229,7 @@ impl IConsoleNameSpace_Vtbl {
         iid == &<IConsoleNameSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IConsoleNameSpace2_Impl: Sized + IConsoleNameSpace_Impl {
     fn Expand(&self, hitem: isize) -> ::windows::core::Result<()>;
@@ -1242,6 +1260,7 @@ impl IConsoleNameSpace2_Vtbl {
         iid == &<IConsoleNameSpace2 as ::windows::core::Interface>::IID || iid == &<IConsoleNameSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IConsolePower_Impl: Sized {
     fn SetExecutionState(&self, dwadd: u32, dwremove: u32) -> ::windows::core::Result<()>;
     fn ResetIdleTimer(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -1269,6 +1288,7 @@ impl IConsolePower_Vtbl {
         iid == &<IConsolePower as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IConsolePowerSink_Impl: Sized {
     fn OnPowerBroadcast(&self, nevent: u32, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::LRESULT>;
@@ -1295,6 +1315,7 @@ impl IConsolePowerSink_Vtbl {
         iid == &<IConsolePowerSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IConsoleVerb_Impl: Sized {
     fn GetVerbState(&self, ecmdid: MMC_CONSOLE_VERB, nstate: MMC_BUTTON_STATE) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -1351,6 +1372,7 @@ impl IConsoleVerb_Vtbl {
         iid == &<IConsoleVerb as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IContextMenuCallback_Impl: Sized {
     fn AddItem(&self, pitem: *const CONTEXTMENUITEM) -> ::windows::core::Result<()>;
 }
@@ -1368,6 +1390,7 @@ impl IContextMenuCallback_Vtbl {
         iid == &<IContextMenuCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IContextMenuCallback2_Impl: Sized {
     fn AddItem(&self, pitem: *const CONTEXTMENUITEM2) -> ::windows::core::Result<()>;
 }
@@ -1385,6 +1408,7 @@ impl IContextMenuCallback2_Vtbl {
         iid == &<IContextMenuCallback2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IContextMenuProvider_Impl: Sized + IContextMenuCallback_Impl {
     fn EmptyMenuList(&self) -> ::windows::core::Result<()>;
@@ -1435,6 +1459,7 @@ impl IContextMenuProvider_Vtbl {
         iid == &<IContextMenuProvider as ::windows::core::Interface>::IID || iid == &<IContextMenuCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IControlbar_Impl: Sized {
     fn Create(&self, ntype: MMC_CONTROL_TYPE, pextendcontrolbar: &::core::option::Option<IExtendControlbar>) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Attach(&self, ntype: MMC_CONTROL_TYPE, lpunknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1475,6 +1500,7 @@ impl IControlbar_Vtbl {
         iid == &<IControlbar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IDisplayHelp_Impl: Sized {
     fn ShowTopic(&self, pszhelptopic: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1492,6 +1518,7 @@ impl IDisplayHelp_Vtbl {
         iid == &<IDisplayHelp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IEnumTASK_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut MMC_TASK, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1539,6 +1566,7 @@ impl IEnumTASK_Vtbl {
         iid == &<IEnumTASK as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IExtendContextMenu_Impl: Sized {
     fn AddMenuItems(&self, pidataobject: &::core::option::Option<super::Com::IDataObject>, picallback: &::core::option::Option<IContextMenuCallback>, pinsertionallowed: *mut i32) -> ::windows::core::Result<()>;
@@ -1569,6 +1597,7 @@ impl IExtendContextMenu_Vtbl {
         iid == &<IExtendContextMenu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IExtendControlbar_Impl: Sized {
     fn SetControlbar(&self, pcontrolbar: &::core::option::Option<IControlbar>) -> ::windows::core::Result<()>;
@@ -1599,6 +1628,7 @@ impl IExtendControlbar_Vtbl {
         iid == &<IExtendControlbar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IExtendPropertySheet_Impl: Sized {
     fn CreatePropertyPages(&self, lpprovider: &::core::option::Option<IPropertySheetCallback>, handle: isize, lpidataobject: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
@@ -1629,6 +1659,7 @@ impl IExtendPropertySheet_Vtbl {
         iid == &<IExtendPropertySheet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IExtendPropertySheet2_Impl: Sized + IExtendPropertySheet_Impl {
     fn GetWatermarks(&self, lpidataobject: &::core::option::Option<super::Com::IDataObject>, lphwatermark: *mut super::super::Graphics::Gdi::HBITMAP, lphheader: *mut super::super::Graphics::Gdi::HBITMAP, lphpalette: *mut super::super::Graphics::Gdi::HPALETTE, bstretch: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1649,6 +1680,7 @@ impl IExtendPropertySheet2_Vtbl {
         iid == &<IExtendPropertySheet2 as ::windows::core::Interface>::IID || iid == &<IExtendPropertySheet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IExtendTaskPad_Impl: Sized {
     fn TaskNotify(&self, pdo: &::core::option::Option<super::Com::IDataObject>, arg: *const super::Com::VARIANT, param2: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -1737,6 +1769,7 @@ impl IExtendTaskPad_Vtbl {
         iid == &<IExtendTaskPad as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IExtendView_Impl: Sized {
     fn GetViews(&self, pdataobject: &::core::option::Option<super::Com::IDataObject>, pviewextensioncallback: &::core::option::Option<IViewExtensionCallback>) -> ::windows::core::Result<()>;
@@ -1757,6 +1790,7 @@ impl IExtendView_Vtbl {
         iid == &<IExtendView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IHeaderCtrl_Impl: Sized {
     fn InsertColumn(&self, ncol: i32, title: &::windows::core::PCWSTR, nformat: i32, nwidth: i32) -> ::windows::core::Result<()>;
     fn DeleteColumn(&self, ncol: i32) -> ::windows::core::Result<()>;
@@ -1824,6 +1858,7 @@ impl IHeaderCtrl_Vtbl {
         iid == &<IHeaderCtrl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IHeaderCtrl2_Impl: Sized + IHeaderCtrl_Impl {
     fn SetChangeTimeOut(&self, utimeout: u32) -> ::windows::core::Result<()>;
     fn SetColumnFilter(&self, ncolumn: u32, dwtype: u32, pfilterdata: *const MMC_FILTERDATA) -> ::windows::core::Result<()>;
@@ -1858,6 +1893,7 @@ impl IHeaderCtrl2_Vtbl {
         iid == &<IHeaderCtrl2 as ::windows::core::Interface>::IID || iid == &<IHeaderCtrl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IImageList_Impl: Sized {
     fn ImageListSetIcon(&self, picon: *const isize, nloc: i32) -> ::windows::core::Result<()>;
@@ -1888,6 +1924,7 @@ impl IImageList_Vtbl {
         iid == &<IImageList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IMMCVersionInfo_Impl: Sized {
     fn GetMMCVersion(&self, pversionmajor: *mut i32, pversionminor: *mut i32) -> ::windows::core::Result<()>;
 }
@@ -1905,6 +1942,7 @@ impl IMMCVersionInfo_Vtbl {
         iid == &<IMMCVersionInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMenuButton_Impl: Sized {
     fn AddButton(&self, idcommand: i32, lpbuttontext: &::windows::core::PCWSTR, lptooltiptext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1942,6 +1980,7 @@ impl IMenuButton_Vtbl {
         iid == &<IMenuButton as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IMessageView_Impl: Sized {
     fn SetTitleText(&self, psztitletext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetBodyText(&self, pszbodytext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1983,6 +2022,7 @@ impl IMessageView_Vtbl {
         iid == &<IMessageView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait INodeProperties_Impl: Sized {
     fn GetProperty(&self, pdataobject: &::core::option::Option<super::Com::IDataObject>, szpropertyname: &::windows::core::BSTR) -> ::windows::core::Result<*mut u16>;
@@ -2009,6 +2049,7 @@ impl INodeProperties_Vtbl {
         iid == &<INodeProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Controls")]
 pub trait IPropertySheetCallback_Impl: Sized {
     fn AddPage(&self, hpage: super::super::UI::Controls::HPROPSHEETPAGE) -> ::windows::core::Result<()>;
@@ -2039,6 +2080,7 @@ impl IPropertySheetCallback_Vtbl {
         iid == &<IPropertySheetCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPropertySheetProvider_Impl: Sized {
     fn CreatePropertySheet(&self, title: &::windows::core::PCWSTR, r#type: u8, cookie: isize, pidataobjectm: &::core::option::Option<super::Com::IDataObject>, dwoptions: u32) -> ::windows::core::Result<()>;
@@ -2090,6 +2132,7 @@ impl IPropertySheetProvider_Vtbl {
         iid == &<IPropertySheetProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait IRequiredExtensions_Impl: Sized {
     fn EnableAllExtensions(&self) -> ::windows::core::Result<()>;
     fn GetFirstExtension(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -2136,6 +2179,7 @@ impl IRequiredExtensions_Vtbl {
         iid == &<IRequiredExtensions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResultData_Impl: Sized {
     fn InsertItem(&self, item: *mut RESULTDATAITEM) -> ::windows::core::Result<()>;
@@ -2269,6 +2313,7 @@ impl IResultData_Vtbl {
         iid == &<IResultData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResultData2_Impl: Sized + IResultData_Impl {
     fn RenameResultItem(&self, itemid: isize) -> ::windows::core::Result<()>;
@@ -2289,6 +2334,7 @@ impl IResultData2_Vtbl {
         iid == &<IResultData2 as ::windows::core::Interface>::IID || iid == &<IResultData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResultDataCompare_Impl: Sized {
     fn Compare(&self, luserparam: super::super::Foundation::LPARAM, cookiea: isize, cookieb: isize, pnresult: *mut i32) -> ::windows::core::Result<()>;
@@ -2309,6 +2355,7 @@ impl IResultDataCompare_Vtbl {
         iid == &<IResultDataCompare as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResultDataCompareEx_Impl: Sized {
     fn Compare(&self, prdc: *const RDCOMPARE) -> ::windows::core::Result<i32>;
@@ -2335,6 +2382,7 @@ impl IResultDataCompareEx_Vtbl {
         iid == &<IResultDataCompareEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResultOwnerData_Impl: Sized {
     fn FindItem(&self, pfindinfo: *const RESULTFINDINFO) -> ::windows::core::Result<i32>;
@@ -2378,6 +2426,7 @@ impl IResultOwnerData_Vtbl {
         iid == &<IResultOwnerData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ISnapinAbout_Impl: Sized {
     fn GetSnapinDescription(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2453,6 +2502,7 @@ impl ISnapinAbout_Vtbl {
         iid == &<ISnapinAbout as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait ISnapinHelp_Impl: Sized {
     fn GetHelpTopic(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -2476,6 +2526,7 @@ impl ISnapinHelp_Vtbl {
         iid == &<ISnapinHelp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait ISnapinHelp2_Impl: Sized + ISnapinHelp_Impl {
     fn GetLinkedTopics(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -2499,6 +2550,7 @@ impl ISnapinHelp2_Vtbl {
         iid == &<ISnapinHelp2 as ::windows::core::Interface>::IID || iid == &<ISnapinHelp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISnapinProperties_Impl: Sized {
     fn Initialize(&self, pproperties: &::core::option::Option<Properties>) -> ::windows::core::Result<()>;
@@ -2536,6 +2588,7 @@ impl ISnapinProperties_Vtbl {
         iid == &<ISnapinProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"implement\"`*"]
 pub trait ISnapinPropertiesCallback_Impl: Sized {
     fn AddPropertyName(&self, pszpropname: &::windows::core::PCWSTR, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -2553,6 +2606,7 @@ impl ISnapinPropertiesCallback_Vtbl {
         iid == &<ISnapinPropertiesCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IStringTable_Impl: Sized {
     fn AddString(&self, pszadd: &::windows::core::PCWSTR) -> ::windows::core::Result<u32>;
@@ -2642,6 +2696,7 @@ impl IStringTable_Vtbl {
         iid == &<IStringTable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IToolbar_Impl: Sized {
     fn AddBitmap(&self, nimages: i32, hbmp: super::super::Graphics::Gdi::HBITMAP, cxsize: i32, cysize: i32, crmask: super::super::Foundation::COLORREF) -> ::windows::core::Result<()>;
@@ -2706,6 +2761,7 @@ impl IToolbar_Vtbl {
         iid == &<IToolbar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IViewExtensionCallback_Impl: Sized {
     fn AddView(&self, pextviewdata: *const MMC_EXT_VIEW_DATA) -> ::windows::core::Result<()>;
@@ -2726,6 +2782,7 @@ impl IViewExtensionCallback_Vtbl {
         iid == &<IViewExtensionCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait MenuItem_Impl: Sized + super::Com::IDispatch_Impl {
     fn DisplayName(&self) -> ::windows::core::Result<*mut u16>;
@@ -2814,6 +2871,7 @@ impl MenuItem_Vtbl {
         iid == &<MenuItem as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Node_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<*mut u16>;
@@ -2895,6 +2953,7 @@ impl Node_Vtbl {
         iid == &<Node as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Nodes_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -2950,6 +3009,7 @@ impl Nodes_Vtbl {
         iid == &<Nodes as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Properties_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3012,6 +3072,7 @@ impl Properties_Vtbl {
         iid == &<Properties as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Property_Impl: Sized + super::Com::IDispatch_Impl {
     fn Value(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -3061,6 +3122,7 @@ impl Property_Vtbl {
         iid == &<Property as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ScopeNamespace_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetParent(&self, node: &::core::option::Option<Node>) -> ::windows::core::Result<Node>;
@@ -3136,6 +3198,7 @@ impl ScopeNamespace_Vtbl {
         iid == &<ScopeNamespace as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait SnapIn_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<*mut u16>;
@@ -3237,6 +3300,7 @@ impl SnapIn_Vtbl {
         iid == &<SnapIn as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait SnapIns_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3312,6 +3376,7 @@ impl SnapIns_Vtbl {
         iid == &<SnapIns as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait View_Impl: Sized + super::Com::IDispatch_Impl {
     fn ActiveScopeNode(&self) -> ::windows::core::Result<Node>;
@@ -3724,6 +3789,7 @@ impl View_Vtbl {
         iid == &<View as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Views_Impl: Sized + super::Com::IDispatch_Impl {
     fn Item(&self, index: i32) -> ::windows::core::Result<View>;
@@ -3786,6 +3852,7 @@ impl Views_Vtbl {
         iid == &<Views as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _AppEvents_Impl: Sized + super::Com::IDispatch_Impl {
     fn OnQuit(&self, application: &::core::option::Option<_Application>) -> ::windows::core::Result<()>;
@@ -3886,6 +3953,7 @@ impl _AppEvents_Vtbl {
         iid == &<_AppEvents as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _Application_Impl: Sized + super::Com::IDispatch_Impl {
     fn Help(&self);
@@ -4022,6 +4090,7 @@ impl _Application_Vtbl {
         iid == &<_Application as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Mmc\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _EventConnector_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConnectTo(&self, application: &::core::option::Option<_Application>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IAdviseSinkEx_Impl: Sized + super::Com::IAdviseSink_Impl {
     fn OnViewStatusChange(&self, dwviewstatus: u32);
@@ -18,6 +19,7 @@ impl IAdviseSinkEx_Vtbl {
         iid == &<IAdviseSinkEx as ::windows::core::Interface>::IID || iid == &<super::Com::IAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ICanHandleException_Impl: Sized {
     fn CanHandleException(&self, pexcepinfo: *const super::Com::EXCEPINFO, pvar: *const super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -38,6 +40,7 @@ impl ICanHandleException_Vtbl {
         iid == &<ICanHandleException as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IClassFactory2_Impl: Sized + super::Com::IClassFactory_Impl {
     fn GetLicInfo(&self, plicinfo: *mut LICINFO) -> ::windows::core::Result<()>;
@@ -81,6 +84,7 @@ impl IClassFactory2_Vtbl {
         iid == &<IClassFactory2 as ::windows::core::Interface>::IID || iid == &<super::Com::IClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IContinue_Impl: Sized {
     fn FContinue(&self) -> ::windows::core::Result<()>;
 }
@@ -98,6 +102,7 @@ impl IContinue_Vtbl {
         iid == &<IContinue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IContinueCallback_Impl: Sized {
     fn FContinue(&self) -> ::windows::core::Result<()>;
     fn FContinuePrinting(&self, ncntprinted: i32, ncurpage: i32, pwszprintstatus: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -125,6 +130,7 @@ impl IContinueCallback_Vtbl {
         iid == &<IContinueCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait ICreateErrorInfo_Impl: Sized {
     fn SetGUID(&self, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SetSource(&self, szsource: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -173,6 +179,7 @@ impl ICreateErrorInfo_Vtbl {
         iid == &<ICreateErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ICreateTypeInfo_Impl: Sized {
     fn SetGuid(&self, guid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -350,6 +357,7 @@ impl ICreateTypeInfo_Vtbl {
         iid == &<ICreateTypeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ICreateTypeInfo2_Impl: Sized + ICreateTypeInfo_Impl {
     fn DeleteFuncDesc(&self, index: u32) -> ::windows::core::Result<()>;
@@ -471,6 +479,7 @@ impl ICreateTypeInfo2_Vtbl {
         iid == &<ICreateTypeInfo2 as ::windows::core::Interface>::IID || iid == &<ICreateTypeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ICreateTypeLib_Impl: Sized {
     fn CreateTypeInfo(&self, szname: &::windows::core::PCWSTR, tkind: super::Com::TYPEKIND) -> ::windows::core::Result<ICreateTypeInfo>;
@@ -563,6 +572,7 @@ impl ICreateTypeLib_Vtbl {
         iid == &<ICreateTypeLib as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ICreateTypeLib2_Impl: Sized + ICreateTypeLib_Impl {
     fn DeleteTypeInfo(&self, szname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -607,6 +617,7 @@ impl ICreateTypeLib2_Vtbl {
         iid == &<ICreateTypeLib2 as ::windows::core::Interface>::IID || iid == &<ICreateTypeLib as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IDispError_Impl: Sized {
     fn QueryErrorInfo(&self, guiderrortype: &::windows::core::GUID) -> ::windows::core::Result<IDispError>;
     fn GetNext(&self) -> ::windows::core::Result<IDispError>;
@@ -692,6 +703,7 @@ impl IDispError_Vtbl {
         iid == &<IDispError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDispatchEx_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetDispID(&self, bstrname: &::windows::core::BSTR, grfdex: u32) -> ::windows::core::Result<i32>;
@@ -794,6 +806,7 @@ impl IDispatchEx_Vtbl {
         iid == &<IDispatchEx as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_SystemServices\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_SystemServices"))]
 pub trait IDropSource_Impl: Sized {
     fn QueryContinueDrag(&self, fescapepressed: super::super::Foundation::BOOL, grfkeystate: super::SystemServices::MODIFIERKEYS_FLAGS) -> ::windows::core::HRESULT;
@@ -824,6 +837,7 @@ impl IDropSource_Vtbl {
         iid == &<IDropSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDropSourceNotify_Impl: Sized {
     fn DragEnterTarget(&self, hwndtarget: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -854,6 +868,7 @@ impl IDropSourceNotify_Vtbl {
         iid == &<IDropSourceNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_SystemServices\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_SystemServices"))]
 pub trait IDropTarget_Impl: Sized {
     fn DragEnter(&self, pdataobj: &::core::option::Option<super::Com::IDataObject>, grfkeystate: super::SystemServices::MODIFIERKEYS_FLAGS, pt: &super::super::Foundation::POINTL, pdweffect: *mut DROPEFFECT) -> ::windows::core::Result<()>;
@@ -898,6 +913,7 @@ impl IDropTarget_Vtbl {
         iid == &<IDropTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnterpriseDropTarget_Impl: Sized {
     fn SetDropSourceEnterpriseId(&self, identity: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -934,6 +950,7 @@ impl IEnterpriseDropTarget_Vtbl {
         iid == &<IEnterpriseDropTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub trait IEnumOLEVERB_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut OLEVERB, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -984,6 +1001,7 @@ impl IEnumOLEVERB_Vtbl {
         iid == &<IEnumOLEVERB as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IEnumOleDocumentViews_Impl: Sized {
     fn Next(&self, cviews: u32, rgpview: *mut ::core::option::Option<IOleDocumentView>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cviews: u32) -> ::windows::core::Result<()>;
@@ -1031,6 +1049,7 @@ impl IEnumOleDocumentViews_Vtbl {
         iid == &<IEnumOleDocumentViews as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IEnumOleUndoUnits_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IOleUndoUnit>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1078,6 +1097,7 @@ impl IEnumOleUndoUnits_Vtbl {
         iid == &<IEnumOleUndoUnits as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IEnumVARIANT_Impl: Sized {
     fn Next(&self, celt: u32, rgvar: *mut super::Com::VARIANT, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
@@ -1128,6 +1148,7 @@ impl IEnumVARIANT_Vtbl {
         iid == &<IEnumVARIANT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IFont_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1378,6 +1399,7 @@ impl IFont_Vtbl {
         iid == &<IFont as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFontDisp_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -1391,6 +1413,7 @@ impl IFontDisp_Vtbl {
         iid == &<IFontDisp as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFontEventsDisp_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -1404,6 +1427,7 @@ impl IFontEventsDisp_Vtbl {
         iid == &<IFontEventsDisp as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IGetOleObject_Impl: Sized {
     fn GetOleObject(&self, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1421,6 +1445,7 @@ impl IGetOleObject_Vtbl {
         iid == &<IGetOleObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IGetVBAObject_Impl: Sized {
     fn GetObject(&self, riid: *const ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void, dwreserved: u32) -> ::windows::core::Result<()>;
 }
@@ -1438,6 +1463,7 @@ impl IGetVBAObject_Vtbl {
         iid == &<IGetVBAObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IObjectIdentity_Impl: Sized {
     fn IsEqualObject(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -1455,6 +1481,7 @@ impl IObjectIdentity_Vtbl {
         iid == &<IObjectIdentity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IObjectWithSite_Impl: Sized {
     fn SetSite(&self, punksite: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetSite(&self, riid: *const ::windows::core::GUID, ppvsite: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1482,6 +1509,7 @@ impl IObjectWithSite_Vtbl {
         iid == &<IObjectWithSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOleAdviseHolder_Impl: Sized {
     fn Advise(&self, padvise: &::core::option::Option<super::Com::IAdviseSink>) -> ::windows::core::Result<u32>;
@@ -1552,6 +1580,7 @@ impl IOleAdviseHolder_Vtbl {
         iid == &<IOleAdviseHolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IOleCache_Impl: Sized {
     fn Cache(&self, pformatetc: *const super::Com::FORMATETC, advf: u32) -> ::windows::core::Result<u32>;
@@ -1615,6 +1644,7 @@ impl IOleCache_Vtbl {
         iid == &<IOleCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IOleCache2_Impl: Sized + IOleCache_Impl {
     fn UpdateCache(&self, pdataobject: &::core::option::Option<super::Com::IDataObject>, grfupdf: UPDFCACHE_FLAGS, preserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1645,6 +1675,7 @@ impl IOleCache2_Vtbl {
         iid == &<IOleCache2 as ::windows::core::Interface>::IID || iid == &<IOleCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOleCacheControl_Impl: Sized {
     fn OnRun(&self, pdataobject: &::core::option::Option<super::Com::IDataObject>) -> ::windows::core::Result<()>;
@@ -1675,6 +1706,7 @@ impl IOleCacheControl_Vtbl {
         iid == &<IOleCacheControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOleClientSite_Impl: Sized {
     fn SaveObject(&self) -> ::windows::core::Result<()>;
@@ -1745,6 +1777,7 @@ impl IOleClientSite_Vtbl {
         iid == &<IOleClientSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOleCommandTarget_Impl: Sized {
     fn QueryStatus(&self, pguidcmdgroup: *const ::windows::core::GUID, ccmds: u32, prgcmds: *mut OLECMD, pcmdtext: *mut OLECMDTEXT) -> ::windows::core::Result<()>;
@@ -1775,6 +1808,7 @@ impl IOleCommandTarget_Vtbl {
         iid == &<IOleCommandTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOleContainer_Impl: Sized + IParseDisplayName_Impl {
     fn EnumObjects(&self, grfflags: OLECONTF) -> ::windows::core::Result<super::Com::IEnumUnknown>;
@@ -1811,6 +1845,7 @@ impl IOleContainer_Vtbl {
         iid == &<IOleContainer as ::windows::core::Interface>::IID || iid == &<IParseDisplayName as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleControl_Impl: Sized {
     fn GetControlInfo(&self, pci: *mut CONTROLINFO) -> ::windows::core::Result<()>;
@@ -1855,6 +1890,7 @@ impl IOleControl_Vtbl {
         iid == &<IOleControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleControlSite_Impl: Sized {
     fn OnControlInfoChanged(&self) -> ::windows::core::Result<()>;
@@ -1926,6 +1962,7 @@ impl IOleControlSite_Vtbl {
         iid == &<IOleControlSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOleDocument_Impl: Sized {
     fn CreateView(&self, pipsite: &::core::option::Option<IOleInPlaceSite>, pstm: &::core::option::Option<super::Com::IStream>, dwreserved: u32) -> ::windows::core::Result<IOleDocumentView>;
@@ -1975,6 +2012,7 @@ impl IOleDocument_Vtbl {
         iid == &<IOleDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IOleDocumentSite_Impl: Sized {
     fn ActivateMe(&self, pviewtoactivate: &::core::option::Option<IOleDocumentView>) -> ::windows::core::Result<()>;
 }
@@ -1992,6 +2030,7 @@ impl IOleDocumentSite_Vtbl {
         iid == &<IOleDocumentSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOleDocumentView_Impl: Sized {
     fn SetInPlaceSite(&self, pipsite: &::core::option::Option<IOleInPlaceSite>) -> ::windows::core::Result<()>;
@@ -2123,6 +2162,7 @@ impl IOleDocumentView_Vtbl {
         iid == &<IOleDocumentView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleInPlaceActiveObject_Impl: Sized + IOleWindow_Impl {
     fn TranslateAccelerator(&self, lpmsg: *const super::super::UI::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
@@ -2174,6 +2214,7 @@ impl IOleInPlaceActiveObject_Vtbl {
         iid == &<IOleInPlaceActiveObject as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleInPlaceFrame_Impl: Sized + IOleInPlaceUIWindow_Impl {
     fn InsertMenus(&self, hmenushared: super::super::UI::WindowsAndMessaging::HMENU, lpmenuwidths: *mut OLEMENUGROUPWIDTHS) -> ::windows::core::Result<()>;
@@ -2232,6 +2273,7 @@ impl IOleInPlaceFrame_Vtbl {
         iid == &<IOleInPlaceFrame as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID || iid == &<IOleInPlaceUIWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleInPlaceObject_Impl: Sized + IOleWindow_Impl {
     fn InPlaceDeactivate(&self) -> ::windows::core::Result<()>;
@@ -2276,6 +2318,7 @@ impl IOleInPlaceObject_Vtbl {
         iid == &<IOleInPlaceObject as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleInPlaceObjectWindowless_Impl: Sized + IOleInPlaceObject_Impl {
     fn OnWindowMessage(&self, msg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::LRESULT>;
@@ -2318,6 +2361,7 @@ impl IOleInPlaceObjectWindowless_Vtbl {
         iid == &<IOleInPlaceObjectWindowless as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID || iid == &<IOleInPlaceObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleInPlaceSite_Impl: Sized + IOleWindow_Impl {
     fn CanInPlaceActivate(&self) -> ::windows::core::Result<()>;
@@ -2404,6 +2448,7 @@ impl IOleInPlaceSite_Vtbl {
         iid == &<IOleInPlaceSite as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleInPlaceSiteEx_Impl: Sized + IOleInPlaceSite_Impl {
     fn OnInPlaceActivateEx(&self, pfnoredraw: *mut super::super::Foundation::BOOL, dwflags: u32) -> ::windows::core::Result<()>;
@@ -2441,6 +2486,7 @@ impl IOleInPlaceSiteEx_Vtbl {
         iid == &<IOleInPlaceSiteEx as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID || iid == &<IOleInPlaceSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleInPlaceSiteWindowless_Impl: Sized + IOleInPlaceSiteEx_Impl {
     fn CanWindowlessActivate(&self) -> ::windows::core::Result<()>;
@@ -2553,6 +2599,7 @@ impl IOleInPlaceSiteWindowless_Vtbl {
         iid == &<IOleInPlaceSiteWindowless as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID || iid == &<IOleInPlaceSite as ::windows::core::Interface>::IID || iid == &<IOleInPlaceSiteEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleInPlaceUIWindow_Impl: Sized + IOleWindow_Impl {
     fn GetBorder(&self) -> ::windows::core::Result<super::super::Foundation::RECT>;
@@ -2603,6 +2650,7 @@ impl IOleInPlaceUIWindow_Vtbl {
         iid == &<IOleInPlaceUIWindow as ::windows::core::Interface>::IID || iid == &<IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IOleItemContainer_Impl: Sized + IOleContainer_Impl {
     fn GetObject(&self, pszitem: &::windows::core::PCWSTR, dwspeedneeded: u32, pbc: &::core::option::Option<super::Com::IBindCtx>, riid: *const ::windows::core::GUID, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2640,6 +2688,7 @@ impl IOleItemContainer_Vtbl {
         iid == &<IOleItemContainer as ::windows::core::Interface>::IID || iid == &<IParseDisplayName as ::windows::core::Interface>::IID || iid == &<IOleContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IOleLink_Impl: Sized {
     fn SetUpdateOptions(&self, dwupdateopt: u32) -> ::windows::core::Result<()>;
@@ -2757,6 +2806,7 @@ impl IOleLink_Vtbl {
         iid == &<IOleLink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IOleObject_Impl: Sized {
     fn SetClientSite(&self, pclientsite: &::core::option::Option<IOleClientSite>) -> ::windows::core::Result<()>;
@@ -2980,6 +3030,7 @@ impl IOleObject_Vtbl {
         iid == &<IOleObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleParentUndoUnit_Impl: Sized + IOleUndoUnit_Impl {
     fn Open(&self, ppuu: &::core::option::Option<IOleParentUndoUnit>) -> ::windows::core::Result<()>;
@@ -3037,6 +3088,7 @@ impl IOleParentUndoUnit_Vtbl {
         iid == &<IOleParentUndoUnit as ::windows::core::Interface>::IID || iid == &<IOleUndoUnit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleUILinkContainerA_Impl: Sized {
     fn GetNextLink(&self, dwlink: u32) -> u32;
@@ -3115,6 +3167,7 @@ impl IOleUILinkContainerA_Vtbl {
         iid == &<IOleUILinkContainerA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleUILinkContainerW_Impl: Sized {
     fn GetNextLink(&self, dwlink: u32) -> u32;
@@ -3193,6 +3246,7 @@ impl IOleUILinkContainerW_Vtbl {
         iid == &<IOleUILinkContainerW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleUILinkInfoA_Impl: Sized + IOleUILinkContainerA_Impl {
     fn GetLastUpdate(&self, dwlink: u32) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
@@ -3219,6 +3273,7 @@ impl IOleUILinkInfoA_Vtbl {
         iid == &<IOleUILinkInfoA as ::windows::core::Interface>::IID || iid == &<IOleUILinkContainerA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleUILinkInfoW_Impl: Sized + IOleUILinkContainerW_Impl {
     fn GetLastUpdate(&self, dwlink: u32) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
@@ -3245,6 +3300,7 @@ impl IOleUILinkInfoW_Vtbl {
         iid == &<IOleUILinkInfoW as ::windows::core::Interface>::IID || iid == &<IOleUILinkContainerW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleUIObjInfoA_Impl: Sized {
     fn GetObjectInfo(&self, dwobject: u32, lpdwobjsize: *mut u32, lplpszlabel: *mut ::windows::core::PSTR, lplpsztype: *mut ::windows::core::PSTR, lplpszshorttype: *mut ::windows::core::PSTR, lplpszlocation: *mut ::windows::core::PSTR) -> ::windows::core::Result<()>;
@@ -3296,6 +3352,7 @@ impl IOleUIObjInfoA_Vtbl {
         iid == &<IOleUIObjInfoA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleUIObjInfoW_Impl: Sized {
     fn GetObjectInfo(&self, dwobject: u32, lpdwobjsize: *mut u32, lplpszlabel: *mut ::windows::core::PWSTR, lplpsztype: *mut ::windows::core::PWSTR, lplpszshorttype: *mut ::windows::core::PWSTR, lplpszlocation: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -3347,6 +3404,7 @@ impl IOleUIObjInfoW_Vtbl {
         iid == &<IOleUIObjInfoW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleUndoManager_Impl: Sized {
     fn Open(&self, ppuu: &::core::option::Option<IOleParentUndoUnit>) -> ::windows::core::Result<()>;
@@ -3477,6 +3535,7 @@ impl IOleUndoManager_Vtbl {
         iid == &<IOleUndoManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IOleUndoUnit_Impl: Sized {
     fn Do(&self, pundomanager: &::core::option::Option<IOleUndoManager>) -> ::windows::core::Result<()>;
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3524,6 +3583,7 @@ impl IOleUndoUnit_Vtbl {
         iid == &<IOleUndoUnit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOleWindow_Impl: Sized {
     fn GetWindow(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -3560,6 +3620,7 @@ impl IOleWindow_Vtbl {
         iid == &<IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IParseDisplayName_Impl: Sized {
     fn ParseDisplayName(&self, pbc: &::core::option::Option<super::Com::IBindCtx>, pszdisplayname: &::windows::core::PCWSTR, pcheaten: *mut u32, ppmkout: *mut ::core::option::Option<super::Com::IMoniker>) -> ::windows::core::Result<()>;
@@ -3580,6 +3641,7 @@ impl IParseDisplayName_Vtbl {
         iid == &<IParseDisplayName as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPerPropertyBrowsing_Impl: Sized {
     fn GetDisplayString(&self, dispid: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3642,6 +3704,7 @@ impl IPerPropertyBrowsing_Vtbl {
         iid == &<IPerPropertyBrowsing as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPersistPropertyBag_Impl: Sized + super::Com::IPersist_Impl {
     fn InitNew(&self) -> ::windows::core::Result<()>;
@@ -3679,6 +3742,7 @@ impl IPersistPropertyBag_Vtbl {
         iid == &<IPersistPropertyBag as ::windows::core::Interface>::IID || iid == &<super::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPersistPropertyBag2_Impl: Sized + super::Com::IPersist_Impl {
     fn InitNew(&self) -> ::windows::core::Result<()>;
@@ -3723,6 +3787,7 @@ impl IPersistPropertyBag2_Vtbl {
         iid == &<IPersistPropertyBag2 as ::windows::core::Interface>::IID || iid == &<super::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IPicture_Impl: Sized {
     fn Handle(&self) -> ::windows::core::Result<OLE_HANDLE>;
@@ -3891,6 +3956,7 @@ impl IPicture_Vtbl {
         iid == &<IPicture as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IPicture2_Impl: Sized {
     fn Handle(&self) -> ::windows::core::Result<usize>;
@@ -4059,6 +4125,7 @@ impl IPicture2_Vtbl {
         iid == &<IPicture2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IPictureDisp_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -4072,6 +4139,7 @@ impl IPictureDisp_Vtbl {
         iid == &<IPictureDisp as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPointerInactive_Impl: Sized {
     fn GetActivationPolicy(&self) -> ::windows::core::Result<POINTERINACTIVE>;
@@ -4115,6 +4183,7 @@ impl IPointerInactive_Vtbl {
         iid == &<IPointerInactive as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPrint_Impl: Sized {
     fn SetInitialPageNum(&self, nfirstpage: i32) -> ::windows::core::Result<()>;
@@ -4152,6 +4221,7 @@ impl IPrint_Vtbl {
         iid == &<IPrint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IPropertyNotifySink_Impl: Sized {
     fn OnChanged(&self, dispid: i32) -> ::windows::core::Result<()>;
     fn OnRequestEdit(&self, dispid: i32) -> ::windows::core::Result<()>;
@@ -4179,6 +4249,7 @@ impl IPropertyNotifySink_Vtbl {
         iid == &<IPropertyNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPropertyPage_Impl: Sized {
     fn SetPageSite(&self, ppagesite: &::core::option::Option<IPropertyPageSite>) -> ::windows::core::Result<()>;
@@ -4278,6 +4349,7 @@ impl IPropertyPage_Vtbl {
         iid == &<IPropertyPage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPropertyPage2_Impl: Sized + IPropertyPage_Impl {
     fn EditProperty(&self, dispid: i32) -> ::windows::core::Result<()>;
@@ -4298,6 +4370,7 @@ impl IPropertyPage2_Vtbl {
         iid == &<IPropertyPage2 as ::windows::core::Interface>::IID || iid == &<IPropertyPage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPropertyPageSite_Impl: Sized {
     fn OnStatusChange(&self, dwflags: PROPPAGESTATUS) -> ::windows::core::Result<()>;
@@ -4354,6 +4427,7 @@ impl IPropertyPageSite_Vtbl {
         iid == &<IPropertyPageSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProtectFocus_Impl: Sized {
     fn AllowFocusChange(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -4380,6 +4454,7 @@ impl IProtectFocus_Vtbl {
         iid == &<IProtectFocus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub trait IProtectedModeMenuServices_Impl: Sized {
     fn CreateMenu(&self) -> ::windows::core::Result<super::super::UI::WindowsAndMessaging::HMENU>;
@@ -4435,6 +4510,7 @@ impl IProtectedModeMenuServices_Vtbl {
         iid == &<IProtectedModeMenuServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IProvideClassInfo_Impl: Sized {
     fn GetClassInfo(&self) -> ::windows::core::Result<super::Com::ITypeInfo>;
@@ -4461,6 +4537,7 @@ impl IProvideClassInfo_Vtbl {
         iid == &<IProvideClassInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IProvideClassInfo2_Impl: Sized + IProvideClassInfo_Impl {
     fn GetGUID(&self, dwguidkind: u32) -> ::windows::core::Result<::windows::core::GUID>;
@@ -4487,6 +4564,7 @@ impl IProvideClassInfo2_Vtbl {
         iid == &<IProvideClassInfo2 as ::windows::core::Interface>::IID || iid == &<IProvideClassInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IProvideMultipleClassInfo_Impl: Sized + IProvideClassInfo2_Impl {
     fn GetMultiTypeInfoCount(&self) -> ::windows::core::Result<u32>;
@@ -4523,6 +4601,7 @@ impl IProvideMultipleClassInfo_Vtbl {
         iid == &<IProvideMultipleClassInfo as ::windows::core::Interface>::IID || iid == &<IProvideClassInfo as ::windows::core::Interface>::IID || iid == &<IProvideClassInfo2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProvideRuntimeContext_Impl: Sized {
     fn GetCurrentSourceContext(&self, pdwcontext: *mut usize, pfexecutingglobalcode: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -4543,6 +4622,7 @@ impl IProvideRuntimeContext_Vtbl {
         iid == &<IProvideRuntimeContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IQuickActivate_Impl: Sized {
     fn QuickActivate(&self, pqacontainer: *const QACONTAINER, pqacontrol: *mut QACONTROL) -> ::windows::core::Result<()>;
@@ -4586,6 +4666,7 @@ impl IQuickActivate_Vtbl {
         iid == &<IQuickActivate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IRecordInfo_Impl: Sized {
     fn RecordInit(&self, pvnew: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -4744,6 +4825,7 @@ impl IRecordInfo_Vtbl {
         iid == &<IRecordInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISimpleFrameSite_Impl: Sized {
     fn PreMessageFilter(&self, hwnd: super::super::Foundation::HWND, msg: u32, wp: super::super::Foundation::WPARAM, lp: super::super::Foundation::LPARAM, plresult: *mut super::super::Foundation::LRESULT, pdwcookie: *mut u32) -> ::windows::core::Result<()>;
@@ -4774,6 +4856,7 @@ impl ISimpleFrameSite_Vtbl {
         iid == &<ISimpleFrameSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait ISpecifyPropertyPages_Impl: Sized {
     fn GetPages(&self) -> ::windows::core::Result<CAUUID>;
 }
@@ -4797,6 +4880,7 @@ impl ISpecifyPropertyPages_Vtbl {
         iid == &<ISpecifyPropertyPages as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITypeChangeEvents_Impl: Sized {
     fn RequestTypeChange(&self, changekind: CHANGEKIND, ptinfobefore: &::core::option::Option<super::Com::ITypeInfo>, pstrname: &::windows::core::PCWSTR) -> ::windows::core::Result<i32>;
@@ -4833,6 +4917,7 @@ impl ITypeChangeEvents_Vtbl {
         iid == &<ITypeChangeEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITypeFactory_Impl: Sized {
     fn CreateFromTypeInfo(&self, ptypeinfo: &::core::option::Option<super::Com::ITypeInfo>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -4859,6 +4944,7 @@ impl ITypeFactory_Vtbl {
         iid == &<ITypeFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait ITypeMarshal_Impl: Sized {
     fn Size(&self, pvtype: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *const ::core::ffi::c_void) -> ::windows::core::Result<u32>;
     fn Marshal(&self, pvtype: *const ::core::ffi::c_void, dwdestcontext: u32, pvdestcontext: *const ::core::ffi::c_void, cbbufferlength: u32, pbuffer: *mut u8, pcbwritten: *mut u32) -> ::windows::core::Result<()>;
@@ -4906,6 +4992,7 @@ impl ITypeMarshal_Vtbl {
         iid == &<ITypeMarshal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IVBFormat_Impl: Sized {
     fn Format(&self, vdata: *mut super::Com::VARIANT, bstrformat: &::windows::core::BSTR, lpbuffer: *mut ::core::ffi::c_void, cb: u16, lcid: i32, sfirstdayofweek: i16, sfirstweekofyear: u16, rcb: *mut u16) -> ::windows::core::Result<()>;
@@ -4926,6 +5013,7 @@ impl IVBFormat_Vtbl {
         iid == &<IVBFormat as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IVBGetControl_Impl: Sized {
     fn EnumControls(&self, dwolecontf: OLECONTF, dwwhich: ENUM_CONTROLS_WHICH_FLAGS) -> ::windows::core::Result<super::Com::IEnumUnknown>;
@@ -4952,6 +5040,7 @@ impl IVBGetControl_Vtbl {
         iid == &<IVBGetControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IVariantChangeType_Impl: Sized {
     fn ChangeType(&self, pvardst: *mut super::Com::VARIANT, pvarsrc: *const super::Com::VARIANT, lcid: u32, vtnew: super::Com::VARENUM) -> ::windows::core::Result<()>;
@@ -4972,6 +5061,7 @@ impl IVariantChangeType_Vtbl {
         iid == &<IVariantChangeType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IViewObject_Impl: Sized {
     fn Draw(&self, dwdrawaspect: super::Com::DVASPECT, lindex: i32, pvaspect: *mut ::core::ffi::c_void, ptd: *const super::Com::DVTARGETDEVICE, hdctargetdev: super::super::Graphics::Gdi::HDC, hdcdraw: super::super::Graphics::Gdi::HDC, lprcbounds: *const super::super::Foundation::RECTL, lprcwbounds: *const super::super::Foundation::RECTL, pfncontinue: isize, dwcontinue: usize) -> ::windows::core::Result<()>;
@@ -5030,6 +5120,7 @@ impl IViewObject_Vtbl {
         iid == &<IViewObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IViewObject2_Impl: Sized + IViewObject_Impl {
     fn GetExtent(&self, dwdrawaspect: super::Com::DVASPECT, lindex: i32, ptd: *const super::Com::DVTARGETDEVICE) -> ::windows::core::Result<super::super::Foundation::SIZE>;
@@ -5056,6 +5147,7 @@ impl IViewObject2_Vtbl {
         iid == &<IViewObject2 as ::windows::core::Interface>::IID || iid == &<IViewObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IViewObjectEx_Impl: Sized + IViewObject2_Impl {
     fn GetRect(&self, dwaspect: u32) -> ::windows::core::Result<super::super::Foundation::RECTL>;
@@ -5137,6 +5229,7 @@ impl IViewObjectEx_Vtbl {
         iid == &<IViewObjectEx as ::windows::core::Interface>::IID || iid == &<IViewObject as ::windows::core::Interface>::IID || iid == &<IViewObject2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Ole\"`, `\"implement\"`*"]
 pub trait IZoomEvents_Impl: Sized {
     fn OnZoomPercentChanged(&self, ulzoompercent: u32) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ParentalControls/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWPCGamesSettings_Impl: Sized + IWPCSettings_Impl {
     fn IsBlocked(&self, guidappid: &::windows::core::GUID) -> ::windows::core::Result<u32>;
@@ -24,6 +25,7 @@ impl IWPCGamesSettings_Vtbl {
         iid == &<IWPCGamesSettings as ::windows::core::Interface>::IID || iid == &<IWPCSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWPCProviderConfig_Impl: Sized {
     fn GetUserSummary(&self, bstrsid: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -67,6 +69,7 @@ impl IWPCProviderConfig_Vtbl {
         iid == &<IWPCProviderConfig as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"implement\"`*"]
 pub trait IWPCProviderState_Impl: Sized {
     fn Enable(&self) -> ::windows::core::Result<()>;
     fn Disable(&self) -> ::windows::core::Result<()>;
@@ -94,6 +97,7 @@ impl IWPCProviderState_Vtbl {
         iid == &<IWPCProviderState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"implement\"`*"]
 pub trait IWPCProviderSupport_Impl: Sized {
     fn GetCurrent(&self) -> ::windows::core::Result<::windows::core::GUID>;
 }
@@ -117,6 +121,7 @@ impl IWPCProviderSupport_Vtbl {
         iid == &<IWPCProviderSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWPCSettings_Impl: Sized {
     fn IsLoggingRequired(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -172,6 +177,7 @@ impl IWPCSettings_Vtbl {
         iid == &<IWPCSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWPCWebSettings_Impl: Sized + IWPCSettings_Impl {
     fn GetSettings(&self) -> ::windows::core::Result<WPCFLAG_WEB_SETTING>;
@@ -214,6 +220,7 @@ impl IWPCWebSettings_Vtbl {
         iid == &<IWPCWebSettings as ::windows::core::Interface>::IID || iid == &<IWPCSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"implement\"`*"]
 pub trait IWindowsParentalControls_Impl: Sized + IWindowsParentalControlsCore_Impl {
     fn GetGamesSettings(&self, pcszsid: &::windows::core::PCWSTR) -> ::windows::core::Result<IWPCGamesSettings>;
 }
@@ -237,6 +244,7 @@ impl IWindowsParentalControls_Vtbl {
         iid == &<IWindowsParentalControls as ::windows::core::Interface>::IID || iid == &<IWindowsParentalControlsCore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ParentalControls\"`, `\"implement\"`*"]
 pub trait IWindowsParentalControlsCore_Impl: Sized {
     fn GetVisibility(&self) -> ::windows::core::Result<WPCFLAG_VISIBILITY>;
     fn GetUserSettings(&self, pcszsid: &::windows::core::PCWSTR) -> ::windows::core::Result<IWPCSettings>;

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DICounterItem_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -11,6 +12,7 @@ impl DICounterItem_Vtbl {
         iid == &<DICounterItem as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DILogFileItem_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -24,6 +26,7 @@ impl DILogFileItem_Vtbl {
         iid == &<DILogFileItem as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DISystemMonitor_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -37,6 +40,7 @@ impl DISystemMonitor_Vtbl {
         iid == &<DISystemMonitor as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DISystemMonitorEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -50,6 +54,7 @@ impl DISystemMonitorEvents_Vtbl {
         iid == &<DISystemMonitorEvents as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DISystemMonitorInternal_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -63,6 +68,7 @@ impl DISystemMonitorInternal_Vtbl {
         iid == &<DISystemMonitorInternal as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAlertDataCollector_Impl: Sized + IDataCollector_Impl {
     fn AlertThresholds(&self) -> ::windows::core::Result<*mut super::Com::SAFEARRAY>;
@@ -239,6 +245,7 @@ impl IAlertDataCollector_Vtbl {
         iid == &<IAlertDataCollector as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDataCollector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IApiTracingDataCollector_Impl: Sized + IDataCollector_Impl {
     fn LogApiNamesOnly(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -395,6 +402,7 @@ impl IApiTracingDataCollector_Vtbl {
         iid == &<IApiTracingDataCollector as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDataCollector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IConfigurationDataCollector_Impl: Sized + IDataCollector_Impl {
     fn FileMaxCount(&self) -> ::windows::core::Result<u32>;
@@ -591,6 +599,7 @@ impl IConfigurationDataCollector_Vtbl {
         iid == &<IConfigurationDataCollector as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDataCollector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"implement\"`*"]
 pub trait ICounterItem_Impl: Sized {
     fn Value(&self) -> ::windows::core::Result<f64>;
     fn SetColor(&self, color: u32) -> ::windows::core::Result<()>;
@@ -724,6 +733,7 @@ impl ICounterItem_Vtbl {
         iid == &<ICounterItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICounterItem2_Impl: Sized + ICounterItem_Impl {
     fn SetSelected(&self, bstate: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -793,6 +803,7 @@ impl ICounterItem2_Vtbl {
         iid == &<ICounterItem2 as ::windows::core::Interface>::IID || iid == &<ICounterItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICounters_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -868,6 +879,7 @@ impl ICounters_Vtbl {
         iid == &<ICounters as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataCollector_Impl: Sized + super::Com::IDispatch_Impl {
     fn DataCollectorSet(&self) -> ::windows::core::Result<IDataCollectorSet>;
@@ -1149,6 +1161,7 @@ impl IDataCollector_Vtbl {
         iid == &<IDataCollector as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataCollectorCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1252,6 +1265,7 @@ impl IDataCollectorCollection_Vtbl {
         iid == &<IDataCollectorCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataCollectorSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn DataCollectors(&self) -> ::windows::core::Result<IDataCollectorCollection>;
@@ -1892,6 +1906,7 @@ impl IDataCollectorSet_Vtbl {
         iid == &<IDataCollectorSet as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataCollectorSetCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1982,6 +1997,7 @@ impl IDataCollectorSetCollection_Vtbl {
         iid == &<IDataCollectorSetCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn Enabled(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2251,6 +2267,7 @@ impl IDataManager_Vtbl {
         iid == &<IDataManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFolderAction_Impl: Sized + super::Com::IDispatch_Impl {
     fn Age(&self) -> ::windows::core::Result<u32>;
@@ -2347,6 +2364,7 @@ impl IFolderAction_Vtbl {
         iid == &<IFolderAction as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFolderActionCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -2443,6 +2461,7 @@ impl IFolderActionCollection_Vtbl {
         iid == &<IFolderActionCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"implement\"`*"]
 pub trait ILogFileItem_Impl: Sized {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -2466,6 +2485,7 @@ impl ILogFileItem_Vtbl {
         iid == &<ILogFileItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ILogFiles_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2541,6 +2561,7 @@ impl ILogFiles_Vtbl {
         iid == &<ILogFiles as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPerformanceCounterDataCollector_Impl: Sized + IDataCollector_Impl {
     fn DataSourceName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2657,6 +2678,7 @@ impl IPerformanceCounterDataCollector_Vtbl {
         iid == &<IPerformanceCounterDataCollector as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDataCollector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISchedule_Impl: Sized + super::Com::IDispatch_Impl {
     fn StartDate(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -2753,6 +2775,7 @@ impl ISchedule_Vtbl {
         iid == &<ISchedule as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IScheduleCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2849,6 +2872,7 @@ impl IScheduleCollection_Vtbl {
         iid == &<IScheduleCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISystemMonitor_Impl: Sized {
     fn Appearance(&self) -> ::windows::core::Result<i32>;
@@ -3613,6 +3637,7 @@ impl ISystemMonitor_Vtbl {
         iid == &<ISystemMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISystemMonitor2_Impl: Sized + ISystemMonitor_Impl {
     fn SetEnableDigitGrouping(&self, bstate: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3811,6 +3836,7 @@ impl ISystemMonitor2_Vtbl {
         iid == &<ISystemMonitor2 as ::windows::core::Interface>::IID || iid == &<ISystemMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"implement\"`*"]
 pub trait ISystemMonitorEvents_Impl: Sized {
     fn OnCounterSelected(&self, index: i32);
     fn OnCounterAdded(&self, index: i32);
@@ -3859,6 +3885,7 @@ impl ISystemMonitorEvents_Vtbl {
         iid == &<ISystemMonitorEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITraceDataCollector_Impl: Sized + IDataCollector_Impl {
     fn BufferSize(&self) -> ::windows::core::Result<u32>;
@@ -4281,6 +4308,7 @@ impl ITraceDataCollector_Vtbl {
         iid == &<ITraceDataCollector as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IDataCollector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITraceDataProvider_Impl: Sized + super::Com::IDispatch_Impl {
     fn DisplayName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4496,6 +4524,7 @@ impl ITraceDataProvider_Vtbl {
         iid == &<ITraceDataProvider as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITraceDataProviderCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4606,6 +4635,7 @@ impl ITraceDataProviderCollection_Vtbl {
         iid == &<ITraceDataProviderCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IValueMap_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4762,6 +4792,7 @@ impl IValueMap_Vtbl {
         iid == &<IValueMap as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IValueMapItem_Impl: Sized + super::Com::IDispatch_Impl {
     fn Description(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4878,6 +4909,7 @@ impl IValueMapItem_Vtbl {
         iid == &<IValueMapItem as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ICounterItemUnion_Impl: Sized {
     fn Value(&self) -> ::windows::core::Result<f64>;
@@ -5067,6 +5099,7 @@ impl _ICounterItemUnion_Vtbl {
         iid == &<_ICounterItemUnion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Performance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ISystemMonitorUnion_Impl: Sized {
     fn Appearance(&self) -> ::windows::core::Result<i32>;

--- a/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RealTimeCommunications/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Networking_WinSock\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Networking_WinSock")]
 pub trait INetworkTransportSettings_Impl: Sized {
     fn ApplySetting(&self, settingid: *const super::super::Networking::WinSock::TRANSPORT_SETTING_ID, lengthin: u32, valuein: *const u8, lengthout: *mut u32, valueout: *mut *mut u8) -> ::windows::core::Result<()>;
@@ -28,6 +29,7 @@ impl INetworkTransportSettings_Vtbl {
         iid == &<INetworkTransportSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait INotificationTransportSync_Impl: Sized {
     fn CompleteDelivery(&self) -> ::windows::core::Result<()>;
     fn Flush(&self) -> ::windows::core::Result<()>;
@@ -55,6 +57,7 @@ impl INotificationTransportSync_Vtbl {
         iid == &<INotificationTransportSync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCBuddy_Impl: Sized + IRTCPresenceContact_Impl {
     fn Status(&self) -> ::windows::core::Result<RTC_PRESENCE_STATUS>;
@@ -97,6 +100,7 @@ impl IRTCBuddy_Vtbl {
         iid == &<IRTCBuddy as ::windows::core::Interface>::IID || iid == &<IRTCPresenceContact as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IRTCBuddy2_Impl: Sized + IRTCBuddy_Impl {
     fn Profile(&self) -> ::windows::core::Result<IRTCProfile2>;
@@ -211,6 +215,7 @@ impl IRTCBuddy2_Vtbl {
         iid == &<IRTCBuddy2 as ::windows::core::Interface>::IID || iid == &<IRTCPresenceContact as ::windows::core::Interface>::IID || iid == &<IRTCBuddy as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCBuddyEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Buddy(&self) -> ::windows::core::Result<IRTCBuddy>;
@@ -237,6 +242,7 @@ impl IRTCBuddyEvent_Vtbl {
         iid == &<IRTCBuddyEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCBuddyEvent2_Impl: Sized + IRTCBuddyEvent_Impl {
     fn EventType(&self) -> ::windows::core::Result<RTC_BUDDY_EVENT_TYPE>;
@@ -292,6 +298,7 @@ impl IRTCBuddyEvent2_Vtbl {
         iid == &<IRTCBuddyEvent2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IRTCBuddyEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRTCBuddyGroup_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -401,6 +408,7 @@ impl IRTCBuddyGroup_Vtbl {
         iid == &<IRTCBuddyGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCBuddyGroupEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn EventType(&self) -> ::windows::core::Result<RTC_GROUP_EVENT_TYPE>;
@@ -469,6 +477,7 @@ impl IRTCBuddyGroupEvent_Vtbl {
         iid == &<IRTCBuddyGroupEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCClient_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
@@ -905,6 +914,7 @@ impl IRTCClient_Vtbl {
         iid == &<IRTCClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_Media_DirectShow\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_DirectShow", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCClient2_Impl: Sized + IRTCClient_Impl {
     fn put_AnswerMode(&self, entype: RTC_SESSION_TYPE, enmode: RTC_ANSWER_MODE) -> ::windows::core::Result<()>;
@@ -1042,6 +1052,7 @@ impl IRTCClient2_Vtbl {
         iid == &<IRTCClient2 as ::windows::core::Interface>::IID || iid == &<IRTCClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCClientEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn EventType(&self) -> ::windows::core::Result<RTC_CLIENT_EVENT_TYPE>;
@@ -1084,6 +1095,7 @@ impl IRTCClientEvent_Vtbl {
         iid == &<IRTCClientEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCClientPortManagement_Impl: Sized {
     fn StartListenAddressAndPort(&self, bstrinternallocaladdress: &::windows::core::BSTR, linternallocalport: i32) -> ::windows::core::Result<()>;
     fn StopListenAddressAndPort(&self, bstrinternallocaladdress: &::windows::core::BSTR, linternallocalport: i32) -> ::windows::core::Result<()>;
@@ -1118,6 +1130,7 @@ impl IRTCClientPortManagement_Vtbl {
         iid == &<IRTCClientPortManagement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCClientPresence_Impl: Sized {
     fn EnablePresence(&self, fusestorage: super::super::Foundation::VARIANT_BOOL, varstorage: &super::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -1320,6 +1333,7 @@ impl IRTCClientPresence_Vtbl {
         iid == &<IRTCClientPresence as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCClientPresence2_Impl: Sized + IRTCClientPresence_Impl {
     fn EnablePresenceEx(&self, pprofile: &::core::option::Option<IRTCProfile>, varstorage: &super::Com::VARIANT, lflags: i32) -> ::windows::core::Result<()>;
@@ -1489,6 +1503,7 @@ impl IRTCClientPresence2_Vtbl {
         iid == &<IRTCClientPresence2 as ::windows::core::Interface>::IID || iid == &<IRTCClientPresence as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRTCClientProvisioning_Impl: Sized {
     fn CreateProfile(&self, bstrprofilexml: &::windows::core::BSTR) -> ::windows::core::Result<IRTCProfile>;
@@ -1578,6 +1593,7 @@ impl IRTCClientProvisioning_Vtbl {
         iid == &<IRTCClientProvisioning as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRTCClientProvisioning2_Impl: Sized + IRTCClientProvisioning_Impl {
     fn EnableProfileEx(&self, pprofile: &::core::option::Option<IRTCProfile>, lregisterflags: i32, lroamingflags: i32) -> ::windows::core::Result<()>;
@@ -1598,6 +1614,7 @@ impl IRTCClientProvisioning2_Vtbl {
         iid == &<IRTCClientProvisioning2 as ::windows::core::Interface>::IID || iid == &<IRTCClientProvisioning as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1653,6 +1670,7 @@ impl IRTCCollection_Vtbl {
         iid == &<IRTCCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCDispatchEventNotification_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -1666,6 +1684,7 @@ impl IRTCDispatchEventNotification_Vtbl {
         iid == &<IRTCDispatchEventNotification as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCEnumBuddies_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<IRTCBuddy>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1713,6 +1732,7 @@ impl IRTCEnumBuddies_Vtbl {
         iid == &<IRTCEnumBuddies as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCEnumGroups_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<IRTCBuddyGroup>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1760,6 +1780,7 @@ impl IRTCEnumGroups_Vtbl {
         iid == &<IRTCEnumGroups as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCEnumParticipants_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<IRTCParticipant>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1807,6 +1828,7 @@ impl IRTCEnumParticipants_Vtbl {
         iid == &<IRTCEnumParticipants as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCEnumPresenceDevices_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<IRTCPresenceDevice>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1854,6 +1876,7 @@ impl IRTCEnumPresenceDevices_Vtbl {
         iid == &<IRTCEnumPresenceDevices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCEnumProfiles_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<IRTCProfile>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1901,6 +1924,7 @@ impl IRTCEnumProfiles_Vtbl {
         iid == &<IRTCEnumProfiles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCEnumUserSearchResults_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<IRTCUserSearchResult>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1948,6 +1972,7 @@ impl IRTCEnumUserSearchResults_Vtbl {
         iid == &<IRTCEnumUserSearchResults as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCEnumWatchers_Impl: Sized {
     fn Next(&self, celt: u32, ppelements: *mut ::core::option::Option<IRTCWatcher>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1995,6 +2020,7 @@ impl IRTCEnumWatchers_Vtbl {
         iid == &<IRTCEnumWatchers as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRTCEventNotification_Impl: Sized {
     fn Event(&self, rtcevent: RTC_EVENT, pevent: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -2015,6 +2041,7 @@ impl IRTCEventNotification_Vtbl {
         iid == &<IRTCEventNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCInfoEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession2>;
@@ -2083,6 +2110,7 @@ impl IRTCInfoEvent_Vtbl {
         iid == &<IRTCInfoEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCIntensityEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Level(&self) -> ::windows::core::Result<i32>;
@@ -2151,6 +2179,7 @@ impl IRTCIntensityEvent_Vtbl {
         iid == &<IRTCIntensityEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCMediaEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn MediaType(&self) -> ::windows::core::Result<i32>;
@@ -2206,6 +2235,7 @@ impl IRTCMediaEvent_Vtbl {
         iid == &<IRTCMediaEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCMediaRequestEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession2>;
@@ -2301,6 +2331,7 @@ impl IRTCMediaRequestEvent_Vtbl {
         iid == &<IRTCMediaRequestEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCMessagingEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession>;
@@ -2395,6 +2426,7 @@ impl IRTCMessagingEvent_Vtbl {
         iid == &<IRTCMessagingEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCParticipant_Impl: Sized {
     fn UserURI(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2476,6 +2508,7 @@ impl IRTCParticipant_Vtbl {
         iid == &<IRTCParticipant as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCParticipantStateChangeEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Participant(&self) -> ::windows::core::Result<IRTCParticipant>;
@@ -2531,6 +2564,7 @@ impl IRTCParticipantStateChangeEvent_Vtbl {
         iid == &<IRTCParticipantStateChangeEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCPortManager_Impl: Sized {
     fn GetMapping(&self, bstrremoteaddress: &::windows::core::BSTR, enporttype: RTC_PORT_TYPE, pbstrinternallocaladdress: *mut ::windows::core::BSTR, plinternallocalport: *mut i32, pbstrexternallocaladdress: *mut ::windows::core::BSTR, plexternallocalport: *mut i32) -> ::windows::core::Result<()>;
     fn UpdateRemoteAddress(&self, bstrremoteaddress: &::windows::core::BSTR, bstrinternallocaladdress: &::windows::core::BSTR, linternallocalport: i32, bstrexternallocaladdress: &::windows::core::BSTR, lexternallocalport: i32) -> ::windows::core::Result<()>;
@@ -2565,6 +2599,7 @@ impl IRTCPortManager_Vtbl {
         iid == &<IRTCPortManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCPresenceContact_Impl: Sized {
     fn PresentityURI(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2661,6 +2696,7 @@ impl IRTCPresenceContact_Vtbl {
         iid == &<IRTCPresenceContact as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCPresenceDataEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
@@ -2710,6 +2746,7 @@ impl IRTCPresenceDataEvent_Vtbl {
         iid == &<IRTCPresenceDataEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCPresenceDevice_Impl: Sized {
     fn Status(&self) -> ::windows::core::Result<RTC_PRESENCE_STATUS>;
     fn Notes(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2769,6 +2806,7 @@ impl IRTCPresenceDevice_Vtbl {
         iid == &<IRTCPresenceDevice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCPresencePropertyEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
@@ -2837,6 +2875,7 @@ impl IRTCPresencePropertyEvent_Vtbl {
         iid == &<IRTCPresencePropertyEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCPresenceStatusEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn StatusCode(&self) -> ::windows::core::Result<i32>;
@@ -2886,6 +2925,7 @@ impl IRTCPresenceStatusEvent_Vtbl {
         iid == &<IRTCPresenceStatusEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCProfile_Impl: Sized {
     fn Key(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3130,6 +3170,7 @@ impl IRTCProfile_Vtbl {
         iid == &<IRTCProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCProfile2_Impl: Sized + IRTCProfile_Impl {
     fn Realm(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3186,6 +3227,7 @@ impl IRTCProfile2_Vtbl {
         iid == &<IRTCProfile2 as ::windows::core::Interface>::IID || iid == &<IRTCProfile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCProfileEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Profile(&self) -> ::windows::core::Result<IRTCProfile>;
@@ -3241,6 +3283,7 @@ impl IRTCProfileEvent_Vtbl {
         iid == &<IRTCProfileEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCProfileEvent2_Impl: Sized + IRTCProfileEvent_Impl {
     fn EventType(&self) -> ::windows::core::Result<RTC_PROFILE_EVENT_TYPE>;
@@ -3267,6 +3310,7 @@ impl IRTCProfileEvent2_Vtbl {
         iid == &<IRTCProfileEvent2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IRTCProfileEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCReInviteEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession2>;
@@ -3330,6 +3374,7 @@ impl IRTCReInviteEvent_Vtbl {
         iid == &<IRTCReInviteEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCRegistrationStateChangeEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Profile(&self) -> ::windows::core::Result<IRTCProfile>;
@@ -3398,6 +3443,7 @@ impl IRTCRegistrationStateChangeEvent_Vtbl {
         iid == &<IRTCRegistrationStateChangeEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCRoamingEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn EventType(&self) -> ::windows::core::Result<RTC_ROAMING_EVENT_TYPE>;
@@ -3466,6 +3512,7 @@ impl IRTCRoamingEvent_Vtbl {
         iid == &<IRTCRoamingEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IRTCSession_Impl: Sized {
     fn Client(&self) -> ::windows::core::Result<IRTCClient>;
@@ -3682,6 +3729,7 @@ impl IRTCSession_Vtbl {
         iid == &<IRTCSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IRTCSession2_Impl: Sized + IRTCSession_Impl {
     fn SendInfo(&self, bstrinfoheader: &::windows::core::BSTR, bstrinfo: &::windows::core::BSTR, lcookie: isize) -> ::windows::core::Result<()>;
@@ -3752,6 +3800,7 @@ impl IRTCSession2_Vtbl {
         iid == &<IRTCSession2 as ::windows::core::Interface>::IID || iid == &<IRTCSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCSessionCallControl_Impl: Sized {
     fn Hold(&self, lcookie: isize) -> ::windows::core::Result<()>;
@@ -3849,6 +3898,7 @@ impl IRTCSessionCallControl_Vtbl {
         iid == &<IRTCSessionCallControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCSessionDescriptionManager_Impl: Sized {
     fn EvaluateSessionDescription(&self, bstrcontenttype: &::windows::core::BSTR, bstrsessiondescription: &::windows::core::BSTR, pfapplicationsession: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3872,6 +3922,7 @@ impl IRTCSessionDescriptionManager_Vtbl {
         iid == &<IRTCSessionDescriptionManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCSessionOperationCompleteEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession>;
@@ -3940,6 +3991,7 @@ impl IRTCSessionOperationCompleteEvent_Vtbl {
         iid == &<IRTCSessionOperationCompleteEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCSessionOperationCompleteEvent2_Impl: Sized + IRTCSessionOperationCompleteEvent_Impl {
     fn Participant(&self) -> ::windows::core::Result<IRTCParticipant>;
@@ -3976,6 +4028,7 @@ impl IRTCSessionOperationCompleteEvent2_Vtbl {
         iid == &<IRTCSessionOperationCompleteEvent2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IRTCSessionOperationCompleteEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCSessionPortManagement_Impl: Sized {
     fn SetPortManager(&self, pportmanager: &::core::option::Option<IRTCPortManager>) -> ::windows::core::Result<()>;
 }
@@ -3993,6 +4046,7 @@ impl IRTCSessionPortManagement_Vtbl {
         iid == &<IRTCSessionPortManagement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCSessionReferStatusEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession2>;
@@ -4061,6 +4115,7 @@ impl IRTCSessionReferStatusEvent_Vtbl {
         iid == &<IRTCSessionReferStatusEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCSessionReferredEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession2>;
@@ -4150,6 +4205,7 @@ impl IRTCSessionReferredEvent_Vtbl {
         iid == &<IRTCSessionReferredEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCSessionStateChangeEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Session(&self) -> ::windows::core::Result<IRTCSession>;
@@ -4218,6 +4274,7 @@ impl IRTCSessionStateChangeEvent_Vtbl {
         iid == &<IRTCSessionStateChangeEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCSessionStateChangeEvent2_Impl: Sized + IRTCSessionStateChangeEvent_Impl {
     fn MediaTypes(&self) -> ::windows::core::Result<i32>;
@@ -4280,6 +4337,7 @@ impl IRTCSessionStateChangeEvent2_Vtbl {
         iid == &<IRTCSessionStateChangeEvent2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IRTCSessionStateChangeEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCUserSearch_Impl: Sized {
     fn CreateQuery(&self) -> ::windows::core::Result<IRTCUserSearchQuery>;
     fn ExecuteSearch(&self, pquery: &::core::option::Option<IRTCUserSearchQuery>, pprofile: &::core::option::Option<IRTCProfile>, lcookie: isize) -> ::windows::core::Result<()>;
@@ -4313,6 +4371,7 @@ impl IRTCUserSearch_Vtbl {
         iid == &<IRTCUserSearch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCUserSearchQuery_Impl: Sized {
     fn put_SearchTerm(&self, bstrname: &::windows::core::BSTR, bstrvalue: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn get_SearchTerm(&self, bstrname: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4399,6 +4458,7 @@ impl IRTCUserSearchQuery_Vtbl {
         iid == &<IRTCUserSearchQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"implement\"`*"]
 pub trait IRTCUserSearchResult_Impl: Sized {
     fn get_Value(&self, encolumn: RTC_USER_SEARCH_COLUMN) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -4422,6 +4482,7 @@ impl IRTCUserSearchResult_Vtbl {
         iid == &<IRTCUserSearchResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCUserSearchResultsEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn EnumerateResults(&self) -> ::windows::core::Result<IRTCEnumUserSearchResults>;
@@ -4529,6 +4590,7 @@ impl IRTCUserSearchResultsEvent_Vtbl {
         iid == &<IRTCUserSearchResultsEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCWatcher_Impl: Sized + IRTCPresenceContact_Impl {
     fn State(&self) -> ::windows::core::Result<RTC_WATCHER_STATE>;
@@ -4565,6 +4627,7 @@ impl IRTCWatcher_Vtbl {
         iid == &<IRTCWatcher as ::windows::core::Interface>::IID || iid == &<IRTCPresenceContact as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRTCWatcher2_Impl: Sized + IRTCWatcher_Impl {
     fn Profile(&self) -> ::windows::core::Result<IRTCProfile2>;
@@ -4603,6 +4666,7 @@ impl IRTCWatcher2_Vtbl {
         iid == &<IRTCWatcher2 as ::windows::core::Interface>::IID || iid == &<IRTCPresenceContact as ::windows::core::Interface>::IID || iid == &<IRTCWatcher as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCWatcherEvent_Impl: Sized + super::Com::IDispatch_Impl {
     fn Watcher(&self) -> ::windows::core::Result<IRTCWatcher>;
@@ -4629,6 +4693,7 @@ impl IRTCWatcherEvent_Vtbl {
         iid == &<IRTCWatcherEvent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRTCWatcherEvent2_Impl: Sized + IRTCWatcherEvent_Impl {
     fn EventType(&self) -> ::windows::core::Result<RTC_WATCHER_EVENT_TYPE>;
@@ -4671,6 +4736,7 @@ impl IRTCWatcherEvent2_Vtbl {
         iid == &<IRTCWatcherEvent2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IRTCWatcherEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RealTimeCommunications\"`, `\"Win32_Networking_WinSock\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Networking_WinSock")]
 pub trait ITransportSettingsInternal_Impl: Sized {
     fn ApplySetting(&self, setting: *mut TRANSPORT_SETTING) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteAssistance/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_RemoteAssistance\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DRendezvousSessionEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -11,6 +12,7 @@ impl DRendezvousSessionEvents_Vtbl {
         iid == &<DRendezvousSessionEvents as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteAssistance\"`, `\"implement\"`*"]
 pub trait IRendezvousApplication_Impl: Sized {
     fn SetRendezvousSession(&self, prendezvoussession: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -28,6 +30,7 @@ impl IRendezvousApplication_Vtbl {
         iid == &<IRendezvousApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteAssistance\"`, `\"implement\"`*"]
 pub trait IRendezvousSession_Impl: Sized {
     fn State(&self) -> ::windows::core::Result<RENDEZVOUS_SESSION_STATE>;
     fn RemoteUser(&self) -> ::windows::core::Result<::windows::core::BSTR>;

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IADsTSUserEx_Impl: Sized + super::Com::IDispatch_Impl {
     fn TerminalServicesProfilePath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -314,6 +315,7 @@ impl IADsTSUserEx_Vtbl {
         iid == &<IADsTSUserEx as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAudioDeviceEndpoint_Impl: Sized {
     fn SetBuffer(&self, maxperiod: i64, u32latencycoefficient: u32) -> ::windows::core::Result<()>;
@@ -370,6 +372,7 @@ impl IAudioDeviceEndpoint_Vtbl {
         iid == &<IAudioDeviceEndpoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_Media_Audio\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_Audio"))]
 pub trait IAudioEndpoint_Impl: Sized {
     fn GetFrameFormat(&self) -> ::windows::core::Result<*mut super::super::Media::Audio::WAVEFORMATEX>;
@@ -439,6 +442,7 @@ impl IAudioEndpoint_Vtbl {
         iid == &<IAudioEndpoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IAudioEndpointControl_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -473,6 +477,7 @@ impl IAudioEndpointControl_Vtbl {
         iid == &<IAudioEndpointControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IAudioEndpointRT_Impl: Sized {
     fn GetCurrentPadding(&self, ppadding: *mut i64, paecurrentposition: *mut AE_CURRENT_POSITION);
     fn ProcessingComplete(&self);
@@ -514,6 +519,7 @@ impl IAudioEndpointRT_Vtbl {
         iid == &<IAudioEndpointRT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio_Apo")]
 pub trait IAudioInputEndpointRT_Impl: Sized {
     fn GetInputDataPointer(&self, pconnectionproperty: *mut super::super::Media::Audio::Apo::APO_CONNECTION_PROPERTY, paetimestamp: *mut AE_CURRENT_POSITION);
@@ -551,6 +557,7 @@ impl IAudioInputEndpointRT_Vtbl {
         iid == &<IAudioInputEndpointRT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Media_Audio_Apo\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Media_Audio_Apo")]
 pub trait IAudioOutputEndpointRT_Impl: Sized {
     fn GetOutputDataPointer(&self, u32framecount: u32, paetimestamp: *const AE_CURRENT_POSITION) -> usize;
@@ -588,6 +595,7 @@ impl IAudioOutputEndpointRT_Vtbl {
         iid == &<IAudioOutputEndpointRT as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRemoteDesktopClient_Impl: Sized + super::Com::IDispatch_Impl {
     fn Connect(&self) -> ::windows::core::Result<()>;
@@ -692,6 +700,7 @@ impl IRemoteDesktopClient_Vtbl {
         iid == &<IRemoteDesktopClient as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRemoteDesktopClientActions_Impl: Sized + super::Com::IDispatch_Impl {
     fn SuspendScreenUpdates(&self) -> ::windows::core::Result<()>;
@@ -742,6 +751,7 @@ impl IRemoteDesktopClientActions_Vtbl {
         iid == &<IRemoteDesktopClientActions as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRemoteDesktopClientSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn ApplySettings(&self, rdpfilecontents: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -798,6 +808,7 @@ impl IRemoteDesktopClientSettings_Vtbl {
         iid == &<IRemoteDesktopClientSettings as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRemoteDesktopClientTouchPointer_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetEnabled(&self, enabled: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -874,6 +885,7 @@ impl IRemoteDesktopClientTouchPointer_Vtbl {
         iid == &<IRemoteDesktopClientTouchPointer as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IRemoteSystemAdditionalInfoProvider_Impl: Sized {
     fn GetAdditionalInfo(&self, deduplicationid: *mut ::windows::core::HSTRING, riid: *const ::windows::core::GUID, mapview: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -891,6 +903,7 @@ impl IRemoteSystemAdditionalInfoProvider_Vtbl {
         iid == &<IRemoteSystemAdditionalInfoProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITSGAccountingEngine_Impl: Sized {
     fn DoAccounting(&self, accountingdatatype: AAAccountingDataType, accountingdata: &AAAccountingData) -> ::windows::core::Result<()>;
 }
@@ -908,6 +921,7 @@ impl ITSGAccountingEngine_Vtbl {
         iid == &<ITSGAccountingEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITSGAuthenticateUserSink_Impl: Sized {
     fn OnUserAuthenticated(&self, username: &::windows::core::BSTR, userdomain: &::windows::core::BSTR, context: usize, usertoken: super::super::Foundation::HANDLE_PTR) -> ::windows::core::Result<()>;
@@ -952,6 +966,7 @@ impl ITSGAuthenticateUserSink_Vtbl {
         iid == &<ITSGAuthenticateUserSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITSGAuthenticationEngine_Impl: Sized {
     fn AuthenticateUser(&self, mainsessionid: &::windows::core::GUID, cookiedata: *const u8, numcookiebytes: u32, context: usize, psink: &::core::option::Option<ITSGAuthenticateUserSink>) -> ::windows::core::Result<()>;
     fn CancelAuthentication(&self, mainsessionid: &::windows::core::GUID, context: usize) -> ::windows::core::Result<()>;
@@ -979,6 +994,7 @@ impl ITSGAuthenticationEngine_Vtbl {
         iid == &<ITSGAuthenticationEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITSGAuthorizeConnectionSink_Impl: Sized {
     fn OnConnectionAuthorized(&self, hrin: ::windows::core::HRESULT, mainsessionid: &::windows::core::GUID, cbsohresponse: u32, pbsohresponse: *const u8, idletimeout: u32, sessiontimeout: u32, sessiontimeoutaction: SESSION_TIMEOUT_ACTION_TYPE, trustclass: AATrustClassID, policyattributes: *const u32) -> ::windows::core::Result<()>;
 }
@@ -996,6 +1012,7 @@ impl ITSGAuthorizeConnectionSink_Vtbl {
         iid == &<ITSGAuthorizeConnectionSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITSGAuthorizeResourceSink_Impl: Sized {
     fn OnChannelAuthorized(&self, hrin: ::windows::core::HRESULT, mainsessionid: &::windows::core::GUID, subsessionid: i32, allowedresourcenames: *const ::windows::core::BSTR, numallowedresourcenames: u32, failedresourcenames: *const ::windows::core::BSTR, numfailedresourcenames: u32) -> ::windows::core::Result<()>;
 }
@@ -1013,6 +1030,7 @@ impl ITSGAuthorizeResourceSink_Vtbl {
         iid == &<ITSGAuthorizeResourceSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITSGPolicyEngine_Impl: Sized {
     fn AuthorizeConnection(&self, mainsessionid: &::windows::core::GUID, username: &::windows::core::BSTR, authtype: AAAuthSchemes, clientmachineip: &::windows::core::BSTR, clientmachinename: &::windows::core::BSTR, sohdata: *const u8, numsohbytes: u32, cookiedata: *const u8, numcookiebytes: u32, usertoken: super::super::Foundation::HANDLE_PTR, psink: &::core::option::Option<ITSGAuthorizeConnectionSink>) -> ::windows::core::Result<()>;
@@ -1077,6 +1095,7 @@ impl ITSGPolicyEngine_Vtbl {
         iid == &<ITSGPolicyEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbBaseNotifySink_Impl: Sized {
     fn OnError(&self, hrerror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnReportStatus(&self, messagetype: CLIENT_MESSAGE_TYPE, messageid: u32) -> ::windows::core::Result<()>;
@@ -1104,6 +1123,7 @@ impl ITsSbBaseNotifySink_Vtbl {
         iid == &<ITsSbBaseNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbClientConnection_Impl: Sized {
     fn UserName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1303,6 +1323,7 @@ impl ITsSbClientConnection_Vtbl {
         iid == &<ITsSbClientConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbClientConnectionPropertySet_Impl: Sized + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
@@ -1316,6 +1337,7 @@ impl ITsSbClientConnectionPropertySet_Vtbl {
         iid == &<ITsSbClientConnectionPropertySet as ::windows::core::Interface>::IID || iid == &<super::Com::StructuredStorage::IPropertyBag as ::windows::core::Interface>::IID || iid == &<ITsSbPropertySet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbEnvironment_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1378,6 +1400,7 @@ impl ITsSbEnvironment_Vtbl {
         iid == &<ITsSbEnvironment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbEnvironmentPropertySet_Impl: Sized + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
@@ -1391,6 +1414,7 @@ impl ITsSbEnvironmentPropertySet_Vtbl {
         iid == &<ITsSbEnvironmentPropertySet as ::windows::core::Interface>::IID || iid == &<super::Com::StructuredStorage::IPropertyBag as ::windows::core::Interface>::IID || iid == &<ITsSbPropertySet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbFilterPluginStore_Impl: Sized {
     fn SaveProperties(&self, ppropertyset: &::core::option::Option<ITsSbPropertySet>) -> ::windows::core::Result<()>;
@@ -1434,6 +1458,7 @@ impl ITsSbFilterPluginStore_Vtbl {
         iid == &<ITsSbFilterPluginStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITsSbGenericNotifySink_Impl: Sized {
     fn OnCompleted(&self, status: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -1470,6 +1495,7 @@ impl ITsSbGenericNotifySink_Vtbl {
         iid == &<ITsSbGenericNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITsSbGlobalStore_Impl: Sized {
     fn QueryTarget(&self, providername: &::windows::core::BSTR, targetname: &::windows::core::BSTR, farmname: &::windows::core::BSTR) -> ::windows::core::Result<ITsSbTarget>;
@@ -1547,6 +1573,7 @@ impl ITsSbGlobalStore_Vtbl {
         iid == &<ITsSbGlobalStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbLoadBalanceResult_Impl: Sized {
     fn TargetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -1570,6 +1597,7 @@ impl ITsSbLoadBalanceResult_Vtbl {
         iid == &<ITsSbLoadBalanceResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbLoadBalancing_Impl: Sized + ITsSbPlugin_Impl {
     fn GetMostSuitableTarget(&self, pconnection: &::core::option::Option<ITsSbClientConnection>, plbsink: &::core::option::Option<ITsSbLoadBalancingNotifySink>) -> ::windows::core::Result<()>;
@@ -1590,6 +1618,7 @@ impl ITsSbLoadBalancing_Vtbl {
         iid == &<ITsSbLoadBalancing as ::windows::core::Interface>::IID || iid == &<ITsSbPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITsSbLoadBalancingNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnGetMostSuitableTarget(&self, plbresult: &::core::option::Option<ITsSbLoadBalanceResult>, fisnewconnection: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -1610,6 +1639,7 @@ impl ITsSbLoadBalancingNotifySink_Vtbl {
         iid == &<ITsSbLoadBalancingNotifySink as ::windows::core::Interface>::IID || iid == &<ITsSbBaseNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbOrchestration_Impl: Sized + ITsSbPlugin_Impl {
     fn PrepareTargetForConnect(&self, pconnection: &::core::option::Option<ITsSbClientConnection>, porchestrationnotifysink: &::core::option::Option<ITsSbOrchestrationNotifySink>) -> ::windows::core::Result<()>;
@@ -1630,6 +1660,7 @@ impl ITsSbOrchestration_Vtbl {
         iid == &<ITsSbOrchestration as ::windows::core::Interface>::IID || iid == &<ITsSbPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbOrchestrationNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnReadyToConnect(&self, ptarget: &::core::option::Option<ITsSbTarget>) -> ::windows::core::Result<()>;
 }
@@ -1647,6 +1678,7 @@ impl ITsSbOrchestrationNotifySink_Vtbl {
         iid == &<ITsSbOrchestrationNotifySink as ::windows::core::Interface>::IID || iid == &<ITsSbBaseNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbPlacement_Impl: Sized + ITsSbPlugin_Impl {
     fn QueryEnvironmentForTarget(&self, pconnection: &::core::option::Option<ITsSbClientConnection>, pplacementsink: &::core::option::Option<ITsSbPlacementNotifySink>) -> ::windows::core::Result<()>;
@@ -1667,6 +1699,7 @@ impl ITsSbPlacement_Vtbl {
         iid == &<ITsSbPlacement as ::windows::core::Interface>::IID || iid == &<ITsSbPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbPlacementNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnQueryEnvironmentCompleted(&self, penvironment: &::core::option::Option<ITsSbEnvironment>) -> ::windows::core::Result<()>;
 }
@@ -1687,6 +1720,7 @@ impl ITsSbPlacementNotifySink_Vtbl {
         iid == &<ITsSbPlacementNotifySink as ::windows::core::Interface>::IID || iid == &<ITsSbBaseNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbPlugin_Impl: Sized {
     fn Initialize(&self, pprovider: &::core::option::Option<ITsSbProvider>, pnotifysink: &::core::option::Option<ITsSbPluginNotifySink>, ppropertyset: &::core::option::Option<ITsSbPluginPropertySet>) -> ::windows::core::Result<()>;
@@ -1717,6 +1751,7 @@ impl ITsSbPlugin_Vtbl {
         iid == &<ITsSbPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbPluginNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnInitialized(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
     fn OnTerminated(&self) -> ::windows::core::Result<()>;
@@ -1744,6 +1779,7 @@ impl ITsSbPluginNotifySink_Vtbl {
         iid == &<ITsSbPluginNotifySink as ::windows::core::Interface>::IID || iid == &<ITsSbBaseNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbPluginPropertySet_Impl: Sized + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
@@ -1757,6 +1793,7 @@ impl ITsSbPluginPropertySet_Vtbl {
         iid == &<ITsSbPluginPropertySet as ::windows::core::Interface>::IID || iid == &<super::Com::StructuredStorage::IPropertyBag as ::windows::core::Interface>::IID || iid == &<ITsSbPropertySet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbPropertySet_Impl: Sized + super::Com::StructuredStorage::IPropertyBag_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
@@ -1770,6 +1807,7 @@ impl ITsSbPropertySet_Vtbl {
         iid == &<ITsSbPropertySet as ::windows::core::Interface>::IID || iid == &<super::Com::StructuredStorage::IPropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbProvider_Impl: Sized {
     fn CreateTargetObject(&self, targetname: &::windows::core::BSTR, environmentname: &::windows::core::BSTR) -> ::windows::core::Result<ITsSbTarget>;
@@ -1930,6 +1968,7 @@ impl ITsSbProvider_Vtbl {
         iid == &<ITsSbProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbProvisioning_Impl: Sized + ITsSbPlugin_Impl {
     fn CreateVirtualMachines(&self, jobxmlstring: &::windows::core::BSTR, jobguid: &::windows::core::BSTR, psink: &::core::option::Option<ITsSbProvisioningPluginNotifySink>) -> ::windows::core::Result<()>;
@@ -1974,6 +2013,7 @@ impl ITsSbProvisioning_Vtbl {
         iid == &<ITsSbProvisioning as ::windows::core::Interface>::IID || iid == &<ITsSbPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbProvisioningPluginNotifySink_Impl: Sized {
     fn OnJobCreated(&self, pvmnotifyinfo: *const VM_NOTIFY_INFO) -> ::windows::core::Result<()>;
     fn OnVirtualMachineStatusChanged(&self, pvmnotifyentry: *const VM_NOTIFY_ENTRY, vmnotifystatus: VM_NOTIFY_STATUS, errorcode: ::windows::core::HRESULT, errordescr: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2029,6 +2069,7 @@ impl ITsSbProvisioningPluginNotifySink_Vtbl {
         iid == &<ITsSbProvisioningPluginNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbResourceNotification_Impl: Sized {
     fn NotifySessionChange(&self, changetype: TSSESSION_STATE, psession: &::core::option::Option<ITsSbSession>) -> ::windows::core::Result<()>;
     fn NotifyTargetChange(&self, targetchangetype: u32, ptarget: &::core::option::Option<ITsSbTarget>) -> ::windows::core::Result<()>;
@@ -2063,6 +2104,7 @@ impl ITsSbResourceNotification_Vtbl {
         iid == &<ITsSbResourceNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbResourceNotificationEx_Impl: Sized {
     fn NotifySessionChangeEx(&self, targetname: &::windows::core::BSTR, username: &::windows::core::BSTR, domain: &::windows::core::BSTR, sessionid: u32, sessionstate: TSSESSION_STATE) -> ::windows::core::Result<()>;
     fn NotifyTargetChangeEx(&self, targetname: &::windows::core::BSTR, targetchangetype: u32) -> ::windows::core::Result<()>;
@@ -2097,6 +2139,7 @@ impl ITsSbResourceNotificationEx_Vtbl {
         iid == &<ITsSbResourceNotificationEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbResourcePlugin_Impl: Sized + ITsSbPlugin_Impl {}
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
@@ -2110,6 +2153,7 @@ impl ITsSbResourcePlugin_Vtbl {
         iid == &<ITsSbResourcePlugin as ::windows::core::Interface>::IID || iid == &<ITsSbPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITsSbResourcePluginStore_Impl: Sized {
     fn QueryTarget(&self, targetname: &::windows::core::BSTR, farmname: &::windows::core::BSTR) -> ::windows::core::Result<ITsSbTarget>;
@@ -2364,6 +2408,7 @@ impl ITsSbResourcePluginStore_Vtbl {
         iid == &<ITsSbResourcePluginStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ITsSbServiceNotification_Impl: Sized {
     fn NotifyServiceFailure(&self) -> ::windows::core::Result<()>;
     fn NotifyServiceSuccess(&self) -> ::windows::core::Result<()>;
@@ -2391,6 +2436,7 @@ impl ITsSbServiceNotification_Vtbl {
         iid == &<ITsSbServiceNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITsSbSession_Impl: Sized {
     fn SessionId(&self) -> ::windows::core::Result<u32>;
@@ -2586,6 +2632,7 @@ impl ITsSbSession_Vtbl {
         iid == &<ITsSbSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbTarget_Impl: Sized {
     fn TargetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2795,6 +2842,7 @@ impl ITsSbTarget_Vtbl {
         iid == &<ITsSbTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait ITsSbTargetPropertySet_Impl: Sized + ITsSbPropertySet_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
@@ -2808,6 +2856,7 @@ impl ITsSbTargetPropertySet_Vtbl {
         iid == &<ITsSbTargetPropertySet as ::windows::core::Interface>::IID || iid == &<super::Com::StructuredStorage::IPropertyBag as ::windows::core::Interface>::IID || iid == &<ITsSbPropertySet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITsSbTaskInfo_Impl: Sized {
     fn TargetId(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2941,6 +2990,7 @@ impl ITsSbTaskInfo_Vtbl {
         iid == &<ITsSbTaskInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait ITsSbTaskPlugin_Impl: Sized + ITsSbPlugin_Impl {
     fn InitializeTaskPlugin(&self, pitssbtaskpluginnotifysink: &::core::option::Option<ITsSbTaskPluginNotifySink>) -> ::windows::core::Result<()>;
@@ -2971,6 +3021,7 @@ impl ITsSbTaskPlugin_Vtbl {
         iid == &<ITsSbTaskPlugin as ::windows::core::Interface>::IID || iid == &<ITsSbPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITsSbTaskPluginNotifySink_Impl: Sized + ITsSbBaseNotifySink_Impl {
     fn OnSetTaskTime(&self, sztargetname: &::windows::core::BSTR, taskstarttime: &super::super::Foundation::FILETIME, taskendtime: &super::super::Foundation::FILETIME, taskdeadline: &super::super::Foundation::FILETIME, sztasklabel: &::windows::core::BSTR, sztaskidentifier: &::windows::core::BSTR, sztaskplugin: &::windows::core::BSTR, dwtaskstatus: u32, sacontext: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -3015,6 +3066,7 @@ impl ITsSbTaskPluginNotifySink_Vtbl {
         iid == &<ITsSbTaskPluginNotifySink as ::windows::core::Interface>::IID || iid == &<ITsSbBaseNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsEnhancedFastReconnectArbitrator_Impl: Sized {
     fn GetSessionForEnhancedFastReconnect(&self, psessionidarray: *const i32, dwsessioncount: u32) -> ::windows::core::Result<i32>;
 }
@@ -3041,6 +3093,7 @@ impl IWRdsEnhancedFastReconnectArbitrator_Vtbl {
         iid == &<IWRdsEnhancedFastReconnectArbitrator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsGraphicsChannel_Impl: Sized {
     fn Write(&self, cbsize: u32, pbuffer: *const u8, pcontext: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -3075,6 +3128,7 @@ impl IWRdsGraphicsChannel_Vtbl {
         iid == &<IWRdsGraphicsChannel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWRdsGraphicsChannelEvents_Impl: Sized {
     fn OnDataReceived(&self, cbsize: u32, pbuffer: *const u8) -> ::windows::core::Result<()>;
@@ -3126,6 +3180,7 @@ impl IWRdsGraphicsChannelEvents_Vtbl {
         iid == &<IWRdsGraphicsChannelEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsGraphicsChannelManager_Impl: Sized {
     fn CreateChannel(&self, pszchannelname: *const u8, channeltype: WRdsGraphicsChannelType) -> ::windows::core::Result<IWRdsGraphicsChannel>;
 }
@@ -3149,6 +3204,7 @@ impl IWRdsGraphicsChannelManager_Vtbl {
         iid == &<IWRdsGraphicsChannelManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWRdsProtocolConnection_Impl: Sized {
     fn GetLogonErrorRedirector(&self) -> ::windows::core::Result<IWRdsProtocolLogonErrorRedirector>;
@@ -3393,6 +3449,7 @@ impl IWRdsProtocolConnection_Vtbl {
         iid == &<IWRdsProtocolConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsProtocolConnectionCallback_Impl: Sized {
     fn OnReady(&self) -> ::windows::core::Result<()>;
     fn BrokenConnection(&self, reason: u32, source: u32) -> ::windows::core::Result<()>;
@@ -3447,6 +3504,7 @@ impl IWRdsProtocolConnectionCallback_Vtbl {
         iid == &<IWRdsProtocolConnectionCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsProtocolConnectionSettings_Impl: Sized {
     fn SetConnectionSetting(&self, propertyid: &::windows::core::GUID, ppropertyentriesin: *const WTS_PROPERTY_VALUE) -> ::windows::core::Result<()>;
     fn GetConnectionSetting(&self, propertyid: &::windows::core::GUID) -> ::windows::core::Result<WTS_PROPERTY_VALUE>;
@@ -3480,6 +3538,7 @@ impl IWRdsProtocolConnectionSettings_Vtbl {
         iid == &<IWRdsProtocolConnectionSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWRdsProtocolLicenseConnection_Impl: Sized {
     fn RequestLicensingCapabilities(&self, pplicensecapabilities: *mut WTS_LICENSE_CAPABILITIES, pcblicensecapabilities: *mut u32) -> ::windows::core::Result<()>;
@@ -3524,6 +3583,7 @@ impl IWRdsProtocolLicenseConnection_Vtbl {
         iid == &<IWRdsProtocolLicenseConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsProtocolListener_Impl: Sized {
     fn GetSettings(&self, wrdslistenersettinglevel: WRDS_LISTENER_SETTING_LEVEL) -> ::windows::core::Result<WRDS_LISTENER_SETTINGS>;
     fn StartListen(&self, pcallback: &::core::option::Option<IWRdsProtocolListenerCallback>) -> ::windows::core::Result<()>;
@@ -3564,6 +3624,7 @@ impl IWRdsProtocolListener_Vtbl {
         iid == &<IWRdsProtocolListener as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWRdsProtocolListenerCallback_Impl: Sized {
     fn OnConnected(&self, pconnection: &::core::option::Option<IWRdsProtocolConnection>, pwrdsconnectionsettings: *const WRDS_CONNECTION_SETTINGS) -> ::windows::core::Result<IWRdsProtocolConnectionCallback>;
@@ -3590,6 +3651,7 @@ impl IWRdsProtocolListenerCallback_Vtbl {
         iid == &<IWRdsProtocolListenerCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsProtocolLogonErrorRedirector_Impl: Sized {
     fn OnBeginPainting(&self) -> ::windows::core::Result<()>;
     fn RedirectStatus(&self, pszmessage: &::windows::core::PCWSTR) -> ::windows::core::Result<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>;
@@ -3649,6 +3711,7 @@ impl IWRdsProtocolLogonErrorRedirector_Vtbl {
         iid == &<IWRdsProtocolLogonErrorRedirector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWRdsProtocolManager_Impl: Sized {
     fn Initialize(&self, piwrdssettings: &::core::option::Option<IWRdsProtocolSettings>, pwrdssettings: *const WRDS_SETTINGS) -> ::windows::core::Result<()>;
@@ -3727,6 +3790,7 @@ impl IWRdsProtocolManager_Vtbl {
         iid == &<IWRdsProtocolManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWRdsProtocolSettings_Impl: Sized {
     fn GetSettings(&self, wrdssettingtype: WRDS_SETTING_TYPE, wrdssettinglevel: WRDS_SETTING_LEVEL) -> ::windows::core::Result<WRDS_SETTINGS>;
@@ -3763,6 +3827,7 @@ impl IWRdsProtocolSettings_Vtbl {
         iid == &<IWRdsProtocolSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsProtocolShadowCallback_Impl: Sized {
     fn StopShadow(&self) -> ::windows::core::Result<()>;
     fn InvokeTargetShadow(&self, ptargetservername: &::windows::core::PCWSTR, targetsessionid: u32, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -3791,6 +3856,7 @@ impl IWRdsProtocolShadowCallback_Vtbl {
         iid == &<IWRdsProtocolShadowCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWRdsProtocolShadowConnection_Impl: Sized {
     fn Start(&self, ptargetservername: &::windows::core::PCWSTR, targetsessionid: u32, hotkeyvk: u8, hotkeymodifiers: u16, pshadowcallback: &::core::option::Option<IWRdsProtocolShadowCallback>) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -3825,6 +3891,7 @@ impl IWRdsProtocolShadowConnection_Vtbl {
         iid == &<IWRdsProtocolShadowConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWRdsWddmIddProps_Impl: Sized {
     fn GetHardwareId(&self, pdisplaydriverhardwareid: &::windows::core::PCWSTR, count: u32) -> ::windows::core::Result<()>;
@@ -3869,6 +3936,7 @@ impl IWRdsWddmIddProps_Vtbl {
         iid == &<IWRdsWddmIddProps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSBitmapRenderService_Impl: Sized {
     fn GetMappedRenderer(&self, mappingid: u64, pmappedrenderercallback: &::core::option::Option<IWTSBitmapRendererCallback>) -> ::windows::core::Result<IWTSBitmapRenderer>;
 }
@@ -3892,6 +3960,7 @@ impl IWTSBitmapRenderService_Vtbl {
         iid == &<IWTSBitmapRenderService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSBitmapRenderer_Impl: Sized {
     fn Render(&self, imageformat: &::windows::core::GUID, dwwidth: u32, dwheight: u32, cbstride: i32, cbimagebuffer: u32, pimagebuffer: *const u8) -> ::windows::core::Result<()>;
     fn GetRendererStatistics(&self) -> ::windows::core::Result<BITMAP_RENDERER_STATISTICS>;
@@ -3932,6 +4001,7 @@ impl IWTSBitmapRenderer_Vtbl {
         iid == &<IWTSBitmapRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWTSBitmapRendererCallback_Impl: Sized {
     fn OnTargetSizeChanged(&self, rcnewsize: &super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -3952,6 +4022,7 @@ impl IWTSBitmapRendererCallback_Vtbl {
         iid == &<IWTSBitmapRendererCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IWTSListener_Impl: Sized {
     fn GetConfiguration(&self) -> ::windows::core::Result<super::Com::StructuredStorage::IPropertyBag>;
@@ -3978,6 +4049,7 @@ impl IWTSListener_Vtbl {
         iid == &<IWTSListener as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWTSListenerCallback_Impl: Sized {
     fn OnNewChannelConnection(&self, pchannel: &::core::option::Option<IWTSVirtualChannel>, data: &::windows::core::BSTR, pbaccept: *mut super::super::Foundation::BOOL, ppcallback: *mut ::core::option::Option<IWTSVirtualChannelCallback>) -> ::windows::core::Result<()>;
@@ -3998,6 +4070,7 @@ impl IWTSListenerCallback_Vtbl {
         iid == &<IWTSListenerCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSPlugin_Impl: Sized {
     fn Initialize(&self, pchannelmgr: &::core::option::Option<IWTSVirtualChannelManager>) -> ::windows::core::Result<()>;
     fn Connected(&self) -> ::windows::core::Result<()>;
@@ -4039,6 +4112,7 @@ impl IWTSPlugin_Vtbl {
         iid == &<IWTSPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSPluginServiceProvider_Impl: Sized {
     fn GetService(&self, serviceid: &::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -4062,6 +4136,7 @@ impl IWTSPluginServiceProvider_Vtbl {
         iid == &<IWTSPluginServiceProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWTSProtocolConnection_Impl: Sized {
     fn GetLogonErrorRedirector(&self) -> ::windows::core::Result<IWTSProtocolLogonErrorRedirector>;
@@ -4293,6 +4368,7 @@ impl IWTSProtocolConnection_Vtbl {
         iid == &<IWTSProtocolConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSProtocolConnectionCallback_Impl: Sized {
     fn OnReady(&self) -> ::windows::core::Result<()>;
     fn BrokenConnection(&self, reason: u32, source: u32) -> ::windows::core::Result<()>;
@@ -4341,6 +4417,7 @@ impl IWTSProtocolConnectionCallback_Vtbl {
         iid == &<IWTSProtocolConnectionCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWTSProtocolLicenseConnection_Impl: Sized {
     fn RequestLicensingCapabilities(&self, pplicensecapabilities: *mut WTS_LICENSE_CAPABILITIES, pcblicensecapabilities: *mut u32) -> ::windows::core::Result<()>;
@@ -4385,6 +4462,7 @@ impl IWTSProtocolLicenseConnection_Vtbl {
         iid == &<IWTSProtocolLicenseConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSProtocolListener_Impl: Sized {
     fn StartListen(&self, pcallback: &::core::option::Option<IWTSProtocolListenerCallback>) -> ::windows::core::Result<()>;
     fn StopListen(&self) -> ::windows::core::Result<()>;
@@ -4412,6 +4490,7 @@ impl IWTSProtocolListener_Vtbl {
         iid == &<IWTSProtocolListener as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSProtocolListenerCallback_Impl: Sized {
     fn OnConnected(&self, pconnection: &::core::option::Option<IWTSProtocolConnection>) -> ::windows::core::Result<IWTSProtocolConnectionCallback>;
 }
@@ -4435,6 +4514,7 @@ impl IWTSProtocolListenerCallback_Vtbl {
         iid == &<IWTSProtocolListenerCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSProtocolLogonErrorRedirector_Impl: Sized {
     fn OnBeginPainting(&self) -> ::windows::core::Result<()>;
     fn RedirectStatus(&self, pszmessage: &::windows::core::PCWSTR) -> ::windows::core::Result<WTS_LOGON_ERROR_REDIRECTOR_RESPONSE>;
@@ -4494,6 +4574,7 @@ impl IWTSProtocolLogonErrorRedirector_Vtbl {
         iid == &<IWTSProtocolLogonErrorRedirector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSProtocolManager_Impl: Sized {
     fn CreateListener(&self, wszlistenername: &::windows::core::PCWSTR) -> ::windows::core::Result<IWTSProtocolListener>;
     fn NotifyServiceStateChange(&self, ptsservicestatechange: *const WTS_SERVICE_STATE) -> ::windows::core::Result<()>;
@@ -4548,6 +4629,7 @@ impl IWTSProtocolManager_Vtbl {
         iid == &<IWTSProtocolManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSProtocolShadowCallback_Impl: Sized {
     fn StopShadow(&self) -> ::windows::core::Result<()>;
     fn InvokeTargetShadow(&self, ptargetservername: &::windows::core::PCWSTR, targetsessionid: u32, pparam1: *const u8, param1size: u32, pparam2: *const u8, param2size: u32, pparam3: *const u8, param3size: u32, pparam4: *const u8, param4size: u32, pclientname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -4576,6 +4658,7 @@ impl IWTSProtocolShadowCallback_Vtbl {
         iid == &<IWTSProtocolShadowCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSProtocolShadowConnection_Impl: Sized {
     fn Start(&self, ptargetservername: &::windows::core::PCWSTR, targetsessionid: u32, hotkeyvk: u8, hotkeymodifiers: u16, pshadowcallback: &::core::option::Option<IWTSProtocolShadowCallback>) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -4610,6 +4693,7 @@ impl IWTSProtocolShadowConnection_Vtbl {
         iid == &<IWTSProtocolShadowConnection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWTSSBPlugin_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<u32>;
@@ -4674,6 +4758,7 @@ impl IWTSSBPlugin_Vtbl {
         iid == &<IWTSSBPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSVirtualChannel_Impl: Sized {
     fn Write(&self, cbsize: u32, pbuffer: *const u8, preserved: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -4701,6 +4786,7 @@ impl IWTSVirtualChannel_Vtbl {
         iid == &<IWTSVirtualChannel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSVirtualChannelCallback_Impl: Sized {
     fn OnDataReceived(&self, cbsize: u32, pbuffer: *const u8) -> ::windows::core::Result<()>;
     fn OnClose(&self) -> ::windows::core::Result<()>;
@@ -4728,6 +4814,7 @@ impl IWTSVirtualChannelCallback_Vtbl {
         iid == &<IWTSVirtualChannelCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWTSVirtualChannelManager_Impl: Sized {
     fn CreateListener(&self, pszchannelname: &::windows::core::PCSTR, uflags: u32, plistenercallback: &::core::option::Option<IWTSListenerCallback>) -> ::windows::core::Result<IWTSListener>;
 }
@@ -4751,6 +4838,7 @@ impl IWTSVirtualChannelManager_Vtbl {
         iid == &<IWTSVirtualChannelManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IWorkspace_Impl: Sized {
     fn GetWorkspaceNames(&self) -> ::windows::core::Result<*mut super::Com::SAFEARRAY>;
@@ -4800,6 +4888,7 @@ impl IWorkspace_Vtbl {
         iid == &<IWorkspace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWorkspace2_Impl: Sized + IWorkspace_Impl {
     fn StartRemoteApplicationEx(&self, bstrworkspaceid: &::windows::core::BSTR, bstrrequestingappid: &::windows::core::BSTR, bstrrequestingappfamilyname: &::windows::core::BSTR, blaunchintoimmersiveclient: super::super::Foundation::VARIANT_BOOL, bstrimmersiveclientactivationcontext: &::windows::core::BSTR, psaparams: *const super::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -4820,6 +4909,7 @@ impl IWorkspace2_Vtbl {
         iid == &<IWorkspace2 as ::windows::core::Interface>::IID || iid == &<IWorkspace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IWorkspace3_Impl: Sized + IWorkspace2_Impl {
     fn GetClaimsToken2(&self, bstrclaimshint: &::windows::core::BSTR, bstruserhint: &::windows::core::BSTR, claimcookie: u32, hwndcreduiparent: u32, rectcreduiparent: &super::super::Foundation::RECT) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4856,6 +4946,7 @@ impl IWorkspace3_Vtbl {
         iid == &<IWorkspace3 as ::windows::core::Interface>::IID || iid == &<IWorkspace as ::windows::core::Interface>::IID || iid == &<IWorkspace2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWorkspaceClientExt_Impl: Sized {
     fn GetResourceId(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetResourceDisplayName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4902,6 +4993,7 @@ impl IWorkspaceClientExt_Vtbl {
         iid == &<IWorkspaceClientExt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWorkspaceRegistration_Impl: Sized {
     fn AddResource(&self, punk: &::core::option::Option<IWorkspaceClientExt>) -> ::windows::core::Result<u32>;
     fn RemoveResource(&self, dwcookieconnection: u32) -> ::windows::core::Result<()>;
@@ -4935,6 +5027,7 @@ impl IWorkspaceRegistration_Vtbl {
         iid == &<IWorkspaceRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait IWorkspaceRegistration2_Impl: Sized + IWorkspaceRegistration_Impl {
     fn AddResourceEx(&self, punk: &::core::option::Option<IWorkspaceClientExt>, bstreventloguploadaddress: &::windows::core::BSTR, pdwcookie: *mut u32, correlationid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn RemoveResourceEx(&self, dwcookieconnection: u32, correlationid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -4962,6 +5055,7 @@ impl IWorkspaceRegistration2_Vtbl {
         iid == &<IWorkspaceRegistration2 as ::windows::core::Interface>::IID || iid == &<IWorkspaceRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWorkspaceReportMessage_Impl: Sized {
     fn RegisterErrorLogMessage(&self, bstrmessage: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -5005,6 +5099,7 @@ impl IWorkspaceReportMessage_Vtbl {
         iid == &<IWorkspaceReportMessage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWorkspaceResTypeRegistry_Impl: Sized + super::Com::IDispatch_Impl {
     fn AddResourceType(&self, fmachinewide: super::super::Foundation::VARIANT_BOOL, bstrfileextension: &::windows::core::BSTR, bstrlauncher: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -5068,6 +5163,7 @@ impl IWorkspaceResTypeRegistry_Vtbl {
         iid == &<IWorkspaceResTypeRegistry as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWorkspaceScriptable_Impl: Sized + super::Com::IDispatch_Impl {
     fn DisconnectWorkspace(&self, bstrworkspaceid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -5145,6 +5241,7 @@ impl IWorkspaceScriptable_Vtbl {
         iid == &<IWorkspaceScriptable as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWorkspaceScriptable2_Impl: Sized + IWorkspaceScriptable_Impl {
     fn StartWorkspaceEx(&self, bstrworkspaceid: &::windows::core::BSTR, bstrworkspacefriendlyname: &::windows::core::BSTR, bstrredirectorname: &::windows::core::BSTR, bstrusername: &::windows::core::BSTR, bstrpassword: &::windows::core::BSTR, bstrappcontainer: &::windows::core::BSTR, bstrworkspaceparams: &::windows::core::BSTR, ltimeout: i32, lflags: i32) -> ::windows::core::Result<()>;
@@ -5175,6 +5272,7 @@ impl IWorkspaceScriptable2_Vtbl {
         iid == &<IWorkspaceScriptable2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWorkspaceScriptable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWorkspaceScriptable3_Impl: Sized + IWorkspaceScriptable2_Impl {
     fn StartWorkspaceEx2(&self, bstrworkspaceid: &::windows::core::BSTR, bstrworkspacefriendlyname: &::windows::core::BSTR, bstrredirectorname: &::windows::core::BSTR, bstrusername: &::windows::core::BSTR, bstrpassword: &::windows::core::BSTR, bstrappcontainer: &::windows::core::BSTR, bstrworkspaceparams: &::windows::core::BSTR, ltimeout: i32, lflags: i32, bstreventloguploadaddress: &::windows::core::BSTR, correlationid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -5196,6 +5294,7 @@ impl IWorkspaceScriptable3_Vtbl {
         iid == &<IWorkspaceScriptable3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWorkspaceScriptable as ::windows::core::Interface>::IID || iid == &<IWorkspaceScriptable2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ItsPubPlugin_Impl: Sized {
     fn GetResourceList(&self, userid: &::windows::core::PCWSTR, pceapplistsize: *mut i32, resourcelist: *mut *mut pluginResource) -> ::windows::core::Result<()>;
     fn GetResource(&self, alias: &::windows::core::PCWSTR, flags: i32) -> ::windows::core::Result<pluginResource>;
@@ -5275,6 +5374,7 @@ impl ItsPubPlugin_Vtbl {
         iid == &<ItsPubPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"implement\"`*"]
 pub trait ItsPubPlugin2_Impl: Sized + ItsPubPlugin_Impl {
     fn GetResource2List(&self, userid: &::windows::core::PCWSTR, pceapplistsize: *mut i32, resourcelist: *mut *mut pluginResource2) -> ::windows::core::Result<()>;
     fn GetResource2(&self, alias: &::windows::core::PCWSTR, flags: i32) -> ::windows::core::Result<pluginResource2>;
@@ -5322,6 +5422,7 @@ impl ItsPubPlugin2_Vtbl {
         iid == &<ItsPubPlugin2 as ::windows::core::Interface>::IID || iid == &<ItsPubPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteDesktop\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _ITSWkspEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSMan_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateSession(&self, connection: &::windows::core::BSTR, flags: i32, connectionoptions: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -66,6 +67,7 @@ impl IWSMan_Vtbl {
         iid == &<IWSMan as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManConnectionOptions_Impl: Sized + super::Com::IDispatch_Impl {
     fn UserName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -109,6 +111,7 @@ impl IWSManConnectionOptions_Vtbl {
         iid == &<IWSManConnectionOptions as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManConnectionOptionsEx_Impl: Sized + IWSManConnectionOptions_Impl {
     fn CertificateThumbprint(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -145,6 +148,7 @@ impl IWSManConnectionOptionsEx_Vtbl {
         iid == &<IWSManConnectionOptionsEx as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWSManConnectionOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManConnectionOptionsEx2_Impl: Sized + IWSManConnectionOptionsEx_Impl {
     fn SetProxy(&self, accesstype: i32, authenticationmechanism: i32, username: &::windows::core::BSTR, password: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -259,6 +263,7 @@ impl IWSManConnectionOptionsEx2_Vtbl {
         iid == &<IWSManConnectionOptionsEx2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWSManConnectionOptions as ::windows::core::Interface>::IID || iid == &<IWSManConnectionOptionsEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManEnumerator_Impl: Sized + super::Com::IDispatch_Impl {
     fn ReadItem(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -314,6 +319,7 @@ impl IWSManEnumerator_Vtbl {
         iid == &<IWSManEnumerator as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManEx_Impl: Sized + IWSMan_Impl {
     fn CreateResourceLocator(&self, strresourcelocator: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -590,6 +596,7 @@ impl IWSManEx_Vtbl {
         iid == &<IWSManEx as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWSMan as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManEx2_Impl: Sized + IWSManEx_Impl {
     fn SessionFlagUseClientCertificate(&self) -> ::windows::core::Result<i32>;
@@ -619,6 +626,7 @@ impl IWSManEx2_Vtbl {
         iid == &<IWSManEx2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWSMan as ::windows::core::Interface>::IID || iid == &<IWSManEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManEx3_Impl: Sized + IWSManEx2_Impl {
     fn SessionFlagUTF16(&self) -> ::windows::core::Result<i32>;
@@ -726,6 +734,7 @@ impl IWSManEx3_Vtbl {
         iid == &<IWSManEx3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWSMan as ::windows::core::Interface>::IID || iid == &<IWSManEx as ::windows::core::Interface>::IID || iid == &<IWSManEx2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManInternal_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConfigSDDL(&self, session: &::core::option::Option<super::Com::IDispatch>, resourceuri: &super::Com::VARIANT, flags: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -752,6 +761,7 @@ impl IWSManInternal_Vtbl {
         iid == &<IWSManInternal as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManResourceLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetResourceURI(&self, uri: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -889,6 +899,7 @@ impl IWSManResourceLocator_Vtbl {
         iid == &<IWSManResourceLocator as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"implement\"`*"]
 pub trait IWSManResourceLocatorInternal_Impl: Sized {}
 impl ::windows::core::RuntimeName for IWSManResourceLocatorInternal {}
 impl IWSManResourceLocatorInternal_Vtbl {
@@ -899,6 +910,7 @@ impl IWSManResourceLocatorInternal_Vtbl {
         iid == &<IWSManResourceLocatorInternal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSManSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn Get(&self, resourceuri: &super::Com::VARIANT, flags: i32) -> ::windows::core::Result<::windows::core::BSTR>;

--- a/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait DataSource_Impl: Sized {
     fn getDataMember(&self, bstrdm: *const u16, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn getDataMemberName(&self, lindex: i32) -> ::windows::core::Result<*mut u16>;
@@ -64,6 +65,7 @@ impl DataSource_Vtbl {
         iid == &<DataSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait DataSourceListener_Impl: Sized {
     fn dataMemberChanged(&self, bstrdm: *const u16) -> ::windows::core::Result<()>;
     fn dataMemberAdded(&self, bstrdm: *const u16) -> ::windows::core::Result<()>;
@@ -98,6 +100,7 @@ impl DataSourceListener_Vtbl {
         iid == &<DataSourceListener as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DataSourceObject_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -111,6 +114,7 @@ impl DataSourceObject_Vtbl {
         iid == &<DataSourceObject as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAccessor_Impl: Sized {
     fn AddRefAccessor(&self, haccessor: HACCESSOR, pcrefcount: *mut u32) -> ::windows::core::Result<()>;
@@ -155,6 +159,7 @@ impl IAccessor_Vtbl {
         iid == &<IAccessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAlterIndex_Impl: Sized {
     fn AlterIndex(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, pindexid: *mut super::super::Storage::IndexServer::DBID, pnewindexid: *mut super::super::Storage::IndexServer::DBID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET) -> ::windows::core::Result<()>;
@@ -175,6 +180,7 @@ impl IAlterIndex_Vtbl {
         iid == &<IAlterIndex as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAlterTable_Impl: Sized {
     fn AlterColumn(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, pcolumnid: *mut super::super::Storage::IndexServer::DBID, dwcolumndescflags: u32, pcolumndesc: *mut DBCOLUMNDESC) -> ::windows::core::Result<()>;
@@ -205,6 +211,7 @@ impl IAlterTable_Vtbl {
         iid == &<IAlterTable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBindResource_Impl: Sized {
     fn Bind(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, pwszurl: &::windows::core::PCWSTR, dwbindurlflags: u32, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pauthenticate: &::core::option::Option<super::Com::IAuthenticate>, pimplsession: *mut DBIMPLICITSESSION, pdwbindstatus: *mut u32, ppunk: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -225,6 +232,7 @@ impl IBindResource_Vtbl {
         iid == &<IBindResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IChapteredRowset_Impl: Sized {
     fn AddRefChapter(&self, hchapter: usize, pcrefcount: *mut u32) -> ::windows::core::Result<()>;
     fn ReleaseChapter(&self, hchapter: usize, pcrefcount: *mut u32) -> ::windows::core::Result<()>;
@@ -252,6 +260,7 @@ impl IChapteredRowset_Vtbl {
         iid == &<IChapteredRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 pub trait IColumnMapper_Impl: Sized {
     fn GetPropInfoFromName(&self, wcspropname: &::windows::core::PCWSTR, pppropid: *mut *mut super::super::Storage::IndexServer::DBID, pproptype: *mut u16, puiwidth: *mut u32) -> ::windows::core::Result<()>;
@@ -296,6 +305,7 @@ impl IColumnMapper_Vtbl {
         iid == &<IColumnMapper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IColumnMapperCreator_Impl: Sized {
     fn GetColumnMapper(&self, wcsmachinename: &::windows::core::PCWSTR, wcscatalogname: &::windows::core::PCWSTR) -> ::windows::core::Result<IColumnMapper>;
 }
@@ -319,6 +329,7 @@ impl IColumnMapperCreator_Vtbl {
         iid == &<IColumnMapperCreator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 pub trait IColumnsInfo_Impl: Sized {
     fn GetColumnInfo(&self, pccolumns: *mut usize, prginfo: *mut *mut DBCOLUMNINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
@@ -349,6 +360,7 @@ impl IColumnsInfo_Vtbl {
         iid == &<IColumnsInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 pub trait IColumnsInfo2_Impl: Sized + IColumnsInfo_Impl {
     fn GetRestrictedColumnInfo(&self, ccolumnidmasks: usize, rgcolumnidmasks: *const super::super::Storage::IndexServer::DBID, dwflags: u32, pccolumns: *mut usize, prgcolumnids: *mut *mut super::super::Storage::IndexServer::DBID, prgcolumninfo: *mut *mut DBCOLUMNINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
@@ -369,6 +381,7 @@ impl IColumnsInfo2_Vtbl {
         iid == &<IColumnsInfo2 as ::windows::core::Interface>::IID || iid == &<IColumnsInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IColumnsRowset_Impl: Sized {
     fn GetAvailableColumns(&self, pcoptcolumns: *mut usize, prgoptcolumns: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
@@ -399,6 +412,7 @@ impl IColumnsRowset_Vtbl {
         iid == &<IColumnsRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ICommand_Impl: Sized {
     fn Cancel(&self) -> ::windows::core::Result<()>;
     fn Execute(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, pparams: *mut DBPARAMS, pcrowsaffected: *mut isize, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -433,6 +447,7 @@ impl ICommand_Vtbl {
         iid == &<ICommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ICommandCost_Impl: Sized {
     fn GetAccumulatedCost(&self, pwszrowsetname: &::windows::core::PCWSTR, pccostlimits: *mut u32, prgcostlimits: *mut *mut DBCOST) -> ::windows::core::Result<()>;
     fn GetCostEstimate(&self, pwszrowsetname: &::windows::core::PCWSTR, pccostestimates: *mut u32, prgcostestimates: *mut DBCOST) -> ::windows::core::Result<()>;
@@ -488,6 +503,7 @@ impl ICommandCost_Vtbl {
         iid == &<ICommandCost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 pub trait ICommandPersist_Impl: Sized {
     fn DeleteCommand(&self, pcommandid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
@@ -532,6 +548,7 @@ impl ICommandPersist_Vtbl {
         iid == &<ICommandPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ICommandPrepare_Impl: Sized {
     fn Prepare(&self, cexpectedruns: u32) -> ::windows::core::Result<()>;
     fn Unprepare(&self) -> ::windows::core::Result<()>;
@@ -559,6 +576,7 @@ impl ICommandPrepare_Vtbl {
         iid == &<ICommandPrepare as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICommandProperties_Impl: Sized {
     fn GetProperties(&self, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::Result<()>;
@@ -589,6 +607,7 @@ impl ICommandProperties_Vtbl {
         iid == &<ICommandProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ICommandStream_Impl: Sized {
     fn GetCommandStream(&self, piid: *mut ::windows::core::GUID, pguiddialect: *mut ::windows::core::GUID, ppcommandstream: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetCommandStream(&self, riid: *const ::windows::core::GUID, rguiddialect: *const ::windows::core::GUID, pcommandstream: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -616,6 +635,7 @@ impl ICommandStream_Vtbl {
         iid == &<ICommandStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ICommandText_Impl: Sized + ICommand_Impl {
     fn GetCommandText(&self, pguiddialect: *mut ::windows::core::GUID, ppwszcommand: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn SetCommandText(&self, rguiddialect: *const ::windows::core::GUID, pwszcommand: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -643,6 +663,7 @@ impl ICommandText_Vtbl {
         iid == &<ICommandText as ::windows::core::Interface>::IID || iid == &<ICommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ICommandValidate_Impl: Sized {
     fn ValidateCompletely(&self) -> ::windows::core::Result<()>;
     fn ValidateSyntax(&self) -> ::windows::core::Result<()>;
@@ -670,6 +691,7 @@ impl ICommandValidate_Vtbl {
         iid == &<ICommandValidate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ICommandWithParameters_Impl: Sized {
     fn GetParameterInfo(&self, pcparams: *mut usize, prgparaminfo: *mut *mut DBPARAMINFO, ppnamesbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
@@ -707,6 +729,7 @@ impl ICommandWithParameters_Vtbl {
         iid == &<ICommandWithParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait ICondition_Impl: Sized + super::Com::IPersistStream_Impl {
     fn GetConditionType(&self) -> ::windows::core::Result<Common::CONDITION_TYPE>;
@@ -796,6 +819,7 @@ impl ICondition_Vtbl {
         iid == &<ICondition as ::windows::core::Interface>::IID || iid == &<super::Com::IPersist as ::windows::core::Interface>::IID || iid == &<super::Com::IPersistStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ICondition2_Impl: Sized + ICondition_Impl {
     fn GetLocale(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -832,6 +856,7 @@ impl ICondition2_Vtbl {
         iid == &<ICondition2 as ::windows::core::Interface>::IID || iid == &<super::Com::IPersist as ::windows::core::Interface>::IID || iid == &<super::Com::IPersistStream as ::windows::core::Interface>::IID || iid == &<ICondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IConditionFactory_Impl: Sized {
     fn MakeNot(&self, pcsub: &::core::option::Option<ICondition>, fsimplify: super::super::Foundation::BOOL) -> ::windows::core::Result<ICondition>;
@@ -900,6 +925,7 @@ impl IConditionFactory_Vtbl {
         iid == &<IConditionFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IConditionFactory2_Impl: Sized + IConditionFactory_Impl {
     fn CreateTrueFalse(&self, fval: super::super::Foundation::BOOL, cco: CONDITION_CREATION_OPTIONS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -979,6 +1005,7 @@ impl IConditionFactory2_Vtbl {
         iid == &<IConditionFactory2 as ::windows::core::Interface>::IID || iid == &<IConditionFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IConditionGenerator_Impl: Sized {
     fn Initialize(&self, pschemaprovider: &::core::option::Option<ISchemaProvider>) -> ::windows::core::Result<()>;
@@ -1037,6 +1064,7 @@ impl IConditionGenerator_Vtbl {
         iid == &<IConditionGenerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IConvertType_Impl: Sized {
     fn CanConvert(&self, wfromtype: u16, wtotype: u16, dwconvertflags: u32) -> ::windows::core::Result<()>;
 }
@@ -1054,6 +1082,7 @@ impl IConvertType_Vtbl {
         iid == &<IConvertType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ICreateRow_Impl: Sized {
     fn CreateRow(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, pwszurl: &::windows::core::PCWSTR, dwbindurlflags: u32, rguid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, pauthenticate: &::core::option::Option<super::Com::IAuthenticate>, pimplsession: *mut DBIMPLICITSESSION, pdwbindstatus: *mut u32, ppwsznewurl: *mut ::windows::core::PWSTR, ppunk: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1074,6 +1103,7 @@ impl ICreateRow_Vtbl {
         iid == &<ICreateRow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IDBAsynchNotify_Impl: Sized {
     fn OnLowResource(&self, dwreserved: usize) -> ::windows::core::Result<()>;
     fn OnProgress(&self, hchapter: usize, eoperation: u32, ulprogress: usize, ulprogressmax: usize, easynchphase: u32, pwszstatustext: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1108,6 +1138,7 @@ impl IDBAsynchNotify_Vtbl {
         iid == &<IDBAsynchNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IDBAsynchStatus_Impl: Sized {
     fn Abort(&self, hchapter: usize, eoperation: u32) -> ::windows::core::Result<()>;
     fn GetStatus(&self, hchapter: usize, eoperation: u32, pulprogress: *mut usize, pulprogressmax: *mut usize, peasynchphase: *mut u32, ppwszstatustext: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -1135,6 +1166,7 @@ impl IDBAsynchStatus_Vtbl {
         iid == &<IDBAsynchStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDBBinderProperties_Impl: Sized + IDBProperties_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -1155,6 +1187,7 @@ impl IDBBinderProperties_Vtbl {
         iid == &<IDBBinderProperties as ::windows::core::Interface>::IID || iid == &<IDBProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IDBCreateCommand_Impl: Sized {
     fn CreateCommand(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -1178,6 +1211,7 @@ impl IDBCreateCommand_Vtbl {
         iid == &<IDBCreateCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IDBCreateSession_Impl: Sized {
     fn CreateSession(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -1201,6 +1235,7 @@ impl IDBCreateSession_Vtbl {
         iid == &<IDBCreateSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDBDataSourceAdmin_Impl: Sized {
     fn CreateDataSource(&self, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppdbsession: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1245,6 +1280,7 @@ impl IDBDataSourceAdmin_Vtbl {
         iid == &<IDBDataSourceAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDBInfo_Impl: Sized {
     fn GetKeywords(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1281,6 +1317,7 @@ impl IDBInfo_Vtbl {
         iid == &<IDBInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IDBInitialize_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
     fn Uninitialize(&self) -> ::windows::core::Result<()>;
@@ -1308,6 +1345,7 @@ impl IDBInitialize_Vtbl {
         iid == &<IDBInitialize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDBPromptInitialize_Impl: Sized {
     fn PromptDataSource(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, hwndparent: super::super::Foundation::HWND, dwpromptoptions: u32, csourcetypefilter: u32, rgsourcetypefilter: *const u32, pwszszzproviderfilter: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppdatasource: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1344,6 +1382,7 @@ impl IDBPromptInitialize_Vtbl {
         iid == &<IDBPromptInitialize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDBProperties_Impl: Sized {
     fn GetProperties(&self, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::Result<()>;
@@ -1381,6 +1420,7 @@ impl IDBProperties_Vtbl {
         iid == &<IDBProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IDBSchemaCommand_Impl: Sized {
     fn GetCommand(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, rguidschema: *const ::windows::core::GUID) -> ::windows::core::Result<ICommand>;
     fn GetSchemas(&self, pcschemas: *mut u32, prgschemas: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1414,6 +1454,7 @@ impl IDBSchemaCommand_Vtbl {
         iid == &<IDBSchemaCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDBSchemaRowset_Impl: Sized {
     fn GetRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, rguidschema: *const ::windows::core::GUID, crestrictions: u32, rgrestrictions: *const super::Com::VARIANT, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1444,6 +1485,7 @@ impl IDBSchemaRowset_Vtbl {
         iid == &<IDBSchemaRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDCInfo_Impl: Sized {
     fn GetInfo(&self, cinfo: u32, rgeinfotype: *const u32, prginfo: *mut *mut DCINFO) -> ::windows::core::Result<()>;
@@ -1474,6 +1516,7 @@ impl IDCInfo_Vtbl {
         iid == &<IDCInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IDataConvert_Impl: Sized {
     fn DataConvert(&self, wsrctype: u16, wdsttype: u16, cbsrclength: usize, pcbdstlength: *mut usize, psrc: *const ::core::ffi::c_void, pdst: *mut ::core::ffi::c_void, cbdstmaxlength: usize, dbssrcstatus: u32, pdbsstatus: *mut u32, bprecision: u8, bscale: u8, dwflags: u32) -> ::windows::core::Result<()>;
     fn CanConvert(&self, wsrctype: u16, wdsttype: u16) -> ::windows::core::Result<()>;
@@ -1522,6 +1565,7 @@ impl IDataConvert_Vtbl {
         iid == &<IDataConvert as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDataInitialize_Impl: Sized {
     fn GetDataSource(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, dwclsctx: u32, pwszinitializationstring: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppdatasource: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1598,6 +1642,7 @@ impl IDataInitialize_Vtbl {
         iid == &<IDataInitialize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDataSourceLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn hWnd(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -1654,6 +1699,7 @@ impl IDataSourceLocator_Vtbl {
         iid == &<IDataSourceLocator as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IEntity_Impl: Sized {
     fn Name(&self, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn Base(&self) -> ::windows::core::Result<IEntity>;
@@ -1741,6 +1787,7 @@ impl IEntity_Vtbl {
         iid == &<IEntity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumItemProperties_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ITEMPROP, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1804,6 +1851,7 @@ impl IEnumItemProperties_Vtbl {
         iid == &<IEnumItemProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IEnumSearchRoots_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<ISearchRoot>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1851,6 +1899,7 @@ impl IEnumSearchRoots_Vtbl {
         iid == &<IEnumSearchRoots as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IEnumSearchScopeRules_Impl: Sized {
     fn Next(&self, celt: u32, pprgelt: *mut ::core::option::Option<ISearchScopeRule>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1898,6 +1947,7 @@ impl IEnumSearchScopeRules_Vtbl {
         iid == &<IEnumSearchScopeRules as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IEnumSubscription_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::windows::core::GUID, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -1958,6 +2008,7 @@ impl IEnumSubscription_Vtbl {
         iid == &<IEnumSubscription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IErrorLookup_Impl: Sized {
     fn GetErrorDescription(&self, hrerror: ::windows::core::HRESULT, dwlookupid: u32, pdispparams: *const super::Com::DISPPARAMS, lcid: u32, pbstrsource: *mut ::windows::core::BSTR, pbstrdescription: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1995,6 +2046,7 @@ impl IErrorLookup_Vtbl {
         iid == &<IErrorLookup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IErrorRecords_Impl: Sized {
     fn AddErrorRecord(&self, perrorinfo: *const ERRORINFO, dwlookupid: u32, pdispparams: *const super::Com::DISPPARAMS, punkcustomerror: &::core::option::Option<::windows::core::IUnknown>, dwdynamicerrorid: u32) -> ::windows::core::Result<()>;
@@ -2077,6 +2129,7 @@ impl IErrorRecords_Vtbl {
         iid == &<IErrorRecords as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IGetDataSource_Impl: Sized {
     fn GetDataSource(&self, riid: *const ::windows::core::GUID, ppdatasource: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -2094,6 +2147,7 @@ impl IGetDataSource_Vtbl {
         iid == &<IGetDataSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IGetRow_Impl: Sized {
     fn GetRowFromHROW(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, hrow: usize, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetURLFromHROW(&self, hrow: usize) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -2133,6 +2187,7 @@ impl IGetRow_Vtbl {
         iid == &<IGetRow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IGetSession_Impl: Sized {
     fn GetSession(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -2156,6 +2211,7 @@ impl IGetSession_Vtbl {
         iid == &<IGetSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IGetSourceRow_Impl: Sized {
     fn GetSourceRow(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -2179,6 +2235,7 @@ impl IGetSourceRow_Vtbl {
         iid == &<IGetSourceRow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IIndexDefinition_Impl: Sized {
     fn CreateIndex(&self, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, cindexcolumndescs: usize, rgindexcolumndescs: *const DBINDEXCOLUMNDESC, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, ppindexid: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
@@ -2209,6 +2266,7 @@ impl IIndexDefinition_Vtbl {
         iid == &<IIndexDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IInterval_Impl: Sized {
     fn GetLimits(&self, pilklower: *mut INTERVAL_LIMIT_KIND, ppropvarlower: *mut super::Com::StructuredStorage::PROPVARIANT, pilkupper: *mut INTERVAL_LIMIT_KIND, ppropvarupper: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -2229,6 +2287,7 @@ impl IInterval_Vtbl {
         iid == &<IInterval as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ILoadFilter_Impl: Sized {
     fn LoadIFilter(&self, pwcspath: &::windows::core::PCWSTR, pfilteredsources: *const FILTERED_DATA_SOURCES, punkouter: &::core::option::Option<::windows::core::IUnknown>, fusedefault: super::super::Foundation::BOOL, pfilterclsid: *mut ::windows::core::GUID, searchdecsize: *mut i32, pwcssearchdesc: *mut *mut u16, ppifilt: *mut ::core::option::Option<super::super::Storage::IndexServer::IFilter>) -> ::windows::core::Result<()>;
@@ -2266,6 +2325,7 @@ impl ILoadFilter_Vtbl {
         iid == &<ILoadFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ILoadFilterWithPrivateComActivation_Impl: Sized + ILoadFilter_Impl {
     fn LoadIFilterWithPrivateComActivation(&self, filteredsources: *const FILTERED_DATA_SOURCES, usedefault: super::super::Foundation::BOOL, filterclsid: *mut ::windows::core::GUID, isfilterprivatecomactivated: *mut super::super::Foundation::BOOL, filterobj: *mut ::core::option::Option<super::super::Storage::IndexServer::IFilter>) -> ::windows::core::Result<()>;
@@ -2289,6 +2349,7 @@ impl ILoadFilterWithPrivateComActivation_Vtbl {
         iid == &<ILoadFilterWithPrivateComActivation as ::windows::core::Interface>::IID || iid == &<ILoadFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMDDataset_Impl: Sized {
     fn FreeAxisInfo(&self, caxes: usize, rgaxisinfo: *mut MDAXISINFO) -> ::windows::core::Result<()>;
@@ -2346,6 +2407,7 @@ impl IMDDataset_Vtbl {
         iid == &<IMDDataset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IMDFind_Impl: Sized {
     fn FindCell(&self, ulstartingordinal: usize, cmembers: usize, rgpwszmember: *mut ::windows::core::PWSTR, pulcellordinal: *mut usize) -> ::windows::core::Result<()>;
     fn FindTuple(&self, ulaxisidentifier: u32, ulstartingordinal: usize, cmembers: usize, rgpwszmember: *mut ::windows::core::PWSTR, pultupleordinal: *mut u32) -> ::windows::core::Result<()>;
@@ -2373,6 +2435,7 @@ impl IMDFind_Vtbl {
         iid == &<IMDFind as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMDRangeRowset_Impl: Sized {
     fn GetRangeRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, ulstartcell: usize, ulendcell: usize, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -2393,6 +2456,7 @@ impl IMDRangeRowset_Vtbl {
         iid == &<IMDRangeRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IMetaData_Impl: Sized {
     fn GetData(&self, ppszkey: *mut ::windows::core::PWSTR, ppszvalue: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
@@ -2410,6 +2474,7 @@ impl IMetaData_Vtbl {
         iid == &<IMetaData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IMultipleResults_Impl: Sized {
     fn GetResult(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, lresultflag: isize, riid: *const ::windows::core::GUID, pcrowsaffected: *mut isize, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -2427,6 +2492,7 @@ impl IMultipleResults_Vtbl {
         iid == &<IMultipleResults as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait INamedEntity_Impl: Sized {
     fn GetValue(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn DefaultPhrase(&self, ppszphrase: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -2460,6 +2526,7 @@ impl INamedEntity_Vtbl {
         iid == &<INamedEntity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait INamedEntityCollector_Impl: Sized {
     fn Add(&self, beginspan: u32, endspan: u32, beginactual: u32, endactual: u32, ptype: &::core::option::Option<IEntity>, pszvalue: &::windows::core::PCWSTR, certainty: NAMED_ENTITY_CERTAINTY) -> ::windows::core::Result<()>;
 }
@@ -2477,6 +2544,7 @@ impl INamedEntityCollector_Vtbl {
         iid == &<INamedEntityCollector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Authorization\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer"))]
 pub trait IObjectAccessControl_Impl: Sized {
     fn GetObjectAccessRights(&self, pobject: *mut SEC_OBJECT, pcaccessentries: *mut u32, prgaccessentries: *mut *mut super::super::Security::Authorization::EXPLICIT_ACCESS_W) -> ::windows::core::Result<()>;
@@ -2528,6 +2596,7 @@ impl IObjectAccessControl_Vtbl {
         iid == &<IObjectAccessControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpLockStatus_Impl: Sized {
     fn IsOplockValid(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -2583,6 +2652,7 @@ impl IOpLockStatus_Vtbl {
         iid == &<IOpLockStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IOpenRowset_Impl: Sized {
     fn OpenRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, ptableid: *const super::super::Storage::IndexServer::DBID, pindexid: *const super::super::Storage::IndexServer::DBID, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -2603,6 +2673,7 @@ impl IOpenRowset_Vtbl {
         iid == &<IOpenRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IParentRowset_Impl: Sized {
     fn GetChildRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, iordinal: usize, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -2626,6 +2697,7 @@ impl IParentRowset_Vtbl {
         iid == &<IParentRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 pub trait IProtocolHandlerSite_Impl: Sized {
     fn GetFilter(&self, pclsidobj: *mut ::windows::core::GUID, pcwszcontenttype: &::windows::core::PCWSTR, pcwszextension: &::windows::core::PCWSTR, ppfilter: *mut ::core::option::Option<super::super::Storage::IndexServer::IFilter>) -> ::windows::core::Result<()>;
@@ -2646,6 +2718,7 @@ impl IProtocolHandlerSite_Vtbl {
         iid == &<IProtocolHandlerSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IProvideMoniker_Impl: Sized {
     fn GetMoniker(&self) -> ::windows::core::Result<super::Com::IMoniker>;
@@ -2672,6 +2745,7 @@ impl IProvideMoniker_Vtbl {
         iid == &<IProvideMoniker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IQueryParser_Impl: Sized {
     fn Parse(&self, pszinputstring: &::windows::core::PCWSTR, pcustomproperties: &::core::option::Option<super::Com::IEnumUnknown>) -> ::windows::core::Result<IQuerySolution>;
@@ -2774,6 +2848,7 @@ impl IQueryParser_Vtbl {
         iid == &<IQueryParser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IQueryParserManager_Impl: Sized {
     fn CreateLoadedParser(&self, pszcatalog: &::windows::core::PCWSTR, langidforkeywords: u16, riid: *const ::windows::core::GUID, ppqueryparser: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2811,6 +2886,7 @@ impl IQueryParserManager_Vtbl {
         iid == &<IQueryParserManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IQuerySolution_Impl: Sized + IConditionFactory_Impl {
     fn GetQuery(&self, ppquerynode: *mut ::core::option::Option<ICondition>, ppmaintype: *mut ::core::option::Option<IEntity>) -> ::windows::core::Result<()>;
@@ -2848,6 +2924,7 @@ impl IQuerySolution_Vtbl {
         iid == &<IQuerySolution as ::windows::core::Interface>::IID || iid == &<IConditionFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IReadData_Impl: Sized {
     fn ReadData(&self, hchapter: usize, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, haccessor: HACCESSOR, crows: isize, pcrowsobtained: *mut usize, ppfixeddata: *mut *mut u8, pcbvariabletotal: *mut usize, ppvariabledata: *mut *mut u8) -> ::windows::core::Result<()>;
     fn ReleaseChapter(&self, hchapter: usize) -> ::windows::core::Result<()>;
@@ -2875,6 +2952,7 @@ impl IReadData_Vtbl {
         iid == &<IReadData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRegisterProvider_Impl: Sized {
     fn GetURLMapping(&self, pwszurl: &::windows::core::PCWSTR, dwreserved: usize) -> ::windows::core::Result<::windows::core::GUID>;
     fn SetURLMapping(&self, pwszurl: &::windows::core::PCWSTR, dwreserved: usize, rclsidprovider: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -2915,6 +2993,7 @@ impl IRegisterProvider_Vtbl {
         iid == &<IRegisterProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRelationship_Impl: Sized {
     fn Name(&self, ppszname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -2978,6 +3057,7 @@ impl IRelationship_Vtbl {
         iid == &<IRelationship as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IRichChunk_Impl: Sized {
     fn GetData(&self, pfirstpos: *mut u32, plength: *mut u32, ppsz: *mut ::windows::core::PWSTR, pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -2998,6 +3078,7 @@ impl IRichChunk_Vtbl {
         iid == &<IRichChunk as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 pub trait IRow_Impl: Sized {
     fn GetColumns(&self, ccolumns: usize, rgcolumns: *mut DBCOLUMNACCESS) -> ::windows::core::Result<()>;
@@ -3035,6 +3116,7 @@ impl IRow_Vtbl {
         iid == &<IRow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 pub trait IRowChange_Impl: Sized {
     fn SetColumns(&self, ccolumns: usize, rgcolumns: *const DBCOLUMNACCESS) -> ::windows::core::Result<()>;
@@ -3055,6 +3137,7 @@ impl IRowChange_Vtbl {
         iid == &<IRowChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowPosition_Impl: Sized {
     fn ClearRowPosition(&self) -> ::windows::core::Result<()>;
     fn GetRowPosition(&self, phchapter: *mut usize, phrow: *mut usize, pdwpositionflags: *mut u32) -> ::windows::core::Result<()>;
@@ -3109,6 +3192,7 @@ impl IRowPosition_Vtbl {
         iid == &<IRowPosition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRowPositionChange_Impl: Sized {
     fn OnRowPositionChange(&self, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3129,6 +3213,7 @@ impl IRowPositionChange_Vtbl {
         iid == &<IRowPositionChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 pub trait IRowSchemaChange_Impl: Sized + IRowChange_Impl {
     fn DeleteColumns(&self, ccolumns: usize, rgcolumnids: *const super::super::Storage::IndexServer::DBID, rgdwstatus: *mut u32) -> ::windows::core::Result<()>;
@@ -3159,6 +3244,7 @@ impl IRowSchemaChange_Vtbl {
         iid == &<IRowSchemaChange as ::windows::core::Interface>::IID || iid == &<IRowChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowset_Impl: Sized {
     fn AddRefRows(&self, crows: usize, rghrows: *const usize, rgrefcounts: *mut u32, rgrowstatus: *mut u32) -> ::windows::core::Result<()>;
     fn GetData(&self, hrow: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3207,6 +3293,7 @@ impl IRowset_Vtbl {
         iid == &<IRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRowsetAsynch_Impl: Sized {
     fn RatioFinished(&self, puldenominator: *mut usize, pulnumerator: *mut usize, pcrows: *mut usize, pfnewrows: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3237,6 +3324,7 @@ impl IRowsetAsynch_Vtbl {
         iid == &<IRowsetAsynch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetBookmark_Impl: Sized {
     fn PositionOnBookmark(&self, hchapter: usize, cbbookmark: usize, pbookmark: *const u8) -> ::windows::core::Result<()>;
 }
@@ -3254,6 +3342,7 @@ impl IRowsetBookmark_Vtbl {
         iid == &<IRowsetBookmark as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetChange_Impl: Sized {
     fn DeleteRows(&self, hreserved: usize, crows: usize, rghrows: *const usize, rgrowstatus: *mut u32) -> ::windows::core::Result<()>;
     fn SetData(&self, hrow: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3288,6 +3377,7 @@ impl IRowsetChange_Vtbl {
         iid == &<IRowsetChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetChangeExtInfo_Impl: Sized {
     fn GetOriginalRow(&self, hreserved: usize, hrow: usize, phroworiginal: *mut usize) -> ::windows::core::Result<()>;
     fn GetPendingColumns(&self, hreserved: usize, hrow: usize, ccolumnordinals: u32, rgiordinals: *const u32, rgcolumnstatus: *mut u32) -> ::windows::core::Result<()>;
@@ -3315,6 +3405,7 @@ impl IRowsetChangeExtInfo_Vtbl {
         iid == &<IRowsetChangeExtInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetChapterMember_Impl: Sized {
     fn IsRowInChapter(&self, hchapter: usize, hrow: usize) -> ::windows::core::Result<()>;
 }
@@ -3332,6 +3423,7 @@ impl IRowsetChapterMember_Vtbl {
         iid == &<IRowsetChapterMember as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetCopyRows_Impl: Sized {
     fn CloseSource(&self, hsourceid: u16) -> ::windows::core::Result<()>;
     fn CopyByHROWS(&self, hsourceid: u16, hreserved: usize, crows: isize, rghrows: *const usize, bflags: u32) -> ::windows::core::Result<()>;
@@ -3373,6 +3465,7 @@ impl IRowsetCopyRows_Vtbl {
         iid == &<IRowsetCopyRows as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRowsetCurrentIndex_Impl: Sized + IRowsetIndex_Impl {
     fn GetIndex(&self, ppindexid: *mut *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
@@ -3403,6 +3496,7 @@ impl IRowsetCurrentIndex_Vtbl {
         iid == &<IRowsetCurrentIndex as ::windows::core::Interface>::IID || iid == &<IRowsetIndex as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IRowsetEvents_Impl: Sized {
     fn OnNewItem(&self, itemid: *const super::Com::StructuredStorage::PROPVARIANT, newitemstate: ROWSETEVENT_ITEMSTATE) -> ::windows::core::Result<()>;
@@ -3447,6 +3541,7 @@ impl IRowsetEvents_Vtbl {
         iid == &<IRowsetEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRowsetFastLoad_Impl: Sized {
     fn InsertRow(&self, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -3477,6 +3572,7 @@ impl IRowsetFastLoad_Vtbl {
         iid == &<IRowsetFastLoad as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetFind_Impl: Sized {
     fn FindNextRow(&self, hchapter: usize, haccessor: HACCESSOR, pfindvalue: *mut ::core::ffi::c_void, compareop: u32, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::Result<()>;
 }
@@ -3494,6 +3590,7 @@ impl IRowsetFind_Vtbl {
         iid == &<IRowsetFind as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetIdentity_Impl: Sized {
     fn IsSameRow(&self, hthisrow: usize, hthatrow: usize) -> ::windows::core::Result<()>;
 }
@@ -3511,6 +3608,7 @@ impl IRowsetIdentity_Vtbl {
         iid == &<IRowsetIdentity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRowsetIndex_Impl: Sized {
     fn GetIndexInfo(&self, pckeycolumns: *mut usize, prgindexcolumndesc: *mut *mut DBINDEXCOLUMNDESC, pcindexpropertysets: *mut u32, prgindexpropertysets: *mut *mut DBPROPSET) -> ::windows::core::Result<()>;
@@ -3548,6 +3646,7 @@ impl IRowsetIndex_Vtbl {
         iid == &<IRowsetIndex as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRowsetInfo_Impl: Sized {
     fn GetProperties(&self, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::Result<()>;
@@ -3585,6 +3684,7 @@ impl IRowsetInfo_Vtbl {
         iid == &<IRowsetInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetKeys_Impl: Sized {
     fn ListKeys(&self, pccolumns: *mut usize, prgcolumns: *mut *mut usize) -> ::windows::core::Result<()>;
 }
@@ -3602,6 +3702,7 @@ impl IRowsetKeys_Vtbl {
         iid == &<IRowsetKeys as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetLocate_Impl: Sized + IRowset_Impl {
     fn Compare(&self, hreserved: usize, cbbookmark1: usize, pbookmark1: *const u8, cbbookmark2: usize, pbookmark2: *const u8, pcomparison: *mut u32) -> ::windows::core::Result<()>;
     fn GetRowsAt(&self, hreserved1: usize, hreserved2: usize, cbbookmark: usize, pbookmark: *const u8, lrowsoffset: isize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::Result<()>;
@@ -3643,6 +3744,7 @@ impl IRowsetLocate_Vtbl {
         iid == &<IRowsetLocate as ::windows::core::Interface>::IID || iid == &<IRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetNewRowAfter_Impl: Sized {
     fn SetNewDataAfter(&self, hchapter: usize, cbbmprevious: u32, pbmprevious: *const u8, haccessor: HACCESSOR, pdata: *mut u8, phrow: *mut usize) -> ::windows::core::Result<()>;
 }
@@ -3660,6 +3762,7 @@ impl IRowsetNewRowAfter_Vtbl {
         iid == &<IRowsetNewRowAfter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetNextRowset_Impl: Sized {
     fn GetNextRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -3683,6 +3786,7 @@ impl IRowsetNextRowset_Vtbl {
         iid == &<IRowsetNextRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRowsetNotify_Impl: Sized {
     fn OnFieldChange(&self, prowset: &::core::option::Option<IRowset>, hrow: usize, ccolumns: usize, rgcolumns: *const usize, ereason: u32, ephase: u32, fcantdeny: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3720,6 +3824,7 @@ impl IRowsetNotify_Vtbl {
         iid == &<IRowsetNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetPrioritization_Impl: Sized {
     fn SetScopePriority(&self, priority: PRIORITY_LEVEL, scopestatisticseventfrequency: u32) -> ::windows::core::Result<()>;
     fn GetScopePriority(&self, priority: *mut PRIORITY_LEVEL, scopestatisticseventfrequency: *mut u32) -> ::windows::core::Result<()>;
@@ -3754,6 +3859,7 @@ impl IRowsetPrioritization_Vtbl {
         iid == &<IRowsetPrioritization as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetQueryStatus_Impl: Sized {
     fn GetStatus(&self, pdwstatus: *mut u32) -> ::windows::core::Result<()>;
     fn GetStatusEx(&self, pdwstatus: *mut u32, pcfiltereddocuments: *mut u32, pcdocumentstofilter: *mut u32, pdwratiofinisheddenominator: *mut usize, pdwratiofinishednumerator: *mut usize, cbbmk: usize, pbmk: *const u8, pirowbmk: *mut usize, pcrowstotal: *mut usize) -> ::windows::core::Result<()>;
@@ -3781,6 +3887,7 @@ impl IRowsetQueryStatus_Vtbl {
         iid == &<IRowsetQueryStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRowsetRefresh_Impl: Sized {
     fn RefreshVisibleData(&self, hchapter: usize, crows: usize, rghrows: *const usize, foverwrite: super::super::Foundation::BOOL, pcrowsrefreshed: *mut usize, prghrowsrefreshed: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::Result<()>;
@@ -3811,6 +3918,7 @@ impl IRowsetRefresh_Vtbl {
         iid == &<IRowsetRefresh as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetResynch_Impl: Sized {
     fn GetVisibleData(&self, hrow: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn ResynchRows(&self, crows: usize, rghrows: *const usize, pcrowsresynched: *mut usize, prghrowsresynched: *mut *mut usize, prgrowstatus: *mut *mut u32) -> ::windows::core::Result<()>;
@@ -3838,6 +3946,7 @@ impl IRowsetResynch_Vtbl {
         iid == &<IRowsetResynch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetScroll_Impl: Sized + IRowsetLocate_Impl {
     fn GetApproximatePosition(&self, hreserved: usize, cbbookmark: usize, pbookmark: *const u8, pulposition: *mut usize, pcrows: *mut usize) -> ::windows::core::Result<()>;
     fn GetRowsAtRatio(&self, hreserved1: usize, hreserved2: usize, ulnumerator: usize, uldenominator: usize, crows: isize, pcrowsobtained: *mut usize, prghrows: *mut *mut usize) -> ::windows::core::Result<()>;
@@ -3865,6 +3974,7 @@ impl IRowsetScroll_Vtbl {
         iid == &<IRowsetScroll as ::windows::core::Interface>::IID || iid == &<IRowset as ::windows::core::Interface>::IID || iid == &<IRowsetLocate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetUpdate_Impl: Sized + IRowsetChange_Impl {
     fn GetOriginalData(&self, hrow: usize, haccessor: HACCESSOR, pdata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetPendingRows(&self, hreserved: usize, dwrowstatus: u32, pcpendingrows: *mut usize, prgpendingrows: *mut *mut usize, prgpendingstatus: *mut *mut u32) -> ::windows::core::Result<()>;
@@ -3913,6 +4023,7 @@ impl IRowsetUpdate_Vtbl {
         iid == &<IRowsetUpdate as ::windows::core::Interface>::IID || iid == &<IRowsetChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetView_Impl: Sized {
     fn CreateView(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn GetView(&self, hchapter: usize, riid: *const ::windows::core::GUID, phchaptersource: *mut usize, ppview: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -3946,6 +4057,7 @@ impl IRowsetView_Vtbl {
         iid == &<IRowsetView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetWatchAll_Impl: Sized {
     fn Acknowledge(&self) -> ::windows::core::Result<()>;
     fn Start(&self) -> ::windows::core::Result<()>;
@@ -3980,6 +4092,7 @@ impl IRowsetWatchAll_Vtbl {
         iid == &<IRowsetWatchAll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetWatchNotify_Impl: Sized {
     fn OnChange(&self, prowset: &::core::option::Option<IRowset>, echangereason: u32) -> ::windows::core::Result<()>;
 }
@@ -3997,6 +4110,7 @@ impl IRowsetWatchNotify_Vtbl {
         iid == &<IRowsetWatchNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IRowsetWatchRegion_Impl: Sized + IRowsetWatchAll_Impl {
     fn CreateWatchRegion(&self, dwwatchmode: u32, phregion: *mut usize) -> ::windows::core::Result<()>;
     fn ChangeWatchMode(&self, hregion: usize, dwwatchmode: u32) -> ::windows::core::Result<()>;
@@ -4052,6 +4166,7 @@ impl IRowsetWatchRegion_Vtbl {
         iid == &<IRowsetWatchRegion as ::windows::core::Interface>::IID || iid == &<IRowsetWatchAll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRowsetWithParameters_Impl: Sized {
     fn GetParameterInfo(&self, pcparams: *mut usize, prgparaminfo: *mut *mut DBPARAMINFO, ppnamesbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
@@ -4082,6 +4197,7 @@ impl IRowsetWithParameters_Vtbl {
         iid == &<IRowsetWithParameters as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISQLErrorInfo_Impl: Sized {
     fn GetSQLInfo(&self, pbstrsqlstate: *mut ::windows::core::BSTR, plnativeerror: *mut i32) -> ::windows::core::Result<()>;
 }
@@ -4099,6 +4215,7 @@ impl ISQLErrorInfo_Vtbl {
         iid == &<ISQLErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISQLGetDiagField_Impl: Sized {
     fn GetDiagField(&self, pdiaginfo: *mut KAGGETDIAG) -> ::windows::core::Result<()>;
@@ -4119,6 +4236,7 @@ impl ISQLGetDiagField_Vtbl {
         iid == &<ISQLGetDiagField as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISQLRequestDiagFields_Impl: Sized {
     fn RequestDiagFields(&self, cdiagfields: u32, rgdiagfields: *const KAGREQDIAG) -> ::windows::core::Result<()>;
@@ -4139,6 +4257,7 @@ impl ISQLRequestDiagFields_Vtbl {
         iid == &<ISQLRequestDiagFields as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISQLServerErrorInfo_Impl: Sized {
     fn GetErrorInfo(&self, pperrorinfo: *mut *mut SSERRORINFO, ppstringsbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
 }
@@ -4156,6 +4275,7 @@ impl ISQLServerErrorInfo_Vtbl {
         iid == &<ISQLServerErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISchemaLocalizerSupport_Impl: Sized {
     fn Localize(&self, pszglobalstring: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -4179,6 +4299,7 @@ impl ISchemaLocalizerSupport_Vtbl {
         iid == &<ISchemaLocalizerSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
 pub trait ISchemaLock_Impl: Sized {
     fn GetSchemaLock(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, lmmode: u32, phlockhandle: *mut super::super::Foundation::HANDLE, ptableversion: *mut u64) -> ::windows::core::Result<()>;
@@ -4209,6 +4330,7 @@ impl ISchemaLock_Vtbl {
         iid == &<ISchemaLock as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISchemaProvider_Impl: Sized {
     fn Entities(&self, riid: *const ::windows::core::GUID, pentities: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn RootEntity(&self) -> ::windows::core::Result<IEntity>;
@@ -4283,6 +4405,7 @@ impl ISchemaProvider_Vtbl {
         iid == &<ISchemaProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IScopedOperations_Impl: Sized + IBindResource_Impl {
     fn Copy(&self, crows: usize, rgpwszsourceurls: *const ::windows::core::PCWSTR, rgpwszdesturls: *const ::windows::core::PCWSTR, dwcopyflags: u32, pauthenticate: &::core::option::Option<super::Com::IAuthenticate>, rgdwstatus: *mut u32, rgpwsznewurls: *mut ::windows::core::PWSTR, ppstringsbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
@@ -4327,6 +4450,7 @@ impl IScopedOperations_Vtbl {
         iid == &<IScopedOperations as ::windows::core::Interface>::IID || iid == &<IBindResource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ISearchCatalogManager_Impl: Sized {
     fn Name(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -4603,6 +4727,7 @@ impl ISearchCatalogManager_Vtbl {
         iid == &<ISearchCatalogManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ISearchCatalogManager2_Impl: Sized + ISearchCatalogManager_Impl {
     fn PrioritizeMatchingURLs(&self, pszpattern: &::windows::core::PCWSTR, dwprioritizeflags: PRIORITIZE_FLAGS) -> ::windows::core::Result<()>;
@@ -4623,6 +4748,7 @@ impl ISearchCatalogManager2_Vtbl {
         iid == &<ISearchCatalogManager2 as ::windows::core::Interface>::IID || iid == &<ISearchCatalogManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISearchCrawlScopeManager_Impl: Sized {
     fn AddDefaultScopeRule(&self, pszurl: &::windows::core::PCWSTR, finclude: super::super::Foundation::BOOL, ffollowflags: u32) -> ::windows::core::Result<()>;
@@ -4787,6 +4913,7 @@ impl ISearchCrawlScopeManager_Vtbl {
         iid == &<ISearchCrawlScopeManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISearchCrawlScopeManager2_Impl: Sized + ISearchCrawlScopeManager_Impl {
     fn GetVersion(&self, plversion: *mut *mut i32, phfilemapping: *mut super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -4807,6 +4934,7 @@ impl ISearchCrawlScopeManager2_Vtbl {
         iid == &<ISearchCrawlScopeManager2 as ::windows::core::Interface>::IID || iid == &<ISearchCrawlScopeManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISearchItemsChangedSink_Impl: Sized {
     fn StartedMonitoringScope(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -4844,6 +4972,7 @@ impl ISearchItemsChangedSink_Vtbl {
         iid == &<ISearchItemsChangedSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISearchLanguageSupport_Impl: Sized {
     fn SetDiacriticSensitivity(&self, fdiacriticsensitive: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4907,6 +5036,7 @@ impl ISearchLanguageSupport_Vtbl {
         iid == &<ISearchLanguageSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ISearchManager_Impl: Sized {
     fn GetIndexerVersionStr(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -5068,6 +5198,7 @@ impl ISearchManager_Vtbl {
         iid == &<ISearchManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ISearchManager2_Impl: Sized + ISearchManager_Impl {
     fn CreateCatalog(&self, pszcatalog: &::windows::core::PCWSTR) -> ::windows::core::Result<ISearchCatalogManager>;
@@ -5104,6 +5235,7 @@ impl ISearchManager2_Vtbl {
         iid == &<ISearchManager2 as ::windows::core::Interface>::IID || iid == &<ISearchManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISearchNotifyInlineSite_Impl: Sized {
     fn OnItemIndexedStatusChange(&self, sipstatus: SEARCH_INDEXING_PHASE, dwnumentries: u32, rgitemstatusentries: *const SEARCH_ITEM_INDEXING_STATUS) -> ::windows::core::Result<()>;
     fn OnCatalogStatusChange(&self, guidcatalogresetsignature: *const ::windows::core::GUID, guidcheckpointsignature: *const ::windows::core::GUID, dwlastcheckpointnumber: u32) -> ::windows::core::Result<()>;
@@ -5131,6 +5263,7 @@ impl ISearchNotifyInlineSite_Vtbl {
         iid == &<ISearchNotifyInlineSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISearchPersistentItemsChangedSink_Impl: Sized {
     fn StartedMonitoringScope(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn StoppedMonitoringScope(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -5165,6 +5298,7 @@ impl ISearchPersistentItemsChangedSink_Vtbl {
         iid == &<ISearchPersistentItemsChangedSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISearchProtocol_Impl: Sized {
     fn Init(&self, ptimeoutinfo: *mut TIMEOUT_INFO, pprotocolhandlersite: &::core::option::Option<IProtocolHandlerSite>, pproxyinfo: *mut PROXY_INFO) -> ::windows::core::Result<()>;
@@ -5209,6 +5343,7 @@ impl ISearchProtocol_Vtbl {
         iid == &<ISearchProtocol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISearchProtocol2_Impl: Sized + ISearchProtocol_Impl {
     fn CreateAccessorEx(&self, pcwszurl: &::windows::core::PCWSTR, pauthenticationinfo: *mut AUTHENTICATION_INFO, pincrementalaccessinfo: *mut INCREMENTAL_ACCESS_INFO, piteminfo: *mut ITEM_INFO, puserdata: *const super::Com::BLOB, ppaccessor: *mut ::core::option::Option<IUrlAccessor>) -> ::windows::core::Result<()>;
@@ -5229,6 +5364,7 @@ impl ISearchProtocol2_Vtbl {
         iid == &<ISearchProtocol2 as ::windows::core::Interface>::IID || iid == &<ISearchProtocol as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISearchProtocolThreadContext_Impl: Sized {
     fn ThreadInit(&self) -> ::windows::core::Result<()>;
     fn ThreadShutdown(&self) -> ::windows::core::Result<()>;
@@ -5263,6 +5399,7 @@ impl ISearchProtocolThreadContext_Vtbl {
         iid == &<ISearchProtocolThreadContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISearchQueryHelper_Impl: Sized {
     fn ConnectionString(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -5492,6 +5629,7 @@ impl ISearchQueryHelper_Vtbl {
         iid == &<ISearchQueryHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com"))]
 pub trait ISearchQueryHits_Impl: Sized {
     fn Init(&self, pflt: &::core::option::Option<super::super::Storage::IndexServer::IFilter>, ulflags: u32) -> i32;
@@ -5529,6 +5667,7 @@ impl ISearchQueryHits_Vtbl {
         iid == &<ISearchQueryHits as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISearchRoot_Impl: Sized {
     fn SetSchedule(&self, psztaskarg: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -5765,6 +5904,7 @@ impl ISearchRoot_Vtbl {
         iid == &<ISearchRoot as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISearchScopeRule_Impl: Sized {
     fn PatternOrURL(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -5833,6 +5973,7 @@ impl ISearchScopeRule_Vtbl {
         iid == &<ISearchScopeRule as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISearchViewChangedSink_Impl: Sized {
     fn OnChange(&self, pdwdocid: *const i32, pchange: *const SEARCH_ITEM_CHANGE, pfinview: *const super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5853,6 +5994,7 @@ impl ISearchViewChangedSink_Vtbl {
         iid == &<ISearchViewChangedSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Security_Authorization\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Security_Authorization")]
 pub trait ISecurityInfo_Impl: Sized {
     fn GetCurrentTrustee(&self, pptrustee: *mut *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::Result<()>;
@@ -5890,6 +6032,7 @@ impl ISecurityInfo_Vtbl {
         iid == &<ISecurityInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IService_Impl: Sized {
     fn InvokeService(&self, punkinner: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -5907,6 +6050,7 @@ impl IService_Vtbl {
         iid == &<IService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISessionProperties_Impl: Sized {
     fn GetProperties(&self, cpropertyidsets: u32, rgpropertyidsets: *const DBPROPIDSET, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET) -> ::windows::core::Result<()>;
@@ -5937,6 +6081,7 @@ impl ISessionProperties_Vtbl {
         iid == &<ISessionProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ISimpleCommandCreator_Impl: Sized {
     fn CreateICommand(&self, ppiunknown: *mut ::core::option::Option<::windows::core::IUnknown>, pouterunk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn VerifyCatalog(&self, pwszmachine: &::windows::core::PCWSTR, pwszcatalogname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -5971,6 +6116,7 @@ impl ISimpleCommandCreator_Vtbl {
         iid == &<ISimpleCommandCreator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISourcesRowset_Impl: Sized {
     fn GetSourcesRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, cpropertysets: u32, rgproperties: *mut DBPROPSET, ppsourcesrowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -5991,6 +6137,7 @@ impl ISourcesRowset_Vtbl {
         iid == &<ISourcesRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStemmer_Impl: Sized {
     fn Init(&self, ulmaxtokensize: u32, pflicense: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -6028,6 +6175,7 @@ impl IStemmer_Vtbl {
         iid == &<IStemmer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISubscriptionItem_Impl: Sized {
     fn GetCookie(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -6111,6 +6259,7 @@ impl ISubscriptionItem_Vtbl {
         iid == &<ISubscriptionItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISubscriptionMgr_Impl: Sized {
     fn DeleteSubscription(&self, pwszurl: &::windows::core::PCWSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -6201,6 +6350,7 @@ impl ISubscriptionMgr_Vtbl {
         iid == &<ISubscriptionMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISubscriptionMgr2_Impl: Sized + ISubscriptionMgr_Impl {
     fn GetItemFromURL(&self, pwszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<ISubscriptionItem>;
@@ -6284,6 +6434,7 @@ impl ISubscriptionMgr2_Vtbl {
         iid == &<ISubscriptionMgr2 as ::windows::core::Interface>::IID || iid == &<ISubscriptionMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITableCreation_Impl: Sized + ITableDefinition_Impl {
     fn GetTableDefinition(&self, ptableid: *const super::super::Storage::IndexServer::DBID, pccolumndescs: *mut usize, prgcolumndescs: *mut *mut DBCOLUMNDESC, pcpropertysets: *mut u32, prgpropertysets: *mut *mut DBPROPSET, pcconstraintdescs: *mut u32, prgconstraintdescs: *mut *mut DBCONSTRAINTDESC, ppwszstringbuffer: *mut *mut u16) -> ::windows::core::Result<()>;
@@ -6304,6 +6455,7 @@ impl ITableCreation_Vtbl {
         iid == &<ITableCreation as ::windows::core::Interface>::IID || iid == &<ITableDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITableDefinition_Impl: Sized {
     fn CreateTable(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, ptableid: *const super::super::Storage::IndexServer::DBID, ccolumndescs: usize, rgcolumndescs: *const DBCOLUMNDESC, riid: *const ::windows::core::GUID, cpropertysets: u32, rgpropertysets: *mut DBPROPSET, pptableid: *mut *mut super::super::Storage::IndexServer::DBID, pprowset: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -6348,6 +6500,7 @@ impl ITableDefinition_Vtbl {
         iid == &<ITableDefinition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITableDefinitionWithConstraints_Impl: Sized + ITableCreation_Impl {
     fn AddConstraint(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, pconstraintdesc: *mut DBCONSTRAINTDESC) -> ::windows::core::Result<()>;
@@ -6386,6 +6539,7 @@ impl ITableDefinitionWithConstraints_Vtbl {
         iid == &<ITableDefinitionWithConstraints as ::windows::core::Interface>::IID || iid == &<ITableDefinition as ::windows::core::Interface>::IID || iid == &<ITableCreation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 pub trait ITableRename_Impl: Sized {
     fn RenameColumn(&self, ptableid: *mut super::super::Storage::IndexServer::DBID, poldcolumnid: *mut super::super::Storage::IndexServer::DBID, pnewcolumnid: *mut super::super::Storage::IndexServer::DBID) -> ::windows::core::Result<()>;
@@ -6416,6 +6570,7 @@ impl ITableRename_Vtbl {
         iid == &<ITableRename as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait ITokenCollection_Impl: Sized {
     fn NumberOfTokens(&self, pcount: *const u32) -> ::windows::core::Result<()>;
     fn GetToken(&self, i: u32, pbegin: *mut u32, plength: *mut u32, ppsz: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -6443,6 +6598,7 @@ impl ITokenCollection_Vtbl {
         iid == &<ITokenCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 pub trait ITransactionJoin_Impl: Sized {
     fn GetOptionsObject(&self) -> ::windows::core::Result<super::DistributedTransactionCoordinator::ITransactionOptions>;
@@ -6479,6 +6635,7 @@ impl ITransactionJoin_Vtbl {
         iid == &<ITransactionJoin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_DistributedTransactionCoordinator"))]
 pub trait ITransactionLocal_Impl: Sized + super::DistributedTransactionCoordinator::ITransaction_Impl {
     fn GetOptionsObject(&self) -> ::windows::core::Result<super::DistributedTransactionCoordinator::ITransactionOptions>;
@@ -6515,6 +6672,7 @@ impl ITransactionLocal_Vtbl {
         iid == &<ITransactionLocal as ::windows::core::Interface>::IID || iid == &<super::DistributedTransactionCoordinator::ITransaction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_DistributedTransactionCoordinator\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_DistributedTransactionCoordinator")]
 pub trait ITransactionObject_Impl: Sized {
     fn GetTransactionObject(&self, ultransactionlevel: u32) -> ::windows::core::Result<super::DistributedTransactionCoordinator::ITransaction>;
@@ -6541,6 +6699,7 @@ impl ITransactionObject_Vtbl {
         iid == &<ITransactionObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Authorization\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITrusteeAdmin_Impl: Sized {
     fn CompareTrustees(&self, ptrustee1: *mut super::super::Security::Authorization::TRUSTEE_W, ptrustee2: *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::Result<()>;
@@ -6592,6 +6751,7 @@ impl ITrusteeAdmin_Vtbl {
         iid == &<ITrusteeAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Security_Authorization\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security_Authorization"))]
 pub trait ITrusteeGroupAdmin_Impl: Sized {
     fn AddMember(&self, pmembershiptrustee: *mut super::super::Security::Authorization::TRUSTEE_W, pmembertrustee: *mut super::super::Security::Authorization::TRUSTEE_W) -> ::windows::core::Result<()>;
@@ -6643,6 +6803,7 @@ impl ITrusteeGroupAdmin_Vtbl {
         iid == &<ITrusteeGroupAdmin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUMS_Impl: Sized {
     fn SqlUmsSuspend(&self, ticks: u32);
@@ -6703,6 +6864,7 @@ impl IUMS {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IUMSInitialize_Impl: Sized {
     fn Initialize(&self, pums: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -6720,6 +6882,7 @@ impl IUMSInitialize_Vtbl {
         iid == &<IUMSInitialize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IUrlAccessor_Impl: Sized {
     fn AddRequestParameter(&self, pspec: *const super::Com::StructuredStorage::PROPSPEC, pvar: *const super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -6863,6 +7026,7 @@ impl IUrlAccessor_Vtbl {
         iid == &<IUrlAccessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IUrlAccessor2_Impl: Sized + IUrlAccessor_Impl {
     fn GetDisplayUrl(&self, wszdocurl: ::windows::core::PWSTR, dwsize: u32, pdwlength: *mut u32) -> ::windows::core::Result<()>;
@@ -6900,6 +7064,7 @@ impl IUrlAccessor2_Vtbl {
         iid == &<IUrlAccessor2 as ::windows::core::Interface>::IID || iid == &<IUrlAccessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IUrlAccessor3_Impl: Sized + IUrlAccessor2_Impl {
     fn GetImpersonationSidBlobs(&self, pcwszurl: &::windows::core::PCWSTR, pcsidcount: *mut u32, ppsidblobs: *mut *mut super::Com::BLOB) -> ::windows::core::Result<()>;
@@ -6920,6 +7085,7 @@ impl IUrlAccessor3_Vtbl {
         iid == &<IUrlAccessor3 as ::windows::core::Interface>::IID || iid == &<IUrlAccessor as ::windows::core::Interface>::IID || iid == &<IUrlAccessor2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IUrlAccessor4_Impl: Sized + IUrlAccessor3_Impl {
     fn ShouldIndexItemContent(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -6962,6 +7128,7 @@ impl IUrlAccessor4_Vtbl {
         iid == &<IUrlAccessor4 as ::windows::core::Interface>::IID || iid == &<IUrlAccessor as ::windows::core::Interface>::IID || iid == &<IUrlAccessor2 as ::windows::core::Interface>::IID || iid == &<IUrlAccessor3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IViewChapter_Impl: Sized {
     fn GetSpecification(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn OpenViewChapter(&self, hsource: usize, phviewchapter: *mut usize) -> ::windows::core::Result<()>;
@@ -6995,6 +7162,7 @@ impl IViewChapter_Vtbl {
         iid == &<IViewChapter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IViewFilter_Impl: Sized {
     fn GetFilter(&self, haccessor: HACCESSOR, pcrows: *mut usize, pcompareops: *mut *mut u32, pcriteriadata: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -7032,6 +7200,7 @@ impl IViewFilter_Vtbl {
         iid == &<IViewFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IViewRowset_Impl: Sized {
     fn GetSpecification(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn OpenViewRowset(&self, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -7071,6 +7240,7 @@ impl IViewRowset_Vtbl {
         iid == &<IViewRowset as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IViewSort_Impl: Sized {
     fn GetSortOrder(&self, pcvalues: *mut usize, prgcolumns: *mut *mut usize, prgorders: *mut *mut u32) -> ::windows::core::Result<()>;
     fn SetSortOrder(&self, cvalues: usize, rgcolumns: *const usize, rgorders: *const u32) -> ::windows::core::Result<()>;
@@ -7098,6 +7268,7 @@ impl IViewSort_Vtbl {
         iid == &<IViewSort as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer"))]
 pub trait IWordBreaker_Impl: Sized {
     fn Init(&self, fquery: super::super::Foundation::BOOL, ulmaxtokensize: u32, pflicense: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -7142,6 +7313,7 @@ impl IWordBreaker_Vtbl {
         iid == &<IWordBreaker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait IWordFormSink_Impl: Sized {
     fn PutAltWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
     fn PutWord(&self, pwcinbuf: &::windows::core::PCWSTR, cwc: u32) -> ::windows::core::Result<()>;
@@ -7169,6 +7341,7 @@ impl IWordFormSink_Vtbl {
         iid == &<IWordFormSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Storage_IndexServer\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_IndexServer")]
 pub trait IWordSink_Impl: Sized {
     fn PutWord(&self, cwc: u32, pwcinbuf: &::windows::core::PCWSTR, cwcsrclen: u32, cwcsrcpos: u32) -> ::windows::core::Result<()>;
@@ -7220,6 +7393,7 @@ impl IWordSink_Vtbl {
         iid == &<IWordSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait OLEDBSimpleProvider_Impl: Sized {
     fn getRowCount(&self) -> ::windows::core::Result<isize>;
@@ -7394,6 +7568,7 @@ impl OLEDBSimpleProvider_Vtbl {
         iid == &<OLEDBSimpleProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Search\"`, `\"implement\"`*"]
 pub trait OLEDBSimpleProviderListener_Impl: Sized {
     fn aboutToChangeCell(&self, irow: isize, icolumn: isize) -> ::windows::core::Result<()>;
     fn cellChanged(&self, irow: isize, icolumn: isize) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SecurityCenter/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_SecurityCenter\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSCDefaultProduct_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetDefaultProduct(&self, etype: SECURITY_PRODUCT_TYPE, pguid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl IWSCDefaultProduct_Vtbl {
         iid == &<IWSCDefaultProduct as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SecurityCenter\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWSCProductList_Impl: Sized + super::Com::IDispatch_Impl {
     fn Initialize(&self, provider: WSC_SECURITY_PROVIDER) -> ::windows::core::Result<()>;
@@ -67,6 +69,7 @@ impl IWSCProductList_Vtbl {
         iid == &<IWSCProductList as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SecurityCenter\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWscProduct_Impl: Sized + super::Com::IDispatch_Impl {
     fn ProductName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -174,6 +177,7 @@ impl IWscProduct_Vtbl {
         iid == &<IWscProduct as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SecurityCenter\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWscProduct2_Impl: Sized + IWscProduct_Impl {
     fn AntivirusScanSubstatus(&self) -> ::windows::core::Result<WSC_SECURITY_PRODUCT_SUBSTATUS>;
@@ -268,6 +272,7 @@ impl IWscProduct2_Vtbl {
         iid == &<IWscProduct2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWscProduct as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SecurityCenter\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWscProduct3_Impl: Sized + IWscProduct2_Impl {
     fn AntivirusDaysUntilExpired(&self) -> ::windows::core::Result<u32>;

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_ServerBackup\"`, `\"implement\"`*"]
 pub trait IWsbApplicationAsync_Impl: Sized {
     fn QueryStatus(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
     fn Abort(&self) -> ::windows::core::Result<()>;
@@ -31,6 +32,7 @@ impl IWsbApplicationAsync_Vtbl {
         iid == &<IWsbApplicationAsync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ServerBackup\"`, `\"implement\"`*"]
 pub trait IWsbApplicationBackupSupport_Impl: Sized {
     fn CheckConsistency(&self, wszwritermetadata: &::windows::core::PCWSTR, wszcomponentname: &::windows::core::PCWSTR, wszcomponentlogicalpath: &::windows::core::PCWSTR, cvolumes: u32, rgwszsourcevolumepath: *const ::windows::core::PCWSTR, rgwszsnapshotvolumepath: *const ::windows::core::PCWSTR) -> ::windows::core::Result<IWsbApplicationAsync>;
 }
@@ -54,6 +56,7 @@ impl IWsbApplicationBackupSupport_Vtbl {
         iid == &<IWsbApplicationBackupSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_ServerBackup\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWsbApplicationRestoreSupport_Impl: Sized {
     fn PreRestore(&self, wszwritermetadata: &::windows::core::PCWSTR, wszcomponentname: &::windows::core::PCWSTR, wszcomponentlogicalpath: &::windows::core::PCWSTR, bnorollforward: super::super::Foundation::BOOLEAN) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IItemEnumerator_Impl: Sized {
     fn Current(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -47,6 +48,7 @@ impl IItemEnumerator_Vtbl {
         iid == &<IItemEnumerator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISettingsContext_Impl: Sized {
     fn Serialize(&self, pstream: &::core::option::Option<super::Com::IStream>, ptarget: &::core::option::Option<ITargetInfo>) -> ::windows::core::Result<()>;
@@ -124,6 +126,7 @@ impl ISettingsContext_Vtbl {
         iid == &<ISettingsContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISettingsEngine_Impl: Sized {
     fn GetNamespaces(&self, flags: WcmNamespaceEnumerationFlags, reserved: *const ::core::ffi::c_void) -> ::windows::core::Result<IItemEnumerator>;
@@ -312,6 +315,7 @@ impl ISettingsEngine_Vtbl {
         iid == &<ISettingsEngine as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"implement\"`*"]
 pub trait ISettingsIdentity_Impl: Sized {
     fn GetAttribute(&self, reserved: *const ::core::ffi::c_void, name: &::windows::core::PCWSTR) -> ::windows::core::Result<::windows::core::BSTR>;
     fn SetAttribute(&self, reserved: *const ::core::ffi::c_void, name: &::windows::core::PCWSTR, value: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -365,6 +369,7 @@ impl ISettingsIdentity_Vtbl {
         iid == &<ISettingsIdentity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISettingsItem_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -631,6 +636,7 @@ impl ISettingsItem_Vtbl {
         iid == &<ISettingsItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISettingsNamespace_Impl: Sized {
     fn GetIdentity(&self) -> ::windows::core::Result<ISettingsIdentity>;
@@ -732,6 +738,7 @@ impl ISettingsNamespace_Vtbl {
         iid == &<ISettingsNamespace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"implement\"`*"]
 pub trait ISettingsResult_Impl: Sized {
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetErrorCode(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
@@ -823,6 +830,7 @@ impl ISettingsResult_Vtbl {
         iid == &<ISettingsResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SettingsManagementInfrastructure\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITargetInfo_Impl: Sized {
     fn GetTargetMode(&self) -> ::windows::core::Result<WcmTargetMode>;

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISideShowBulkCapabilities_Impl: Sized + ISideShowCapabilities_Impl {
     fn GetCapabilities(&self, in_keycollection: &::core::option::Option<ISideShowKeyCollection>, inout_pvalues: *mut ::core::option::Option<ISideShowPropVariantCollection>) -> ::windows::core::Result<()>;
@@ -18,6 +19,7 @@ impl ISideShowBulkCapabilities_Vtbl {
         iid == &<ISideShowBulkCapabilities as ::windows::core::Interface>::IID || iid == &<ISideShowCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISideShowCapabilities_Impl: Sized {
     fn GetCapability(&self, in_keycapability: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, inout_pvalue: *mut super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -38,6 +40,7 @@ impl ISideShowCapabilities_Vtbl {
         iid == &<ISideShowCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"implement\"`*"]
 pub trait ISideShowCapabilitiesCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, in_dwindex: u32) -> ::windows::core::Result<ISideShowCapabilities>;
@@ -77,6 +80,7 @@ impl ISideShowCapabilitiesCollection_Vtbl {
         iid == &<ISideShowCapabilitiesCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISideShowContent_Impl: Sized {
     fn GetContent(&self, in_picapabilities: &::core::option::Option<ISideShowCapabilities>, out_pdwsize: *mut u32, out_ppbdata: *mut *mut u8) -> ::windows::core::Result<()>;
@@ -126,6 +130,7 @@ impl ISideShowContent_Vtbl {
         iid == &<ISideShowContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"implement\"`*"]
 pub trait ISideShowContentManager_Impl: Sized {
     fn Add(&self, in_picontent: &::core::option::Option<ISideShowContent>) -> ::windows::core::Result<()>;
     fn Remove(&self, in_contentid: u32) -> ::windows::core::Result<()>;
@@ -180,6 +185,7 @@ impl ISideShowContentManager_Vtbl {
         iid == &<ISideShowContentManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"implement\"`*"]
 pub trait ISideShowEvents_Impl: Sized {
     fn ContentMissing(&self, in_contentid: u32) -> ::windows::core::Result<ISideShowContent>;
     fn ApplicationEvent(&self, in_picapabilities: &::core::option::Option<ISideShowCapabilities>, in_dweventid: u32, in_dweventsize: u32, in_pbeventdata: *const u8) -> ::windows::core::Result<()>;
@@ -227,6 +233,7 @@ impl ISideShowEvents_Vtbl {
         iid == &<ISideShowEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait ISideShowKeyCollection_Impl: Sized {
     fn Add(&self, key: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<()>;
@@ -278,6 +285,7 @@ impl ISideShowKeyCollection_Vtbl {
         iid == &<ISideShowKeyCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ISideShowNotification_Impl: Sized {
     fn NotificationId(&self) -> ::windows::core::Result<u32>;
@@ -394,6 +402,7 @@ impl ISideShowNotification_Vtbl {
         iid == &<ISideShowNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"implement\"`*"]
 pub trait ISideShowNotificationManager_Impl: Sized {
     fn Show(&self, in_pinotification: &::core::option::Option<ISideShowNotification>) -> ::windows::core::Result<()>;
     fn Revoke(&self, in_notificationid: u32) -> ::windows::core::Result<()>;
@@ -428,6 +437,7 @@ impl ISideShowNotificationManager_Vtbl {
         iid == &<ISideShowNotificationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait ISideShowPropVariantCollection_Impl: Sized {
     fn Add(&self, pvalue: *const super::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -479,6 +489,7 @@ impl ISideShowPropVariantCollection_Vtbl {
         iid == &<ISideShowPropVariantCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_SideShow\"`, `\"implement\"`*"]
 pub trait ISideShowSession_Impl: Sized {
     fn RegisterContent(&self, in_applicationid: *const ::windows::core::GUID, in_endpointid: *const ::windows::core::GUID) -> ::windows::core::Result<ISideShowContentManager>;
     fn RegisterNotifications(&self, in_applicationid: *const ::windows::core::GUID) -> ::windows::core::Result<ISideShowNotificationManager>;

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAction_Impl: Sized + super::Com::IDispatch_Impl {
     fn Id(&self, pid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -35,6 +36,7 @@ impl IAction_Vtbl {
         iid == &<IAction as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IActionCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self, pcount: *mut i32) -> ::windows::core::Result<()>;
@@ -139,6 +141,7 @@ impl IActionCollection_Vtbl {
         iid == &<IActionCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IBootTrigger_Impl: Sized + ITrigger_Impl {
     fn Delay(&self, pdelay: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -165,6 +168,7 @@ impl IBootTrigger_Vtbl {
         iid == &<IBootTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComHandlerAction_Impl: Sized + IAction_Impl {
     fn ClassId(&self, pclsid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -209,6 +213,7 @@ impl IComHandlerAction_Vtbl {
         iid == &<IComHandlerAction as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDailyTrigger_Impl: Sized + ITrigger_Impl {
     fn DaysInterval(&self, pdays: *mut i16) -> ::windows::core::Result<()>;
@@ -253,6 +258,7 @@ impl IDailyTrigger_Vtbl {
         iid == &<IDailyTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEmailAction_Impl: Sized + IAction_Impl {
     fn Server(&self, pserver: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -415,6 +421,7 @@ impl IEmailAction_Vtbl {
         iid == &<IEmailAction as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"implement\"`*"]
 pub trait IEnumWorkItems_Impl: Sized {
     fn Next(&self, celt: u32, rgpwsznames: *mut *mut ::windows::core::PWSTR, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
     fn Skip(&self, celt: u32) -> ::windows::core::HRESULT;
@@ -462,6 +469,7 @@ impl IEnumWorkItems_Vtbl {
         iid == &<IEnumWorkItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEventTrigger_Impl: Sized + ITrigger_Impl {
     fn Subscription(&self, pquery: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -526,6 +534,7 @@ impl IEventTrigger_Vtbl {
         iid == &<IEventTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IExecAction_Impl: Sized + IAction_Impl {
     fn Path(&self, ppath: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -584,6 +593,7 @@ impl IExecAction_Vtbl {
         iid == &<IExecAction as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IExecAction2_Impl: Sized + IExecAction_Impl {
     fn HideAppWindow(&self, phideappwindow: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -614,6 +624,7 @@ impl IExecAction2_Vtbl {
         iid == &<IExecAction2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAction as ::windows::core::Interface>::IID || iid == &<IExecAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IIdleSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn IdleDuration(&self, pdelay: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -686,6 +697,7 @@ impl IIdleSettings_Vtbl {
         iid == &<IIdleSettings as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IIdleTrigger_Impl: Sized + ITrigger_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -699,6 +711,7 @@ impl IIdleTrigger_Vtbl {
         iid == &<IIdleTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ILogonTrigger_Impl: Sized + ITrigger_Impl {
     fn Delay(&self, pdelay: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -743,6 +756,7 @@ impl ILogonTrigger_Vtbl {
         iid == &<ILogonTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMaintenanceSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn SetPeriod(&self, value: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -801,6 +815,7 @@ impl IMaintenanceSettings_Vtbl {
         iid == &<IMaintenanceSettings as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMonthlyDOWTrigger_Impl: Sized + ITrigger_Impl {
     fn DaysOfWeek(&self, pdays: *mut i16) -> ::windows::core::Result<()>;
@@ -887,6 +902,7 @@ impl IMonthlyDOWTrigger_Vtbl {
         iid == &<IMonthlyDOWTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMonthlyTrigger_Impl: Sized + ITrigger_Impl {
     fn DaysOfMonth(&self, pdays: *mut i32) -> ::windows::core::Result<()>;
@@ -959,6 +975,7 @@ impl IMonthlyTrigger_Vtbl {
         iid == &<IMonthlyTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INetworkSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self, pname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1003,6 +1020,7 @@ impl INetworkSettings_Vtbl {
         iid == &<INetworkSettings as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrincipal_Impl: Sized + super::Com::IDispatch_Impl {
     fn Id(&self, pid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1103,6 +1121,7 @@ impl IPrincipal_Vtbl {
         iid == &<IPrincipal as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPrincipal2_Impl: Sized + super::Com::IDispatch_Impl {
     fn ProcessTokenSidType(&self, pprocesstokensidtype: *mut TASK_PROCESSTOKENSID_TYPE) -> ::windows::core::Result<()>;
@@ -1154,6 +1173,7 @@ impl IPrincipal2_Vtbl {
         iid == &<IPrincipal2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 pub trait IProvideTaskPage_Impl: Sized {
     fn GetPage(&self, tptype: TASKPAGE, fpersistchanges: super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::UI::Controls::HPROPSHEETPAGE>;
@@ -1180,6 +1200,7 @@ impl IProvideTaskPage_Vtbl {
         iid == &<IProvideTaskPage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRegisteredTask_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1406,6 +1427,7 @@ impl IRegisteredTask_Vtbl {
         iid == &<IRegisteredTask as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRegisteredTaskCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1461,6 +1483,7 @@ impl IRegisteredTaskCollection_Vtbl {
         iid == &<IRegisteredTaskCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRegistrationInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn Description(&self, pdescription: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1603,6 +1626,7 @@ impl IRegistrationInfo_Vtbl {
         iid == &<IRegistrationInfo as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRegistrationTrigger_Impl: Sized + ITrigger_Impl {
     fn Delay(&self, pdelay: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1629,6 +1653,7 @@ impl IRegistrationTrigger_Vtbl {
         iid == &<IRegistrationTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRepetitionPattern_Impl: Sized + super::Com::IDispatch_Impl {
     fn Interval(&self, pinterval: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -1687,6 +1712,7 @@ impl IRepetitionPattern_Vtbl {
         iid == &<IRepetitionPattern as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRunningTask_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1795,6 +1821,7 @@ impl IRunningTask_Vtbl {
         iid == &<IRunningTask as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRunningTaskCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1850,6 +1877,7 @@ impl IRunningTaskCollection_Vtbl {
         iid == &<IRunningTaskCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IScheduledWorkItem_Impl: Sized {
     fn CreateTrigger(&self, pinewtrigger: *mut u16, pptrigger: *mut ::core::option::Option<ITaskTrigger>) -> ::windows::core::Result<()>;
@@ -2141,6 +2169,7 @@ impl IScheduledWorkItem_Vtbl {
         iid == &<IScheduledWorkItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISessionStateChangeTrigger_Impl: Sized + ITrigger_Impl {
     fn Delay(&self, pdelay: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2199,6 +2228,7 @@ impl ISessionStateChangeTrigger_Vtbl {
         iid == &<ISessionStateChangeTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShowMessageAction_Impl: Sized + IAction_Impl {
     fn Title(&self, ptitle: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2243,6 +2273,7 @@ impl IShowMessageAction_Vtbl {
         iid == &<IShowMessageAction as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITask_Impl: Sized + IScheduledWorkItem_Impl {
     fn SetApplicationName(&self, pwszapplicationname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -2379,6 +2410,7 @@ impl ITask_Vtbl {
         iid == &<ITask as ::windows::core::Interface>::IID || iid == &<IScheduledWorkItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskDefinition_Impl: Sized + super::Com::IDispatch_Impl {
     fn RegistrationInfo(&self) -> ::windows::core::Result<IRegistrationInfo>;
@@ -2523,6 +2555,7 @@ impl ITaskDefinition_Vtbl {
         iid == &<ITaskDefinition as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskFolder_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2690,6 +2723,7 @@ impl ITaskFolder_Vtbl {
         iid == &<ITaskFolder as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskFolderCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2745,6 +2779,7 @@ impl ITaskFolderCollection_Vtbl {
         iid == &<ITaskFolderCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"implement\"`*"]
 pub trait ITaskHandler_Impl: Sized {
     fn Start(&self, phandlerservices: &::core::option::Option<::windows::core::IUnknown>, data: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<::windows::core::HRESULT>;
@@ -2792,6 +2827,7 @@ impl ITaskHandler_Vtbl {
         iid == &<ITaskHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"implement\"`*"]
 pub trait ITaskHandlerStatus_Impl: Sized {
     fn UpdateStatus(&self, percentcomplete: i16, statusmessage: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn TaskCompleted(&self, taskerrcode: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -2819,6 +2855,7 @@ impl ITaskHandlerStatus_Vtbl {
         iid == &<ITaskHandlerStatus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskNamedValueCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self, pcount: *mut i32) -> ::windows::core::Result<()>;
@@ -2895,6 +2932,7 @@ impl ITaskNamedValueCollection_Vtbl {
         iid == &<ITaskNamedValueCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskNamedValuePair_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self, pname: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -2939,6 +2977,7 @@ impl ITaskNamedValuePair_Vtbl {
         iid == &<ITaskNamedValuePair as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"implement\"`*"]
 pub trait ITaskScheduler_Impl: Sized {
     fn SetTargetComputer(&self, pwszcomputer: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetTargetComputer(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -3032,6 +3071,7 @@ impl ITaskScheduler_Vtbl {
         iid == &<ITaskScheduler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskService_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetFolder(&self, path: &::windows::core::BSTR) -> ::windows::core::Result<ITaskFolder>;
@@ -3159,6 +3199,7 @@ impl ITaskService_Vtbl {
         iid == &<ITaskService as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn AllowDemandStart(&self, pallowdemandstart: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3467,6 +3508,7 @@ impl ITaskSettings_Vtbl {
         iid == &<ITaskSettings as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskSettings2_Impl: Sized + super::Com::IDispatch_Impl {
     fn DisallowStartOnRemoteAppSession(&self, pdisallowstart: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3511,6 +3553,7 @@ impl ITaskSettings2_Vtbl {
         iid == &<ITaskSettings2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITaskSettings3_Impl: Sized + ITaskSettings_Impl {
     fn DisallowStartOnRemoteAppSession(&self, pdisallowstart: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -3602,6 +3645,7 @@ impl ITaskSettings3_Vtbl {
         iid == &<ITaskSettings3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITaskSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"implement\"`*"]
 pub trait ITaskTrigger_Impl: Sized {
     fn SetTrigger(&self, ptrigger: *const TASK_TRIGGER) -> ::windows::core::Result<()>;
     fn GetTrigger(&self) -> ::windows::core::Result<TASK_TRIGGER>;
@@ -3648,6 +3692,7 @@ impl ITaskTrigger_Vtbl {
         iid == &<ITaskTrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"implement\"`*"]
 pub trait ITaskVariables_Impl: Sized {
     fn GetInput(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn SetOutput(&self, input: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3694,6 +3739,7 @@ impl ITaskVariables_Vtbl {
         iid == &<ITaskVariables as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITimeTrigger_Impl: Sized + ITrigger_Impl {
     fn RandomDelay(&self, prandomdelay: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -3724,6 +3770,7 @@ impl ITimeTrigger_Vtbl {
         iid == &<ITimeTrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITrigger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITrigger_Impl: Sized + super::Com::IDispatch_Impl {
     fn Type(&self, ptype: *mut TASK_TRIGGER_TYPE2) -> ::windows::core::Result<()>;
@@ -3837,6 +3884,7 @@ impl ITrigger_Vtbl {
         iid == &<ITrigger as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITriggerCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn Count(&self, pcount: *mut i32) -> ::windows::core::Result<()>;
@@ -3913,6 +3961,7 @@ impl ITriggerCollection_Vtbl {
         iid == &<ITriggerCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TaskScheduler\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWeeklyTrigger_Impl: Sized + ITrigger_Impl {
     fn DaysOfWeek(&self, pdays: *mut i16) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/TransactionServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TransactionServer/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_TransactionServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICatalog_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetCollection(&self, bstrcollname: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::IDispatch>;
@@ -54,6 +55,7 @@ impl ICatalog_Vtbl {
         iid == &<ICatalog as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TransactionServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IComponentUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn InstallComponent(&self, bstrdllfile: &::windows::core::BSTR, bstrtypelibfile: &::windows::core::BSTR, bstrproxystubdllfile: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -98,6 +100,7 @@ impl IComponentUtil_Vtbl {
         iid == &<IComponentUtil as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TransactionServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPackageUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn InstallPackage(&self, bstrpackagefile: &::windows::core::BSTR, bstrinstallpath: &::windows::core::BSTR, loptions: i32) -> ::windows::core::Result<()>;
@@ -135,6 +138,7 @@ impl IPackageUtil_Vtbl {
         iid == &<IPackageUtil as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TransactionServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRemoteComponentUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn InstallRemoteComponent(&self, bstrserver: &::windows::core::BSTR, bstrpackageid: &::windows::core::BSTR, bstrclsid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -165,6 +169,7 @@ impl IRemoteComponentUtil_Vtbl {
         iid == &<IRemoteComponentUtil as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_TransactionServer\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRoleAssociationUtil_Impl: Sized + super::Com::IDispatch_Impl {
     fn AssociateRole(&self, bstrroleid: &::windows::core::BSTR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAutomaticUpdates_Impl: Sized + super::Com::IDispatch_Impl {
     fn DetectNow(&self) -> ::windows::core::Result<()>;
@@ -75,6 +76,7 @@ impl IAutomaticUpdates_Vtbl {
         iid == &<IAutomaticUpdates as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAutomaticUpdates2_Impl: Sized + IAutomaticUpdates_Impl {
     fn Results(&self) -> ::windows::core::Result<IAutomaticUpdatesResults>;
@@ -101,6 +103,7 @@ impl IAutomaticUpdates2_Vtbl {
         iid == &<IAutomaticUpdates2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAutomaticUpdates as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAutomaticUpdatesResults_Impl: Sized + super::Com::IDispatch_Impl {
     fn LastSearchSuccessDate(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -143,6 +146,7 @@ impl IAutomaticUpdatesResults_Vtbl {
         iid == &<IAutomaticUpdatesResults as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAutomaticUpdatesSettings_Impl: Sized + super::Com::IDispatch_Impl {
     fn NotificationLevel(&self) -> ::windows::core::Result<AutomaticUpdatesNotificationLevel>;
@@ -259,6 +263,7 @@ impl IAutomaticUpdatesSettings_Vtbl {
         iid == &<IAutomaticUpdatesSettings as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAutomaticUpdatesSettings2_Impl: Sized + IAutomaticUpdatesSettings_Impl {
     fn IncludeRecommendedUpdates(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -308,6 +313,7 @@ impl IAutomaticUpdatesSettings2_Vtbl {
         iid == &<IAutomaticUpdatesSettings2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAutomaticUpdatesSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAutomaticUpdatesSettings3_Impl: Sized + IAutomaticUpdatesSettings2_Impl {
     fn NonAdministratorsElevated(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -364,6 +370,7 @@ impl IAutomaticUpdatesSettings3_Vtbl {
         iid == &<IAutomaticUpdatesSettings3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IAutomaticUpdatesSettings as ::windows::core::Interface>::IID || iid == &<IAutomaticUpdatesSettings2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICategory_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -497,6 +504,7 @@ impl ICategory_Vtbl {
         iid == &<ICategory as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICategoryCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<ICategory>;
@@ -552,6 +560,7 @@ impl ICategoryCollection_Vtbl {
         iid == &<ICategoryCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDownloadCompletedCallback_Impl: Sized {
     fn Invoke(&self, downloadjob: &::core::option::Option<IDownloadJob>, callbackargs: &::core::option::Option<IDownloadCompletedCallbackArgs>) -> ::windows::core::Result<()>;
@@ -572,6 +581,7 @@ impl IDownloadCompletedCallback_Vtbl {
         iid == &<IDownloadCompletedCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDownloadCompletedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -585,6 +595,7 @@ impl IDownloadCompletedCallbackArgs_Vtbl {
         iid == &<IDownloadCompletedCallbackArgs as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDownloadJob_Impl: Sized + super::Com::IDispatch_Impl {
     fn AsyncState(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -667,6 +678,7 @@ impl IDownloadJob_Vtbl {
         iid == &<IDownloadJob as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDownloadProgress_Impl: Sized + super::Com::IDispatch_Impl {
     fn CurrentUpdateBytesDownloaded(&self) -> ::windows::core::Result<super::super::Foundation::DECIMAL>;
@@ -800,6 +812,7 @@ impl IDownloadProgress_Vtbl {
         iid == &<IDownloadProgress as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDownloadProgressChangedCallback_Impl: Sized {
     fn Invoke(&self, downloadjob: &::core::option::Option<IDownloadJob>, callbackargs: &::core::option::Option<IDownloadProgressChangedCallbackArgs>) -> ::windows::core::Result<()>;
@@ -820,6 +833,7 @@ impl IDownloadProgressChangedCallback_Vtbl {
         iid == &<IDownloadProgressChangedCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDownloadProgressChangedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {
     fn Progress(&self) -> ::windows::core::Result<IDownloadProgress>;
@@ -846,6 +860,7 @@ impl IDownloadProgressChangedCallbackArgs_Vtbl {
         iid == &<IDownloadProgressChangedCallbackArgs as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDownloadResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn HResult(&self) -> ::windows::core::Result<i32>;
@@ -901,6 +916,7 @@ impl IDownloadResult_Vtbl {
         iid == &<IDownloadResult as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IImageInformation_Impl: Sized + super::Com::IDispatch_Impl {
     fn AltText(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -969,6 +985,7 @@ impl IImageInformation_Vtbl {
         iid == &<IImageInformation as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationAgent_Impl: Sized + super::Com::IDispatch_Impl {
     fn RecordInstallationResult(&self, installationresultcookie: &::windows::core::BSTR, hresult: i32, extendedreportingdata: &::core::option::Option<IStringCollection>) -> ::windows::core::Result<()>;
@@ -992,6 +1009,7 @@ impl IInstallationAgent_Vtbl {
         iid == &<IInstallationAgent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationBehavior_Impl: Sized + super::Com::IDispatch_Impl {
     fn CanRequestUserInput(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -1060,6 +1078,7 @@ impl IInstallationBehavior_Vtbl {
         iid == &<IInstallationBehavior as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IInstallationCompletedCallback_Impl: Sized {
     fn Invoke(&self, installationjob: &::core::option::Option<IInstallationJob>, callbackargs: &::core::option::Option<IInstallationCompletedCallbackArgs>) -> ::windows::core::Result<()>;
@@ -1080,6 +1099,7 @@ impl IInstallationCompletedCallback_Vtbl {
         iid == &<IInstallationCompletedCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationCompletedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -1093,6 +1113,7 @@ impl IInstallationCompletedCallbackArgs_Vtbl {
         iid == &<IInstallationCompletedCallbackArgs as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationJob_Impl: Sized + super::Com::IDispatch_Impl {
     fn AsyncState(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -1175,6 +1196,7 @@ impl IInstallationJob_Vtbl {
         iid == &<IInstallationJob as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationProgress_Impl: Sized + super::Com::IDispatch_Impl {
     fn CurrentUpdateIndex(&self) -> ::windows::core::Result<i32>;
@@ -1243,6 +1265,7 @@ impl IInstallationProgress_Vtbl {
         iid == &<IInstallationProgress as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IInstallationProgressChangedCallback_Impl: Sized {
     fn Invoke(&self, installationjob: &::core::option::Option<IInstallationJob>, callbackargs: &::core::option::Option<IInstallationProgressChangedCallbackArgs>) -> ::windows::core::Result<()>;
@@ -1263,6 +1286,7 @@ impl IInstallationProgressChangedCallback_Vtbl {
         iid == &<IInstallationProgressChangedCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationProgressChangedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {
     fn Progress(&self) -> ::windows::core::Result<IInstallationProgress>;
@@ -1289,6 +1313,7 @@ impl IInstallationProgressChangedCallbackArgs_Vtbl {
         iid == &<IInstallationProgressChangedCallbackArgs as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInstallationResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn HResult(&self) -> ::windows::core::Result<i32>;
@@ -1357,6 +1382,7 @@ impl IInstallationResult_Vtbl {
         iid == &<IInstallationResult as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInvalidProductLicenseException_Impl: Sized + IUpdateException_Impl {
     fn Product(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1383,6 +1409,7 @@ impl IInvalidProductLicenseException_Vtbl {
         iid == &<IInvalidProductLicenseException as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateException as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISearchCompletedCallback_Impl: Sized {
     fn Invoke(&self, searchjob: &::core::option::Option<ISearchJob>, callbackargs: &::core::option::Option<ISearchCompletedCallbackArgs>) -> ::windows::core::Result<()>;
@@ -1403,6 +1430,7 @@ impl ISearchCompletedCallback_Vtbl {
         iid == &<ISearchCompletedCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISearchCompletedCallbackArgs_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -1416,6 +1444,7 @@ impl ISearchCompletedCallbackArgs_Vtbl {
         iid == &<ISearchCompletedCallbackArgs as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISearchJob_Impl: Sized + super::Com::IDispatch_Impl {
     fn AsyncState(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -1472,6 +1501,7 @@ impl ISearchJob_Vtbl {
         iid == &<ISearchJob as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISearchResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn ResultCode(&self) -> ::windows::core::Result<OperationResultCode>;
@@ -1540,6 +1570,7 @@ impl ISearchResult_Vtbl {
         iid == &<ISearchResult as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IStringCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1662,6 +1693,7 @@ impl IStringCollection_Vtbl {
         iid == &<IStringCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISystemInformation_Impl: Sized + super::Com::IDispatch_Impl {
     fn OemHardwareSupportLink(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1704,6 +1736,7 @@ impl ISystemInformation_Vtbl {
         iid == &<ISystemInformation as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdate_Impl: Sized + super::Com::IDispatch_Impl {
     fn Title(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2287,6 +2320,7 @@ impl IUpdate_Vtbl {
         iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdate2_Impl: Sized + IUpdate_Impl {
     fn RebootRequired(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2349,6 +2383,7 @@ impl IUpdate2_Vtbl {
         iid == &<IUpdate2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdate3_Impl: Sized + IUpdate2_Impl {
     fn BrowseOnly(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2375,6 +2410,7 @@ impl IUpdate3_Vtbl {
         iid == &<IUpdate3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<IUpdate2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdate4_Impl: Sized + IUpdate3_Impl {
     fn PerUser(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2401,6 +2437,7 @@ impl IUpdate4_Vtbl {
         iid == &<IUpdate4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<IUpdate2 as ::windows::core::Interface>::IID || iid == &<IUpdate3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdate5_Impl: Sized + IUpdate4_Impl {
     fn AutoSelection(&self) -> ::windows::core::Result<AutoSelectionMode>;
@@ -2443,6 +2480,7 @@ impl IUpdate5_Vtbl {
         iid == &<IUpdate5 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<IUpdate2 as ::windows::core::Interface>::IID || iid == &<IUpdate3 as ::windows::core::Interface>::IID || iid == &<IUpdate4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IUpdate>;
@@ -2565,6 +2603,7 @@ impl IUpdateCollection_Vtbl {
         iid == &<IUpdateCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateDownloadContent_Impl: Sized + super::Com::IDispatch_Impl {
     fn DownloadUrl(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2591,6 +2630,7 @@ impl IUpdateDownloadContent_Vtbl {
         iid == &<IUpdateDownloadContent as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateDownloadContent2_Impl: Sized + IUpdateDownloadContent_Impl {
     fn IsDeltaCompressedContent(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2620,6 +2660,7 @@ impl IUpdateDownloadContent2_Vtbl {
         iid == &<IUpdateDownloadContent2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateDownloadContent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateDownloadContentCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IUpdateDownloadContent>;
@@ -2675,6 +2716,7 @@ impl IUpdateDownloadContentCollection_Vtbl {
         iid == &<IUpdateDownloadContentCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateDownloadResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn HResult(&self) -> ::windows::core::Result<i32>;
@@ -2717,6 +2759,7 @@ impl IUpdateDownloadResult_Vtbl {
         iid == &<IUpdateDownloadResult as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateDownloader_Impl: Sized + super::Com::IDispatch_Impl {
     fn ClientApplicationID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2852,6 +2895,7 @@ impl IUpdateDownloader_Vtbl {
         iid == &<IUpdateDownloader as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateException_Impl: Sized + super::Com::IDispatch_Impl {
     fn Message(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2907,6 +2951,7 @@ impl IUpdateException_Vtbl {
         iid == &<IUpdateException as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateExceptionCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IUpdateException>;
@@ -2962,6 +3007,7 @@ impl IUpdateExceptionCollection_Vtbl {
         iid == &<IUpdateExceptionCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateHistoryEntry_Impl: Sized + super::Com::IDispatch_Impl {
     fn Operation(&self) -> ::windows::core::Result<UpdateOperation>;
@@ -3160,6 +3206,7 @@ impl IUpdateHistoryEntry_Vtbl {
         iid == &<IUpdateHistoryEntry as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateHistoryEntry2_Impl: Sized + IUpdateHistoryEntry_Impl {
     fn Categories(&self) -> ::windows::core::Result<ICategoryCollection>;
@@ -3186,6 +3233,7 @@ impl IUpdateHistoryEntry2_Vtbl {
         iid == &<IUpdateHistoryEntry2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateHistoryEntry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateHistoryEntryCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IUpdateHistoryEntry>;
@@ -3241,6 +3289,7 @@ impl IUpdateHistoryEntryCollection_Vtbl {
         iid == &<IUpdateHistoryEntryCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateIdentity_Impl: Sized + super::Com::IDispatch_Impl {
     fn RevisionNumber(&self) -> ::windows::core::Result<i32>;
@@ -3283,6 +3332,7 @@ impl IUpdateIdentity_Vtbl {
         iid == &<IUpdateIdentity as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateInstallationResult_Impl: Sized + super::Com::IDispatch_Impl {
     fn HResult(&self) -> ::windows::core::Result<i32>;
@@ -3338,6 +3388,7 @@ impl IUpdateInstallationResult_Vtbl {
         iid == &<IUpdateInstallationResult as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateInstaller_Impl: Sized + super::Com::IDispatch_Impl {
     fn ClientApplicationID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3591,6 +3642,7 @@ impl IUpdateInstaller_Vtbl {
         iid == &<IUpdateInstaller as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateInstaller2_Impl: Sized + IUpdateInstaller_Impl {
     fn ForceQuiet(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3627,6 +3679,7 @@ impl IUpdateInstaller2_Vtbl {
         iid == &<IUpdateInstaller2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateInstaller as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateInstaller3_Impl: Sized + IUpdateInstaller2_Impl {
     fn AttemptCloseAppsIfNecessary(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3663,6 +3716,7 @@ impl IUpdateInstaller3_Vtbl {
         iid == &<IUpdateInstaller3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateInstaller as ::windows::core::Interface>::IID || iid == &<IUpdateInstaller2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateInstaller4_Impl: Sized + IUpdateInstaller3_Impl {
     fn Commit(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -3683,6 +3737,7 @@ impl IUpdateInstaller4_Vtbl {
         iid == &<IUpdateInstaller4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateInstaller as ::windows::core::Interface>::IID || iid == &<IUpdateInstaller2 as ::windows::core::Interface>::IID || iid == &<IUpdateInstaller3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"implement\"`*"]
 pub trait IUpdateLockdown_Impl: Sized {
     fn LockDown(&self, flags: i32) -> ::windows::core::Result<()>;
 }
@@ -3700,6 +3755,7 @@ impl IUpdateLockdown_Vtbl {
         iid == &<IUpdateLockdown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateSearcher_Impl: Sized + super::Com::IDispatch_Impl {
     fn CanAutomaticallyUpgradeService(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3914,6 +3970,7 @@ impl IUpdateSearcher_Vtbl {
         iid == &<IUpdateSearcher as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateSearcher2_Impl: Sized + IUpdateSearcher_Impl {
     fn IgnoreDownloadPriority(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -3950,6 +4007,7 @@ impl IUpdateSearcher2_Vtbl {
         iid == &<IUpdateSearcher2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateSearcher as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateSearcher3_Impl: Sized + IUpdateSearcher2_Impl {
     fn SearchScope(&self) -> ::windows::core::Result<SearchScope>;
@@ -3986,6 +4044,7 @@ impl IUpdateSearcher3_Vtbl {
         iid == &<IUpdateSearcher3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateSearcher as ::windows::core::Interface>::IID || iid == &<IUpdateSearcher2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateService_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4171,6 +4230,7 @@ impl IUpdateService_Vtbl {
         iid == &<IUpdateService as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateService2_Impl: Sized + IUpdateService_Impl {
     fn IsDefaultAUService(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -4197,6 +4257,7 @@ impl IUpdateService2_Vtbl {
         iid == &<IUpdateService2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateServiceCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IUpdateService>;
@@ -4252,6 +4313,7 @@ impl IUpdateServiceCollection_Vtbl {
         iid == &<IUpdateServiceCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateServiceManager_Impl: Sized + super::Com::IDispatch_Impl {
     fn Services(&self) -> ::windows::core::Result<IUpdateServiceCollection>;
@@ -4335,6 +4397,7 @@ impl IUpdateServiceManager_Vtbl {
         iid == &<IUpdateServiceManager as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateServiceManager2_Impl: Sized + IUpdateServiceManager_Impl {
     fn ClientApplicationID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4397,6 +4460,7 @@ impl IUpdateServiceManager2_Vtbl {
         iid == &<IUpdateServiceManager2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateServiceManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateServiceRegistration_Impl: Sized + super::Com::IDispatch_Impl {
     fn RegistrationState(&self) -> ::windows::core::Result<UpdateServiceRegistrationState>;
@@ -4465,6 +4529,7 @@ impl IUpdateServiceRegistration_Vtbl {
         iid == &<IUpdateServiceRegistration as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateSession_Impl: Sized + super::Com::IDispatch_Impl {
     fn ClientApplicationID(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4573,6 +4638,7 @@ impl IUpdateSession_Vtbl {
         iid == &<IUpdateSession as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateSession2_Impl: Sized + IUpdateSession_Impl {
     fn UserLocale(&self) -> ::windows::core::Result<u32>;
@@ -4609,6 +4675,7 @@ impl IUpdateSession2_Vtbl {
         iid == &<IUpdateSession2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUpdateSession3_Impl: Sized + IUpdateSession2_Impl {
     fn CreateUpdateServiceManager(&self) -> ::windows::core::Result<IUpdateServiceManager2>;
@@ -4651,6 +4718,7 @@ impl IUpdateSession3_Vtbl {
         iid == &<IUpdateSession3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdateSession as ::windows::core::Interface>::IID || iid == &<IUpdateSession2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWebProxy_Impl: Sized + super::Com::IDispatch_Impl {
     fn Address(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4801,6 +4869,7 @@ impl IWebProxy_Vtbl {
         iid == &<IWebProxy as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsDriverUpdate_Impl: Sized + IUpdate_Impl {
     fn DriverClass(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4921,6 +4990,7 @@ impl IWindowsDriverUpdate_Vtbl {
         iid == &<IWindowsDriverUpdate as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsDriverUpdate2_Impl: Sized + IWindowsDriverUpdate_Impl {
     fn RebootRequired(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -4983,6 +5053,7 @@ impl IWindowsDriverUpdate2_Vtbl {
         iid == &<IWindowsDriverUpdate2 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsDriverUpdate3_Impl: Sized + IWindowsDriverUpdate2_Impl {
     fn BrowseOnly(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -5009,6 +5080,7 @@ impl IWindowsDriverUpdate3_Vtbl {
         iid == &<IWindowsDriverUpdate3 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsDriverUpdate4_Impl: Sized + IWindowsDriverUpdate3_Impl {
     fn WindowsDriverUpdateEntries(&self) -> ::windows::core::Result<IWindowsDriverUpdateEntryCollection>;
@@ -5051,6 +5123,7 @@ impl IWindowsDriverUpdate4_Vtbl {
         iid == &<IWindowsDriverUpdate4 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate2 as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsDriverUpdate5_Impl: Sized + IWindowsDriverUpdate4_Impl {
     fn AutoSelection(&self) -> ::windows::core::Result<AutoSelectionMode>;
@@ -5093,6 +5166,7 @@ impl IWindowsDriverUpdate5_Vtbl {
         iid == &<IWindowsDriverUpdate5 as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IUpdate as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate2 as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate3 as ::windows::core::Interface>::IID || iid == &<IWindowsDriverUpdate4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsDriverUpdateEntry_Impl: Sized + super::Com::IDispatch_Impl {
     fn DriverClass(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5213,6 +5287,7 @@ impl IWindowsDriverUpdateEntry_Vtbl {
         iid == &<IWindowsDriverUpdateEntry as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsDriverUpdateEntryCollection_Impl: Sized + super::Com::IDispatch_Impl {
     fn get_Item(&self, index: i32) -> ::windows::core::Result<IWindowsDriverUpdateEntry>;
@@ -5268,6 +5343,7 @@ impl IWindowsDriverUpdateEntryCollection_Vtbl {
         iid == &<IWindowsDriverUpdateEntryCollection as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_UpdateAgent\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWindowsUpdateAgentInfo_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetInfo(&self, varinfoidentifier: &super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT>;

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAssessment/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_UpdateAssessment\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWaaSAssessor_Impl: Sized {
     fn GetOSUpdateAssessment(&self) -> ::windows::core::Result<OSUpdateAssessment>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/AllJoyn/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_AllJoyn\"`, `\"implement\"`*"]
 pub trait IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Impl: Sized {
     fn CreateFromWin32Handle(&self, win32handle: u64, enableaboutdata: u8, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -18,6 +19,7 @@ impl IWindowsDevicesAllJoynBusAttachmentFactoryInterop_Vtbl {
         iid == &<IWindowsDevicesAllJoynBusAttachmentFactoryInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_AllJoyn\"`, `\"implement\"`*"]
 pub trait IWindowsDevicesAllJoynBusAttachmentInterop_Impl: Sized {
     fn Win32Handle(&self) -> ::windows::core::Result<u64>;
 }
@@ -44,6 +46,7 @@ impl IWindowsDevicesAllJoynBusAttachmentInterop_Vtbl {
         iid == &<IWindowsDevicesAllJoynBusAttachmentInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_AllJoyn\"`, `\"implement\"`*"]
 pub trait IWindowsDevicesAllJoynBusObjectFactoryInterop_Impl: Sized {
     fn CreateFromWin32Handle(&self, win32handle: u64, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -64,6 +67,7 @@ impl IWindowsDevicesAllJoynBusObjectFactoryInterop_Vtbl {
         iid == &<IWindowsDevicesAllJoynBusObjectFactoryInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_AllJoyn\"`, `\"implement\"`*"]
 pub trait IWindowsDevicesAllJoynBusObjectInterop_Impl: Sized {
     fn AddPropertyGetHandler(&self, context: *const ::core::ffi::c_void, interfacename: &::windows::core::HSTRING, callback: isize) -> ::windows::core::Result<()>;
     fn AddPropertySetHandler(&self, context: *const ::core::ffi::c_void, interfacename: &::windows::core::HSTRING, callback: isize) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Composition/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"UI_Composition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "UI_Composition", feature = "Win32_Foundation"))]
 pub trait ICompositionCapabilitiesInteropFactory_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::super::Foundation::HWND) -> ::windows::core::Result<super::super::super::super::UI::Composition::CompositionCapabilities>;
@@ -27,6 +28,7 @@ impl ICompositionCapabilitiesInteropFactory_Vtbl {
         iid == &<ICompositionCapabilitiesInteropFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICompositionDrawingSurfaceInterop_Impl: Sized {
     fn BeginDraw(&self, updaterect: *const super::super::super::Foundation::RECT, iid: *const ::windows::core::GUID, updateobject: *mut *mut ::core::ffi::c_void, updateoffset: *mut super::super::super::Foundation::POINT) -> ::windows::core::Result<()>;
@@ -85,6 +87,7 @@ impl ICompositionDrawingSurfaceInterop_Vtbl {
         iid == &<ICompositionDrawingSurfaceInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICompositionDrawingSurfaceInterop2_Impl: Sized + ICompositionDrawingSurfaceInterop_Impl {
     fn CopySurface(&self, destinationresource: &::core::option::Option<::windows::core::IUnknown>, destinationoffsetx: i32, destinationoffsety: i32, sourcerectangle: *const super::super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -105,6 +108,7 @@ impl ICompositionDrawingSurfaceInterop2_Vtbl {
         iid == &<ICompositionDrawingSurfaceInterop2 as ::windows::core::Interface>::IID || iid == &<ICompositionDrawingSurfaceInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"implement\"`*"]
 pub trait ICompositionGraphicsDeviceInterop_Impl: Sized {
     fn GetRenderingDevice(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn SetRenderingDevice(&self, value: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -138,6 +142,7 @@ impl ICompositionGraphicsDeviceInterop_Vtbl {
         iid == &<ICompositionGraphicsDeviceInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"UI_Composition_Desktop\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "UI_Composition_Desktop", feature = "Win32_Foundation"))]
 pub trait ICompositorDesktopInterop_Impl: Sized {
     fn CreateDesktopWindowTarget(&self, hwndtarget: super::super::super::Foundation::HWND, istopmost: super::super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::super::super::UI::Composition::Desktop::DesktopWindowTarget>;
@@ -174,6 +179,7 @@ impl ICompositorDesktopInterop_Vtbl {
         iid == &<ICompositorDesktopInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"UI_Composition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "UI_Composition", feature = "Win32_Foundation"))]
 pub trait ICompositorInterop_Impl: Sized {
     fn CreateCompositionSurfaceForHandle(&self, swapchain: super::super::super::Foundation::HANDLE) -> ::windows::core::Result<super::super::super::super::UI::Composition::ICompositionSurface>;
@@ -229,6 +235,7 @@ impl ICompositorInterop_Vtbl {
         iid == &<ICompositorInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDesktopWindowTargetInterop_Impl: Sized {
     fn Hwnd(&self) -> ::windows::core::Result<super::super::super::Foundation::HWND>;
@@ -255,6 +262,7 @@ impl IDesktopWindowTargetInterop_Vtbl {
         iid == &<IDesktopWindowTargetInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"implement\"`*"]
 pub trait ISwapChainInterop_Impl: Sized {
     fn SetSwapChain(&self, swapchain: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -272,6 +280,7 @@ impl ISwapChainInterop_Vtbl {
         iid == &<ISwapChainInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Composition\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Input_Pointer\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Input_Pointer", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IVisualInteractionSourceInterop_Impl: Sized {
     fn TryRedirectForManipulation(&self, pointerinfo: *const super::super::super::UI::Input::Pointer::POINTER_INFO) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/CoreInputView/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/CoreInputView/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_CoreInputView\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICoreFrameworkInputViewInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, coreframeworkinputview: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Direct3D11/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Direct3D11\"`, `\"implement\"`*"]
 pub trait IDirect3DDxgiInterfaceAccess_Impl: Sized {
     fn GetInterface(&self, iid: *const ::windows::core::GUID, p: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Display\"`, `\"Win32_Foundation\"`, `\"Win32_Security\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 pub trait IDisplayDeviceInterop_Impl: Sized {
     fn CreateSharedHandle(&self, pobject: &::core::option::Option<::windows::core::IInspectable>, psecurityattributes: *const super::super::super::Security::SECURITY_ATTRIBUTES, access: u32, name: &::windows::core::HSTRING) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
@@ -40,6 +41,7 @@ impl IDisplayDeviceInterop_Vtbl {
         iid == &<IDisplayDeviceInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Display\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDisplayPathInterop_Impl: Sized {
     fn CreateSourcePresentationHandle(&self) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Capture/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Graphics_Capture\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IGraphicsCaptureItemInterop_Impl: Sized {
     fn CreateForWindow(&self, window: super::super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, result: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Direct2D/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct2D")]
 pub trait IGeometrySource2DInterop_Impl: Sized {
     fn GetGeometry(&self) -> ::windows::core::Result<super::super::super::super::Graphics::Direct2D::ID2D1Geometry>;
@@ -34,6 +35,7 @@ impl IGeometrySource2DInterop_Vtbl {
         iid == &<IGeometrySource2DInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Graphics_Direct2D\"`, `\"Foundation\"`, `\"Graphics_Effects\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Foundation", feature = "Graphics_Effects"))]
 pub trait IGraphicsEffectD2D1Interop_Impl: Sized {
     fn GetEffectId(&self) -> ::windows::core::Result<::windows::core::GUID>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Graphics_Imaging\"`, `\"implement\"`*"]
 pub trait ISoftwareBitmapNative_Impl: Sized {
     fn GetData(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl ISoftwareBitmapNative_Vtbl {
         iid == &<ISoftwareBitmapNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Imaging\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Imaging", feature = "Win32_Media_MediaFoundation"))]
 pub trait ISoftwareBitmapNativeFactory_Impl: Sized {
     fn CreateFromWICBitmap(&self, data: &::core::option::Option<super::super::super::super::Graphics::Imaging::IWICBitmap>, forcereadonly: super::super::super::super::Foundation::BOOL, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Holographic/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Holographic\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IHolographicCameraInterop_Impl: Sized {
     fn CreateDirect3D12BackBufferResource(&self, pdevice: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Device>, ptexture2ddesc: *const super::super::super::Graphics::Direct3D12::D3D12_RESOURCE_DESC) -> ::windows::core::Result<super::super::super::Graphics::Direct3D12::ID3D12Resource>;
@@ -61,6 +62,7 @@ impl IHolographicCameraInterop_Vtbl {
         iid == &<IHolographicCameraInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Holographic\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IHolographicCameraRenderingParametersInterop_Impl: Sized {
     fn CommitDirect3D12Resource(&self, pcolorresourcetocommit: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>, pcolorresourcefence: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Fence>, colorresourcefencesignalvalue: u64) -> ::windows::core::Result<()>;
@@ -91,6 +93,7 @@ impl IHolographicCameraRenderingParametersInterop_Vtbl {
         iid == &<IHolographicCameraRenderingParametersInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Holographic\"`, `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Graphics_Dxgi_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Direct3D12", feature = "Win32_Graphics_Dxgi_Common"))]
 pub trait IHolographicQuadLayerInterop_Impl: Sized {
     fn CreateDirect3D12ContentBufferResource(&self, pdevice: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Device>, ptexture2ddesc: *const super::super::super::Graphics::Direct3D12::D3D12_RESOURCE_DESC) -> ::windows::core::Result<super::super::super::Graphics::Direct3D12::ID3D12Resource>;
@@ -154,6 +157,7 @@ impl IHolographicQuadLayerInterop_Vtbl {
         iid == &<IHolographicQuadLayerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Holographic\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait IHolographicQuadLayerUpdateParametersInterop_Impl: Sized {
     fn CommitDirect3D12Resource(&self, pcolorresourcetocommit: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>, pcolorresourcefence: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Fence>, colorresourcefencesignalvalue: u64) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Isolation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Isolation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IIsolatedEnvironmentInterop_Impl: Sized {
     fn GetHostHwndInterop(&self, containerhwnd: super::super::super::Foundation::HWND) -> ::windows::core::Result<super::super::super::Foundation::HWND>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/ML/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_ML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ILearningModelDeviceFactoryNative_Impl: Sized {
     fn CreateFromD3D12CommandQueue(&self, value: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12CommandQueue>) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -27,6 +28,7 @@ impl ILearningModelDeviceFactoryNative_Vtbl {
         iid == &<ILearningModelDeviceFactoryNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_ML\"`, `\"Win32_AI_MachineLearning_WinML\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_AI_MachineLearning_WinML")]
 pub trait ILearningModelOperatorProviderNative_Impl: Sized {
     fn GetRegistry(&self) -> ::windows::core::Result<super::super::super::AI::MachineLearning::WinML::IMLOperatorRegistry>;
@@ -53,6 +55,7 @@ impl ILearningModelOperatorProviderNative_Vtbl {
         iid == &<ILearningModelOperatorProviderNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_ML\"`, `\"implement\"`*"]
 pub trait ILearningModelSessionOptionsNative_Impl: Sized {
     fn SetIntraOpNumThreadsOverride(&self, intraopnumthreads: u32) -> ::windows::core::Result<()>;
 }
@@ -73,6 +76,7 @@ impl ILearningModelSessionOptionsNative_Vtbl {
         iid == &<ILearningModelSessionOptionsNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_ML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ITensorNative_Impl: Sized {
     fn GetBuffer(&self, value: *mut *mut u8, capacity: *mut u32) -> ::windows::core::Result<()>;
@@ -109,6 +113,7 @@ impl ITensorNative_Vtbl {
         iid == &<ITensorNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_ML\"`, `\"Win32_Graphics_Direct3D12\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Direct3D12")]
 pub trait ITensorStaticsNative_Impl: Sized {
     fn CreateFromD3D12Resource(&self, value: &::core::option::Option<super::super::super::Graphics::Direct3D12::ID3D12Resource>, shape: *mut i64, shapecount: i32, result: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Media\"`, `\"implement\"`*"]
 pub trait IAudioFrameNative_Impl: Sized {
     fn GetData(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IAudioFrameNative_Vtbl {
         iid == &<IAudioFrameNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Media\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IAudioFrameNativeFactory_Impl: Sized {
     fn CreateFromMFSample(&self, data: &::core::option::Option<super::super::super::Media::MediaFoundation::IMFSample>, forcereadonly: super::super::super::Foundation::BOOL, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -38,6 +40,7 @@ impl IAudioFrameNativeFactory_Vtbl {
         iid == &<IAudioFrameNativeFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Media\"`, `\"implement\"`*"]
 pub trait IVideoFrameNative_Impl: Sized {
     fn GetData(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetDevice(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -65,6 +68,7 @@ impl IVideoFrameNative_Vtbl {
         iid == &<IVideoFrameNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Media\"`, `\"Win32_Foundation\"`, `\"Win32_Media_MediaFoundation\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Media_MediaFoundation"))]
 pub trait IVideoFrameNativeFactory_Impl: Sized {
     fn CreateFromMFSample(&self, data: &::core::option::Option<super::super::super::Media::MediaFoundation::IMFSample>, subtype: *const ::windows::core::GUID, width: u32, height: u32, forcereadonly: super::super::super::Foundation::BOOL, mindisplayaperture: *const super::super::super::Media::MediaFoundation::MFVideoArea, device: &::core::option::Option<super::super::super::Media::MediaFoundation::IMFDXGIDeviceManager>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Pdf/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Pdf\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D_Common\"`, `\"Win32_Graphics_Dxgi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D_Common", feature = "Win32_Graphics_Dxgi"))]
 pub trait IPdfRendererNative_Impl: Sized {
     fn RenderPageToSurface(&self, pdfpage: &::core::option::Option<::windows::core::IUnknown>, psurface: &::core::option::Option<super::super::super::Graphics::Dxgi::IDXGISurface>, offset: &super::super::super::Foundation::POINT, prenderparams: *const PDF_RENDER_PARAMS) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Printing/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Printing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPrintManagerInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, printmanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -28,6 +29,7 @@ impl IPrintManagerInterop_Vtbl {
         iid == &<IPrintManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Printing\"`, `\"Win32_Graphics_Printing\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Printing", feature = "Win32_System_Com"))]
 pub trait IPrintWorkflowConfigurationNative_Impl: Sized {
     fn PrinterQueue(&self) -> ::windows::core::Result<super::super::super::Graphics::Printing::IPrinterQueue>;
@@ -83,6 +85,7 @@ impl IPrintWorkflowConfigurationNative_Vtbl {
         iid == &<IPrintWorkflowConfigurationNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Printing\"`, `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_Xps")]
 pub trait IPrintWorkflowObjectModelSourceFileContentNative_Impl: Sized {
     fn StartXpsOMGeneration(&self, receiver: &::core::option::Option<IPrintWorkflowXpsReceiver>) -> ::windows::core::Result<()>;
@@ -119,6 +122,7 @@ impl IPrintWorkflowObjectModelSourceFileContentNative_Vtbl {
         iid == &<IPrintWorkflowObjectModelSourceFileContentNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Printing\"`, `\"Win32_Storage_Xps\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Storage_Xps")]
 pub trait IPrintWorkflowXpsObjectModelTargetPackageNative_Impl: Sized {
     fn DocumentPackageTarget(&self) -> ::windows::core::Result<super::super::super::Storage::Xps::IXpsDocumentPackageTarget>;
@@ -145,6 +149,7 @@ impl IPrintWorkflowXpsObjectModelTargetPackageNative_Vtbl {
         iid == &<IPrintWorkflowXpsObjectModelTargetPackageNative as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Printing\"`, `\"Win32_Storage_Xps\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Xps", feature = "Win32_System_Com"))]
 pub trait IPrintWorkflowXpsReceiver_Impl: Sized {
     fn SetDocumentSequencePrintTicket(&self, documentsequenceprintticket: &::core::option::Option<super::super::Com::IStream>) -> ::windows::core::Result<()>;
@@ -196,6 +201,7 @@ impl IPrintWorkflowXpsReceiver_Vtbl {
         iid == &<IPrintWorkflowXpsReceiver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Printing\"`, `\"Win32_Storage_Xps\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Storage_Xps", feature = "Win32_System_Com"))]
 pub trait IPrintWorkflowXpsReceiver2_Impl: Sized + IPrintWorkflowXpsReceiver_Impl {
     fn Failed(&self, xpserror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -216,6 +222,7 @@ impl IPrintWorkflowXpsReceiver2_Vtbl {
         iid == &<IPrintWorkflowXpsReceiver2 as ::windows::core::Interface>::IID || iid == &<IPrintWorkflowXpsReceiver as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Printing\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPrinting3DManagerInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, printmanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Shell/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Shell\"`, `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell")]
 pub trait IDDEInitializer_Impl: Sized {
     fn Initialize(&self, fileextensionorprotocol: &::windows::core::PCWSTR, method: CreateProcessMethod, currentdirectory: &::windows::core::PCWSTR, exectarget: &::core::option::Option<super::super::super::UI::Shell::IShellItem>, site: &::core::option::Option<::windows::core::IUnknown>, application: &::windows::core::PCWSTR, targetfile: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, verb: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`, `\"implement\"`*"]
 pub trait IOplockBreakingHandler_Impl: Sized {
     fn OplockBreaking(&self) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IOplockBreakingHandler_Vtbl {
         iid == &<IOplockBreakingHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`, `\"implement\"`*"]
 pub trait IRandomAccessStreamFileAccessMode_Impl: Sized {
     fn GetMode(&self) -> ::windows::core::Result<u32>;
 }
@@ -38,6 +40,7 @@ impl IRandomAccessStreamFileAccessMode_Vtbl {
         iid == &<IRandomAccessStreamFileAccessMode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStorageFolderHandleAccess_Impl: Sized {
     fn Create(&self, filename: &::windows::core::PCWSTR, creationoptions: HANDLE_CREATION_OPTIONS, accessoptions: HANDLE_ACCESS_OPTIONS, sharingoptions: HANDLE_SHARING_OPTIONS, options: HANDLE_OPTIONS, oplockbreakinghandler: &::core::option::Option<IOplockBreakingHandler>) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
@@ -64,6 +67,7 @@ impl IStorageFolderHandleAccess_Vtbl {
         iid == &<IStorageFolderHandleAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStorageItemHandleAccess_Impl: Sized {
     fn Create(&self, accessoptions: HANDLE_ACCESS_OPTIONS, sharingoptions: HANDLE_SHARING_OPTIONS, options: HANDLE_OPTIONS, oplockbreakinghandler: &::core::option::Option<IOplockBreakingHandler>) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
@@ -90,6 +94,7 @@ impl IStorageItemHandleAccess_Vtbl {
         iid == &<IStorageItemHandleAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`, `\"implement\"`*"]
 pub trait IUnbufferedFileHandleOplockCallback_Impl: Sized {
     fn OnBrokenCallback(&self) -> ::windows::core::Result<()>;
 }
@@ -107,6 +112,7 @@ impl IUnbufferedFileHandleOplockCallback_Vtbl {
         iid == &<IUnbufferedFileHandleOplockCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT_Storage\"`, `\"implement\"`*"]
 pub trait IUnbufferedFileHandleProvider_Impl: Sized {
     fn OpenUnbufferedFileHandle(&self, oplockbreakcallback: &::core::option::Option<IUnbufferedFileHandleOplockCallback>) -> ::windows::core::Result<usize>;
     fn CloseUnbufferedFileHandle(&self) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAccountsSettingsPaneInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, accountssettingspane: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -35,6 +36,7 @@ impl IAccountsSettingsPaneInterop_Vtbl {
         iid == &<IAccountsSettingsPaneInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IActivationFactory_Impl: Sized {
     fn ActivateInstance(&self) -> ::windows::core::Result<::windows::core::IInspectable>;
 }
@@ -61,6 +63,7 @@ impl IActivationFactory_Vtbl {
         iid == &<IActivationFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IAgileReference_Impl: Sized {
     fn Resolve(&self, riid: *const ::windows::core::GUID, ppvobjectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -78,6 +81,7 @@ impl IAgileReference_Vtbl {
         iid == &<IAgileReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IApartmentShutdown_Impl: Sized {
     fn OnUninitialize(&self, ui64apartmentidentifier: u64);
 }
@@ -95,6 +99,7 @@ impl IApartmentShutdown_Vtbl {
         iid == &<IApartmentShutdown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IAppServiceConnectionExtendedExecution_Impl: Sized {
     fn OpenForExtendedExecutionAsync(&self, riid: *const ::windows::core::GUID, operation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -115,6 +120,7 @@ impl IAppServiceConnectionExtendedExecution_Vtbl {
         iid == &<IAppServiceConnectionExtendedExecution as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IBufferByteAccess_Impl: Sized {
     fn Buffer(&self) -> ::windows::core::Result<*mut u8>;
 }
@@ -138,6 +144,7 @@ impl IBufferByteAccess_Vtbl {
         iid == &<IBufferByteAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ICastingController_Impl: Sized {
     fn Initialize(&self, castingengine: &::core::option::Option<::windows::core::IUnknown>, castingsource: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Connect(&self) -> ::windows::core::Result<()>;
@@ -192,6 +199,7 @@ impl ICastingController_Vtbl {
         iid == &<ICastingController as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ICastingEventHandler_Impl: Sized {
     fn OnStateChanged(&self, newstate: CASTING_CONNECTION_STATE) -> ::windows::core::Result<()>;
     fn OnError(&self, errorstatus: CASTING_CONNECTION_ERROR_STATUS, errormessage: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -219,6 +227,7 @@ impl ICastingEventHandler_Vtbl {
         iid == &<ICastingEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait ICastingSourceInfo_Impl: Sized {
     fn GetController(&self) -> ::windows::core::Result<ICastingController>;
@@ -261,6 +270,7 @@ impl ICastingSourceInfo_Vtbl {
         iid == &<ICastingSourceInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ICoreInputInterop_Impl: Sized {
     fn SetInputSource(&self, value: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetMessageHandled(&self, value: u8) -> ::windows::core::Result<()>;
@@ -288,6 +298,7 @@ impl ICoreInputInterop_Vtbl {
         iid == &<ICoreInputInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ICoreWindowAdapterInterop_Impl: Sized {
     fn AppActivationClientAdapter(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn ApplicationViewClientAdapter(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -399,6 +410,7 @@ impl ICoreWindowAdapterInterop_Vtbl {
         iid == &<ICoreWindowAdapterInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICoreWindowComponentInterop_Impl: Sized {
     fn ConfigureComponentInput(&self, hostviewinstanceid: u32, hwndhost: super::super::Foundation::HWND, inputsourcevisual: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -435,6 +447,7 @@ impl ICoreWindowComponentInterop_Vtbl {
         iid == &<ICoreWindowComponentInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICoreWindowInterop_Impl: Sized {
     fn WindowHandle(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -471,6 +484,7 @@ impl ICoreWindowInterop_Vtbl {
         iid == &<ICoreWindowInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ICorrelationVectorInformation_Impl: Sized {
     fn LastCorrelationVectorForThread(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
     fn NextCorrelationVectorForThread(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
@@ -517,6 +531,7 @@ impl ICorrelationVectorInformation_Vtbl {
         iid == &<ICorrelationVectorInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ICorrelationVectorSource_Impl: Sized {
     fn CorrelationVector(&self) -> ::windows::core::Result<::windows::core::HSTRING>;
 }
@@ -540,6 +555,7 @@ impl ICorrelationVectorSource_Vtbl {
         iid == &<ICorrelationVectorSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDragDropManagerInterop_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -563,6 +579,7 @@ impl IDragDropManagerInterop_Vtbl {
         iid == &<IDragDropManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IHolographicSpaceInterop_Impl: Sized {
     fn CreateForWindow(&self, window: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, holographicspace: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -586,6 +603,7 @@ impl IHolographicSpaceInterop_Vtbl {
         iid == &<IHolographicSpaceInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInputPaneInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, inputpane: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -606,6 +624,7 @@ impl IInputPaneInterop_Vtbl {
         iid == &<IInputPaneInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ILanguageExceptionErrorInfo_Impl: Sized {
     fn GetLanguageException(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -629,6 +648,7 @@ impl ILanguageExceptionErrorInfo_Vtbl {
         iid == &<ILanguageExceptionErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ILanguageExceptionErrorInfo2_Impl: Sized + ILanguageExceptionErrorInfo_Impl {
     fn GetPreviousLanguageExceptionErrorInfo(&self) -> ::windows::core::Result<ILanguageExceptionErrorInfo2>;
     fn CapturePropagationContext(&self, languageexception: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -675,6 +695,7 @@ impl ILanguageExceptionErrorInfo2_Vtbl {
         iid == &<ILanguageExceptionErrorInfo2 as ::windows::core::Interface>::IID || iid == &<ILanguageExceptionErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ILanguageExceptionStackBackTrace_Impl: Sized {
     fn GetStackBackTrace(&self, maxframestocapture: u32, stackbacktrace: *mut usize, framescaptured: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -692,6 +713,7 @@ impl ILanguageExceptionStackBackTrace_Vtbl {
         iid == &<ILanguageExceptionStackBackTrace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait ILanguageExceptionTransform_Impl: Sized {
     fn GetTransformedRestrictedErrorInfo(&self) -> ::windows::core::Result<IRestrictedErrorInfo>;
 }
@@ -718,6 +740,7 @@ impl ILanguageExceptionTransform_Vtbl {
         iid == &<ILanguageExceptionTransform as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IMemoryBufferByteAccess_Impl: Sized {
     fn GetBuffer(&self, value: *mut *mut u8, capacity: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -735,6 +758,7 @@ impl IMemoryBufferByteAccess_Vtbl {
         iid == &<IMemoryBufferByteAccess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IMessageDispatcher_Impl: Sized {
     fn PumpMessages(&self) -> ::windows::core::Result<()>;
 }
@@ -752,6 +776,7 @@ impl IMessageDispatcher_Vtbl {
         iid == &<IMessageDispatcher as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPlayToManagerInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, playtomanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -782,6 +807,7 @@ impl IPlayToManagerInterop_Vtbl {
         iid == &<IPlayToManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IRestrictedErrorInfo_Impl: Sized {
     fn GetErrorDetails(&self, description: *mut ::windows::core::BSTR, error: *mut ::windows::core::HRESULT, restricteddescription: *mut ::windows::core::BSTR, capabilitysid: *mut ::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn GetReference(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -815,6 +841,7 @@ impl IRestrictedErrorInfo_Vtbl {
         iid == &<IRestrictedErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IRoMetaDataLocator_Impl: Sized {
     fn Locate(&self, nameelement: &::windows::core::PCWSTR, metadatadestination: &::core::option::Option<IRoSimpleMetaDataBuilder>) -> ::windows::core::Result<()>;
 }
@@ -840,6 +867,7 @@ impl IRoMetaDataLocator {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IRoSimpleMetaDataBuilder_Impl: Sized {
     fn SetWinRtInterface(&self, iid: &::windows::core::GUID) -> ::windows::core::Result<()>;
     fn SetDelegate(&self, iid: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -930,6 +958,7 @@ impl IRoSimpleMetaDataBuilder {
         unsafe { ::windows::core::ScopedInterface::new(::std::mem::transmute(&this.vtable)) }
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IShareWindowCommandEventArgsInterop_Impl: Sized {
     fn GetWindow(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -956,6 +985,7 @@ impl IShareWindowCommandEventArgsInterop_Vtbl {
         iid == &<IShareWindowCommandEventArgsInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IShareWindowCommandSourceInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, sharewindowcommandsource: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -976,6 +1006,7 @@ impl IShareWindowCommandSourceInterop_Vtbl {
         iid == &<IShareWindowCommandSourceInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISpatialInteractionManagerInterop_Impl: Sized {
     fn GetForWindow(&self, window: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, spatialinteractionmanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -999,6 +1030,7 @@ impl ISpatialInteractionManagerInterop_Vtbl {
         iid == &<ISpatialInteractionManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISystemMediaTransportControlsInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, mediatransportcontrol: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1022,6 +1054,7 @@ impl ISystemMediaTransportControlsInterop_Vtbl {
         iid == &<ISystemMediaTransportControlsInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIViewSettingsInterop_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1045,6 +1078,7 @@ impl IUIViewSettingsInterop_Vtbl {
         iid == &<IUIViewSettingsInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUserActivityInterop_Impl: Sized {
     fn CreateSessionForWindow(&self, window: super::super::Foundation::HWND, iid: *const ::windows::core::GUID, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1068,6 +1102,7 @@ impl IUserActivityInterop_Vtbl {
         iid == &<IUserActivityInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUserActivityRequestManagerInterop_Impl: Sized {
     fn GetForWindow(&self, window: super::super::Foundation::HWND, iid: *const ::windows::core::GUID, value: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1091,6 +1126,7 @@ impl IUserActivityRequestManagerInterop_Vtbl {
         iid == &<IUserActivityRequestManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IUserActivitySourceHostInterop_Impl: Sized {
     fn SetActivitySourceHost(&self, activitysourcehost: &::windows::core::HSTRING) -> ::windows::core::Result<()>;
 }
@@ -1111,6 +1147,7 @@ impl IUserActivitySourceHostInterop_Vtbl {
         iid == &<IUserActivitySourceHostInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUserConsentVerifierInterop_Impl: Sized {
     fn RequestVerificationForWindowAsync(&self, appwindow: super::super::Foundation::HWND, message: &::windows::core::HSTRING, riid: *const ::windows::core::GUID, asyncoperation: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1134,6 +1171,7 @@ impl IUserConsentVerifierInterop_Vtbl {
         iid == &<IUserConsentVerifierInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IWeakReference_Impl: Sized {
     fn Resolve(&self, riid: *const ::windows::core::GUID, objectreference: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -1151,6 +1189,7 @@ impl IWeakReference_Vtbl {
         iid == &<IWeakReference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"implement\"`*"]
 pub trait IWeakReferenceSource_Impl: Sized {
     fn GetWeakReference(&self) -> ::windows::core::Result<IWeakReference>;
 }
@@ -1174,6 +1213,7 @@ impl IWeakReferenceSource_Vtbl {
         iid == &<IWeakReferenceSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WinRT\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWebAuthenticationCoreManagerInterop_Impl: Sized {
     fn RequestTokenForWindowAsync(&self, appwindow: super::super::Foundation::HWND, request: &::core::option::Option<::windows::core::IInspectable>, riid: *const ::windows::core::GUID, asyncinfo: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ICameraUIControl_Impl: Sized {
     fn Show(&self, pwindow: &::core::option::Option<::windows::core::IUnknown>, mode: CameraUIControlMode, selectionmode: CameraUIControlLinearSelectionMode, capturemode: CameraUIControlCaptureMode, photoformat: CameraUIControlPhotoFormat, videoformat: CameraUIControlVideoFormat, bhasclosebutton: super::super::Foundation::BOOL, peventcallback: &::core::option::Option<ICameraUIControlEventCallback>) -> ::windows::core::Result<()>;
@@ -88,6 +89,7 @@ impl ICameraUIControl_Vtbl {
         iid == &<ICameraUIControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"implement\"`*"]
 pub trait ICameraUIControlEventCallback_Impl: Sized {
     fn OnStartupComplete(&self);
     fn OnSuspendComplete(&self);
@@ -136,6 +138,7 @@ impl ICameraUIControlEventCallback_Vtbl {
         iid == &<ICameraUIControlEventCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"implement\"`*"]
 pub trait IClipServiceNotificationHelper_Impl: Sized {
     fn ShowToast(&self, titletext: &::windows::core::BSTR, bodytext: &::windows::core::BSTR, packagename: &::windows::core::BSTR, appid: &::windows::core::BSTR, launchcommand: &::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -153,6 +156,7 @@ impl IClipServiceNotificationHelper_Vtbl {
         iid == &<IClipServiceNotificationHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContainerActivationHelper_Impl: Sized {
     fn CanActivateClientVM(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -179,6 +183,7 @@ impl IContainerActivationHelper_Vtbl {
         iid == &<IContainerActivationHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDefaultBrowserSyncSettings_Impl: Sized {
     fn IsEnabled(&self) -> super::super::Foundation::BOOL;
@@ -199,6 +204,7 @@ impl IDefaultBrowserSyncSettings_Vtbl {
         iid == &<IDefaultBrowserSyncSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"implement\"`*"]
 pub trait IDeleteBrowsingHistory_Impl: Sized {
     fn DeleteBrowsingHistory(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -216,6 +222,7 @@ impl IDeleteBrowsingHistory_Vtbl {
         iid == &<IDeleteBrowsingHistory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Ole")]
 pub trait IEditionUpgradeBroker_Impl: Sized {
     fn InitializeParentWindow(&self, parenthandle: super::Ole::OLE_HANDLE) -> ::windows::core::Result<()>;
@@ -260,6 +267,7 @@ impl IEditionUpgradeBroker_Vtbl {
         iid == &<IEditionUpgradeBroker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEditionUpgradeHelper_Impl: Sized {
     fn CanUpgrade(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -329,6 +337,7 @@ impl IEditionUpgradeHelper_Vtbl {
         iid == &<IEditionUpgradeHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWindowsLockModeHelper_Impl: Sized {
     fn GetSMode(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAsynchronousDataRetriever_Impl: Sized {
     fn GetIdParameters(&self, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::Result<()>;
@@ -42,6 +43,7 @@ impl IAsynchronousDataRetriever_Vtbl {
         iid == &<IAsynchronousDataRetriever as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IChangeConflict_Impl: Sized {
     fn GetDestinationProviderConflictingChange(&self) -> ::windows::core::Result<ISyncChange>;
     fn GetSourceProviderConflictingChange(&self) -> ::windows::core::Result<ISyncChange>;
@@ -135,6 +137,7 @@ impl IChangeConflict_Vtbl {
         iid == &<IChangeConflict as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IChangeUnitException_Impl: Sized {
     fn GetItemId(&self, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetChangeUnitId(&self, pbchangeunitid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
@@ -169,6 +172,7 @@ impl IChangeUnitException_Vtbl {
         iid == &<IChangeUnitException as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IChangeUnitListFilterInfo_Impl: Sized + ISyncFilterInfo_Impl {
     fn Initialize(&self, ppbchangeunitids: *const *const u8, dwchangeunitcount: u32) -> ::windows::core::Result<()>;
     fn GetChangeUnitIdCount(&self, pdwchangeunitidcount: *mut u32) -> ::windows::core::Result<()>;
@@ -203,6 +207,7 @@ impl IChangeUnitListFilterInfo_Vtbl {
         iid == &<IChangeUnitListFilterInfo as ::windows::core::Interface>::IID || iid == &<ISyncFilterInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IClockVector_Impl: Sized {
     fn GetClockVectorElements(&self, riid: *const ::windows::core::GUID, ppienumclockvector: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetClockVectorElementCount(&self, pdwcount: *mut u32) -> ::windows::core::Result<()>;
@@ -230,6 +235,7 @@ impl IClockVector_Vtbl {
         iid == &<IClockVector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IClockVectorElement_Impl: Sized {
     fn GetReplicaKey(&self, pdwreplicakey: *mut u32) -> ::windows::core::Result<()>;
     fn GetTickCount(&self, pulltickcount: *mut u64) -> ::windows::core::Result<()>;
@@ -257,6 +263,7 @@ impl IClockVectorElement_Vtbl {
         iid == &<IClockVectorElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ICombinedFilterInfo_Impl: Sized + ISyncFilterInfo_Impl {
     fn GetFilterCount(&self, pdwfiltercount: *mut u32) -> ::windows::core::Result<()>;
     fn GetFilterInfo(&self, dwfilterindex: u32) -> ::windows::core::Result<ISyncFilterInfo>;
@@ -297,6 +304,7 @@ impl ICombinedFilterInfo_Vtbl {
         iid == &<ICombinedFilterInfo as ::windows::core::Interface>::IID || iid == &<ISyncFilterInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IConstraintConflict_Impl: Sized {
     fn GetDestinationProviderConflictingChange(&self) -> ::windows::core::Result<ISyncChange>;
     fn GetSourceProviderConflictingChange(&self) -> ::windows::core::Result<ISyncChange>;
@@ -430,6 +438,7 @@ impl IConstraintConflict_Vtbl {
         iid == &<IConstraintConflict as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IConstructReplicaKeyMap_Impl: Sized {
     fn FindOrAddReplica(&self, pbreplicaid: *const u8, pdwreplicakey: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -447,6 +456,7 @@ impl IConstructReplicaKeyMap_Vtbl {
         iid == &<IConstructReplicaKeyMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ICoreFragment_Impl: Sized {
     fn NextColumn(&self, pchangeunitid: *mut u8, pchangeunitidsize: *mut u32) -> ::windows::core::Result<()>;
     fn NextRange(&self, pitemid: *mut u8, pitemidsize: *mut u32, piclockvector: *mut ::core::option::Option<IClockVector>) -> ::windows::core::Result<()>;
@@ -495,6 +505,7 @@ impl ICoreFragment_Vtbl {
         iid == &<ICoreFragment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ICoreFragmentInspector_Impl: Sized {
     fn NextCoreFragments(&self, requestedcount: u32, ppicorefragments: *mut ::core::option::Option<ICoreFragment>, pfetchedcount: *mut u32) -> ::windows::core::Result<()>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -522,6 +533,7 @@ impl ICoreFragmentInspector_Vtbl {
         iid == &<ICoreFragmentInspector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ICustomFilterInfo_Impl: Sized + ISyncFilterInfo_Impl {
     fn GetSyncFilter(&self) -> ::windows::core::Result<ISyncFilter>;
 }
@@ -545,6 +557,7 @@ impl ICustomFilterInfo_Vtbl {
         iid == &<ICustomFilterInfo as ::windows::core::Interface>::IID || iid == &<ISyncFilterInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IDataRetrieverCallback_Impl: Sized {
     fn LoadChangeDataComplete(&self, punkdata: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn LoadChangeDataError(&self, hrerror: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -572,6 +585,7 @@ impl IDataRetrieverCallback_Vtbl {
         iid == &<IDataRetrieverCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumChangeUnitExceptions_Impl: Sized {
     fn Next(&self, cexceptions: u32, ppchangeunitexception: *mut ::core::option::Option<IChangeUnitException>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cexceptions: u32) -> ::windows::core::Result<()>;
@@ -619,6 +633,7 @@ impl IEnumChangeUnitExceptions_Vtbl {
         iid == &<IEnumChangeUnitExceptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumClockVector_Impl: Sized {
     fn Next(&self, cclockvectorelements: u32, ppiclockvectorelements: *mut ::core::option::Option<IClockVectorElement>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, csyncversions: u32) -> ::windows::core::Result<()>;
@@ -666,6 +681,7 @@ impl IEnumClockVector_Vtbl {
         iid == &<IEnumClockVector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumFeedClockVector_Impl: Sized {
     fn Next(&self, cclockvectorelements: u32, ppiclockvectorelements: *mut ::core::option::Option<IFeedClockVectorElement>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, csyncversions: u32) -> ::windows::core::Result<()>;
@@ -713,6 +729,7 @@ impl IEnumFeedClockVector_Vtbl {
         iid == &<IEnumFeedClockVector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumItemIds_Impl: Sized {
     fn Next(&self, pbitemid: *mut u8, pcbitemidsize: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -730,6 +747,7 @@ impl IEnumItemIds_Vtbl {
         iid == &<IEnumItemIds as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumRangeExceptions_Impl: Sized {
     fn Next(&self, cexceptions: u32, pprangeexception: *mut ::core::option::Option<IRangeException>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cexceptions: u32) -> ::windows::core::Result<()>;
@@ -777,6 +795,7 @@ impl IEnumRangeExceptions_Vtbl {
         iid == &<IEnumRangeExceptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumSingleItemExceptions_Impl: Sized {
     fn Next(&self, cexceptions: u32, ppsingleitemexception: *mut ::core::option::Option<ISingleItemException>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cexceptions: u32) -> ::windows::core::Result<()>;
@@ -824,6 +843,7 @@ impl IEnumSingleItemExceptions_Vtbl {
         iid == &<IEnumSingleItemExceptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumSyncChangeUnits_Impl: Sized {
     fn Next(&self, cchanges: u32, ppchangeunit: *mut ::core::option::Option<ISyncChangeUnit>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cchanges: u32) -> ::windows::core::Result<()>;
@@ -871,6 +891,7 @@ impl IEnumSyncChangeUnits_Vtbl {
         iid == &<IEnumSyncChangeUnits as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IEnumSyncChanges_Impl: Sized {
     fn Next(&self, cchanges: u32, ppchange: *mut ::core::option::Option<ISyncChange>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, cchanges: u32) -> ::windows::core::Result<()>;
@@ -918,6 +939,7 @@ impl IEnumSyncChanges_Vtbl {
         iid == &<IEnumSyncChanges as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IEnumSyncProviderConfigUIInfos_Impl: Sized {
     fn Next(&self, cfactories: u32, ppsyncproviderconfiguiinfo: *mut ::core::option::Option<ISyncProviderConfigUIInfo>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -968,6 +990,7 @@ impl IEnumSyncProviderConfigUIInfos_Vtbl {
         iid == &<IEnumSyncProviderConfigUIInfos as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IEnumSyncProviderInfos_Impl: Sized {
     fn Next(&self, cinstances: u32, ppsyncproviderinfo: *mut ::core::option::Option<ISyncProviderInfo>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1018,6 +1041,7 @@ impl IEnumSyncProviderInfos_Vtbl {
         iid == &<IEnumSyncProviderInfos as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFeedClockVector_Impl: Sized + IClockVector_Impl {
     fn GetUpdateCount(&self, pdwupdatecount: *mut u32) -> ::windows::core::Result<()>;
@@ -1048,6 +1072,7 @@ impl IFeedClockVector_Vtbl {
         iid == &<IFeedClockVector as ::windows::core::Interface>::IID || iid == &<IClockVector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IFeedClockVectorElement_Impl: Sized + IClockVectorElement_Impl {
     fn GetSyncTime(&self, psynctime: *mut SYNC_TIME) -> ::windows::core::Result<()>;
     fn GetFlags(&self, pbflags: *mut u8) -> ::windows::core::Result<()>;
@@ -1075,6 +1100,7 @@ impl IFeedClockVectorElement_Vtbl {
         iid == &<IFeedClockVectorElement as ::windows::core::Interface>::IID || iid == &<IClockVectorElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IFilterKeyMap_Impl: Sized {
     fn GetCount(&self, pdwcount: *mut u32) -> ::windows::core::Result<()>;
     fn AddFilter(&self, pisyncfilter: &::core::option::Option<ISyncFilter>, pdwfilterkey: *mut u32) -> ::windows::core::Result<()>;
@@ -1122,6 +1148,7 @@ impl IFilterKeyMap_Vtbl {
         iid == &<IFilterKeyMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IFilterRequestCallback_Impl: Sized {
     fn RequestFilter(&self, pfilter: &::core::option::Option<::windows::core::IUnknown>, filteringtype: FILTERING_TYPE) -> ::windows::core::Result<()>;
 }
@@ -1139,6 +1166,7 @@ impl IFilterRequestCallback_Vtbl {
         iid == &<IFilterRequestCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IFilterTrackingProvider_Impl: Sized {
     fn SpecifyTrackedFilters(&self, pcallback: &::core::option::Option<IFilterTrackingRequestCallback>) -> ::windows::core::Result<()>;
     fn AddTrackedFilter(&self, pfilter: &::core::option::Option<ISyncFilter>) -> ::windows::core::Result<()>;
@@ -1166,6 +1194,7 @@ impl IFilterTrackingProvider_Vtbl {
         iid == &<IFilterTrackingProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IFilterTrackingRequestCallback_Impl: Sized {
     fn RequestTrackedFilter(&self, pfilter: &::core::option::Option<ISyncFilter>) -> ::windows::core::Result<()>;
 }
@@ -1183,6 +1212,7 @@ impl IFilterTrackingRequestCallback_Vtbl {
         iid == &<IFilterTrackingRequestCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFilterTrackingSyncChangeBuilder_Impl: Sized {
     fn AddFilterChange(&self, dwfilterkey: u32, pfilterchange: *const SYNC_FILTER_CHANGE) -> ::windows::core::Result<()>;
@@ -1213,6 +1243,7 @@ impl IFilterTrackingSyncChangeBuilder_Vtbl {
         iid == &<IFilterTrackingSyncChangeBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IForgottenKnowledge_Impl: Sized + ISyncKnowledge_Impl {
     fn ForgetToVersion(&self, pknowledge: &::core::option::Option<ISyncKnowledge>, pversion: *const SYNC_VERSION) -> ::windows::core::Result<()>;
@@ -1233,6 +1264,7 @@ impl IForgottenKnowledge_Vtbl {
         iid == &<IForgottenKnowledge as ::windows::core::Interface>::IID || iid == &<ISyncKnowledge as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IKnowledgeSyncProvider_Impl: Sized + ISyncProvider_Impl {
     fn BeginSession(&self, role: SYNC_PROVIDER_ROLE, psessionstate: &::core::option::Option<ISyncSessionState>) -> ::windows::core::Result<()>;
@@ -1298,6 +1330,7 @@ impl IKnowledgeSyncProvider_Vtbl {
         iid == &<IKnowledgeSyncProvider as ::windows::core::Interface>::IID || iid == &<ISyncProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ILoadChangeContext_Impl: Sized {
     fn GetSyncChange(&self) -> ::windows::core::Result<ISyncChange>;
     fn SetRecoverableErrorOnChange(&self, hrerror: ::windows::core::HRESULT, perrordata: &::core::option::Option<IRecoverableErrorData>) -> ::windows::core::Result<()>;
@@ -1338,6 +1371,7 @@ impl ILoadChangeContext_Vtbl {
         iid == &<ILoadChangeContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IProviderConverter_Impl: Sized {
     fn Initialize(&self, pisyncprovider: &::core::option::Option<ISyncProvider>) -> ::windows::core::Result<()>;
 }
@@ -1355,6 +1389,7 @@ impl IProviderConverter_Vtbl {
         iid == &<IProviderConverter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IRangeException_Impl: Sized {
     fn GetClosedRangeStart(&self, pbclosedrangestart: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetClosedRangeEnd(&self, pbclosedrangeend: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
@@ -1389,6 +1424,7 @@ impl IRangeException_Vtbl {
         iid == &<IRangeException as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IRecoverableError_Impl: Sized {
     fn GetStage(&self, pstage: *mut SYNC_PROGRESS_STAGE) -> ::windows::core::Result<()>;
     fn GetProvider(&self, pproviderrole: *mut SYNC_PROVIDER_ROLE) -> ::windows::core::Result<()>;
@@ -1443,6 +1479,7 @@ impl IRecoverableError_Vtbl {
         iid == &<IRecoverableError as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IRecoverableErrorData_Impl: Sized {
     fn Initialize(&self, pcszitemdisplayname: &::windows::core::PCWSTR, pcszerrordescription: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetItemDisplayName(&self, pszitemdisplayname: &::windows::core::PCWSTR, pcchitemdisplayname: *mut u32) -> ::windows::core::Result<()>;
@@ -1477,6 +1514,7 @@ impl IRecoverableErrorData_Vtbl {
         iid == &<IRecoverableErrorData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IRegisteredSyncProvider_Impl: Sized {
     fn Init(&self, pguidinstanceid: *const ::windows::core::GUID, pguidcontenttype: *const ::windows::core::GUID, pcontextpropertystore: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
@@ -1520,6 +1558,7 @@ impl IRegisteredSyncProvider_Vtbl {
         iid == &<IRegisteredSyncProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IReplicaKeyMap_Impl: Sized {
     fn LookupReplicaKey(&self, pbreplicaid: *const u8, pdwreplicakey: *mut u32) -> ::windows::core::Result<()>;
     fn LookupReplicaId(&self, dwreplicakey: u32, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
@@ -1554,6 +1593,7 @@ impl IReplicaKeyMap_Vtbl {
         iid == &<IReplicaKeyMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait IRequestFilteredSync_Impl: Sized {
     fn SpecifyFilter(&self, pcallback: &::core::option::Option<IFilterRequestCallback>) -> ::windows::core::Result<()>;
 }
@@ -1571,6 +1611,7 @@ impl IRequestFilteredSync_Vtbl {
         iid == &<IRequestFilteredSync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISingleItemException_Impl: Sized {
     fn GetItemId(&self, pbitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetClockVector(&self, riid: *const ::windows::core::GUID, ppunk: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1598,6 +1639,7 @@ impl ISingleItemException_Vtbl {
         iid == &<ISingleItemException as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISupportFilteredSync_Impl: Sized {
     fn AddFilter(&self, pfilter: &::core::option::Option<::windows::core::IUnknown>, filteringtype: FILTERING_TYPE) -> ::windows::core::Result<()>;
 }
@@ -1615,6 +1657,7 @@ impl ISupportFilteredSync_Vtbl {
         iid == &<ISupportFilteredSync as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISupportLastWriteTime_Impl: Sized {
     fn GetItemChangeTime(&self, pbitemid: *const u8, pulltimestamp: *mut u64) -> ::windows::core::Result<()>;
     fn GetChangeUnitChangeTime(&self, pbitemid: *const u8, pbchangeunitid: *const u8, pulltimestamp: *mut u64) -> ::windows::core::Result<()>;
@@ -1642,6 +1685,7 @@ impl ISupportLastWriteTime_Vtbl {
         iid == &<ISupportLastWriteTime as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncCallback_Impl: Sized {
     fn OnProgress(&self, provider: SYNC_PROVIDER_ROLE, syncstage: SYNC_PROGRESS_STAGE, dwcompletedwork: u32, dwtotalwork: u32) -> ::windows::core::Result<()>;
     fn OnChange(&self, psyncchange: &::core::option::Option<ISyncChange>) -> ::windows::core::Result<()>;
@@ -1690,6 +1734,7 @@ impl ISyncCallback_Vtbl {
         iid == &<ISyncCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncCallback2_Impl: Sized + ISyncCallback_Impl {
     fn OnChangeApplied(&self, dwchangesapplied: u32, dwchangesfailed: u32) -> ::windows::core::Result<()>;
     fn OnChangeFailed(&self, dwchangesapplied: u32, dwchangesfailed: u32) -> ::windows::core::Result<()>;
@@ -1717,6 +1762,7 @@ impl ISyncCallback2_Vtbl {
         iid == &<ISyncCallback2 as ::windows::core::Interface>::IID || iid == &<ISyncCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncChange_Impl: Sized {
     fn GetOwnerReplicaId(&self, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
     fn GetRootItemId(&self, pbrootitemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
@@ -1818,6 +1864,7 @@ impl ISyncChange_Vtbl {
         iid == &<ISyncChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncChangeBatch_Impl: Sized + ISyncChangeBatchBase_Impl {
     fn BeginUnorderedGroup(&self) -> ::windows::core::Result<()>;
@@ -1861,6 +1908,7 @@ impl ISyncChangeBatch_Vtbl {
         iid == &<ISyncChangeBatch as ::windows::core::Interface>::IID || iid == &<ISyncChangeBatchBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncChangeBatch2_Impl: Sized + ISyncChangeBatch_Impl {
     fn AddMergeTombstoneMetadataToGroup(&self, pbownerreplicaid: *const u8, pbwinneritemid: *const u8, pbitemid: *const u8, pchangeversion: *const SYNC_VERSION, pcreationversion: *const SYNC_VERSION, dwworkforchange: u32) -> ::windows::core::Result<ISyncChangeBuilder>;
@@ -1903,6 +1951,7 @@ impl ISyncChangeBatch2_Vtbl {
         iid == &<ISyncChangeBatch2 as ::windows::core::Interface>::IID || iid == &<ISyncChangeBatchBase as ::windows::core::Interface>::IID || iid == &<ISyncChangeBatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncChangeBatchAdvanced_Impl: Sized {
     fn GetFilterInfo(&self) -> ::windows::core::Result<ISyncFilterInfo>;
@@ -1959,6 +2008,7 @@ impl ISyncChangeBatchAdvanced_Vtbl {
         iid == &<ISyncChangeBatchAdvanced as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncChangeBatchBase_Impl: Sized {
     fn GetChangeEnumerator(&self) -> ::windows::core::Result<IEnumSyncChanges>;
@@ -2103,6 +2153,7 @@ impl ISyncChangeBatchBase_Vtbl {
         iid == &<ISyncChangeBatchBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncChangeBatchBase2_Impl: Sized + ISyncChangeBatchBase_Impl {
     fn SerializeWithOptions(&self, targetformatversion: SYNC_SERIALIZATION_VERSION, dwflags: u32, pbbuffer: *mut u8, pdwserializedsize: *mut u32) -> ::windows::core::Result<()>;
@@ -2123,6 +2174,7 @@ impl ISyncChangeBatchBase2_Vtbl {
         iid == &<ISyncChangeBatchBase2 as ::windows::core::Interface>::IID || iid == &<ISyncChangeBatchBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncChangeBatchWithFilterKeyMap_Impl: Sized {
     fn GetFilterKeyMap(&self) -> ::windows::core::Result<IFilterKeyMap>;
     fn SetFilterKeyMap(&self, pifilterkeymap: &::core::option::Option<IFilterKeyMap>) -> ::windows::core::Result<()>;
@@ -2228,6 +2280,7 @@ impl ISyncChangeBatchWithFilterKeyMap_Vtbl {
         iid == &<ISyncChangeBatchWithFilterKeyMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncChangeBatchWithPrerequisite_Impl: Sized + ISyncChangeBatchBase_Impl {
     fn SetPrerequisiteKnowledge(&self, pprerequisiteknowledge: &::core::option::Option<ISyncKnowledge>) -> ::windows::core::Result<()>;
@@ -2277,6 +2330,7 @@ impl ISyncChangeBatchWithPrerequisite_Vtbl {
         iid == &<ISyncChangeBatchWithPrerequisite as ::windows::core::Interface>::IID || iid == &<ISyncChangeBatchBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncChangeBuilder_Impl: Sized {
     fn AddChangeUnitMetadata(&self, pbchangeunitid: *const u8, pchangeunitversion: *const SYNC_VERSION) -> ::windows::core::Result<()>;
 }
@@ -2294,6 +2348,7 @@ impl ISyncChangeBuilder_Vtbl {
         iid == &<ISyncChangeBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncChangeUnit_Impl: Sized {
     fn GetItemChange(&self) -> ::windows::core::Result<ISyncChange>;
     fn GetChangeUnitId(&self, pbchangeunitid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
@@ -2334,6 +2389,7 @@ impl ISyncChangeUnit_Vtbl {
         iid == &<ISyncChangeUnit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncChangeWithFilterKeyMap_Impl: Sized {
     fn GetFilterCount(&self, pdwfiltercount: *mut u32) -> ::windows::core::Result<()>;
@@ -2449,6 +2505,7 @@ impl ISyncChangeWithFilterKeyMap_Vtbl {
         iid == &<ISyncChangeWithFilterKeyMap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncChangeWithPrerequisite_Impl: Sized {
     fn GetPrerequisiteKnowledge(&self) -> ::windows::core::Result<ISyncKnowledge>;
     fn GetLearnedKnowledgeWithPrerequisite(&self, pdestinationknowledge: &::core::option::Option<ISyncKnowledge>) -> ::windows::core::Result<ISyncKnowledge>;
@@ -2488,6 +2545,7 @@ impl ISyncChangeWithPrerequisite_Vtbl {
         iid == &<ISyncChangeWithPrerequisite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncConstraintCallback_Impl: Sized {
     fn OnConstraintConflict(&self, pconflict: &::core::option::Option<IConstraintConflict>) -> ::windows::core::Result<()>;
 }
@@ -2505,6 +2563,7 @@ impl ISyncConstraintCallback_Vtbl {
         iid == &<ISyncConstraintCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncDataConverter_Impl: Sized {
     fn ConvertDataRetrieverFromProviderFormat(&self, punkdataretrieverin: &::core::option::Option<::windows::core::IUnknown>, penumsyncchanges: &::core::option::Option<IEnumSyncChanges>) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn ConvertDataRetrieverToProviderFormat(&self, punkdataretrieverin: &::core::option::Option<::windows::core::IUnknown>, penumsyncchanges: &::core::option::Option<IEnumSyncChanges>) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -2570,6 +2629,7 @@ impl ISyncDataConverter_Vtbl {
         iid == &<ISyncDataConverter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncFilter_Impl: Sized {
     fn IsIdentical(&self, psyncfilter: &::core::option::Option<ISyncFilter>) -> ::windows::core::Result<()>;
     fn Serialize(&self, pbsyncfilter: *mut u8, pcbsyncfilter: *mut u32) -> ::windows::core::Result<()>;
@@ -2597,6 +2657,7 @@ impl ISyncFilter_Vtbl {
         iid == &<ISyncFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncFilterDeserializer_Impl: Sized {
     fn DeserializeSyncFilter(&self, pbsyncfilter: *const u8, dwcbsyncfilter: u32) -> ::windows::core::Result<ISyncFilter>;
 }
@@ -2620,6 +2681,7 @@ impl ISyncFilterDeserializer_Vtbl {
         iid == &<ISyncFilterDeserializer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncFilterInfo_Impl: Sized {
     fn Serialize(&self, pbbuffer: *mut u8, pcbbuffer: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -2637,6 +2699,7 @@ impl ISyncFilterInfo_Vtbl {
         iid == &<ISyncFilterInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncFilterInfo2_Impl: Sized + ISyncFilterInfo_Impl {
     fn GetFlags(&self, pdwflags: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -2654,6 +2717,7 @@ impl ISyncFilterInfo2_Vtbl {
         iid == &<ISyncFilterInfo2 as ::windows::core::Interface>::IID || iid == &<ISyncFilterInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncFullEnumerationChange_Impl: Sized {
     fn GetLearnedKnowledgeAfterRecoveryComplete(&self) -> ::windows::core::Result<ISyncKnowledge>;
     fn GetLearnedForgottenKnowledge(&self) -> ::windows::core::Result<IForgottenKnowledge>;
@@ -2693,6 +2757,7 @@ impl ISyncFullEnumerationChange_Vtbl {
         iid == &<ISyncFullEnumerationChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncFullEnumerationChangeBatch_Impl: Sized + ISyncChangeBatchBase_Impl {
     fn GetLearnedKnowledgeAfterRecoveryComplete(&self) -> ::windows::core::Result<ISyncKnowledge>;
@@ -2736,6 +2801,7 @@ impl ISyncFullEnumerationChangeBatch_Vtbl {
         iid == &<ISyncFullEnumerationChangeBatch as ::windows::core::Interface>::IID || iid == &<ISyncChangeBatchBase as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncFullEnumerationChangeBatch2_Impl: Sized + ISyncFullEnumerationChangeBatch_Impl {
     fn AddMergeTombstoneMetadataToGroup(&self, pbownerreplicaid: *const u8, pbwinneritemid: *const u8, pbitemid: *const u8, pchangeversion: *const SYNC_VERSION, pcreationversion: *const SYNC_VERSION, dwworkforchange: u32) -> ::windows::core::Result<ISyncChangeBuilder>;
@@ -2765,6 +2831,7 @@ impl ISyncFullEnumerationChangeBatch2_Vtbl {
         iid == &<ISyncFullEnumerationChangeBatch2 as ::windows::core::Interface>::IID || iid == &<ISyncChangeBatchBase as ::windows::core::Interface>::IID || iid == &<ISyncFullEnumerationChangeBatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncKnowledge_Impl: Sized {
     fn GetOwnerReplicaId(&self, pbreplicaid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
@@ -2985,6 +3052,7 @@ impl ISyncKnowledge_Vtbl {
         iid == &<ISyncKnowledge as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncKnowledge2_Impl: Sized + ISyncKnowledge_Impl {
     fn GetIdParameters(&self, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::Result<()>;
@@ -3123,6 +3191,7 @@ impl ISyncKnowledge2_Vtbl {
         iid == &<ISyncKnowledge2 as ::windows::core::Interface>::IID || iid == &<ISyncKnowledge as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncMergeTombstoneChange_Impl: Sized {
     fn GetWinnerItemId(&self, pbwinneritemid: *mut u8, pcbidsize: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -3140,6 +3209,7 @@ impl ISyncMergeTombstoneChange_Vtbl {
         iid == &<ISyncMergeTombstoneChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncProvider_Impl: Sized {
     fn GetIdParameters(&self, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::Result<()>;
@@ -3160,6 +3230,7 @@ impl ISyncProvider_Vtbl {
         iid == &<ISyncProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISyncProviderConfigUI_Impl: Sized {
     fn Init(&self, pguidinstanceid: *const ::windows::core::GUID, pguidcontenttype: *const ::windows::core::GUID, pconfigurationproperties: &::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
@@ -3216,6 +3287,7 @@ impl ISyncProviderConfigUI_Vtbl {
         iid == &<ISyncProviderConfigUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISyncProviderConfigUIInfo_Impl: Sized + super::super::UI::Shell::PropertiesSystem::IPropertyStore_Impl {
     fn GetSyncProviderConfigUI(&self, dwclscontext: u32) -> ::windows::core::Result<ISyncProviderConfigUI>;
@@ -3245,6 +3317,7 @@ impl ISyncProviderConfigUIInfo_Vtbl {
         iid == &<ISyncProviderConfigUIInfo as ::windows::core::Interface>::IID || iid == &<super::super::UI::Shell::PropertiesSystem::IPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISyncProviderInfo_Impl: Sized + super::super::UI::Shell::PropertiesSystem::IPropertyStore_Impl {
     fn GetSyncProvider(&self, dwclscontext: u32) -> ::windows::core::Result<IRegisteredSyncProvider>;
@@ -3274,6 +3347,7 @@ impl ISyncProviderInfo_Vtbl {
         iid == &<ISyncProviderInfo as ::windows::core::Interface>::IID || iid == &<super::super::UI::Shell::PropertiesSystem::IPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISyncProviderRegistration_Impl: Sized {
     fn CreateSyncProviderConfigUIRegistrationInstance(&self, pconfiguiconfig: *const SyncProviderConfigUIConfiguration) -> ::windows::core::Result<ISyncProviderConfigUIInfo>;
@@ -3468,6 +3542,7 @@ impl ISyncProviderRegistration_Vtbl {
         iid == &<ISyncProviderRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncRegistrationChange_Impl: Sized {
     fn GetEvent(&self) -> ::windows::core::Result<SYNC_REGISTRATION_EVENT>;
     fn GetInstanceId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3507,6 +3582,7 @@ impl ISyncRegistrationChange_Vtbl {
         iid == &<ISyncRegistrationChange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"implement\"`*"]
 pub trait ISyncSessionExtendedErrorInfo_Impl: Sized {
     fn GetSyncProviderWithError(&self) -> ::windows::core::Result<ISyncProvider>;
 }
@@ -3530,6 +3606,7 @@ impl ISyncSessionExtendedErrorInfo_Vtbl {
         iid == &<ISyncSessionExtendedErrorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncSessionState_Impl: Sized {
     fn IsCanceled(&self, pfiscanceled: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3595,6 +3672,7 @@ impl ISyncSessionState_Vtbl {
         iid == &<ISyncSessionState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncSessionState2_Impl: Sized + ISyncSessionState_Impl {
     fn SetProviderWithError(&self, fself: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3625,6 +3703,7 @@ impl ISyncSessionState2_Vtbl {
         iid == &<ISyncSessionState2 as ::windows::core::Interface>::IID || iid == &<ISyncSessionState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_WindowsSync\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISynchronousDataRetriever_Impl: Sized {
     fn GetIdParameters(&self, pidparameters: *mut ID_PARAMETERS) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IEnumWbemClassObject_Impl: Sized {
     fn Reset(&self) -> ::windows::core::Result<()>;
     fn Next(&self, ltimeout: i32, ucount: u32, apobjects: *mut ::core::option::Option<IWbemClassObject>, pureturned: *mut u32) -> ::windows::core::HRESULT;
@@ -52,6 +53,7 @@ impl IEnumWbemClassObject_Vtbl {
         iid == &<IEnumWbemClassObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IMofCompiler_Impl: Sized {
     fn CompileFile(&self, filename: &::windows::core::PCWSTR, serverandnamespace: &::windows::core::PCWSTR, user: &::windows::core::PCWSTR, authority: &::windows::core::PCWSTR, password: &::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::Result<()>;
     fn CompileBuffer(&self, buffsize: i32, pbuffer: *const u8, serverandnamespace: &::windows::core::PCWSTR, user: &::windows::core::PCWSTR, authority: &::windows::core::PCWSTR, password: &::windows::core::PCWSTR, loptionflags: i32, lclassflags: i32, linstanceflags: i32, pinfo: *mut WBEM_COMPILE_STATUS_INFO) -> ::windows::core::Result<()>;
@@ -86,6 +88,7 @@ impl IMofCompiler_Vtbl {
         iid == &<IMofCompiler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemDateTime_Impl: Sized + super::Com::IDispatch_Impl {
     fn Value(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -502,6 +505,7 @@ impl ISWbemDateTime_Vtbl {
         iid == &<ISWbemDateTime as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemEventSource_Impl: Sized + super::Com::IDispatch_Impl {
     fn NextEvent(&self, itimeoutms: i32) -> ::windows::core::Result<ISWbemObject>;
@@ -544,6 +548,7 @@ impl ISWbemEventSource_Vtbl {
         iid == &<ISWbemEventSource as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemLastError_Impl: Sized + ISWbemObject_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -557,6 +562,7 @@ impl ISWbemLastError_Vtbl {
         iid == &<ISWbemLastError as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISWbemObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemLocator_Impl: Sized + super::Com::IDispatch_Impl {
     fn ConnectServer(&self, strserver: &::windows::core::BSTR, strnamespace: &::windows::core::BSTR, struser: &::windows::core::BSTR, strpassword: &::windows::core::BSTR, strlocale: &::windows::core::BSTR, strauthority: &::windows::core::BSTR, isecurityflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<ISWbemServices>;
@@ -599,6 +605,7 @@ impl ISWbemLocator_Vtbl {
         iid == &<ISWbemLocator as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemMethod_Impl: Sized + super::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -680,6 +687,7 @@ impl ISWbemMethod_Vtbl {
         iid == &<ISWbemMethod as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemMethodSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -735,6 +743,7 @@ impl ISWbemMethodSet_Vtbl {
         iid == &<ISWbemMethodSet as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemNamedValue_Impl: Sized + super::Com::IDispatch_Impl {
     fn Value(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -784,6 +793,7 @@ impl ISWbemNamedValue_Vtbl {
         iid == &<ISWbemNamedValue as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemNamedValueSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -879,6 +889,7 @@ impl ISWbemNamedValueSet_Vtbl {
         iid == &<ISWbemNamedValueSet as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemObject_Impl: Sized + super::Com::IDispatch_Impl {
     fn Put_(&self, iflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<ISWbemObjectPath>;
@@ -1186,6 +1197,7 @@ impl ISWbemObject_Vtbl {
         iid == &<ISWbemObject as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemObjectEx_Impl: Sized + ISWbemObject_Impl {
     fn Refresh_(&self, iflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -1242,6 +1254,7 @@ impl ISWbemObjectEx_Vtbl {
         iid == &<ISWbemObjectEx as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISWbemObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemObjectPath_Impl: Sized + super::Com::IDispatch_Impl {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1497,6 +1510,7 @@ impl ISWbemObjectPath_Vtbl {
         iid == &<ISWbemObjectPath as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemObjectSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1578,6 +1592,7 @@ impl ISWbemObjectSet_Vtbl {
         iid == &<ISWbemObjectSet as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemPrivilege_Impl: Sized + super::Com::IDispatch_Impl {
     fn IsEnabled(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -1653,6 +1668,7 @@ impl ISWbemPrivilege_Vtbl {
         iid == &<ISWbemPrivilege as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemPrivilegeSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1748,6 +1764,7 @@ impl ISWbemPrivilegeSet_Vtbl {
         iid == &<ISWbemPrivilegeSet as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemProperty_Impl: Sized + super::Com::IDispatch_Impl {
     fn Value(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -1862,6 +1879,7 @@ impl ISWbemProperty_Vtbl {
         iid == &<ISWbemProperty as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemPropertySet_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -1937,6 +1955,7 @@ impl ISWbemPropertySet_Vtbl {
         iid == &<ISWbemPropertySet as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemQualifier_Impl: Sized + super::Com::IDispatch_Impl {
     fn Value(&self) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -2072,6 +2091,7 @@ impl ISWbemQualifier_Vtbl {
         iid == &<ISWbemQualifier as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemQualifierSet_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -2147,6 +2167,7 @@ impl ISWbemQualifierSet_Vtbl {
         iid == &<ISWbemQualifierSet as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemRefreshableItem_Impl: Sized + super::Com::IDispatch_Impl {
     fn Index(&self) -> ::windows::core::Result<i32>;
@@ -2235,6 +2256,7 @@ impl ISWbemRefreshableItem_Vtbl {
         iid == &<ISWbemRefreshableItem as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemRefresher_Impl: Sized + super::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -2357,6 +2379,7 @@ impl ISWbemRefresher_Vtbl {
         iid == &<ISWbemRefresher as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemSecurity_Impl: Sized + super::Com::IDispatch_Impl {
     fn ImpersonationLevel(&self) -> ::windows::core::Result<WbemImpersonationLevelEnum>;
@@ -2426,6 +2449,7 @@ impl ISWbemSecurity_Vtbl {
         iid == &<ISWbemSecurity as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemServices_Impl: Sized + super::Com::IDispatch_Impl {
     fn Get(&self, strobjectpath: &::windows::core::BSTR, iflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<ISWbemObject>;
@@ -2644,6 +2668,7 @@ impl ISWbemServices_Vtbl {
         iid == &<ISWbemServices as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemServicesEx_Impl: Sized + ISWbemServices_Impl {
     fn Put(&self, objwbemobject: &::core::option::Option<ISWbemObjectEx>, iflags: i32, objwbemnamedvalueset: &::core::option::Option<super::Com::IDispatch>) -> ::windows::core::Result<ISWbemObjectPath>;
@@ -2676,6 +2701,7 @@ impl ISWbemServicesEx_Vtbl {
         iid == &<ISWbemServicesEx as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ISWbemServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemSink_Impl: Sized + super::Com::IDispatch_Impl {
     fn Cancel(&self) -> ::windows::core::Result<()>;
@@ -2696,6 +2722,7 @@ impl ISWbemSink_Vtbl {
         iid == &<ISWbemSink as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISWbemSinkEvents_Impl: Sized + super::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -2709,6 +2736,7 @@ impl ISWbemSinkEvents_Vtbl {
         iid == &<ISWbemSinkEvents as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IUnsecuredApartment_Impl: Sized {
     fn CreateObjectStub(&self, pobject: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -2732,6 +2760,7 @@ impl IUnsecuredApartment_Vtbl {
         iid == &<IUnsecuredApartment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWMIExtension_Impl: Sized + super::Com::IDispatch_Impl {
     fn WMIObjectPath(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2787,6 +2816,7 @@ impl IWMIExtension_Vtbl {
         iid == &<IWMIExtension as ::windows::core::Interface>::IID || iid == &<super::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemAddressResolution_Impl: Sized {
     fn Resolve(&self, wsznamespacepath: &::windows::core::PCWSTR, wszaddresstype: ::windows::core::PWSTR, pdwaddresslength: *mut u32, pabbinaryaddress: *mut *mut u8) -> ::windows::core::Result<()>;
 }
@@ -2804,6 +2834,7 @@ impl IWbemAddressResolution_Vtbl {
         iid == &<IWbemAddressResolution as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemBackupRestore_Impl: Sized {
     fn Backup(&self, strbackuptofile: &::windows::core::PCWSTR, lflags: i32) -> ::windows::core::Result<()>;
     fn Restore(&self, strrestorefromfile: &::windows::core::PCWSTR, lflags: i32) -> ::windows::core::Result<()>;
@@ -2831,6 +2862,7 @@ impl IWbemBackupRestore_Vtbl {
         iid == &<IWbemBackupRestore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemBackupRestoreEx_Impl: Sized + IWbemBackupRestore_Impl {
     fn Pause(&self) -> ::windows::core::Result<()>;
     fn Resume(&self) -> ::windows::core::Result<()>;
@@ -2858,6 +2890,7 @@ impl IWbemBackupRestoreEx_Vtbl {
         iid == &<IWbemBackupRestoreEx as ::windows::core::Interface>::IID || iid == &<IWbemBackupRestore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemCallResult_Impl: Sized {
     fn GetResultObject(&self, ltimeout: i32) -> ::windows::core::Result<IWbemClassObject>;
     fn GetResultString(&self, ltimeout: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2923,6 +2956,7 @@ impl IWbemCallResult_Vtbl {
         iid == &<IWbemCallResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWbemClassObject_Impl: Sized {
     fn GetQualifierSet(&self) -> ::windows::core::Result<IWbemQualifierSet>;
@@ -3167,6 +3201,7 @@ impl IWbemClassObject_Vtbl {
         iid == &<IWbemClassObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemClientConnectionTransport_Impl: Sized {
     fn Open(&self, straddresstype: &::windows::core::BSTR, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strobject: &::windows::core::BSTR, struser: &::windows::core::BSTR, strpassword: &::windows::core::BSTR, strlocale: &::windows::core::BSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void, pcallres: *mut ::core::option::Option<IWbemCallResult>) -> ::windows::core::Result<()>;
     fn OpenAsync(&self, straddresstype: &::windows::core::BSTR, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strobject: &::windows::core::BSTR, struser: &::windows::core::BSTR, strpassword: &::windows::core::BSTR, strlocale: &::windows::core::BSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, riid: *const ::windows::core::GUID, presponsehandler: &::core::option::Option<IWbemObjectSink>) -> ::windows::core::Result<()>;
@@ -3202,6 +3237,7 @@ impl IWbemClientConnectionTransport_Vtbl {
         iid == &<IWbemClientConnectionTransport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemClientTransport_Impl: Sized {
     fn ConnectServer(&self, straddresstype: &::windows::core::BSTR, dwbinaryaddresslength: u32, abbinaryaddress: *const u8, strnetworkresource: &::windows::core::BSTR, struser: &::windows::core::BSTR, strpassword: &::windows::core::BSTR, strlocale: &::windows::core::BSTR, lsecurityflags: i32, strauthority: &::windows::core::BSTR, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
 }
@@ -3225,6 +3261,7 @@ impl IWbemClientTransport_Vtbl {
         iid == &<IWbemClientTransport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemConfigureRefresher_Impl: Sized {
     fn AddObjectByPath(&self, pnamespace: &::core::option::Option<IWbemServices>, wszpath: &::windows::core::PCWSTR, lflags: i32, pcontext: &::core::option::Option<IWbemContext>, pprefreshable: *mut ::core::option::Option<IWbemClassObject>, plid: *mut i32) -> ::windows::core::Result<()>;
     fn AddObjectByTemplate(&self, pnamespace: &::core::option::Option<IWbemServices>, ptemplate: &::core::option::Option<IWbemClassObject>, lflags: i32, pcontext: &::core::option::Option<IWbemContext>, pprefreshable: *mut ::core::option::Option<IWbemClassObject>, plid: *mut i32) -> ::windows::core::Result<()>;
@@ -3273,6 +3310,7 @@ impl IWbemConfigureRefresher_Vtbl {
         iid == &<IWbemConfigureRefresher as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemConnectorLogin_Impl: Sized {
     fn ConnectorLogin(&self, wsznetworkresource: &::windows::core::PCWSTR, wszpreferredlocale: &::windows::core::PCWSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, riid: *const ::windows::core::GUID, pinterface: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -3290,6 +3328,7 @@ impl IWbemConnectorLogin_Vtbl {
         iid == &<IWbemConnectorLogin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemConstructClassObject_Impl: Sized {
     fn SetInheritanceChain(&self, lnumantecedents: i32, awszantecedents: *const ::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn SetPropertyOrigin(&self, wszpropertyname: &::windows::core::PCWSTR, loriginindex: i32) -> ::windows::core::Result<()>;
@@ -3331,6 +3370,7 @@ impl IWbemConstructClassObject_Vtbl {
         iid == &<IWbemConstructClassObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWbemContext_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IWbemContext>;
@@ -3428,6 +3468,7 @@ impl IWbemContext_Vtbl {
         iid == &<IWbemContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemDecoupledBasicEventProvider_Impl: Sized + IWbemDecoupledRegistrar_Impl {
     fn GetSink(&self, a_flags: i32, a_context: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemObjectSink>;
     fn GetService(&self, a_flags: i32, a_context: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
@@ -3467,6 +3508,7 @@ impl IWbemDecoupledBasicEventProvider_Vtbl {
         iid == &<IWbemDecoupledBasicEventProvider as ::windows::core::Interface>::IID || iid == &<IWbemDecoupledRegistrar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemDecoupledRegistrar_Impl: Sized {
     fn Register(&self, a_flags: i32, a_context: &::core::option::Option<IWbemContext>, a_user: &::windows::core::PCWSTR, a_locale: &::windows::core::PCWSTR, a_scope: &::windows::core::PCWSTR, a_registration: &::windows::core::PCWSTR, piunknown: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn UnRegister(&self) -> ::windows::core::Result<()>;
@@ -3494,6 +3536,7 @@ impl IWbemDecoupledRegistrar_Vtbl {
         iid == &<IWbemDecoupledRegistrar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemEventConsumerProvider_Impl: Sized {
     fn FindConsumer(&self, plogicalconsumer: &::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<IWbemUnboundObjectSink>;
 }
@@ -3517,6 +3560,7 @@ impl IWbemEventConsumerProvider_Vtbl {
         iid == &<IWbemEventConsumerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemEventProvider_Impl: Sized {
     fn ProvideEvents(&self, psink: &::core::option::Option<IWbemObjectSink>, lflags: i32) -> ::windows::core::Result<()>;
 }
@@ -3534,6 +3578,7 @@ impl IWbemEventProvider_Vtbl {
         iid == &<IWbemEventProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemEventProviderQuerySink_Impl: Sized {
     fn NewQuery(&self, dwid: u32, wszquerylanguage: *const u16, wszquery: *const u16) -> ::windows::core::Result<()>;
     fn CancelQuery(&self, dwid: u32) -> ::windows::core::Result<()>;
@@ -3561,6 +3606,7 @@ impl IWbemEventProviderQuerySink_Vtbl {
         iid == &<IWbemEventProviderQuerySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemEventProviderSecurity_Impl: Sized {
     fn AccessCheck(&self, wszquerylanguage: *const u16, wszquery: *const u16, lsidlength: i32, psid: *const u8) -> ::windows::core::Result<()>;
 }
@@ -3578,6 +3624,7 @@ impl IWbemEventProviderSecurity_Vtbl {
         iid == &<IWbemEventProviderSecurity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemEventSink_Impl: Sized + IWbemObjectSink_Impl {
     fn SetSinkSecurity(&self, lsdlength: i32, psd: *const u8) -> ::windows::core::Result<()>;
     fn IsActive(&self) -> ::windows::core::Result<()>;
@@ -3625,6 +3672,7 @@ impl IWbemEventSink_Vtbl {
         iid == &<IWbemEventSink as ::windows::core::Interface>::IID || iid == &<IWbemObjectSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemHiPerfEnum_Impl: Sized {
     fn AddObjects(&self, lflags: i32, unumobjects: u32, apids: *const i32, apobj: *const ::core::option::Option<IWbemObjectAccess>) -> ::windows::core::Result<()>;
     fn RemoveObjects(&self, lflags: i32, unumobjects: u32, apids: *const i32) -> ::windows::core::Result<()>;
@@ -3666,6 +3714,7 @@ impl IWbemHiPerfEnum_Vtbl {
         iid == &<IWbemHiPerfEnum as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemHiPerfProvider_Impl: Sized {
     fn QueryInstances(&self, pnamespace: &::core::option::Option<IWbemServices>, wszclass: &::windows::core::PCWSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, psink: &::core::option::Option<IWbemObjectSink>) -> ::windows::core::Result<()>;
     fn CreateRefresher(&self, pnamespace: &::core::option::Option<IWbemServices>, lflags: i32) -> ::windows::core::Result<IWbemRefresher>;
@@ -3733,6 +3782,7 @@ impl IWbemHiPerfProvider_Vtbl {
         iid == &<IWbemHiPerfProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemLevel1Login_Impl: Sized {
     fn EstablishPosition(&self, wszlocalelist: &::windows::core::PCWSTR, dwnumlocales: u32) -> ::windows::core::Result<u32>;
     fn RequestChallenge(&self, wsznetworkresource: &::windows::core::PCWSTR, wszuser: &::windows::core::PCWSTR) -> ::windows::core::Result<u8>;
@@ -3798,6 +3848,7 @@ impl IWbemLevel1Login_Vtbl {
         iid == &<IWbemLevel1Login as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemLocator_Impl: Sized {
     fn ConnectServer(&self, strnetworkresource: &::windows::core::BSTR, struser: &::windows::core::BSTR, strpassword: &::windows::core::BSTR, strlocale: &::windows::core::BSTR, lsecurityflags: i32, strauthority: &::windows::core::BSTR, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemServices>;
 }
@@ -3821,6 +3872,7 @@ impl IWbemLocator_Vtbl {
         iid == &<IWbemLocator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWbemObjectAccess_Impl: Sized + IWbemClassObject_Impl {
     fn GetPropertyHandle(&self, wszpropertyname: &::windows::core::PCWSTR, ptype: *mut i32, plhandle: *mut i32) -> ::windows::core::Result<()>;
@@ -3919,6 +3971,7 @@ impl IWbemObjectAccess_Vtbl {
         iid == &<IWbemObjectAccess as ::windows::core::Interface>::IID || iid == &<IWbemClassObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemObjectSink_Impl: Sized {
     fn Indicate(&self, lobjectcount: i32, apobjarray: *const ::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<()>;
     fn SetStatus(&self, lflags: i32, hresult: ::windows::core::HRESULT, strparam: &::windows::core::BSTR, pobjparam: &::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<()>;
@@ -3946,6 +3999,7 @@ impl IWbemObjectSink_Vtbl {
         iid == &<IWbemObjectSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWbemObjectSinkEx_Impl: Sized + IWbemObjectSink_Impl {
     fn WriteMessage(&self, uchannel: u32, strmessage: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4009,6 +4063,7 @@ impl IWbemObjectSinkEx_Vtbl {
         iid == &<IWbemObjectSinkEx as ::windows::core::Interface>::IID || iid == &<IWbemObjectSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemObjectTextSrc_Impl: Sized {
     fn GetText(&self, lflags: i32, pobj: &::core::option::Option<IWbemClassObject>, uobjtextformat: u32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<::windows::core::BSTR>;
     fn CreateFromText(&self, lflags: i32, strtext: &::windows::core::BSTR, uobjtextformat: u32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<IWbemClassObject>;
@@ -4048,6 +4103,7 @@ impl IWbemObjectTextSrc_Vtbl {
         iid == &<IWbemObjectTextSrc as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWbemPath_Impl: Sized {
     fn SetText(&self, umode: u32, pszpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -4270,6 +4326,7 @@ impl IWbemPath_Vtbl {
         iid == &<IWbemPath as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWbemPathKeyList_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -4368,6 +4425,7 @@ impl IWbemPathKeyList_Vtbl {
         iid == &<IWbemPathKeyList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWbemPropertyProvider_Impl: Sized {
     fn GetProperty(&self, lflags: i32, strlocale: &::windows::core::BSTR, strclassmapping: &::windows::core::BSTR, strinstmapping: &::windows::core::BSTR, strpropmapping: &::windows::core::BSTR) -> ::windows::core::Result<super::Com::VARIANT>;
@@ -4404,6 +4462,7 @@ impl IWbemPropertyProvider_Vtbl {
         iid == &<IWbemPropertyProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemProviderIdentity_Impl: Sized {
     fn SetRegistrationObject(&self, lflags: i32, pprovreg: &::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<()>;
 }
@@ -4421,6 +4480,7 @@ impl IWbemProviderIdentity_Vtbl {
         iid == &<IWbemProviderIdentity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemProviderInit_Impl: Sized {
     fn Initialize(&self, wszuser: &::windows::core::PCWSTR, lflags: i32, wsznamespace: &::windows::core::PCWSTR, wszlocale: &::windows::core::PCWSTR, pnamespace: &::core::option::Option<IWbemServices>, pctx: &::core::option::Option<IWbemContext>, pinitsink: &::core::option::Option<IWbemProviderInitSink>) -> ::windows::core::Result<()>;
 }
@@ -4438,6 +4498,7 @@ impl IWbemProviderInit_Vtbl {
         iid == &<IWbemProviderInit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemProviderInitSink_Impl: Sized {
     fn SetStatus(&self, lstatus: i32, lflags: i32) -> ::windows::core::Result<()>;
 }
@@ -4455,6 +4516,7 @@ impl IWbemProviderInitSink_Vtbl {
         iid == &<IWbemProviderInitSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWbemQualifierSet_Impl: Sized {
     fn Get(&self, wszname: &::windows::core::PCWSTR, lflags: i32, pval: *mut super::Com::VARIANT, plflavor: *mut i32) -> ::windows::core::Result<()>;
@@ -4526,6 +4588,7 @@ impl IWbemQualifierSet_Vtbl {
         iid == &<IWbemQualifierSet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemQuery_Impl: Sized {
     fn Empty(&self) -> ::windows::core::Result<()>;
     fn SetLanguageFeatures(&self, uflags: u32, uarraysize: u32, pufeatures: *const u32) -> ::windows::core::Result<()>;
@@ -4588,6 +4651,7 @@ impl IWbemQuery_Vtbl {
         iid == &<IWbemQuery as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemRefresher_Impl: Sized {
     fn Refresh(&self, lflags: i32) -> ::windows::core::Result<()>;
 }
@@ -4605,6 +4669,7 @@ impl IWbemRefresher_Vtbl {
         iid == &<IWbemRefresher as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemServices_Impl: Sized {
     fn OpenNamespace(&self, strnamespace: &::windows::core::BSTR, lflags: i32, pctx: &::core::option::Option<IWbemContext>, ppworkingnamespace: *mut ::core::option::Option<IWbemServices>, ppresult: *mut ::core::option::Option<IWbemCallResult>) -> ::windows::core::Result<()>;
     fn CancelAsyncCall(&self, psink: &::core::option::Option<IWbemObjectSink>) -> ::windows::core::Result<()>;
@@ -4809,6 +4874,7 @@ impl IWbemServices_Vtbl {
         iid == &<IWbemServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemShutdown_Impl: Sized {
     fn Shutdown(&self, ureason: i32, umaxmilliseconds: u32, pctx: &::core::option::Option<IWbemContext>) -> ::windows::core::Result<()>;
 }
@@ -4826,6 +4892,7 @@ impl IWbemShutdown_Vtbl {
         iid == &<IWbemShutdown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemStatusCodeText_Impl: Sized {
     fn GetErrorCodeText(&self, hres: ::windows::core::HRESULT, localeid: u32, lflags: i32) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetFacilityCodeText(&self, hres: ::windows::core::HRESULT, localeid: u32, lflags: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4865,6 +4932,7 @@ impl IWbemStatusCodeText_Vtbl {
         iid == &<IWbemStatusCodeText as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemTransport_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
 }
@@ -4882,6 +4950,7 @@ impl IWbemTransport_Vtbl {
         iid == &<IWbemTransport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemUnboundObjectSink_Impl: Sized {
     fn IndicateToConsumer(&self, plogicalconsumer: &::core::option::Option<IWbemClassObject>, lnumobjects: i32, apobjects: *const ::core::option::Option<IWbemClassObject>) -> ::windows::core::Result<()>;
 }
@@ -4899,6 +4968,7 @@ impl IWbemUnboundObjectSink_Vtbl {
         iid == &<IWbemUnboundObjectSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_System_Wmi\"`, `\"implement\"`*"]
 pub trait IWbemUnsecuredApartment_Impl: Sized + IUnsecuredApartment_Impl {
     fn CreateSinkStub(&self, psink: &::core::option::Option<IWbemObjectSink>, dwflags: u32, wszreserved: &::windows::core::PCWSTR) -> ::windows::core::Result<IWbemObjectSink>;
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IAccIdentity_Impl: Sized {
     fn GetIdentityString(&self, dwidchild: u32, ppidstring: *mut *mut u8, pdwidstringlen: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IAccIdentity_Vtbl {
         iid == &<IAccIdentity as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAccPropServer_Impl: Sized {
     fn GetPropValue(&self, pidstring: *const u8, dwidstringlen: u32, idprop: &::windows::core::GUID, pvarvalue: *mut super::super::System::Com::VARIANT, pfhasprop: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -35,6 +37,7 @@ impl IAccPropServer_Vtbl {
         iid == &<IAccPropServer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IAccPropServices_Impl: Sized {
     fn SetPropValue(&self, pidstring: *const u8, dwidstringlen: u32, idprop: &::windows::core::GUID, var: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -156,6 +159,7 @@ impl IAccPropServices_Vtbl {
         iid == &<IAccPropServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAccessible_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn accParent(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -409,6 +413,7 @@ impl IAccessible_Vtbl {
         iid == &<IAccessible as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAccessibleEx_Impl: Sized {
     fn GetObjectForChild(&self, idchild: i32) -> ::windows::core::Result<IAccessibleEx>;
@@ -471,6 +476,7 @@ impl IAccessibleEx_Vtbl {
         iid == &<IAccessibleEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAccessibleHandler_Impl: Sized {
     fn AccessibleObjectFromID(&self, hwnd: i32, lobjectid: i32) -> ::windows::core::Result<IAccessible>;
@@ -497,6 +503,7 @@ impl IAccessibleHandler_Vtbl {
         iid == &<IAccessibleHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAccessibleHostingElementProviders_Impl: Sized {
     fn GetEmbeddedFragmentRoots(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -539,6 +546,7 @@ impl IAccessibleHostingElementProviders_Vtbl {
         iid == &<IAccessibleHostingElementProviders as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAccessibleWindowlessSite_Impl: Sized {
     fn AcquireObjectIdRange(&self, rangesize: i32, prangeowner: &::core::option::Option<IAccessibleHandler>) -> ::windows::core::Result<i32>;
@@ -601,6 +609,7 @@ impl IAccessibleWindowlessSite_Vtbl {
         iid == &<IAccessibleWindowlessSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IAnnotationProvider_Impl: Sized {
     fn AnnotationTypeId(&self) -> ::windows::core::Result<UIA_ANNOTATIONTYPE>;
     fn AnnotationTypeName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -679,6 +688,7 @@ impl IAnnotationProvider_Vtbl {
         iid == &<IAnnotationProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait ICustomNavigationProvider_Impl: Sized {
     fn Navigate(&self, direction: NavigateDirection) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
@@ -702,6 +712,7 @@ impl ICustomNavigationProvider_Vtbl {
         iid == &<ICustomNavigationProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IDockProvider_Impl: Sized {
     fn SetDockPosition(&self, dockposition: DockPosition) -> ::windows::core::Result<()>;
     fn DockPosition(&self) -> ::windows::core::Result<DockPosition>;
@@ -735,6 +746,7 @@ impl IDockProvider_Vtbl {
         iid == &<IDockProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDragProvider_Impl: Sized {
     fn IsGrabbed(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -803,6 +815,7 @@ impl IDragProvider_Vtbl {
         iid == &<IDragProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDropTargetProvider_Impl: Sized {
     fn DropTargetEffect(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -845,6 +858,7 @@ impl IDropTargetProvider_Vtbl {
         iid == &<IDropTargetProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IExpandCollapseProvider_Impl: Sized {
     fn Expand(&self) -> ::windows::core::Result<()>;
     fn Collapse(&self) -> ::windows::core::Result<()>;
@@ -885,6 +899,7 @@ impl IExpandCollapseProvider_Vtbl {
         iid == &<IExpandCollapseProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IGridItemProvider_Impl: Sized {
     fn Row(&self) -> ::windows::core::Result<i32>;
     fn Column(&self) -> ::windows::core::Result<i32>;
@@ -963,6 +978,7 @@ impl IGridItemProvider_Vtbl {
         iid == &<IGridItemProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IGridProvider_Impl: Sized {
     fn GetItem(&self, row: i32, column: i32) -> ::windows::core::Result<IRawElementProviderSimple>;
     fn RowCount(&self) -> ::windows::core::Result<i32>;
@@ -1015,6 +1031,7 @@ impl IGridProvider_Vtbl {
         iid == &<IGridProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IInvokeProvider_Impl: Sized {
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
@@ -1032,6 +1049,7 @@ impl IInvokeProvider_Vtbl {
         iid == &<IInvokeProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IItemContainerProvider_Impl: Sized {
     fn FindItemByProperty(&self, pstartafter: &::core::option::Option<IRawElementProviderSimple>, propertyid: UIA_PROPERTY_ID, value: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IRawElementProviderSimple>;
@@ -1058,6 +1076,7 @@ impl IItemContainerProvider_Vtbl {
         iid == &<IItemContainerProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ILegacyIAccessibleProvider_Impl: Sized {
     fn Select(&self, flagsselect: i32) -> ::windows::core::Result<()>;
@@ -1238,6 +1257,7 @@ impl ILegacyIAccessibleProvider_Vtbl {
         iid == &<ILegacyIAccessibleProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IMultipleViewProvider_Impl: Sized {
     fn GetViewName(&self, viewid: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -1300,6 +1320,7 @@ impl IMultipleViewProvider_Vtbl {
         iid == &<IMultipleViewProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IObjectModelProvider_Impl: Sized {
     fn GetUnderlyingObjectModel(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -1323,6 +1344,7 @@ impl IObjectModelProvider_Vtbl {
         iid == &<IObjectModelProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProxyProviderWinEventHandler_Impl: Sized {
     fn RespondToWinEvent(&self, idwinevent: u32, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32, psink: &::core::option::Option<IProxyProviderWinEventSink>) -> ::windows::core::Result<()>;
@@ -1343,6 +1365,7 @@ impl IProxyProviderWinEventHandler_Vtbl {
         iid == &<IProxyProviderWinEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IProxyProviderWinEventSink_Impl: Sized {
     fn AddAutomationPropertyChangedEvent(&self, pprovider: &::core::option::Option<IRawElementProviderSimple>, id: UIA_PROPERTY_ID, newvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -1380,6 +1403,7 @@ impl IProxyProviderWinEventSink_Vtbl {
         iid == &<IProxyProviderWinEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRangeValueProvider_Impl: Sized {
     fn SetValue(&self, val: f64) -> ::windows::core::Result<()>;
@@ -1481,6 +1505,7 @@ impl IRangeValueProvider_Vtbl {
         iid == &<IRangeValueProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRawElementProviderAdviseEvents_Impl: Sized {
     fn AdviseEventAdded(&self, eventid: UIA_EVENT_ID, propertyids: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -1511,6 +1536,7 @@ impl IRawElementProviderAdviseEvents_Vtbl {
         iid == &<IRawElementProviderAdviseEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRawElementProviderFragment_Impl: Sized {
     fn Navigate(&self, direction: NavigateDirection) -> ::windows::core::Result<IRawElementProviderFragment>;
@@ -1599,6 +1625,7 @@ impl IRawElementProviderFragment_Vtbl {
         iid == &<IRawElementProviderFragment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IRawElementProviderFragmentRoot_Impl: Sized {
     fn ElementProviderFromPoint(&self, x: f64, y: f64) -> ::windows::core::Result<IRawElementProviderFragment>;
     fn GetFocus(&self) -> ::windows::core::Result<IRawElementProviderFragment>;
@@ -1638,6 +1665,7 @@ impl IRawElementProviderFragmentRoot_Vtbl {
         iid == &<IRawElementProviderFragmentRoot as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRawElementProviderHostingAccessibles_Impl: Sized {
     fn GetEmbeddedAccessibles(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -1664,6 +1692,7 @@ impl IRawElementProviderHostingAccessibles_Vtbl {
         iid == &<IRawElementProviderHostingAccessibles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRawElementProviderHwndOverride_Impl: Sized {
     fn GetOverrideProviderForHwnd(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<IRawElementProviderSimple>;
@@ -1693,6 +1722,7 @@ impl IRawElementProviderHwndOverride_Vtbl {
         iid == &<IRawElementProviderHwndOverride as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRawElementProviderSimple_Impl: Sized {
     fn ProviderOptions(&self) -> ::windows::core::Result<ProviderOptions>;
@@ -1761,6 +1791,7 @@ impl IRawElementProviderSimple_Vtbl {
         iid == &<IRawElementProviderSimple as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRawElementProviderSimple2_Impl: Sized + IRawElementProviderSimple_Impl {
     fn ShowContextMenu(&self) -> ::windows::core::Result<()>;
@@ -1781,6 +1812,7 @@ impl IRawElementProviderSimple2_Vtbl {
         iid == &<IRawElementProviderSimple2 as ::windows::core::Interface>::IID || iid == &<IRawElementProviderSimple as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRawElementProviderSimple3_Impl: Sized + IRawElementProviderSimple2_Impl {
     fn GetMetadataValue(&self, targetid: i32, metadataid: UIA_METADATA_ID) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -1807,6 +1839,7 @@ impl IRawElementProviderSimple3_Vtbl {
         iid == &<IRawElementProviderSimple3 as ::windows::core::Interface>::IID || iid == &<IRawElementProviderSimple as ::windows::core::Interface>::IID || iid == &<IRawElementProviderSimple2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IRawElementProviderWindowlessSite_Impl: Sized {
     fn GetAdjacentFragment(&self, direction: NavigateDirection) -> ::windows::core::Result<IRawElementProviderFragment>;
@@ -1849,6 +1882,7 @@ impl IRawElementProviderWindowlessSite_Vtbl {
         iid == &<IRawElementProviderWindowlessSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IRichEditUiaInformation_Impl: Sized {
     fn GetBoundaryRectangle(&self, puiarect: *mut UiaRect) -> ::windows::core::Result<()>;
     fn IsVisible(&self) -> ::windows::core::Result<()>;
@@ -1876,6 +1910,7 @@ impl IRichEditUiaInformation_Vtbl {
         iid == &<IRichEditUiaInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IRicheditWindowlessAccessibility_Impl: Sized {
     fn CreateProvider(&self, psite: &::core::option::Option<IRawElementProviderWindowlessSite>) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
@@ -1899,6 +1934,7 @@ impl IRicheditWindowlessAccessibility_Vtbl {
         iid == &<IRicheditWindowlessAccessibility as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IScrollItemProvider_Impl: Sized {
     fn ScrollIntoView(&self) -> ::windows::core::Result<()>;
 }
@@ -1916,6 +1952,7 @@ impl IScrollItemProvider_Vtbl {
         iid == &<IScrollItemProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IScrollProvider_Impl: Sized {
     fn Scroll(&self, horizontalamount: ScrollAmount, verticalamount: ScrollAmount) -> ::windows::core::Result<()>;
@@ -2024,6 +2061,7 @@ impl IScrollProvider_Vtbl {
         iid == &<IScrollProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISelectionItemProvider_Impl: Sized {
     fn Select(&self) -> ::windows::core::Result<()>;
@@ -2087,6 +2125,7 @@ impl ISelectionItemProvider_Vtbl {
         iid == &<ISelectionItemProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISelectionProvider_Impl: Sized {
     fn GetSelection(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -2142,6 +2181,7 @@ impl ISelectionProvider_Vtbl {
         iid == &<ISelectionProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ISelectionProvider2_Impl: Sized + ISelectionProvider_Impl {
     fn FirstSelectedItem(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
@@ -2210,6 +2250,7 @@ impl ISelectionProvider2_Vtbl {
         iid == &<ISelectionProvider2 as ::windows::core::Interface>::IID || iid == &<ISelectionProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISpreadsheetItemProvider_Impl: Sized {
     fn Formula(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2265,6 +2306,7 @@ impl ISpreadsheetItemProvider_Vtbl {
         iid == &<ISpreadsheetItemProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait ISpreadsheetProvider_Impl: Sized {
     fn GetItemByName(&self, name: &::windows::core::PCWSTR) -> ::windows::core::Result<IRawElementProviderSimple>;
 }
@@ -2288,6 +2330,7 @@ impl ISpreadsheetProvider_Vtbl {
         iid == &<ISpreadsheetProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IStylesProvider_Impl: Sized {
     fn StyleId(&self) -> ::windows::core::Result<UIA_STYLE_ID>;
     fn StyleName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2392,6 +2435,7 @@ impl IStylesProvider_Vtbl {
         iid == &<IStylesProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait ISynchronizedInputProvider_Impl: Sized {
     fn StartListening(&self, inputtype: SynchronizedInputType) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
@@ -2419,6 +2463,7 @@ impl ISynchronizedInputProvider_Vtbl {
         iid == &<ISynchronizedInputProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITableItemProvider_Impl: Sized {
     fn GetRowHeaderItems(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -2461,6 +2506,7 @@ impl ITableItemProvider_Vtbl {
         iid == &<ITableItemProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITableProvider_Impl: Sized {
     fn GetRowHeaders(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -2516,6 +2562,7 @@ impl ITableProvider_Vtbl {
         iid == &<ITableProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait ITextChildProvider_Impl: Sized {
     fn TextContainer(&self) -> ::windows::core::Result<IRawElementProviderSimple>;
     fn TextRange(&self) -> ::windows::core::Result<ITextRangeProvider>;
@@ -2555,6 +2602,7 @@ impl ITextChildProvider_Vtbl {
         iid == &<ITextChildProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITextEditProvider_Impl: Sized + ITextProvider_Impl {
     fn GetActiveComposition(&self) -> ::windows::core::Result<ITextRangeProvider>;
@@ -2597,6 +2645,7 @@ impl ITextEditProvider_Vtbl {
         iid == &<ITextEditProvider as ::windows::core::Interface>::IID || iid == &<ITextProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITextProvider_Impl: Sized {
     fn GetSelection(&self) -> ::windows::core::Result<*mut super::super::System::Com::SAFEARRAY>;
@@ -2691,6 +2740,7 @@ impl ITextProvider_Vtbl {
         iid == &<ITextProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITextProvider2_Impl: Sized + ITextProvider_Impl {
     fn RangeFromAnnotation(&self, annotationelement: &::core::option::Option<IRawElementProviderSimple>) -> ::windows::core::Result<ITextRangeProvider>;
@@ -2727,6 +2777,7 @@ impl ITextProvider2_Vtbl {
         iid == &<ITextProvider2 as ::windows::core::Interface>::IID || iid == &<ITextProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextRangeProvider_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<ITextRangeProvider>;
@@ -2941,6 +2992,7 @@ impl ITextRangeProvider_Vtbl {
         iid == &<ITextRangeProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextRangeProvider2_Impl: Sized + ITextRangeProvider_Impl {
     fn ShowContextMenu(&self) -> ::windows::core::Result<()>;
@@ -2961,6 +3013,7 @@ impl ITextRangeProvider2_Vtbl {
         iid == &<ITextRangeProvider2 as ::windows::core::Interface>::IID || iid == &<ITextRangeProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IToggleProvider_Impl: Sized {
     fn Toggle(&self) -> ::windows::core::Result<()>;
     fn ToggleState(&self) -> ::windows::core::Result<ToggleState>;
@@ -2994,6 +3047,7 @@ impl IToggleProvider_Vtbl {
         iid == &<IToggleProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransformProvider_Impl: Sized {
     fn Move(&self, x: f64, y: f64) -> ::windows::core::Result<()>;
@@ -3070,6 +3124,7 @@ impl ITransformProvider_Vtbl {
         iid == &<ITransformProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITransformProvider2_Impl: Sized + ITransformProvider_Impl {
     fn Zoom(&self, zoom: f64) -> ::windows::core::Result<()>;
@@ -3152,6 +3207,7 @@ impl ITransformProvider2_Vtbl {
         iid == &<ITransformProvider2 as ::windows::core::Interface>::IID || iid == &<ITransformProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomation_Impl: Sized {
     fn CompareElements(&self, el1: &::core::option::Option<IUIAutomationElement>, el2: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3799,6 +3855,7 @@ impl IUIAutomation_Vtbl {
         iid == &<IUIAutomation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomation2_Impl: Sized + IUIAutomation_Impl {
     fn AutoSetFocus(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3875,6 +3932,7 @@ impl IUIAutomation2_Vtbl {
         iid == &<IUIAutomation2 as ::windows::core::Interface>::IID || iid == &<IUIAutomation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomation3_Impl: Sized + IUIAutomation2_Impl {
     fn AddTextEditTextChangedEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, scope: TreeScope, texteditchangetype: TextEditChangeType, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationTextEditTextChangedEventHandler>) -> ::windows::core::Result<()>;
@@ -3905,6 +3963,7 @@ impl IUIAutomation3_Vtbl {
         iid == &<IUIAutomation3 as ::windows::core::Interface>::IID || iid == &<IUIAutomation as ::windows::core::Interface>::IID || iid == &<IUIAutomation2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomation4_Impl: Sized + IUIAutomation3_Impl {
     fn AddChangesEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, scope: TreeScope, changetypes: *const i32, changescount: i32, pcacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationChangesEventHandler>) -> ::windows::core::Result<()>;
@@ -3935,6 +3994,7 @@ impl IUIAutomation4_Vtbl {
         iid == &<IUIAutomation4 as ::windows::core::Interface>::IID || iid == &<IUIAutomation as ::windows::core::Interface>::IID || iid == &<IUIAutomation2 as ::windows::core::Interface>::IID || iid == &<IUIAutomation3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomation5_Impl: Sized + IUIAutomation4_Impl {
     fn AddNotificationEventHandler(&self, element: &::core::option::Option<IUIAutomationElement>, scope: TreeScope, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationNotificationEventHandler>) -> ::windows::core::Result<()>;
@@ -3965,6 +4025,7 @@ impl IUIAutomation5_Vtbl {
         iid == &<IUIAutomation5 as ::windows::core::Interface>::IID || iid == &<IUIAutomation as ::windows::core::Interface>::IID || iid == &<IUIAutomation2 as ::windows::core::Interface>::IID || iid == &<IUIAutomation3 as ::windows::core::Interface>::IID || iid == &<IUIAutomation4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomation6_Impl: Sized + IUIAutomation5_Impl {
     fn CreateEventHandlerGroup(&self) -> ::windows::core::Result<IUIAutomationEventHandlerGroup>;
@@ -4062,6 +4123,7 @@ impl IUIAutomation6_Vtbl {
         iid == &<IUIAutomation6 as ::windows::core::Interface>::IID || iid == &<IUIAutomation as ::windows::core::Interface>::IID || iid == &<IUIAutomation2 as ::windows::core::Interface>::IID || iid == &<IUIAutomation3 as ::windows::core::Interface>::IID || iid == &<IUIAutomation4 as ::windows::core::Interface>::IID || iid == &<IUIAutomation5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationActiveTextPositionChangedEventHandler_Impl: Sized {
     fn HandleActiveTextPositionChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, range: &::core::option::Option<IUIAutomationTextRange>) -> ::windows::core::Result<()>;
 }
@@ -4082,6 +4144,7 @@ impl IUIAutomationActiveTextPositionChangedEventHandler_Vtbl {
         iid == &<IUIAutomationActiveTextPositionChangedEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationAndCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn ChildCount(&self) -> ::windows::core::Result<i32>;
@@ -4131,6 +4194,7 @@ impl IUIAutomationAndCondition_Vtbl {
         iid == &<IUIAutomationAndCondition as ::windows::core::Interface>::IID || iid == &<IUIAutomationCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationAnnotationPattern_Impl: Sized {
     fn CurrentAnnotationTypeId(&self) -> ::windows::core::Result<UIA_ANNOTATIONTYPE>;
     fn CurrentAnnotationTypeName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4274,6 +4338,7 @@ impl IUIAutomationAnnotationPattern_Vtbl {
         iid == &<IUIAutomationAnnotationPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationBoolCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn BooleanValue(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -4300,6 +4365,7 @@ impl IUIAutomationBoolCondition_Vtbl {
         iid == &<IUIAutomationBoolCondition as ::windows::core::Interface>::IID || iid == &<IUIAutomationCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationCacheRequest_Impl: Sized {
     fn AddProperty(&self, propertyid: UIA_PROPERTY_ID) -> ::windows::core::Result<()>;
     fn AddPattern(&self, patternid: UIA_PATTERN_ID) -> ::windows::core::Result<()>;
@@ -4400,6 +4466,7 @@ impl IUIAutomationCacheRequest_Vtbl {
         iid == &<IUIAutomationCacheRequest as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationChangesEventHandler_Impl: Sized {
     fn HandleChangesEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, uiachanges: *const UiaChangeInfo, changescount: i32) -> ::windows::core::Result<()>;
@@ -4420,6 +4487,7 @@ impl IUIAutomationChangesEventHandler_Vtbl {
         iid == &<IUIAutomationChangesEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationCondition_Impl: Sized {}
 impl ::windows::core::RuntimeName for IUIAutomationCondition {}
 impl IUIAutomationCondition_Vtbl {
@@ -4430,6 +4498,7 @@ impl IUIAutomationCondition_Vtbl {
         iid == &<IUIAutomationCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationCustomNavigationPattern_Impl: Sized {
     fn Navigate(&self, direction: NavigateDirection) -> ::windows::core::Result<IUIAutomationElement>;
 }
@@ -4453,6 +4522,7 @@ impl IUIAutomationCustomNavigationPattern_Vtbl {
         iid == &<IUIAutomationCustomNavigationPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationDockPattern_Impl: Sized {
     fn SetDockPosition(&self, dockpos: DockPosition) -> ::windows::core::Result<()>;
     fn CurrentDockPosition(&self) -> ::windows::core::Result<DockPosition>;
@@ -4499,6 +4569,7 @@ impl IUIAutomationDockPattern_Vtbl {
         iid == &<IUIAutomationDockPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IUIAutomationDragPattern_Impl: Sized {
     fn CurrentIsGrabbed(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -4619,6 +4690,7 @@ impl IUIAutomationDragPattern_Vtbl {
         iid == &<IUIAutomationDragPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationDropTargetPattern_Impl: Sized {
     fn CurrentDropTargetEffect(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4687,6 +4759,7 @@ impl IUIAutomationDropTargetPattern_Vtbl {
         iid == &<IUIAutomationDropTargetPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement_Impl: Sized {
     fn SetFocus(&self) -> ::windows::core::Result<()>;
@@ -5745,6 +5818,7 @@ impl IUIAutomationElement_Vtbl {
         iid == &<IUIAutomationElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement2_Impl: Sized + IUIAutomationElement_Impl {
     fn CurrentOptimizeForVisualContent(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -5839,6 +5913,7 @@ impl IUIAutomationElement2_Vtbl {
         iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement3_Impl: Sized + IUIAutomationElement2_Impl {
     fn ShowContextMenu(&self) -> ::windows::core::Result<()>;
@@ -5888,6 +5963,7 @@ impl IUIAutomationElement3_Vtbl {
         iid == &<IUIAutomationElement3 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement4_Impl: Sized + IUIAutomationElement3_Impl {
     fn CurrentPositionInSet(&self) -> ::windows::core::Result<i32>;
@@ -6034,6 +6110,7 @@ impl IUIAutomationElement4_Vtbl {
         iid == &<IUIAutomationElement4 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement5_Impl: Sized + IUIAutomationElement4_Impl {
     fn CurrentLandmarkType(&self) -> ::windows::core::Result<UIA_LANDMARKTYPE_ID>;
@@ -6102,6 +6179,7 @@ impl IUIAutomationElement5_Vtbl {
         iid == &<IUIAutomationElement5 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement3 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement6_Impl: Sized + IUIAutomationElement5_Impl {
     fn CurrentFullDescription(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -6144,6 +6222,7 @@ impl IUIAutomationElement6_Vtbl {
         iid == &<IUIAutomationElement6 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement3 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement4 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement7_Impl: Sized + IUIAutomationElement6_Impl {
     fn FindFirstWithOptions(&self, scope: TreeScope, condition: &::core::option::Option<IUIAutomationCondition>, traversaloptions: TreeTraversalOptions, root: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<IUIAutomationElement>;
@@ -6225,6 +6304,7 @@ impl IUIAutomationElement7_Vtbl {
         iid == &<IUIAutomationElement7 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement3 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement4 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement5 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement8_Impl: Sized + IUIAutomationElement7_Impl {
     fn CurrentHeadingLevel(&self) -> ::windows::core::Result<UIA_HEADINGLEVEL_ID>;
@@ -6267,6 +6347,7 @@ impl IUIAutomationElement8_Vtbl {
         iid == &<IUIAutomationElement8 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement3 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement4 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement5 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement6 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationElement9_Impl: Sized + IUIAutomationElement8_Impl {
     fn CurrentIsDialog(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -6309,6 +6390,7 @@ impl IUIAutomationElement9_Vtbl {
         iid == &<IUIAutomationElement9 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement3 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement4 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement5 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement6 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement7 as ::windows::core::Interface>::IID || iid == &<IUIAutomationElement8 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationElementArray_Impl: Sized {
     fn Length(&self) -> ::windows::core::Result<i32>;
     fn GetElement(&self, index: i32) -> ::windows::core::Result<IUIAutomationElement>;
@@ -6348,6 +6430,7 @@ impl IUIAutomationElementArray_Vtbl {
         iid == &<IUIAutomationElementArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationEventHandler_Impl: Sized {
     fn HandleAutomationEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, eventid: UIA_EVENT_ID) -> ::windows::core::Result<()>;
 }
@@ -6365,6 +6448,7 @@ impl IUIAutomationEventHandler_Vtbl {
         iid == &<IUIAutomationEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationEventHandlerGroup_Impl: Sized {
     fn AddActiveTextPositionChangedEventHandler(&self, scope: TreeScope, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationActiveTextPositionChangedEventHandler>) -> ::windows::core::Result<()>;
     fn AddAutomationEventHandler(&self, eventid: UIA_EVENT_ID, scope: TreeScope, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>, handler: &::core::option::Option<IUIAutomationEventHandler>) -> ::windows::core::Result<()>;
@@ -6427,6 +6511,7 @@ impl IUIAutomationEventHandlerGroup_Vtbl {
         iid == &<IUIAutomationEventHandlerGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationExpandCollapsePattern_Impl: Sized {
     fn Expand(&self) -> ::windows::core::Result<()>;
     fn Collapse(&self) -> ::windows::core::Result<()>;
@@ -6480,6 +6565,7 @@ impl IUIAutomationExpandCollapsePattern_Vtbl {
         iid == &<IUIAutomationExpandCollapsePattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationFocusChangedEventHandler_Impl: Sized {
     fn HandleFocusChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<()>;
 }
@@ -6497,6 +6583,7 @@ impl IUIAutomationFocusChangedEventHandler_Vtbl {
         iid == &<IUIAutomationFocusChangedEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationGridItemPattern_Impl: Sized {
     fn CurrentContainingGrid(&self) -> ::windows::core::Result<IUIAutomationElement>;
     fn CurrentRow(&self) -> ::windows::core::Result<i32>;
@@ -6640,6 +6727,7 @@ impl IUIAutomationGridItemPattern_Vtbl {
         iid == &<IUIAutomationGridItemPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationGridPattern_Impl: Sized {
     fn GetItem(&self, row: i32, column: i32) -> ::windows::core::Result<IUIAutomationElement>;
     fn CurrentRowCount(&self) -> ::windows::core::Result<i32>;
@@ -6718,6 +6806,7 @@ impl IUIAutomationGridPattern_Vtbl {
         iid == &<IUIAutomationGridPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationInvokePattern_Impl: Sized {
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
@@ -6735,6 +6824,7 @@ impl IUIAutomationInvokePattern_Vtbl {
         iid == &<IUIAutomationInvokePattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationItemContainerPattern_Impl: Sized {
     fn FindItemByProperty(&self, pstartafter: &::core::option::Option<IUIAutomationElement>, propertyid: UIA_PROPERTY_ID, value: &super::super::System::Com::VARIANT) -> ::windows::core::Result<IUIAutomationElement>;
@@ -6761,6 +6851,7 @@ impl IUIAutomationItemContainerPattern_Vtbl {
         iid == &<IUIAutomationItemContainerPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationLegacyIAccessiblePattern_Impl: Sized {
     fn Select(&self, flagsselect: i32) -> ::windows::core::Result<()>;
@@ -7071,6 +7162,7 @@ impl IUIAutomationLegacyIAccessiblePattern_Vtbl {
         iid == &<IUIAutomationLegacyIAccessiblePattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationMultipleViewPattern_Impl: Sized {
     fn GetViewName(&self, view: i32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7159,6 +7251,7 @@ impl IUIAutomationMultipleViewPattern_Vtbl {
         iid == &<IUIAutomationMultipleViewPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationNotCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn GetChild(&self) -> ::windows::core::Result<IUIAutomationCondition>;
 }
@@ -7182,6 +7275,7 @@ impl IUIAutomationNotCondition_Vtbl {
         iid == &<IUIAutomationNotCondition as ::windows::core::Interface>::IID || iid == &<IUIAutomationCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationNotificationEventHandler_Impl: Sized {
     fn HandleNotificationEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, notificationkind: NotificationKind, notificationprocessing: NotificationProcessing, displaystring: &::windows::core::BSTR, activityid: &::windows::core::BSTR) -> ::windows::core::Result<()>;
 }
@@ -7199,6 +7293,7 @@ impl IUIAutomationNotificationEventHandler_Vtbl {
         iid == &<IUIAutomationNotificationEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationObjectModelPattern_Impl: Sized {
     fn GetUnderlyingObjectModel(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -7222,6 +7317,7 @@ impl IUIAutomationObjectModelPattern_Vtbl {
         iid == &<IUIAutomationObjectModelPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationOrCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn ChildCount(&self) -> ::windows::core::Result<i32>;
@@ -7271,6 +7367,7 @@ impl IUIAutomationOrCondition_Vtbl {
         iid == &<IUIAutomationOrCondition as ::windows::core::Interface>::IID || iid == &<IUIAutomationCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationPatternHandler_Impl: Sized {
     fn CreateClientWrapper(&self, ppatterninstance: &::core::option::Option<IUIAutomationPatternInstance>) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Dispatch(&self, ptarget: &::core::option::Option<::windows::core::IUnknown>, index: u32, pparams: *const UIAutomationParameter, cparams: u32) -> ::windows::core::Result<()>;
@@ -7304,6 +7401,7 @@ impl IUIAutomationPatternHandler_Vtbl {
         iid == &<IUIAutomationPatternHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationPatternInstance_Impl: Sized {
     fn GetProperty(&self, index: u32, cached: super::super::Foundation::BOOL, r#type: UIAutomationType, pptr: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -7334,6 +7432,7 @@ impl IUIAutomationPatternInstance_Vtbl {
         iid == &<IUIAutomationPatternInstance as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationPropertyChangedEventHandler_Impl: Sized {
     fn HandlePropertyChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, propertyid: UIA_PROPERTY_ID, newvalue: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -7357,6 +7456,7 @@ impl IUIAutomationPropertyChangedEventHandler_Vtbl {
         iid == &<IUIAutomationPropertyChangedEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationPropertyCondition_Impl: Sized + IUIAutomationCondition_Impl {
     fn PropertyId(&self) -> ::windows::core::Result<UIA_PROPERTY_ID>;
@@ -7412,6 +7512,7 @@ impl IUIAutomationPropertyCondition_Vtbl {
         iid == &<IUIAutomationPropertyCondition as ::windows::core::Interface>::IID || iid == &<IUIAutomationCondition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationProxyFactory_Impl: Sized {
     fn CreateProvider(&self, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32) -> ::windows::core::Result<IRawElementProviderSimple>;
@@ -7454,6 +7555,7 @@ impl IUIAutomationProxyFactory_Vtbl {
         iid == &<IUIAutomationProxyFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IUIAutomationProxyFactoryEntry_Impl: Sized {
     fn ProxyFactory(&self) -> ::windows::core::Result<IUIAutomationProxyFactory>;
@@ -7603,6 +7705,7 @@ impl IUIAutomationProxyFactoryEntry_Vtbl {
         iid == &<IUIAutomationProxyFactoryEntry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationProxyFactoryMapping_Impl: Sized {
     fn Count(&self) -> ::windows::core::Result<u32>;
@@ -7700,6 +7803,7 @@ impl IUIAutomationProxyFactoryMapping_Vtbl {
         iid == &<IUIAutomationProxyFactoryMapping as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationRangeValuePattern_Impl: Sized {
     fn SetValue(&self, val: f64) -> ::windows::core::Result<()>;
@@ -7879,6 +7983,7 @@ impl IUIAutomationRangeValuePattern_Vtbl {
         iid == &<IUIAutomationRangeValuePattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationRegistrar_Impl: Sized {
     fn RegisterProperty(&self, property: *const UIAutomationPropertyInfo) -> ::windows::core::Result<i32>;
@@ -7928,6 +8033,7 @@ impl IUIAutomationRegistrar_Vtbl {
         iid == &<IUIAutomationRegistrar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationScrollItemPattern_Impl: Sized {
     fn ScrollIntoView(&self) -> ::windows::core::Result<()>;
 }
@@ -7945,6 +8051,7 @@ impl IUIAutomationScrollItemPattern_Vtbl {
         iid == &<IUIAutomationScrollItemPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationScrollPattern_Impl: Sized {
     fn Scroll(&self, horizontalamount: ScrollAmount, verticalamount: ScrollAmount) -> ::windows::core::Result<()>;
@@ -8131,6 +8238,7 @@ impl IUIAutomationScrollPattern_Vtbl {
         iid == &<IUIAutomationScrollPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationSelectionItemPattern_Impl: Sized {
     fn Select(&self) -> ::windows::core::Result<()>;
@@ -8220,6 +8328,7 @@ impl IUIAutomationSelectionItemPattern_Vtbl {
         iid == &<IUIAutomationSelectionItemPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationSelectionPattern_Impl: Sized {
     fn GetCurrentSelection(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
@@ -8314,6 +8423,7 @@ impl IUIAutomationSelectionPattern_Vtbl {
         iid == &<IUIAutomationSelectionPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationSelectionPattern2_Impl: Sized + IUIAutomationSelectionPattern_Impl {
     fn CurrentFirstSelectedItem(&self) -> ::windows::core::Result<IUIAutomationElement>;
@@ -8434,6 +8544,7 @@ impl IUIAutomationSelectionPattern2_Vtbl {
         iid == &<IUIAutomationSelectionPattern2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationSelectionPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationSpreadsheetItemPattern_Impl: Sized {
     fn CurrentFormula(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -8528,6 +8639,7 @@ impl IUIAutomationSpreadsheetItemPattern_Vtbl {
         iid == &<IUIAutomationSpreadsheetItemPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationSpreadsheetPattern_Impl: Sized {
     fn GetItemByName(&self, name: &::windows::core::BSTR) -> ::windows::core::Result<IUIAutomationElement>;
 }
@@ -8551,6 +8663,7 @@ impl IUIAutomationSpreadsheetPattern_Vtbl {
         iid == &<IUIAutomationSpreadsheetPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationStructureChangedEventHandler_Impl: Sized {
     fn HandleStructureChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, changetype: StructureChangeType, runtimeid: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -8574,6 +8687,7 @@ impl IUIAutomationStructureChangedEventHandler_Vtbl {
         iid == &<IUIAutomationStructureChangedEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationStylesPattern_Impl: Sized {
     fn CurrentStyleId(&self) -> ::windows::core::Result<UIA_STYLE_ID>;
     fn CurrentStyleName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -8783,6 +8897,7 @@ impl IUIAutomationStylesPattern_Vtbl {
         iid == &<IUIAutomationStylesPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationSynchronizedInputPattern_Impl: Sized {
     fn StartListening(&self, inputtype: SynchronizedInputType) -> ::windows::core::Result<()>;
     fn Cancel(&self) -> ::windows::core::Result<()>;
@@ -8810,6 +8925,7 @@ impl IUIAutomationSynchronizedInputPattern_Vtbl {
         iid == &<IUIAutomationSynchronizedInputPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationTableItemPattern_Impl: Sized {
     fn GetCurrentRowHeaderItems(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
     fn GetCurrentColumnHeaderItems(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
@@ -8875,6 +8991,7 @@ impl IUIAutomationTableItemPattern_Vtbl {
         iid == &<IUIAutomationTableItemPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationTablePattern_Impl: Sized {
     fn GetCurrentRowHeaders(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
     fn GetCurrentColumnHeaders(&self) -> ::windows::core::Result<IUIAutomationElementArray>;
@@ -8966,6 +9083,7 @@ impl IUIAutomationTablePattern_Vtbl {
         iid == &<IUIAutomationTablePattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationTextChildPattern_Impl: Sized {
     fn TextContainer(&self) -> ::windows::core::Result<IUIAutomationElement>;
     fn TextRange(&self) -> ::windows::core::Result<IUIAutomationTextRange>;
@@ -9005,6 +9123,7 @@ impl IUIAutomationTextChildPattern_Vtbl {
         iid == &<IUIAutomationTextChildPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationTextEditPattern_Impl: Sized + IUIAutomationTextPattern_Impl {
     fn GetActiveComposition(&self) -> ::windows::core::Result<IUIAutomationTextRange>;
@@ -9047,6 +9166,7 @@ impl IUIAutomationTextEditPattern_Vtbl {
         iid == &<IUIAutomationTextEditPattern as ::windows::core::Interface>::IID || iid == &<IUIAutomationTextPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIAutomationTextEditTextChangedEventHandler_Impl: Sized {
     fn HandleTextEditTextChangedEvent(&self, sender: &::core::option::Option<IUIAutomationElement>, texteditchangetype: TextEditChangeType, eventstrings: *const super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -9070,6 +9190,7 @@ impl IUIAutomationTextEditTextChangedEventHandler_Vtbl {
         iid == &<IUIAutomationTextEditTextChangedEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationTextPattern_Impl: Sized {
     fn RangeFromPoint(&self, pt: &super::super::Foundation::POINT) -> ::windows::core::Result<IUIAutomationTextRange>;
@@ -9164,6 +9285,7 @@ impl IUIAutomationTextPattern_Vtbl {
         iid == &<IUIAutomationTextPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationTextPattern2_Impl: Sized + IUIAutomationTextPattern_Impl {
     fn RangeFromAnnotation(&self, annotation: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<IUIAutomationTextRange>;
@@ -9200,6 +9322,7 @@ impl IUIAutomationTextPattern2_Vtbl {
         iid == &<IUIAutomationTextPattern2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationTextPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationTextRange_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IUIAutomationTextRange>;
@@ -9414,6 +9537,7 @@ impl IUIAutomationTextRange_Vtbl {
         iid == &<IUIAutomationTextRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationTextRange2_Impl: Sized + IUIAutomationTextRange_Impl {
     fn ShowContextMenu(&self) -> ::windows::core::Result<()>;
@@ -9434,6 +9558,7 @@ impl IUIAutomationTextRange2_Vtbl {
         iid == &<IUIAutomationTextRange2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationTextRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IUIAutomationTextRange3_Impl: Sized + IUIAutomationTextRange2_Impl {
     fn GetEnclosingElementBuildCache(&self, cacherequest: &::core::option::Option<IUIAutomationCacheRequest>) -> ::windows::core::Result<IUIAutomationElement>;
@@ -9489,6 +9614,7 @@ impl IUIAutomationTextRange3_Vtbl {
         iid == &<IUIAutomationTextRange3 as ::windows::core::Interface>::IID || iid == &<IUIAutomationTextRange as ::windows::core::Interface>::IID || iid == &<IUIAutomationTextRange2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationTextRangeArray_Impl: Sized {
     fn Length(&self) -> ::windows::core::Result<i32>;
     fn GetElement(&self, index: i32) -> ::windows::core::Result<IUIAutomationTextRange>;
@@ -9528,6 +9654,7 @@ impl IUIAutomationTextRangeArray_Vtbl {
         iid == &<IUIAutomationTextRangeArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationTogglePattern_Impl: Sized {
     fn Toggle(&self) -> ::windows::core::Result<()>;
     fn CurrentToggleState(&self) -> ::windows::core::Result<ToggleState>;
@@ -9574,6 +9701,7 @@ impl IUIAutomationTogglePattern_Vtbl {
         iid == &<IUIAutomationTogglePattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationTransformPattern_Impl: Sized {
     fn Move(&self, x: f64, y: f64) -> ::windows::core::Result<()>;
@@ -9689,6 +9817,7 @@ impl IUIAutomationTransformPattern_Vtbl {
         iid == &<IUIAutomationTransformPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationTransformPattern2_Impl: Sized + IUIAutomationTransformPattern_Impl {
     fn Zoom(&self, zoomvalue: f64) -> ::windows::core::Result<()>;
@@ -9823,6 +9952,7 @@ impl IUIAutomationTransformPattern2_Vtbl {
         iid == &<IUIAutomationTransformPattern2 as ::windows::core::Interface>::IID || iid == &<IUIAutomationTransformPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationTreeWalker_Impl: Sized {
     fn GetParentElement(&self, element: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<IUIAutomationElement>;
     fn GetFirstChildElement(&self, element: &::core::option::Option<IUIAutomationElement>) -> ::windows::core::Result<IUIAutomationElement>;
@@ -10005,6 +10135,7 @@ impl IUIAutomationTreeWalker_Vtbl {
         iid == &<IUIAutomationTreeWalker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationValuePattern_Impl: Sized {
     fn SetValue(&self, val: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -10080,6 +10211,7 @@ impl IUIAutomationValuePattern_Vtbl {
         iid == &<IUIAutomationValuePattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IUIAutomationVirtualizedItemPattern_Impl: Sized {
     fn Realize(&self) -> ::windows::core::Result<()>;
 }
@@ -10097,6 +10229,7 @@ impl IUIAutomationVirtualizedItemPattern_Vtbl {
         iid == &<IUIAutomationVirtualizedItemPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAutomationWindowPattern_Impl: Sized {
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -10296,6 +10429,7 @@ impl IUIAutomationWindowPattern_Vtbl {
         iid == &<IUIAutomationWindowPattern as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IValueProvider_Impl: Sized {
     fn SetValue(&self, val: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -10345,6 +10479,7 @@ impl IValueProvider_Vtbl {
         iid == &<IValueProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"implement\"`*"]
 pub trait IVirtualizedItemProvider_Impl: Sized {
     fn Realize(&self) -> ::windows::core::Result<()>;
 }
@@ -10362,6 +10497,7 @@ impl IVirtualizedItemProvider_Vtbl {
         iid == &<IVirtualizedItemProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Accessibility\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IWindowProvider_Impl: Sized {
     fn SetVisualState(&self, state: WindowVisualState) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationInterpolator_Impl: Sized {
     fn SetInitialValueAndVelocity(&self, initialvalue: f64, initialvelocity: f64) -> ::windows::core::Result<()>;
     fn SetDuration(&self, duration: f64) -> ::windows::core::Result<()>;
@@ -84,6 +85,7 @@ impl IUIAnimationInterpolator_Vtbl {
         iid == &<IUIAnimationInterpolator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationInterpolator2_Impl: Sized {
     fn GetDimension(&self) -> ::windows::core::Result<u32>;
     fn SetInitialValueAndVelocity(&self, initialvalue: *const f64, initialvelocity: *const f64, cdimension: u32) -> ::windows::core::Result<()>;
@@ -172,6 +174,7 @@ impl IUIAnimationInterpolator2_Vtbl {
         iid == &<IUIAnimationInterpolator2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationLoopIterationChangeHandler2_Impl: Sized {
     fn OnLoopIterationChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, id: usize, newiterationcount: u32, olditerationcount: u32) -> ::windows::core::Result<()>;
 }
@@ -189,6 +192,7 @@ impl IUIAnimationLoopIterationChangeHandler2_Vtbl {
         iid == &<IUIAnimationLoopIterationChangeHandler2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationManager_Impl: Sized {
     fn CreateAnimationVariable(&self, initialvalue: f64) -> ::windows::core::Result<IUIAnimationVariable>;
     fn ScheduleTransition(&self, variable: &::core::option::Option<IUIAnimationVariable>, transition: &::core::option::Option<IUIAnimationTransition>, timenow: f64) -> ::windows::core::Result<()>;
@@ -365,6 +369,7 @@ impl IUIAnimationManager_Vtbl {
         iid == &<IUIAnimationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAnimationManager2_Impl: Sized {
     fn CreateAnimationVectorVariable(&self, initialvalue: *const f64, cdimension: u32) -> ::windows::core::Result<IUIAnimationVariable2>;
@@ -570,6 +575,7 @@ impl IUIAnimationManager2_Vtbl {
         iid == &<IUIAnimationManager2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationManagerEventHandler_Impl: Sized {
     fn OnManagerStatusChanged(&self, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::Result<()>;
 }
@@ -587,6 +593,7 @@ impl IUIAnimationManagerEventHandler_Vtbl {
         iid == &<IUIAnimationManagerEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationManagerEventHandler2_Impl: Sized {
     fn OnManagerStatusChanged(&self, newstatus: UI_ANIMATION_MANAGER_STATUS, previousstatus: UI_ANIMATION_MANAGER_STATUS) -> ::windows::core::Result<()>;
 }
@@ -604,6 +611,7 @@ impl IUIAnimationManagerEventHandler2_Vtbl {
         iid == &<IUIAnimationManagerEventHandler2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationPrimitiveInterpolation_Impl: Sized {
     fn AddCubic(&self, dimension: u32, beginoffset: f64, constantcoefficient: f32, linearcoefficient: f32, quadraticcoefficient: f32, cubiccoefficient: f32) -> ::windows::core::Result<()>;
     fn AddSinusoidal(&self, dimension: u32, beginoffset: f64, bias: f32, amplitude: f32, frequency: f32, phase: f32) -> ::windows::core::Result<()>;
@@ -631,6 +639,7 @@ impl IUIAnimationPrimitiveInterpolation_Vtbl {
         iid == &<IUIAnimationPrimitiveInterpolation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationPriorityComparison_Impl: Sized {
     fn HasPriority(&self, scheduledstoryboard: &::core::option::Option<IUIAnimationStoryboard>, newstoryboard: &::core::option::Option<IUIAnimationStoryboard>, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::Result<()>;
 }
@@ -648,6 +657,7 @@ impl IUIAnimationPriorityComparison_Vtbl {
         iid == &<IUIAnimationPriorityComparison as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationPriorityComparison2_Impl: Sized {
     fn HasPriority(&self, scheduledstoryboard: &::core::option::Option<IUIAnimationStoryboard2>, newstoryboard: &::core::option::Option<IUIAnimationStoryboard2>, priorityeffect: UI_ANIMATION_PRIORITY_EFFECT) -> ::windows::core::Result<()>;
 }
@@ -665,6 +675,7 @@ impl IUIAnimationPriorityComparison2_Vtbl {
         iid == &<IUIAnimationPriorityComparison2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationStoryboard_Impl: Sized {
     fn AddTransition(&self, variable: &::core::option::Option<IUIAnimationVariable>, transition: &::core::option::Option<IUIAnimationTransition>) -> ::windows::core::Result<()>;
     fn AddKeyframeAtOffset(&self, existingkeyframe: UI_ANIMATION_KEYFRAME, offset: f64) -> ::windows::core::Result<UI_ANIMATION_KEYFRAME>;
@@ -821,6 +832,7 @@ impl IUIAnimationStoryboard_Vtbl {
         iid == &<IUIAnimationStoryboard as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIAnimationStoryboard2_Impl: Sized {
     fn AddTransition(&self, variable: &::core::option::Option<IUIAnimationVariable2>, transition: &::core::option::Option<IUIAnimationTransition2>) -> ::windows::core::Result<()>;
@@ -987,6 +999,7 @@ impl IUIAnimationStoryboard2_Vtbl {
         iid == &<IUIAnimationStoryboard2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationStoryboardEventHandler_Impl: Sized {
     fn OnStoryboardStatusChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::Result<()>;
     fn OnStoryboardUpdated(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>) -> ::windows::core::Result<()>;
@@ -1014,6 +1027,7 @@ impl IUIAnimationStoryboardEventHandler_Vtbl {
         iid == &<IUIAnimationStoryboardEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationStoryboardEventHandler2_Impl: Sized {
     fn OnStoryboardStatusChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, newstatus: UI_ANIMATION_STORYBOARD_STATUS, previousstatus: UI_ANIMATION_STORYBOARD_STATUS) -> ::windows::core::Result<()>;
     fn OnStoryboardUpdated(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>) -> ::windows::core::Result<()>;
@@ -1041,6 +1055,7 @@ impl IUIAnimationStoryboardEventHandler2_Vtbl {
         iid == &<IUIAnimationStoryboardEventHandler2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTimer_Impl: Sized {
     fn SetTimerUpdateHandler(&self, updatehandler: &::core::option::Option<IUIAnimationTimerUpdateHandler>, idlebehavior: UI_ANIMATION_IDLE_BEHAVIOR) -> ::windows::core::Result<()>;
     fn SetTimerEventHandler(&self, handler: &::core::option::Option<IUIAnimationTimerEventHandler>) -> ::windows::core::Result<()>;
@@ -1109,6 +1124,7 @@ impl IUIAnimationTimer_Vtbl {
         iid == &<IUIAnimationTimer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTimerClientEventHandler_Impl: Sized {
     fn OnTimerClientStatusChanged(&self, newstatus: UI_ANIMATION_TIMER_CLIENT_STATUS, previousstatus: UI_ANIMATION_TIMER_CLIENT_STATUS) -> ::windows::core::Result<()>;
 }
@@ -1129,6 +1145,7 @@ impl IUIAnimationTimerClientEventHandler_Vtbl {
         iid == &<IUIAnimationTimerClientEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTimerEventHandler_Impl: Sized {
     fn OnPreUpdate(&self) -> ::windows::core::Result<()>;
     fn OnPostUpdate(&self) -> ::windows::core::Result<()>;
@@ -1163,6 +1180,7 @@ impl IUIAnimationTimerEventHandler_Vtbl {
         iid == &<IUIAnimationTimerEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTimerUpdateHandler_Impl: Sized {
     fn OnUpdate(&self, timenow: f64) -> ::windows::core::Result<UI_ANIMATION_UPDATE_RESULT>;
     fn SetTimerClientEventHandler(&self, handler: &::core::option::Option<IUIAnimationTimerClientEventHandler>) -> ::windows::core::Result<()>;
@@ -1203,6 +1221,7 @@ impl IUIAnimationTimerUpdateHandler_Vtbl {
         iid == &<IUIAnimationTimerUpdateHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTransition_Impl: Sized {
     fn SetInitialValue(&self, value: f64) -> ::windows::core::Result<()>;
     fn SetInitialVelocity(&self, velocity: f64) -> ::windows::core::Result<()>;
@@ -1250,6 +1269,7 @@ impl IUIAnimationTransition_Vtbl {
         iid == &<IUIAnimationTransition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTransition2_Impl: Sized {
     fn GetDimension(&self) -> ::windows::core::Result<u32>;
     fn SetInitialValue(&self, value: f64) -> ::windows::core::Result<()>;
@@ -1324,6 +1344,7 @@ impl IUIAnimationTransition2_Vtbl {
         iid == &<IUIAnimationTransition2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTransitionFactory_Impl: Sized {
     fn CreateTransition(&self, interpolator: &::core::option::Option<IUIAnimationInterpolator>) -> ::windows::core::Result<IUIAnimationTransition>;
 }
@@ -1347,6 +1368,7 @@ impl IUIAnimationTransitionFactory_Vtbl {
         iid == &<IUIAnimationTransitionFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTransitionFactory2_Impl: Sized {
     fn CreateTransition(&self, interpolator: &::core::option::Option<IUIAnimationInterpolator2>) -> ::windows::core::Result<IUIAnimationTransition2>;
 }
@@ -1370,6 +1392,7 @@ impl IUIAnimationTransitionFactory2_Vtbl {
         iid == &<IUIAnimationTransitionFactory2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTransitionLibrary_Impl: Sized {
     fn CreateInstantaneousTransition(&self, finalvalue: f64) -> ::windows::core::Result<IUIAnimationTransition>;
     fn CreateConstantTransition(&self, duration: f64) -> ::windows::core::Result<IUIAnimationTransition>;
@@ -1539,6 +1562,7 @@ impl IUIAnimationTransitionLibrary_Vtbl {
         iid == &<IUIAnimationTransitionLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationTransitionLibrary2_Impl: Sized {
     fn CreateInstantaneousTransition(&self, finalvalue: f64) -> ::windows::core::Result<IUIAnimationTransition2>;
     fn CreateInstantaneousVectorTransition(&self, finalvalue: *const f64, cdimension: u32) -> ::windows::core::Result<IUIAnimationTransition2>;
@@ -1799,6 +1823,7 @@ impl IUIAnimationTransitionLibrary2_Vtbl {
         iid == &<IUIAnimationTransitionLibrary2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationVariable_Impl: Sized {
     fn GetValue(&self) -> ::windows::core::Result<f64>;
     fn GetFinalValue(&self) -> ::windows::core::Result<f64>;
@@ -1952,6 +1977,7 @@ impl IUIAnimationVariable_Vtbl {
         iid == &<IUIAnimationVariable as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_DirectComposition"))]
 pub trait IUIAnimationVariable2_Impl: Sized {
     fn GetDimension(&self) -> ::windows::core::Result<u32>;
@@ -2198,6 +2224,7 @@ impl IUIAnimationVariable2_Vtbl {
         iid == &<IUIAnimationVariable2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationVariableChangeHandler_Impl: Sized {
     fn OnValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>, variable: &::core::option::Option<IUIAnimationVariable>, newvalue: f64, previousvalue: f64) -> ::windows::core::Result<()>;
 }
@@ -2215,6 +2242,7 @@ impl IUIAnimationVariableChangeHandler_Vtbl {
         iid == &<IUIAnimationVariableChangeHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationVariableChangeHandler2_Impl: Sized {
     fn OnValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, variable: &::core::option::Option<IUIAnimationVariable2>, newvalue: *const f64, previousvalue: *const f64, cdimension: u32) -> ::windows::core::Result<()>;
 }
@@ -2232,6 +2260,7 @@ impl IUIAnimationVariableChangeHandler2_Vtbl {
         iid == &<IUIAnimationVariableChangeHandler2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationVariableCurveChangeHandler2_Impl: Sized {
     fn OnCurveChanged(&self, variable: &::core::option::Option<IUIAnimationVariable2>) -> ::windows::core::Result<()>;
 }
@@ -2249,6 +2278,7 @@ impl IUIAnimationVariableCurveChangeHandler2_Vtbl {
         iid == &<IUIAnimationVariableCurveChangeHandler2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationVariableIntegerChangeHandler_Impl: Sized {
     fn OnIntegerValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard>, variable: &::core::option::Option<IUIAnimationVariable>, newvalue: i32, previousvalue: i32) -> ::windows::core::Result<()>;
 }
@@ -2266,6 +2296,7 @@ impl IUIAnimationVariableIntegerChangeHandler_Vtbl {
         iid == &<IUIAnimationVariableIntegerChangeHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Animation\"`, `\"implement\"`*"]
 pub trait IUIAnimationVariableIntegerChangeHandler2_Impl: Sized {
     fn OnIntegerValueChanged(&self, storyboard: &::core::option::Option<IUIAnimationStoryboard2>, variable: &::core::option::Option<IUIAnimationVariable2>, newvalue: *const i32, previousvalue: *const i32, cdimension: u32) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDeviceModelPlugIn_Impl: Sized {
     fn Initialize(&self, bstrxml: &::windows::core::BSTR, cnummodels: u32, imodelposition: u32) -> ::windows::core::Result<()>;
@@ -121,6 +122,7 @@ impl IDeviceModelPlugIn_Vtbl {
         iid == &<IDeviceModelPlugIn as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"implement\"`*"]
 pub trait IGamutMapModelPlugIn_Impl: Sized {
     fn Initialize(&self, bstrxml: &::windows::core::BSTR, psrcplugin: &::core::option::Option<IDeviceModelPlugIn>, pdestplugin: &::core::option::Option<IDeviceModelPlugIn>, psrcgbd: *const GamutBoundaryDescription, pdestgbd: *const GamutBoundaryDescription) -> ::windows::core::Result<()>;
     fn SourceToDestinationAppearanceColors(&self, ccolors: u32, pinputcolors: *const JChColorF, poutputcolors: *mut JChColorF) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Controls_Dialogs\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPrintDialogCallback_Impl: Sized {
     fn InitDone(&self) -> ::windows::core::Result<()>;
@@ -35,6 +36,7 @@ impl IPrintDialogCallback_Vtbl {
         iid == &<IPrintDialogCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_Dialogs\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IPrintDialogServices_Impl: Sized {
     fn GetCurrentDevMode(&self, pdevmode: *mut super::super::super::Graphics::Gdi::DEVMODEA, pcbsize: *mut u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole"))]
 pub trait IRichEditOle_Impl: Sized {
     fn GetClientSite(&self) -> ::windows::core::Result<super::super::super::System::Ole::IOleClientSite>;
@@ -132,6 +133,7 @@ impl IRichEditOle_Vtbl {
         iid == &<IRichEditOle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Ole\"`, `\"Win32_System_SystemServices\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Ole", feature = "Win32_System_SystemServices", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IRichEditOleCallback_Impl: Sized {
     fn GetNewStorage(&self) -> ::windows::core::Result<super::super::super::System::Com::StructuredStorage::IStorage>;
@@ -224,6 +226,7 @@ impl IRichEditOleCallback_Vtbl {
         iid == &<IRichEditOleCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IRicheditUiaOverrides_Impl: Sized {
     fn GetPropertyOverrideValue(&self, propertyid: i32, pretvalue: *mut super::super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -244,6 +247,7 @@ impl IRicheditUiaOverrides_Vtbl {
         iid == &<IRicheditUiaOverrides as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextDisplays_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -257,6 +261,7 @@ impl ITextDisplays_Vtbl {
         iid == &<ITextDisplays as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextDocument_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -478,6 +483,7 @@ impl ITextDocument_Vtbl {
         iid == &<ITextDocument as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextDocument2_Impl: Sized + ITextDocument_Impl {
     fn GetCaretType(&self) -> ::windows::core::Result<i32>;
@@ -946,6 +952,7 @@ impl ITextDocument2_Vtbl {
         iid == &<ITextDocument2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextDocument2Old_Impl: Sized + ITextDocument_Impl {
     fn AttachMsgFilter(&self, pfilter: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1190,6 +1197,7 @@ impl ITextDocument2Old_Vtbl {
         iid == &<ITextDocument2Old as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextDocument as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextFont_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetDuplicate(&self) -> ::windows::core::Result<ITextFont>;
@@ -1759,6 +1767,7 @@ impl ITextFont_Vtbl {
         iid == &<ITextFont as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextFont2_Impl: Sized + ITextFont_Impl {
     fn GetCount(&self) -> ::windows::core::Result<i32>;
@@ -2229,6 +2238,7 @@ impl ITextFont2_Vtbl {
         iid == &<ITextFont2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextFont as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITextHost_Impl: Sized {
     fn TxGetDC(&self) -> super::super::super::Graphics::Gdi::HDC;
@@ -2524,6 +2534,7 @@ impl ITextHost_Vtbl {
         iid == &<ITextHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITextHost2_Impl: Sized + ITextHost_Impl {
     fn TxIsDoubleClickPending(&self) -> super::super::super::Foundation::BOOL;
@@ -2624,6 +2635,7 @@ impl ITextHost2_Vtbl {
         iid == &<ITextHost2 as ::windows::core::Interface>::IID || iid == &<ITextHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextPara_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetDuplicate(&self) -> ::windows::core::Result<ITextPara>;
@@ -3120,6 +3132,7 @@ impl ITextPara_Vtbl {
         iid == &<ITextPara as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextPara2_Impl: Sized + ITextPara_Impl {
     fn GetBorders(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -3296,6 +3309,7 @@ impl ITextPara2_Vtbl {
         iid == &<ITextPara2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextPara as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextRange_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetText(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -3879,6 +3893,7 @@ impl ITextRange_Vtbl {
         iid == &<ITextRange as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextRange2_Impl: Sized + ITextSelection_Impl {
     fn GetCch(&self) -> ::windows::core::Result<i32>;
@@ -4277,6 +4292,7 @@ impl ITextRange2_Vtbl {
         iid == &<ITextRange2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextRange as ::windows::core::Interface>::IID || iid == &<ITextSelection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextRow_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn GetAlignment(&self) -> ::windows::core::Result<i32>;
@@ -4741,6 +4757,7 @@ impl ITextRow_Vtbl {
         iid == &<ITextRow as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextSelection_Impl: Sized + ITextRange_Impl {
     fn GetFlags(&self) -> ::windows::core::Result<i32>;
@@ -4875,6 +4892,7 @@ impl ITextSelection_Vtbl {
         iid == &<ITextSelection as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextSelection2_Impl: Sized + ITextRange2_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -4888,6 +4906,7 @@ impl ITextSelection2_Vtbl {
         iid == &<ITextSelection2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextRange as ::windows::core::Interface>::IID || iid == &<ITextSelection as ::windows::core::Interface>::IID || iid == &<ITextRange2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextServices_Impl: Sized {
     fn TxSendMessage(&self, msg: u32, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM, plresult: *mut super::super::super::Foundation::LRESULT) -> ::windows::core::Result<()>;
@@ -5050,6 +5069,7 @@ impl ITextServices_Vtbl {
         iid == &<ITextServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Direct2D", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextServices2_Impl: Sized + ITextServices_Impl {
     fn TxGetNaturalSize2(&self, dwaspect: u32, hdcdraw: super::super::super::Graphics::Gdi::HDC, hictargetdev: super::super::super::Graphics::Gdi::HDC, ptd: *mut super::super::super::System::Com::DVTARGETDEVICE, dwmode: u32, psizelextent: *const super::super::super::Foundation::SIZE, pwidth: *mut i32, pheight: *mut i32, pascent: *mut i32) -> ::windows::core::Result<()>;
@@ -5080,6 +5100,7 @@ impl ITextServices2_Vtbl {
         iid == &<ITextServices2 as ::windows::core::Interface>::IID || iid == &<ITextServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITextStory_Impl: Sized {
     fn GetActive(&self) -> ::windows::core::Result<i32>;
@@ -5222,6 +5243,7 @@ impl ITextStory_Vtbl {
         iid == &<ITextStory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextStoryRanges_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -5277,6 +5299,7 @@ impl ITextStoryRanges_Vtbl {
         iid == &<ITextStoryRanges as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextStoryRanges2_Impl: Sized + ITextStoryRanges_Impl {
     fn Item2(&self, index: i32) -> ::windows::core::Result<ITextRange2>;
@@ -5303,6 +5326,7 @@ impl ITextStoryRanges2_Vtbl {
         iid == &<ITextStoryRanges2 as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<ITextStoryRanges as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextStrings_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn Item(&self, index: i32) -> ::windows::core::Result<ITextRange2>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Controls\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IImageList_Impl: Sized {
     fn Add(&self, hbmimage: super::super::Graphics::Gdi::HBITMAP, hbmmask: super::super::Graphics::Gdi::HBITMAP) -> ::windows::core::Result<i32>;
@@ -283,6 +284,7 @@ impl IImageList_Vtbl {
         iid == &<IImageList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Controls\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IImageList2_Impl: Sized + IImageList_Impl {
     fn Resize(&self, cxnewiconsize: i32, cynewiconsize: i32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"Win32_Globalization\"`, `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_UI_TextServices"))]
 pub trait IActiveIME_Impl: Sized {
     fn Inquire(&self, dwsysteminfoflags: u32, pimeinfo: *mut IMEINFO, szwndclass: ::windows::core::PWSTR, pdwprivate: *mut u32) -> ::windows::core::Result<()>;
@@ -151,6 +152,7 @@ impl IActiveIME_Vtbl {
         iid == &<IActiveIME as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"Win32_Globalization\"`, `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_UI_TextServices"))]
 pub trait IActiveIME2_Impl: Sized + IActiveIME_Impl {
     fn Sleep(&self) -> ::windows::core::Result<()>;
@@ -177,6 +179,7 @@ impl IActiveIME2_Vtbl {
         iid == &<IActiveIME2 as ::windows::core::Interface>::IID || iid == &<IActiveIME as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_TextServices"))]
 pub trait IActiveIMMApp_Impl: Sized {
     fn AssociateContext(&self, hwnd: super::super::super::Foundation::HWND, hime: super::super::super::Globalization::HIMC) -> ::windows::core::Result<super::super::super::Globalization::HIMC>;
@@ -783,6 +786,7 @@ impl IActiveIMMApp_Vtbl {
         iid == &<IActiveIMMApp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Globalization", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_TextServices"))]
 pub trait IActiveIMMIME_Impl: Sized {
     fn AssociateContext(&self, hwnd: super::super::super::Foundation::HWND, hime: super::super::super::Globalization::HIMC) -> ::windows::core::Result<super::super::super::Globalization::HIMC>;
@@ -1589,6 +1593,7 @@ impl IActiveIMMIME_Vtbl {
         iid == &<IActiveIMMIME as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IActiveIMMMessagePumpOwner_Impl: Sized {
     fn Start(&self) -> ::windows::core::Result<()>;
@@ -1646,6 +1651,7 @@ impl IActiveIMMMessagePumpOwner_Vtbl {
         iid == &<IActiveIMMMessagePumpOwner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"implement\"`*"]
 pub trait IActiveIMMRegistrar_Impl: Sized {
     fn RegisterIME(&self, rclsid: *const ::windows::core::GUID, lgid: u16, psziconfile: &::windows::core::PCWSTR, pszdesc: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn UnregisterIME(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -1673,6 +1679,7 @@ impl IActiveIMMRegistrar_Vtbl {
         iid == &<IActiveIMMRegistrar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Globalization\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Globalization")]
 pub trait IEnumInputContext_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumInputContext>;
@@ -1723,6 +1730,7 @@ impl IEnumInputContext_Vtbl {
         iid == &<IEnumInputContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"implement\"`*"]
 pub trait IEnumRegisterWordA_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumRegisterWordA>;
     fn Next(&self, ulcount: u32, rgregisterword: *mut REGISTERWORDA, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1770,6 +1778,7 @@ impl IEnumRegisterWordA_Vtbl {
         iid == &<IEnumRegisterWordA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"implement\"`*"]
 pub trait IEnumRegisterWordW_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumRegisterWordW>;
     fn Next(&self, ulcount: u32, rgregisterword: *mut REGISTERWORDW, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1817,6 +1826,7 @@ impl IEnumRegisterWordW_Vtbl {
         iid == &<IEnumRegisterWordW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFEClassFactory_Impl: Sized + super::super::super::System::Com::IClassFactory_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -1830,6 +1840,7 @@ impl IFEClassFactory_Vtbl {
         iid == &<IFEClassFactory as ::windows::core::Interface>::IID || iid == &<super::super::super::System::Com::IClassFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFECommon_Impl: Sized {
     fn IsDefaultIME(&self, szname: &::windows::core::PCSTR, cszname: i32) -> ::windows::core::Result<()>;
@@ -1874,6 +1885,7 @@ impl IFECommon_Vtbl {
         iid == &<IFECommon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFEDictionary_Impl: Sized {
     fn Open(&self, pchdictpath: &::windows::core::PSTR, pshf: *mut IMESHF) -> ::windows::core::Result<()>;
@@ -2009,6 +2021,7 @@ impl IFEDictionary_Vtbl {
         iid == &<IFEDictionary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"implement\"`*"]
 pub trait IFELanguage_Impl: Sized {
     fn Open(&self) -> ::windows::core::Result<()>;
     fn Close(&self) -> ::windows::core::Result<()>;
@@ -2064,6 +2077,7 @@ impl IFELanguage_Vtbl {
         iid == &<IFELanguage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IImePad_Impl: Sized {
     fn Request(&self, piimepadapplet: &::core::option::Option<IImePadApplet>, reqid: IME_PAD_REQUEST_FLAGS, wparam: super::super::super::Foundation::WPARAM, lparam: super::super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -2084,6 +2098,7 @@ impl IImePad_Vtbl {
         iid == &<IImePad as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IImePadApplet_Impl: Sized {
     fn Initialize(&self, lpiimepad: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -2135,6 +2150,7 @@ impl IImePadApplet_Vtbl {
         iid == &<IImePadApplet as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IImePlugInDictDictionaryList_Impl: Sized {
     fn GetDictionariesInUse(&self, prgdictionaryguid: *mut *mut super::super::super::System::Com::SAFEARRAY, prgdatecreated: *mut *mut super::super::super::System::Com::SAFEARRAY, prgfencrypted: *mut *mut super::super::super::System::Com::SAFEARRAY) -> ::windows::core::Result<()>;
@@ -2165,6 +2181,7 @@ impl IImePlugInDictDictionaryList_Vtbl {
         iid == &<IImePlugInDictDictionaryList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ime\"`, `\"implement\"`*"]
 pub trait IImeSpecifyApplets_Impl: Sized {
     fn GetAppletIIDList(&self, refiid: *const ::windows::core::GUID, lpiidlist: *mut APPLETIDLIST) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ink/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Input_Ink\"`, `\"implement\"`*"]
 pub trait IInkCommitRequestHandler_Impl: Sized {
     fn OnCommitRequested(&self) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl IInkCommitRequestHandler_Vtbl {
         iid == &<IInkCommitRequestHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ink\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInkD2DRenderer_Impl: Sized {
     fn Draw(&self, pd2d1devicecontext: &::core::option::Option<::windows::core::IUnknown>, pinkstrokeiterable: &::core::option::Option<::windows::core::IUnknown>, fhighcontrast: super::super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -35,6 +37,7 @@ impl IInkD2DRenderer_Vtbl {
         iid == &<IInkD2DRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ink\"`, `\"implement\"`*"]
 pub trait IInkD2DRenderer2_Impl: Sized {
     fn Draw(&self, pd2d1devicecontext: &::core::option::Option<::windows::core::IUnknown>, pinkstrokeiterable: &::core::option::Option<::windows::core::IUnknown>, highcontrastadjustment: INK_HIGH_CONTRAST_ADJUSTMENT) -> ::windows::core::Result<()>;
 }
@@ -52,6 +55,7 @@ impl IInkD2DRenderer2_Vtbl {
         iid == &<IInkD2DRenderer2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ink\"`, `\"implement\"`*"]
 pub trait IInkDesktopHost_Impl: Sized {
     fn QueueWorkItem(&self, workitem: &::core::option::Option<IInkHostWorkItem>) -> ::windows::core::Result<()>;
     fn CreateInkPresenter(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -86,6 +90,7 @@ impl IInkDesktopHost_Vtbl {
         iid == &<IInkDesktopHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ink\"`, `\"implement\"`*"]
 pub trait IInkHostWorkItem_Impl: Sized {
     fn Invoke(&self) -> ::windows::core::Result<()>;
 }
@@ -103,6 +108,7 @@ impl IInkHostWorkItem_Vtbl {
         iid == &<IInkHostWorkItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Ink\"`, `\"implement\"`*"]
 pub trait IInkPresenterDesktop_Impl: Sized {
     fn SetRootVisual(&self, rootvisual: &::core::option::Option<::windows::core::IUnknown>, device: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetCommitRequestHandler(&self, handler: &::core::option::Option<IInkCommitRequestHandler>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Radial/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Radial/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Input_Radial\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRadialControllerConfigurationInterop_Impl: Sized {
     fn GetForWindow(&self, hwnd: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -21,6 +22,7 @@ impl IRadialControllerConfigurationInterop_Vtbl {
         iid == &<IRadialControllerConfigurationInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Radial\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRadialControllerIndependentInputSourceInterop_Impl: Sized {
     fn CreateForWindow(&self, hwnd: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -44,6 +46,7 @@ impl IRadialControllerIndependentInputSourceInterop_Vtbl {
         iid == &<IRadialControllerIndependentInputSourceInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Radial\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRadialControllerInterop_Impl: Sized {
     fn CreateForWindow(&self, hwnd: super::super::super::Foundation::HWND, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Input_Touch\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInertiaProcessor_Impl: Sized {
     fn InitialOriginX(&self) -> ::windows::core::Result<f32>;
@@ -501,6 +502,7 @@ impl IInertiaProcessor_Vtbl {
         iid == &<IInertiaProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Touch\"`, `\"implement\"`*"]
 pub trait IManipulationProcessor_Impl: Sized {
     fn SupportedManipulations(&self) -> ::windows::core::Result<MANIPULATION_PROCESSOR_MANIPULATIONS>;
     fn SetSupportedManipulations(&self, manipulations: MANIPULATION_PROCESSOR_MANIPULATIONS) -> ::windows::core::Result<()>;
@@ -715,6 +717,7 @@ impl IManipulationProcessor_Vtbl {
         iid == &<IManipulationProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Input_Touch\"`, `\"implement\"`*"]
 pub trait _IManipulationEvents_Impl: Sized {
     fn ManipulationStarted(&self, x: f32, y: f32) -> ::windows::core::Result<()>;
     fn ManipulationDelta(&self, x: f32, y: f32, translationdeltax: f32, translationdeltay: f32, scaledelta: f32, expansiondelta: f32, rotationdelta: f32, cumulativetranslationx: f32, cumulativetranslationy: f32, cumulativescale: f32, cumulativeexpansion: f32, cumulativerotation: f32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/LegacyWindowsEnvironmentFeatures/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Ole")]
 pub trait IADesktopP2_Impl: Sized {
     fn ReReadWallpaper(&self) -> ::windows::core::Result<()>;
@@ -42,6 +43,7 @@ impl IADesktopP2_Vtbl {
         iid == &<IADesktopP2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"implement\"`*"]
 pub trait IActiveDesktopP_Impl: Sized {
     fn SetSafeMode(&self, dwflags: u32) -> ::windows::core::Result<()>;
     fn EnsureUpdateHTML(&self) -> ::windows::core::Result<()>;
@@ -83,6 +85,7 @@ impl IActiveDesktopP_Vtbl {
         iid == &<IActiveDesktopP as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IBriefcaseInitiator_Impl: Sized {
     fn IsMonikerInBriefcase(&self, pmk: &::core::option::Option<super::super::System::Com::IMoniker>) -> ::windows::core::Result<()>;
@@ -103,6 +106,7 @@ impl IBriefcaseInitiator_Vtbl {
         iid == &<IBriefcaseInitiator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait IEmptyVolumeCache_Impl: Sized {
     fn Initialize(&self, hkregkey: super::super::System::Registry::HKEY, pcwszvolume: &::windows::core::PCWSTR, ppwszdisplayname: *mut ::windows::core::PWSTR, ppwszdescription: *mut ::windows::core::PWSTR, pdwflags: *mut EMPTY_VOLUME_CACHE_FLAGS) -> ::windows::core::Result<()>;
@@ -160,6 +164,7 @@ impl IEmptyVolumeCache_Vtbl {
         iid == &<IEmptyVolumeCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait IEmptyVolumeCache2_Impl: Sized + IEmptyVolumeCache_Impl {
     fn InitializeEx(&self, hkregkey: super::super::System::Registry::HKEY, pcwszvolume: &::windows::core::PCWSTR, pcwszkeyname: &::windows::core::PCWSTR, ppwszdisplayname: *mut ::windows::core::PWSTR, ppwszdescription: *mut ::windows::core::PWSTR, ppwszbtntext: *mut ::windows::core::PWSTR, pdwflags: *mut EMPTY_VOLUME_CACHE_FLAGS) -> ::windows::core::Result<()>;
@@ -180,6 +185,7 @@ impl IEmptyVolumeCache2_Vtbl {
         iid == &<IEmptyVolumeCache2 as ::windows::core::Interface>::IID || iid == &<IEmptyVolumeCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"implement\"`*"]
 pub trait IEmptyVolumeCacheCallBack_Impl: Sized {
     fn ScanProgress(&self, dwlspaceused: u64, dwflags: u32, pcwszstatus: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn PurgeProgress(&self, dwlspacefreed: u64, dwlspacetofree: u64, dwflags: u32, pcwszstatus: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -207,6 +213,7 @@ impl IEmptyVolumeCacheCallBack_Vtbl {
         iid == &<IEmptyVolumeCacheCallBack as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IReconcilableObject_Impl: Sized {
     fn Reconcile(&self, pinitiator: &::core::option::Option<IReconcileInitiator>, dwflags: u32, hwndowner: super::super::Foundation::HWND, hwndprogressfeedback: super::super::Foundation::HWND, ulcinput: u32, rgpmkotherinput: *mut ::core::option::Option<super::super::System::Com::IMoniker>, ploutindex: *mut i32, pstgnewresidues: &::core::option::Option<super::super::System::Com::StructuredStorage::IStorage>, pvreserved: *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -243,6 +250,7 @@ impl IReconcilableObject_Vtbl {
         iid == &<IReconcilableObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_LegacyWindowsEnvironmentFeatures\"`, `\"implement\"`*"]
 pub trait IReconcileInitiator_Impl: Sized {
     fn SetAbortCallback(&self, punkforabort: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn SetProgressFeedback(&self, ulprogress: u32, ulprogressmax: u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Notifications/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Notifications/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Notifications\"`, `\"implement\"`*"]
 pub trait INotificationActivationCallback_Impl: Sized {
     fn Activate(&self, appusermodelid: &::windows::core::PCWSTR, invokedargs: &::windows::core::PCWSTR, data: *const NOTIFICATION_USER_INPUT_DATA, count: u32) -> ::windows::core::Result<()>;
 }

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"implement\"`*"]
 pub trait IUIApplication_Impl: Sized {
     fn OnViewChanged(&self, viewid: u32, typeid: UI_VIEWTYPE, view: &::core::option::Option<::windows::core::IUnknown>, verb: UI_VIEWVERB, ureasoncode: i32) -> ::windows::core::Result<()>;
     fn OnCreateUICommand(&self, commandid: u32, typeid: UI_COMMANDTYPE) -> ::windows::core::Result<IUICommandHandler>;
@@ -38,6 +39,7 @@ impl IUIApplication_Vtbl {
         iid == &<IUIApplication as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"implement\"`*"]
 pub trait IUICollection_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetItem(&self, index: u32) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -112,6 +114,7 @@ impl IUICollection_Vtbl {
         iid == &<IUICollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"implement\"`*"]
 pub trait IUICollectionChangedEvent_Impl: Sized {
     fn OnChanged(&self, action: UI_COLLECTIONCHANGE, oldindex: u32, olditem: &::core::option::Option<::windows::core::IUnknown>, newindex: u32, newitem: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -129,6 +132,7 @@ impl IUICollectionChangedEvent_Vtbl {
         iid == &<IUICollectionChangedEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IUICommandHandler_Impl: Sized {
     fn Execute(&self, commandid: u32, verb: UI_EXECUTIONVERB, key: *const super::Shell::PropertiesSystem::PROPERTYKEY, currentvalue: *const super::super::System::Com::StructuredStorage::PROPVARIANT, commandexecutionproperties: &::core::option::Option<IUISimplePropertySet>) -> ::windows::core::Result<()>;
@@ -165,6 +169,7 @@ impl IUICommandHandler_Vtbl {
         iid == &<IUICommandHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"implement\"`*"]
 pub trait IUIContextualUI_Impl: Sized {
     fn ShowAtLocation(&self, x: i32, y: i32) -> ::windows::core::Result<()>;
 }
@@ -182,6 +187,7 @@ impl IUIContextualUI_Vtbl {
         iid == &<IUIContextualUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"implement\"`*"]
 pub trait IUIEventLogger_Impl: Sized {
     fn OnUIEvent(&self, peventparams: *const UI_EVENTPARAMS);
 }
@@ -199,6 +205,7 @@ impl IUIEventLogger_Vtbl {
         iid == &<IUIEventLogger as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"implement\"`*"]
 pub trait IUIEventingManager_Impl: Sized {
     fn SetEventLogger(&self, eventlogger: &::core::option::Option<IUIEventLogger>) -> ::windows::core::Result<()>;
 }
@@ -216,6 +223,7 @@ impl IUIEventingManager_Vtbl {
         iid == &<IUIEventingManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IUIFramework_Impl: Sized {
     fn Initialize(&self, framewnd: super::super::Foundation::HWND, application: &::core::option::Option<IUIApplication>) -> ::windows::core::Result<()>;
@@ -301,6 +309,7 @@ impl IUIFramework_Vtbl {
         iid == &<IUIFramework as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IUIImage_Impl: Sized {
     fn GetBitmap(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
@@ -327,6 +336,7 @@ impl IUIImage_Vtbl {
         iid == &<IUIImage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IUIImageFromBitmap_Impl: Sized {
     fn CreateImage(&self, bitmap: super::super::Graphics::Gdi::HBITMAP, options: UI_OWNERSHIP) -> ::windows::core::Result<IUIImage>;
@@ -353,6 +363,7 @@ impl IUIImageFromBitmap_Vtbl {
         iid == &<IUIImageFromBitmap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUIRibbon_Impl: Sized {
     fn GetHeight(&self) -> ::windows::core::Result<u32>;
@@ -396,6 +407,7 @@ impl IUIRibbon_Vtbl {
         iid == &<IUIRibbon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Ribbon\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IUISimplePropertySet_Impl: Sized {
     fn GetValue(&self, key: *const super::Shell::PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/Common/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 pub trait IObjectArray_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, uiindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -31,6 +32,7 @@ impl IObjectArray_Vtbl {
         iid == &<IObjectArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 pub trait IObjectCollection_Impl: Sized + IObjectArray_Impl {
     fn AddObject(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn AddFromArray(&self, poasource: &::core::option::Option<IObjectArray>) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait ICreateObject_Impl: Sized {
     fn CreateObject(&self, clsid: *const ::windows::core::GUID, punkouter: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -15,6 +16,7 @@ impl ICreateObject_Vtbl {
         iid == &<ICreateObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IDelayedPropertyStoreFactory_Impl: Sized + IPropertyStoreFactory_Impl {
     fn GetDelayedPropertyStore(&self, flags: GETPROPERTYSTOREFLAGS, dwstoreid: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -32,6 +34,7 @@ impl IDelayedPropertyStoreFactory_Vtbl {
         iid == &<IDelayedPropertyStoreFactory as ::windows::core::Interface>::IID || iid == &<IPropertyStoreFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IInitializeWithFile_Impl: Sized {
     fn Initialize(&self, pszfilepath: &::windows::core::PCWSTR, grfmode: u32) -> ::windows::core::Result<()>;
 }
@@ -49,6 +52,7 @@ impl IInitializeWithFile_Vtbl {
         iid == &<IInitializeWithFile as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IInitializeWithStream_Impl: Sized {
     fn Initialize(&self, pstream: &::core::option::Option<super::super::super::System::Com::IStream>, grfmode: u32) -> ::windows::core::Result<()>;
@@ -69,6 +73,7 @@ impl IInitializeWithStream_Vtbl {
         iid == &<IInitializeWithStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait INamedPropertyStore_Impl: Sized {
     fn GetNamedValue(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<super::super::super::System::Com::StructuredStorage::PROPVARIANT>;
@@ -131,6 +136,7 @@ impl INamedPropertyStore_Vtbl {
         iid == &<INamedPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IObjectWithPropertyKey_Impl: Sized {
     fn SetPropertyKey(&self, key: *const PROPERTYKEY) -> ::windows::core::Result<()>;
     fn GetPropertyKey(&self) -> ::windows::core::Result<PROPERTYKEY>;
@@ -164,6 +170,7 @@ impl IObjectWithPropertyKey_Vtbl {
         iid == &<IObjectWithPropertyKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IPersistSerializedPropStorage_Impl: Sized {
     fn SetFlags(&self, flags: i32) -> ::windows::core::Result<()>;
     fn SetPropertyStorage(&self, psps: *const SERIALIZEDPROPSTORAGE, cb: u32) -> ::windows::core::Result<()>;
@@ -198,6 +205,7 @@ impl IPersistSerializedPropStorage_Vtbl {
         iid == &<IPersistSerializedPropStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IPersistSerializedPropStorage2_Impl: Sized + IPersistSerializedPropStorage_Impl {
     fn GetPropertyStorageSize(&self) -> ::windows::core::Result<u32>;
     fn GetPropertyStorageBuffer(&self, psps: *mut SERIALIZEDPROPSTORAGE, cb: u32, pcbwritten: *mut u32) -> ::windows::core::Result<()>;
@@ -231,6 +239,7 @@ impl IPersistSerializedPropStorage2_Vtbl {
         iid == &<IPersistSerializedPropStorage2 as ::windows::core::Interface>::IID || iid == &<IPersistSerializedPropStorage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertyChange_Impl: Sized + IObjectWithPropertyKey_Impl {
     fn ApplyToPropVariant(&self, propvarin: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<super::super::super::System::Com::StructuredStorage::PROPVARIANT>;
@@ -257,6 +266,7 @@ impl IPropertyChange_Vtbl {
         iid == &<IPropertyChange as ::windows::core::Interface>::IID || iid == &<IObjectWithPropertyKey as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IPropertyChangeArray_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, iindex: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -325,6 +335,7 @@ impl IPropertyChangeArray_Vtbl {
         iid == &<IPropertyChangeArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IPropertyDescription_Impl: Sized {
     fn GetPropertyKey(&self) -> ::windows::core::Result<PROPERTYKEY>;
@@ -584,6 +595,7 @@ impl IPropertyDescription_Vtbl {
         iid == &<IPropertyDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IPropertyDescription2_Impl: Sized + IPropertyDescription_Impl {
     fn GetImageReferenceForValue(&self, propvar: *const super::super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -613,6 +625,7 @@ impl IPropertyDescription2_Vtbl {
         iid == &<IPropertyDescription2 as ::windows::core::Interface>::IID || iid == &<IPropertyDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IPropertyDescriptionAliasInfo_Impl: Sized + IPropertyDescription_Impl {
     fn GetSortByAlias(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -643,6 +656,7 @@ impl IPropertyDescriptionAliasInfo_Vtbl {
         iid == &<IPropertyDescriptionAliasInfo as ::windows::core::Interface>::IID || iid == &<IPropertyDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IPropertyDescriptionList_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetAt(&self, ielem: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -676,6 +690,7 @@ impl IPropertyDescriptionList_Vtbl {
         iid == &<IPropertyDescriptionList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IPropertyDescriptionRelatedPropertyInfo_Impl: Sized + IPropertyDescription_Impl {
     fn GetRelatedProperty(&self, pszrelationshipname: &::windows::core::PCWSTR, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -696,6 +711,7 @@ impl IPropertyDescriptionRelatedPropertyInfo_Vtbl {
         iid == &<IPropertyDescriptionRelatedPropertyInfo as ::windows::core::Interface>::IID || iid == &<IPropertyDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_Search_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_Search_Common"))]
 pub trait IPropertyDescriptionSearchInfo_Impl: Sized + IPropertyDescription_Impl {
     fn GetSearchInfoFlags(&self) -> ::windows::core::Result<PROPDESC_SEARCHINFO_FLAGS>;
@@ -764,6 +780,7 @@ impl IPropertyDescriptionSearchInfo_Vtbl {
         iid == &<IPropertyDescriptionSearchInfo as ::windows::core::Interface>::IID || iid == &<IPropertyDescription as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertyEnumType_Impl: Sized {
     fn GetEnumType(&self) -> ::windows::core::Result<PROPENUMTYPE>;
@@ -845,6 +862,7 @@ impl IPropertyEnumType_Vtbl {
         iid == &<IPropertyEnumType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertyEnumType2_Impl: Sized + IPropertyEnumType_Impl {
     fn GetImageReference(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -871,6 +889,7 @@ impl IPropertyEnumType2_Vtbl {
         iid == &<IPropertyEnumType2 as ::windows::core::Interface>::IID || iid == &<IPropertyEnumType as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertyEnumTypeList_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -927,6 +946,7 @@ impl IPropertyEnumTypeList_Vtbl {
         iid == &<IPropertyEnumTypeList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertyStore_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -996,6 +1016,7 @@ impl IPropertyStore_Vtbl {
         iid == &<IPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertyStoreCache_Impl: Sized + IPropertyStore_Impl {
     fn GetState(&self, key: *const PROPERTYKEY) -> ::windows::core::Result<PSC_STATE>;
@@ -1046,6 +1067,7 @@ impl IPropertyStoreCache_Vtbl {
         iid == &<IPropertyStoreCache as ::windows::core::Interface>::IID || iid == &<IPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IPropertyStoreCapabilities_Impl: Sized {
     fn IsPropertyWritable(&self, key: *const PROPERTYKEY) -> ::windows::core::Result<()>;
 }
@@ -1063,6 +1085,7 @@ impl IPropertyStoreCapabilities_Vtbl {
         iid == &<IPropertyStoreCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IPropertyStoreFactory_Impl: Sized {
     fn GetPropertyStore(&self, flags: GETPROPERTYSTOREFLAGS, punkfactory: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetPropertyStoreForKeys(&self, rgkeys: *const PROPERTYKEY, ckeys: u32, flags: GETPROPERTYSTOREFLAGS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1090,6 +1113,7 @@ impl IPropertyStoreFactory_Vtbl {
         iid == &<IPropertyStoreFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertySystem_Impl: Sized {
     fn GetPropertyDescription(&self, propkey: *const PROPERTYKEY, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1175,6 +1199,7 @@ impl IPropertySystem_Vtbl {
         iid == &<IPropertySystem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 pub trait IPropertySystemChangeNotify_Impl: Sized {
     fn SchemaRefreshed(&self) -> ::windows::core::Result<()>;
 }
@@ -1192,6 +1217,7 @@ impl IPropertySystemChangeNotify_Vtbl {
         iid == &<IPropertySystemChangeNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IPropertyUI_Impl: Sized {
     fn ParsePropertyName(&self, pszname: &::windows::core::PCWSTR, pfmtid: *mut ::windows::core::GUID, ppid: *mut u32, pcheaten: *mut u32) -> ::windows::core::Result<()>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 pub trait CIE4ConnectionPoint_Impl: Sized + super::super::System::Com::IConnectionPoint_Impl {
     fn DoInvokeIE4(&self, pf: *mut super::super::Foundation::BOOL, ppv: *mut *mut ::core::ffi::c_void, dispid: i32, pdispparams: *mut super::super::System::Com::DISPPARAMS) -> ::windows::core::Result<()>;
@@ -28,6 +29,7 @@ impl CIE4ConnectionPoint_Vtbl {
         iid == &<CIE4ConnectionPoint as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IConnectionPoint as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DFConstraint_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -70,6 +72,7 @@ impl DFConstraint_Vtbl {
         iid == &<DFConstraint as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DShellFolderViewEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -83,6 +86,7 @@ impl DShellFolderViewEvents_Vtbl {
         iid == &<DShellFolderViewEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DShellNameSpaceEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -96,6 +100,7 @@ impl DShellNameSpaceEvents_Vtbl {
         iid == &<DShellNameSpaceEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DShellWindowsEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -109,6 +114,7 @@ impl DShellWindowsEvents_Vtbl {
         iid == &<DShellWindowsEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DWebBrowserEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -122,6 +128,7 @@ impl DWebBrowserEvents_Vtbl {
         iid == &<DWebBrowserEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait DWebBrowserEvents2_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -135,6 +142,7 @@ impl DWebBrowserEvents2_Vtbl {
         iid == &<DWebBrowserEvents2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Folder_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Title(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -263,6 +271,7 @@ impl Folder_Vtbl {
         iid == &<Folder as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Folder2_Impl: Sized + Folder_Impl {
     fn Self_(&self) -> ::windows::core::Result<FolderItem>;
@@ -332,6 +341,7 @@ impl Folder2_Vtbl {
         iid == &<Folder2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<Folder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait Folder3_Impl: Sized + Folder2_Impl {
     fn ShowWebViewBarricade(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -368,6 +378,7 @@ impl Folder3_Vtbl {
         iid == &<Folder3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<Folder as ::windows::core::Interface>::IID || iid == &<Folder2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait FolderItem_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Application(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -587,6 +598,7 @@ impl FolderItem_Vtbl {
         iid == &<FolderItem as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait FolderItem2_Impl: Sized + FolderItem_Impl {
     fn InvokeVerbEx(&self, vverb: &super::super::System::Com::VARIANT, vargs: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -623,6 +635,7 @@ impl FolderItem2_Vtbl {
         iid == &<FolderItem2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<FolderItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait FolderItemVerb_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Application(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -685,6 +698,7 @@ impl FolderItemVerb_Vtbl {
         iid == &<FolderItemVerb as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait FolderItemVerbs_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -766,6 +780,7 @@ impl FolderItemVerbs_Vtbl {
         iid == &<FolderItemVerbs as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait FolderItems_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -847,6 +862,7 @@ impl FolderItems_Vtbl {
         iid == &<FolderItems as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait FolderItems2_Impl: Sized + FolderItems_Impl {
     fn InvokeVerbEx(&self, vverb: &super::super::System::Com::VARIANT, vargs: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -867,6 +883,7 @@ impl FolderItems2_Vtbl {
         iid == &<FolderItems2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<FolderItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait FolderItems3_Impl: Sized + FolderItems2_Impl {
     fn Filter(&self, grfflags: i32, bstrfilespec: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -899,6 +916,7 @@ impl FolderItems3_Vtbl {
         iid == &<FolderItems3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<FolderItems as ::windows::core::Interface>::IID || iid == &<FolderItems2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IACList_Impl: Sized {
     fn Expand(&self, pszexpand: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -916,6 +934,7 @@ impl IACList_Vtbl {
         iid == &<IACList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IACList2_Impl: Sized + IACList_Impl {
     fn SetOptions(&self, dwflag: u32) -> ::windows::core::Result<()>;
     fn GetOptions(&self) -> ::windows::core::Result<u32>;
@@ -949,6 +968,7 @@ impl IACList2_Vtbl {
         iid == &<IACList2 as ::windows::core::Interface>::IID || iid == &<IACList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IAccessibilityDockingService_Impl: Sized {
     fn GetAvailableSize(&self, hmonitor: super::super::Graphics::Gdi::HMONITOR, pcxfixed: *mut u32, pcymax: *mut u32) -> ::windows::core::Result<()>;
@@ -986,6 +1006,7 @@ impl IAccessibilityDockingService_Vtbl {
         iid == &<IAccessibilityDockingService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IAccessibilityDockingServiceCallback_Impl: Sized {
     fn Undocked(&self, undockreason: UNDOCK_REASON) -> ::windows::core::Result<()>;
 }
@@ -1003,6 +1024,7 @@ impl IAccessibilityDockingServiceCallback_Vtbl {
         iid == &<IAccessibilityDockingServiceCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IAccessibleObject_Impl: Sized {
     fn SetAccessibleName(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1020,6 +1042,7 @@ impl IAccessibleObject_Vtbl {
         iid == &<IAccessibleObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IActionProgress_Impl: Sized {
     fn Begin(&self, action: SPACTION, flags: u32) -> ::windows::core::Result<()>;
@@ -1084,6 +1107,7 @@ impl IActionProgress_Vtbl {
         iid == &<IActionProgress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IActionProgressDialog_Impl: Sized {
     fn Initialize(&self, flags: u32, psztitle: &::windows::core::PCWSTR, pszcancel: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn Stop(&self) -> ::windows::core::Result<()>;
@@ -1111,6 +1135,7 @@ impl IActionProgressDialog_Vtbl {
         iid == &<IActionProgressDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IAppActivationUIInfo_Impl: Sized {
     fn GetMonitor(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HMONITOR>;
@@ -1192,6 +1217,7 @@ impl IAppActivationUIInfo_Vtbl {
         iid == &<IAppActivationUIInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IAppPublisher_Impl: Sized {
     fn GetNumberOfCategories(&self) -> ::windows::core::Result<u32>;
     fn GetCategories(&self) -> ::windows::core::Result<APPCATEGORYINFOLIST>;
@@ -1257,6 +1283,7 @@ impl IAppPublisher_Vtbl {
         iid == &<IAppPublisher as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IAppVisibility_Impl: Sized {
     fn GetAppVisibilityOnMonitor(&self, hmonitor: super::super::Graphics::Gdi::HMONITOR) -> ::windows::core::Result<MONITOR_APP_VISIBILITY>;
@@ -1319,6 +1346,7 @@ impl IAppVisibility_Vtbl {
         iid == &<IAppVisibility as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IAppVisibilityEvents_Impl: Sized {
     fn AppVisibilityOnMonitorChanged(&self, hmonitor: super::super::Graphics::Gdi::HMONITOR, previousmode: MONITOR_APP_VISIBILITY, currentmode: MONITOR_APP_VISIBILITY) -> ::windows::core::Result<()>;
@@ -1349,6 +1377,7 @@ impl IAppVisibilityEvents_Vtbl {
         iid == &<IAppVisibilityEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IApplicationActivationManager_Impl: Sized {
     fn ActivateApplication(&self, appusermodelid: &::windows::core::PCWSTR, arguments: &::windows::core::PCWSTR, options: ACTIVATEOPTIONS) -> ::windows::core::Result<u32>;
     fn ActivateForFile(&self, appusermodelid: &::windows::core::PCWSTR, itemarray: &::core::option::Option<IShellItemArray>, verb: &::windows::core::PCWSTR) -> ::windows::core::Result<u32>;
@@ -1401,6 +1430,7 @@ impl IApplicationActivationManager_Vtbl {
         iid == &<IApplicationActivationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IApplicationAssociationRegistration_Impl: Sized {
     fn QueryCurrentDefault(&self, pszquery: &::windows::core::PCWSTR, atquerytype: ASSOCIATIONTYPE, alquerylevel: ASSOCIATIONLEVEL) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1477,6 +1507,7 @@ impl IApplicationAssociationRegistration_Vtbl {
         iid == &<IApplicationAssociationRegistration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IApplicationAssociationRegistrationUI_Impl: Sized {
     fn LaunchAdvancedAssociationUI(&self, pszappregistryname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -1497,6 +1528,7 @@ impl IApplicationAssociationRegistrationUI_Vtbl {
         iid == &<IApplicationAssociationRegistrationUI as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IApplicationDesignModeSettings_Impl: Sized {
     fn SetNativeDisplaySize(&self, nativedisplaysizepixels: &super::super::Foundation::SIZE) -> ::windows::core::Result<()>;
@@ -1567,6 +1599,7 @@ impl IApplicationDesignModeSettings_Vtbl {
         iid == &<IApplicationDesignModeSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IApplicationDesignModeSettings2_Impl: Sized + IApplicationDesignModeSettings_Impl {
     fn SetNativeDisplayOrientation(&self, nativedisplayorientation: NATIVE_DISPLAY_ORIENTATION) -> ::windows::core::Result<()>;
@@ -1638,6 +1671,7 @@ impl IApplicationDesignModeSettings2_Vtbl {
         iid == &<IApplicationDesignModeSettings2 as ::windows::core::Interface>::IID || iid == &<IApplicationDesignModeSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IApplicationDestinations_Impl: Sized {
     fn SetAppID(&self, pszappid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn RemoveDestination(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -1672,6 +1706,7 @@ impl IApplicationDestinations_Vtbl {
         iid == &<IApplicationDestinations as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IApplicationDocumentLists_Impl: Sized {
     fn SetAppID(&self, pszappid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetList(&self, listtype: APPDOCLISTTYPE, citemsdesired: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -1699,6 +1734,7 @@ impl IApplicationDocumentLists_Vtbl {
         iid == &<IApplicationDocumentLists as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IAssocHandler_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -1782,6 +1818,7 @@ impl IAssocHandler_Vtbl {
         iid == &<IAssocHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IAssocHandlerInvoker_Impl: Sized {
     fn SupportsSelection(&self) -> ::windows::core::Result<()>;
     fn Invoke(&self) -> ::windows::core::Result<()>;
@@ -1809,6 +1846,7 @@ impl IAssocHandlerInvoker_Vtbl {
         iid == &<IAssocHandlerInvoker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAttachmentExecute_Impl: Sized {
     fn SetClientTitle(&self, psztitle: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1915,6 +1953,7 @@ impl IAttachmentExecute_Vtbl {
         iid == &<IAttachmentExecute as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAutoComplete_Impl: Sized {
     fn Init(&self, hwndedit: super::super::Foundation::HWND, punkacl: &::core::option::Option<::windows::core::IUnknown>, pwszregkeypath: &::windows::core::PCWSTR, pwszquickcomplete: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -1945,6 +1984,7 @@ impl IAutoComplete_Vtbl {
         iid == &<IAutoComplete as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAutoComplete2_Impl: Sized + IAutoComplete_Impl {
     fn SetOptions(&self, dwflag: u32) -> ::windows::core::Result<()>;
@@ -1981,6 +2021,7 @@ impl IAutoComplete2_Vtbl {
         iid == &<IAutoComplete2 as ::windows::core::Interface>::IID || iid == &<IAutoComplete as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IAutoCompleteDropDown_Impl: Sized {
     fn GetDropDownStatus(&self, pdwflags: *mut u32, ppwszstring: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn ResetEnumerator(&self) -> ::windows::core::Result<()>;
@@ -2008,6 +2049,7 @@ impl IAutoCompleteDropDown_Vtbl {
         iid == &<IAutoCompleteDropDown as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IBandHost_Impl: Sized {
     fn CreateBand(&self, rclsidband: *const ::windows::core::GUID, favailable: super::super::Foundation::BOOL, fvisible: super::super::Foundation::BOOL, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -2045,6 +2087,7 @@ impl IBandHost_Vtbl {
         iid == &<IBandHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Ole")]
 pub trait IBandSite_Impl: Sized {
     fn AddBand(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -2123,6 +2166,7 @@ impl IBandSite_Vtbl {
         iid == &<IBandSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IBannerNotificationHandler_Impl: Sized {
     fn OnBannerEvent(&self, notification: *const BANNER_NOTIFICATION) -> ::windows::core::Result<()>;
 }
@@ -2140,6 +2184,7 @@ impl IBannerNotificationHandler_Vtbl {
         iid == &<IBannerNotificationHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IBanneredBar_Impl: Sized {
     fn SetIconSize(&self, iicon: u32) -> ::windows::core::Result<()>;
@@ -2196,6 +2241,7 @@ impl IBanneredBar_Vtbl {
         iid == &<IBanneredBar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IBrowserFrameOptions_Impl: Sized {
     fn GetFrameOptions(&self, dwmask: u32) -> ::windows::core::Result<u32>;
 }
@@ -2219,6 +2265,7 @@ impl IBrowserFrameOptions_Vtbl {
         iid == &<IBrowserFrameOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 pub trait IBrowserService_Impl: Sized {
     fn GetParentSite(&self) -> ::windows::core::Result<super::super::System::Ole::IOleInPlaceSite>;
@@ -2523,6 +2570,7 @@ impl IBrowserService_Vtbl {
         iid == &<IBrowserService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IBrowserService2_Impl: Sized + IBrowserService_Impl {
     fn WndProcBS(&self, hwnd: super::super::Foundation::HWND, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> super::super::Foundation::LRESULT;
@@ -2997,6 +3045,7 @@ impl IBrowserService2_Vtbl {
         iid == &<IBrowserService2 as ::windows::core::Interface>::IID || iid == &<IBrowserService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IBrowserService3_Impl: Sized + IBrowserService2_Impl {
     fn _PositionViewWindow(&self, hwnd: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -3033,6 +3082,7 @@ impl IBrowserService3_Vtbl {
         iid == &<IBrowserService3 as ::windows::core::Interface>::IID || iid == &<IBrowserService as ::windows::core::Interface>::IID || iid == &<IBrowserService2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IBrowserService4_Impl: Sized + IBrowserService3_Impl {
     fn ActivateView(&self, fpendingview: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -3070,6 +3120,7 @@ impl IBrowserService4_Vtbl {
         iid == &<IBrowserService4 as ::windows::core::Interface>::IID || iid == &<IBrowserService as ::windows::core::Interface>::IID || iid == &<IBrowserService2 as ::windows::core::Interface>::IID || iid == &<IBrowserService3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICDBurn_Impl: Sized {
     fn GetRecorderDriveLetter(&self, pszdrive: ::windows::core::PWSTR, cch: u32) -> ::windows::core::Result<()>;
@@ -3113,6 +3164,7 @@ impl ICDBurn_Vtbl {
         iid == &<ICDBurn as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICDBurnExt_Impl: Sized {
     fn GetSupportedActionTypes(&self) -> ::windows::core::Result<u32>;
 }
@@ -3136,6 +3188,7 @@ impl ICDBurnExt_Vtbl {
         iid == &<ICDBurnExt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait ICategorizer_Impl: Sized {
     fn GetDescription(&self, pszdesc: ::windows::core::PWSTR, cch: u32) -> ::windows::core::Result<()>;
@@ -3186,6 +3239,7 @@ impl ICategorizer_Vtbl {
         iid == &<ICategorizer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ICategoryProvider_Impl: Sized {
     fn CanCategorizeOnSCID(&self, pscid: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<()>;
@@ -3256,6 +3310,7 @@ impl ICategoryProvider_Vtbl {
         iid == &<ICategoryProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IColumnManager_Impl: Sized {
     fn SetColumnInfo(&self, propkey: *const PropertiesSystem::PROPERTYKEY, pcmci: *const CM_COLUMNINFO) -> ::windows::core::Result<()>;
@@ -3313,6 +3368,7 @@ impl IColumnManager_Vtbl {
         iid == &<IColumnManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IColumnProvider_Impl: Sized {
     fn Initialize(&self, psci: *const SHCOLUMNINIT) -> ::windows::core::Result<()>;
@@ -3362,6 +3418,7 @@ impl IColumnProvider_Vtbl {
         iid == &<IColumnProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 pub trait ICommDlgBrowser_Impl: Sized {
     fn OnDefaultCommand(&self, ppshv: &::core::option::Option<IShellView>) -> ::windows::core::Result<()>;
@@ -3399,6 +3456,7 @@ impl ICommDlgBrowser_Vtbl {
         iid == &<ICommDlgBrowser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 pub trait ICommDlgBrowser2_Impl: Sized + ICommDlgBrowser_Impl {
     fn Notify(&self, ppshv: &::core::option::Option<IShellView>, dwnotifytype: u32) -> ::windows::core::Result<()>;
@@ -3442,6 +3500,7 @@ impl ICommDlgBrowser2_Vtbl {
         iid == &<ICommDlgBrowser2 as ::windows::core::Interface>::IID || iid == &<ICommDlgBrowser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 pub trait ICommDlgBrowser3_Impl: Sized + ICommDlgBrowser2_Impl {
     fn OnColumnClicked(&self, ppshv: &::core::option::Option<IShellView>, icolumn: i32) -> ::windows::core::Result<()>;
@@ -3479,6 +3538,7 @@ impl ICommDlgBrowser3_Vtbl {
         iid == &<ICommDlgBrowser3 as ::windows::core::Interface>::IID || iid == &<ICommDlgBrowser as ::windows::core::Interface>::IID || iid == &<ICommDlgBrowser2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IComputerInfoChangeNotify_Impl: Sized {
     fn ComputerInfoChanged(&self) -> ::windows::core::Result<()>;
 }
@@ -3496,6 +3556,7 @@ impl IComputerInfoChangeNotify_Vtbl {
         iid == &<IComputerInfoChangeNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IConnectableCredentialProviderCredential_Impl: Sized + ICredentialProviderCredential_Impl {
     fn Connect(&self, pqcws: &::core::option::Option<IQueryContinueWithStatus>) -> ::windows::core::Result<()>;
@@ -3526,6 +3587,7 @@ impl IConnectableCredentialProviderCredential_Vtbl {
         iid == &<IConnectableCredentialProviderCredential as ::windows::core::Interface>::IID || iid == &<ICredentialProviderCredential as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContactManagerInterop_Impl: Sized {
     fn ShowContactCardForWindow(&self, appwindow: super::super::Foundation::HWND, contact: &::core::option::Option<::windows::core::IUnknown>, selection: *const super::super::Foundation::RECT, preferredplacement: FLYOUT_PLACEMENT) -> ::windows::core::Result<()>;
@@ -3546,6 +3608,7 @@ impl IContactManagerInterop_Vtbl {
         iid == &<IContactManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IContextMenu_Impl: Sized {
     fn QueryContextMenu(&self, hmenu: super::WindowsAndMessaging::HMENU, indexmenu: u32, idcmdfirst: u32, idcmdlast: u32, uflags: u32) -> ::windows::core::Result<()>;
@@ -3583,6 +3646,7 @@ impl IContextMenu_Vtbl {
         iid == &<IContextMenu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IContextMenu2_Impl: Sized + IContextMenu_Impl {
     fn HandleMenuMsg(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -3603,6 +3667,7 @@ impl IContextMenu2_Vtbl {
         iid == &<IContextMenu2 as ::windows::core::Interface>::IID || iid == &<IContextMenu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IContextMenu3_Impl: Sized + IContextMenu2_Impl {
     fn HandleMenuMsg2(&self, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM, plresult: *mut super::super::Foundation::LRESULT) -> ::windows::core::Result<()>;
@@ -3623,6 +3688,7 @@ impl IContextMenu3_Vtbl {
         iid == &<IContextMenu3 as ::windows::core::Interface>::IID || iid == &<IContextMenu as ::windows::core::Interface>::IID || iid == &<IContextMenu2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IContextMenuCB_Impl: Sized {
     fn CallBack(&self, psf: &::core::option::Option<IShellFolder>, hwndowner: super::super::Foundation::HWND, pdtobj: &::core::option::Option<super::super::System::Com::IDataObject>, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -3643,6 +3709,7 @@ impl IContextMenuCB_Vtbl {
         iid == &<IContextMenuCB as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IContextMenuSite_Impl: Sized {
     fn DoContextMenuPopup(&self, punkcontextmenu: &::core::option::Option<::windows::core::IUnknown>, fflags: u32, pt: &super::super::Foundation::POINT) -> ::windows::core::Result<()>;
@@ -3663,6 +3730,7 @@ impl IContextMenuSite_Vtbl {
         iid == &<IContextMenuSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICopyHookA_Impl: Sized {
     fn CopyCallback(&self, hwnd: super::super::Foundation::HWND, wfunc: u32, wflags: u32, pszsrcfile: &::windows::core::PCSTR, dwsrcattribs: u32, pszdestfile: &::windows::core::PCSTR, dwdestattribs: u32) -> u32;
@@ -3683,6 +3751,7 @@ impl ICopyHookA_Vtbl {
         iid == &<ICopyHookA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICopyHookW_Impl: Sized {
     fn CopyCallback(&self, hwnd: super::super::Foundation::HWND, wfunc: u32, wflags: u32, pszsrcfile: &::windows::core::PCWSTR, dwsrcattribs: u32, pszdestfile: &::windows::core::PCWSTR, dwdestattribs: u32) -> u32;
@@ -3703,6 +3772,7 @@ impl ICopyHookW_Vtbl {
         iid == &<ICopyHookW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICreateProcessInputs_Impl: Sized {
     fn GetCreateFlags(&self) -> ::windows::core::Result<u32>;
     fn SetCreateFlags(&self, dwcreationflags: u32) -> ::windows::core::Result<()>;
@@ -3771,6 +3841,7 @@ impl ICreateProcessInputs_Vtbl {
         iid == &<ICreateProcessInputs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICreatingProcess_Impl: Sized {
     fn OnCreating(&self, pcpi: &::core::option::Option<ICreateProcessInputs>) -> ::windows::core::Result<()>;
 }
@@ -3788,6 +3859,7 @@ impl ICreatingProcess_Vtbl {
         iid == &<ICreatingProcess as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICredentialProvider_Impl: Sized {
     fn SetUsageScenario(&self, cpus: CREDENTIAL_PROVIDER_USAGE_SCENARIO, dwflags: u32) -> ::windows::core::Result<()>;
@@ -3878,6 +3950,7 @@ impl ICredentialProvider_Vtbl {
         iid == &<ICredentialProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ICredentialProviderCredential_Impl: Sized {
     fn Advise(&self, pcpce: &::core::option::Option<ICredentialProviderCredentialEvents>) -> ::windows::core::Result<()>;
@@ -4043,6 +4116,7 @@ impl ICredentialProviderCredential_Vtbl {
         iid == &<ICredentialProviderCredential as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ICredentialProviderCredential2_Impl: Sized + ICredentialProviderCredential_Impl {
     fn GetUserSid(&self, sid: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
@@ -4063,6 +4137,7 @@ impl ICredentialProviderCredential2_Vtbl {
         iid == &<ICredentialProviderCredential2 as ::windows::core::Interface>::IID || iid == &<ICredentialProviderCredential as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ICredentialProviderCredentialEvents_Impl: Sized {
     fn SetFieldState(&self, pcpc: &::core::option::Option<ICredentialProviderCredential>, dwfieldid: u32, cpfs: CREDENTIAL_PROVIDER_FIELD_STATE) -> ::windows::core::Result<()>;
@@ -4155,6 +4230,7 @@ impl ICredentialProviderCredentialEvents_Vtbl {
         iid == &<ICredentialProviderCredentialEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ICredentialProviderCredentialEvents2_Impl: Sized + ICredentialProviderCredentialEvents_Impl {
     fn BeginFieldUpdates(&self) -> ::windows::core::Result<()>;
@@ -4192,6 +4268,7 @@ impl ICredentialProviderCredentialEvents2_Vtbl {
         iid == &<ICredentialProviderCredentialEvents2 as ::windows::core::Interface>::IID || iid == &<ICredentialProviderCredentialEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICredentialProviderCredentialWithFieldOptions_Impl: Sized {
     fn GetFieldOptions(&self, fieldid: u32) -> ::windows::core::Result<CREDENTIAL_PROVIDER_CREDENTIAL_FIELD_OPTIONS>;
 }
@@ -4215,6 +4292,7 @@ impl ICredentialProviderCredentialWithFieldOptions_Vtbl {
         iid == &<ICredentialProviderCredentialWithFieldOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICredentialProviderEvents_Impl: Sized {
     fn CredentialsChanged(&self, upadvisecontext: usize) -> ::windows::core::Result<()>;
 }
@@ -4232,6 +4310,7 @@ impl ICredentialProviderEvents_Vtbl {
         iid == &<ICredentialProviderEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ICredentialProviderFilter_Impl: Sized {
     fn Filter(&self, cpus: CREDENTIAL_PROVIDER_USAGE_SCENARIO, dwflags: u32, rgclsidproviders: *const ::windows::core::GUID, rgballow: *mut super::super::Foundation::BOOL, cproviders: u32) -> ::windows::core::Result<()>;
@@ -4268,6 +4347,7 @@ impl ICredentialProviderFilter_Vtbl {
         iid == &<ICredentialProviderFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICredentialProviderSetUserArray_Impl: Sized {
     fn SetUserArray(&self, users: &::core::option::Option<ICredentialProviderUserArray>) -> ::windows::core::Result<()>;
 }
@@ -4285,6 +4365,7 @@ impl ICredentialProviderSetUserArray_Vtbl {
         iid == &<ICredentialProviderSetUserArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ICredentialProviderUser_Impl: Sized {
     fn GetSid(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -4353,6 +4434,7 @@ impl ICredentialProviderUser_Vtbl {
         iid == &<ICredentialProviderUser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICredentialProviderUserArray_Impl: Sized {
     fn SetProviderFilter(&self, guidprovidertofilterto: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn GetAccountOptions(&self) -> ::windows::core::Result<CREDENTIAL_PROVIDER_ACCOUNT_OPTIONS>;
@@ -4412,6 +4494,7 @@ impl ICredentialProviderUserArray_Vtbl {
         iid == &<ICredentialProviderUserArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait ICurrentItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -4425,6 +4508,7 @@ impl ICurrentItem_Vtbl {
         iid == &<ICurrentItem as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ICurrentWorkingDirectory_Impl: Sized {
     fn GetDirectory(&self, pwzpath: ::windows::core::PWSTR, cchsize: u32) -> ::windows::core::Result<()>;
     fn SetDirectory(&self, pwzpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -4452,6 +4536,7 @@ impl ICurrentWorkingDirectory_Vtbl {
         iid == &<ICurrentWorkingDirectory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait ICustomDestinationList_Impl: Sized {
     fn SetAppID(&self, pszappid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -4531,6 +4616,7 @@ impl ICustomDestinationList_Vtbl {
         iid == &<ICustomDestinationList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDataObjectAsyncCapability_Impl: Sized {
     fn SetAsyncMode(&self, fdoopasync: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4594,6 +4680,7 @@ impl IDataObjectAsyncCapability_Vtbl {
         iid == &<IDataObjectAsyncCapability as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDataObjectProvider_Impl: Sized {
     fn GetDataObject(&self) -> ::windows::core::Result<super::super::System::Com::IDataObject>;
@@ -4630,6 +4717,7 @@ impl IDataObjectProvider_Vtbl {
         iid == &<IDataObjectProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDataTransferManagerInterop_Impl: Sized {
     fn GetForWindow(&self, appwindow: super::super::Foundation::HWND, riid: *const ::windows::core::GUID, datatransfermanager: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -4660,6 +4748,7 @@ impl IDataTransferManagerInterop_Vtbl {
         iid == &<IDataTransferManagerInterop as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Registry")]
 pub trait IDefaultExtractIconInit_Impl: Sized {
     fn SetFlags(&self, uflags: u32) -> ::windows::core::Result<()>;
@@ -4718,6 +4807,7 @@ impl IDefaultExtractIconInit_Vtbl {
         iid == &<IDefaultExtractIconInit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
 pub trait IDefaultFolderMenuInitialize_Impl: Sized {
     fn Initialize(&self, hwnd: super::super::Foundation::HWND, pcmcb: &::core::option::Option<IContextMenuCB>, pidlfolder: *const Common::ITEMIDLIST, psf: &::core::option::Option<IShellFolder>, cidl: u32, apidl: *const *const Common::ITEMIDLIST, punkassociation: &::core::option::Option<::windows::core::IUnknown>, ckeys: u32, akeys: *const super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
@@ -4768,6 +4858,7 @@ impl IDefaultFolderMenuInitialize_Vtbl {
         iid == &<IDefaultFolderMenuInitialize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDelegateFolder_Impl: Sized {
     fn SetItemAlloc(&self, pmalloc: &::core::option::Option<super::super::System::Com::IMalloc>) -> ::windows::core::Result<()>;
@@ -4788,6 +4879,7 @@ impl IDelegateFolder_Vtbl {
         iid == &<IDelegateFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IDelegateItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -4801,6 +4893,7 @@ impl IDelegateItem_Vtbl {
         iid == &<IDelegateItem as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDeskBand_Impl: Sized + IDockingWindow_Impl {
     fn GetBandInfo(&self, dwbandid: u32, dwviewmode: u32, pdbi: *mut DESKBANDINFO) -> ::windows::core::Result<()>;
@@ -4821,6 +4914,7 @@ impl IDeskBand_Vtbl {
         iid == &<IDeskBand as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID || iid == &<IDockingWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDeskBand2_Impl: Sized + IDeskBand_Impl {
     fn CanRenderComposited(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -4870,6 +4964,7 @@ impl IDeskBand2_Vtbl {
         iid == &<IDeskBand2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID || iid == &<IDockingWindow as ::windows::core::Interface>::IID || iid == &<IDeskBand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IDeskBandInfo_Impl: Sized {
     fn GetDefaultBandWidth(&self, dwbandid: u32, dwviewmode: u32) -> ::windows::core::Result<i32>;
 }
@@ -4893,6 +4988,7 @@ impl IDeskBandInfo_Vtbl {
         iid == &<IDeskBandInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDeskBar_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn SetClient(&self, punkclient: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -4936,6 +5032,7 @@ impl IDeskBar_Vtbl {
         iid == &<IDeskBar as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDeskBarClient_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn SetDeskBarSite(&self, punksite: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -4986,6 +5083,7 @@ impl IDeskBarClient_Vtbl {
         iid == &<IDeskBarClient as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IDesktopGadget_Impl: Sized {
     fn RunGadget(&self, gadgetpath: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -5003,6 +5101,7 @@ impl IDesktopGadget_Vtbl {
         iid == &<IDesktopGadget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IDesktopWallpaper_Impl: Sized {
     fn SetWallpaper(&self, monitorid: &::windows::core::PCWSTR, wallpaper: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -5179,6 +5278,7 @@ impl IDesktopWallpaper_Vtbl {
         iid == &<IDesktopWallpaper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IDestinationStreamFactory_Impl: Sized {
     fn GetDestinationStream(&self) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -5205,6 +5305,7 @@ impl IDestinationStreamFactory_Vtbl {
         iid == &<IDestinationStreamFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IDisplayItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -5218,6 +5319,7 @@ impl IDisplayItem_Vtbl {
         iid == &<IDisplayItem as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDocViewSite_Impl: Sized {
     fn OnSetTitle(&self, pvtitle: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -5238,6 +5340,7 @@ impl IDocViewSite_Vtbl {
         iid == &<IDocViewSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDockingWindow_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn ShowDW(&self, fshow: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5275,6 +5378,7 @@ impl IDockingWindow_Vtbl {
         iid == &<IDockingWindow as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDockingWindowFrame_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn AddToolbar(&self, punksrc: &::core::option::Option<::windows::core::IUnknown>, pwszitem: &::windows::core::PCWSTR, dwaddflags: u32) -> ::windows::core::Result<()>;
@@ -5312,6 +5416,7 @@ impl IDockingWindowFrame_Vtbl {
         iid == &<IDockingWindowFrame as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IDockingWindowSite_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn GetBorderDW(&self, punkobj: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<super::super::Foundation::RECT>;
@@ -5355,6 +5460,7 @@ impl IDockingWindowSite_Vtbl {
         iid == &<IDockingWindowSite as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IDragSourceHelper_Impl: Sized {
     fn InitializeFromBitmap(&self, pshdi: *const SHDRAGIMAGE, pdataobject: &::core::option::Option<super::super::System::Com::IDataObject>) -> ::windows::core::Result<()>;
@@ -5385,6 +5491,7 @@ impl IDragSourceHelper_Vtbl {
         iid == &<IDragSourceHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub trait IDragSourceHelper2_Impl: Sized + IDragSourceHelper_Impl {
     fn SetFlags(&self, dwflags: u32) -> ::windows::core::Result<()>;
@@ -5405,6 +5512,7 @@ impl IDragSourceHelper2_Vtbl {
         iid == &<IDragSourceHelper2 as ::windows::core::Interface>::IID || iid == &<IDragSourceHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IDropTargetHelper_Impl: Sized {
     fn DragEnter(&self, hwndtarget: super::super::Foundation::HWND, pdataobject: &::core::option::Option<super::super::System::Com::IDataObject>, ppt: *const super::super::Foundation::POINT, dweffect: super::super::System::Ole::DROPEFFECT) -> ::windows::core::Result<()>;
@@ -5456,6 +5564,7 @@ impl IDropTargetHelper_Vtbl {
         iid == &<IDropTargetHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IDynamicHWHandler_Impl: Sized {
     fn GetDynamicInfo(&self, pszdeviceid: &::windows::core::PCWSTR, dwcontenttype: u32) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -5479,6 +5588,7 @@ impl IDynamicHWHandler_Vtbl {
         iid == &<IDynamicHWHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IEnumACString_Impl: Sized + super::super::System::Com::IEnumString_Impl {
     fn NextItem(&self, pszurl: ::windows::core::PWSTR, cchmax: u32, pulsortindex: *mut u32) -> ::windows::core::Result<()>;
@@ -5522,6 +5632,7 @@ impl IEnumACString_Vtbl {
         iid == &<IEnumACString as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IEnumString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumAssocHandlers_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IAssocHandler>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
 }
@@ -5539,6 +5650,7 @@ impl IEnumAssocHandlers_Vtbl {
         iid == &<IEnumAssocHandlers as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumExplorerCommand_Impl: Sized {
     fn Next(&self, celt: u32, puicommand: *mut ::core::option::Option<IExplorerCommand>, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -5586,6 +5698,7 @@ impl IEnumExplorerCommand_Vtbl {
         iid == &<IEnumExplorerCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumExtraSearch_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut EXTRASEARCH, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -5633,6 +5746,7 @@ impl IEnumExtraSearch_Vtbl {
         iid == &<IEnumExtraSearch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IEnumFullIDList_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut *mut Common::ITEMIDLIST, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -5683,6 +5797,7 @@ impl IEnumFullIDList_Vtbl {
         iid == &<IEnumFullIDList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumHLITEM_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut HLITEM, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -5730,6 +5845,7 @@ impl IEnumHLITEM_Vtbl {
         iid == &<IEnumHLITEM as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IEnumIDList_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut *mut Common::ITEMIDLIST, pceltfetched: *mut u32) -> ::windows::core::HRESULT;
@@ -5774,6 +5890,7 @@ impl IEnumIDList_Vtbl {
         iid == &<IEnumIDList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumObjects_Impl: Sized {
     fn Next(&self, celt: u32, riid: *const ::windows::core::GUID, rgelt: *mut *mut ::core::ffi::c_void, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -5821,6 +5938,7 @@ impl IEnumObjects_Vtbl {
         iid == &<IEnumObjects as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumPublishedApps_Impl: Sized {
     fn Next(&self) -> ::windows::core::Result<IPublishedApp>;
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -5850,6 +5968,7 @@ impl IEnumPublishedApps_Vtbl {
         iid == &<IEnumPublishedApps as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumReadyCallback_Impl: Sized {
     fn EnumReady(&self) -> ::windows::core::Result<()>;
 }
@@ -5867,6 +5986,7 @@ impl IEnumReadyCallback_Vtbl {
         iid == &<IEnumReadyCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumResources_Impl: Sized {
     fn Next(&self, celt: u32, psir: *mut SHELL_ITEM_RESOURCE, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -5914,6 +6034,7 @@ impl IEnumResources_Vtbl {
         iid == &<IEnumResources as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumShellItems_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<IShellItem>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -5961,6 +6082,7 @@ impl IEnumShellItems_Vtbl {
         iid == &<IEnumShellItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumSyncMgrConflict_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<ISyncMgrConflict>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -6008,6 +6130,7 @@ impl IEnumSyncMgrConflict_Vtbl {
         iid == &<IEnumSyncMgrConflict as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumSyncMgrEvents_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<ISyncMgrEvent>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -6055,6 +6178,7 @@ impl IEnumSyncMgrEvents_Vtbl {
         iid == &<IEnumSyncMgrEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumSyncMgrSyncItems_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<ISyncMgrSyncItem>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -6102,6 +6226,7 @@ impl IEnumSyncMgrSyncItems_Vtbl {
         iid == &<IEnumSyncMgrSyncItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IEnumTravelLogEntry_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut ::core::option::Option<ITravelLogEntry>, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
     fn Skip(&self, celt: u32) -> ::windows::core::Result<()>;
@@ -6149,6 +6274,7 @@ impl IEnumTravelLogEntry_Vtbl {
         iid == &<IEnumTravelLogEntry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IEnumerableView_Impl: Sized {
     fn SetEnumReadyCallback(&self, percb: &::core::option::Option<IEnumReadyCallback>) -> ::windows::core::Result<()>;
@@ -6185,6 +6311,7 @@ impl IEnumerableView_Vtbl {
         iid == &<IEnumerableView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IExecuteCommand_Impl: Sized {
     fn SetKeyState(&self, grfkeystate: u32) -> ::windows::core::Result<()>;
@@ -6250,6 +6377,7 @@ impl IExecuteCommand_Vtbl {
         iid == &<IExecuteCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IExecuteCommandApplicationHostEnvironment_Impl: Sized {
     fn GetValue(&self) -> ::windows::core::Result<AHE_TYPE>;
 }
@@ -6273,6 +6401,7 @@ impl IExecuteCommandApplicationHostEnvironment_Vtbl {
         iid == &<IExecuteCommandApplicationHostEnvironment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IExecuteCommandHost_Impl: Sized {
     fn GetUIMode(&self) -> ::windows::core::Result<EC_HOST_UI_MODE>;
 }
@@ -6296,6 +6425,7 @@ impl IExecuteCommandHost_Vtbl {
         iid == &<IExecuteCommandHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IExpDispSupport_Impl: Sized {
     fn FindConnectionPoint(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::System::Com::IConnectionPoint>;
@@ -6339,6 +6469,7 @@ impl IExpDispSupport_Vtbl {
         iid == &<IExpDispSupport as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IExpDispSupportXP_Impl: Sized {
     fn FindCIE4ConnectionPoint(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<CIE4ConnectionPoint>;
@@ -6382,6 +6513,7 @@ impl IExpDispSupportXP_Vtbl {
         iid == &<IExpDispSupportXP as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IExplorerBrowser_Impl: Sized {
     fn Initialize(&self, hwndparent: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT, pfs: *const FOLDERSETTINGS) -> ::windows::core::Result<()>;
@@ -6515,6 +6647,7 @@ impl IExplorerBrowser_Vtbl {
         iid == &<IExplorerBrowser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 pub trait IExplorerBrowserEvents_Impl: Sized {
     fn OnNavigationPending(&self, pidlfolder: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -6559,6 +6692,7 @@ impl IExplorerBrowserEvents_Vtbl {
         iid == &<IExplorerBrowserEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IExplorerCommand_Impl: Sized {
     fn GetTitle(&self, psiitemarray: &::core::option::Option<IShellItemArray>) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -6673,6 +6807,7 @@ impl IExplorerCommand_Vtbl {
         iid == &<IExplorerCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IExplorerCommandProvider_Impl: Sized {
     fn GetCommands(&self, punksite: &::core::option::Option<::windows::core::IUnknown>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetCommand(&self, rguidcommandid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -6700,6 +6835,7 @@ impl IExplorerCommandProvider_Vtbl {
         iid == &<IExplorerCommandProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IExplorerCommandState_Impl: Sized {
     fn GetState(&self, psiitemarray: &::core::option::Option<IShellItemArray>, foktobeslow: super::super::Foundation::BOOL) -> ::windows::core::Result<u32>;
@@ -6726,6 +6862,7 @@ impl IExplorerCommandState_Vtbl {
         iid == &<IExplorerCommandState as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IExplorerPaneVisibility_Impl: Sized {
     fn GetPaneState(&self, ep: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
 }
@@ -6749,6 +6886,7 @@ impl IExplorerPaneVisibility_Vtbl {
         iid == &<IExplorerPaneVisibility as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IExtensionServices_Impl: Sized {
     fn SetAdditionalHeaders(&self, pwzadditionalheaders: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -6779,6 +6917,7 @@ impl IExtensionServices_Vtbl {
         iid == &<IExtensionServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub trait IExtractIconA_Impl: Sized {
     fn GetIconLocation(&self, uflags: u32, psziconfile: ::windows::core::PSTR, cchmax: u32, piindex: *mut i32, pwflags: *mut u32) -> ::windows::core::Result<()>;
@@ -6809,6 +6948,7 @@ impl IExtractIconA_Vtbl {
         iid == &<IExtractIconA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub trait IExtractIconW_Impl: Sized {
     fn GetIconLocation(&self, uflags: u32, psziconfile: ::windows::core::PWSTR, cchmax: u32, piindex: *mut i32, pwflags: *mut u32) -> ::windows::core::Result<()>;
@@ -6839,6 +6979,7 @@ impl IExtractIconW_Vtbl {
         iid == &<IExtractIconW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IExtractImage_Impl: Sized {
     fn GetLocation(&self, pszpathbuffer: ::windows::core::PWSTR, cch: u32, pdwpriority: *mut u32, prgsize: *const super::super::Foundation::SIZE, dwrecclrdepth: u32, pdwflags: *mut u32) -> ::windows::core::Result<()>;
@@ -6875,6 +7016,7 @@ impl IExtractImage_Vtbl {
         iid == &<IExtractImage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IExtractImage2_Impl: Sized + IExtractImage_Impl {
     fn GetDateStamp(&self) -> ::windows::core::Result<super::super::Foundation::FILETIME>;
@@ -6901,6 +7043,7 @@ impl IExtractImage2_Vtbl {
         iid == &<IExtractImage2 as ::windows::core::Interface>::IID || iid == &<IExtractImage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IFileDialog_Impl: Sized + IModalWindow_Impl {
     fn SetFileTypes(&self, cfiletypes: u32, rgfilterspec: *const Common::COMDLG_FILTERSPEC) -> ::windows::core::Result<()>;
@@ -7120,6 +7263,7 @@ impl IFileDialog_Vtbl {
         iid == &<IFileDialog as ::windows::core::Interface>::IID || iid == &<IModalWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IFileDialog2_Impl: Sized + IFileDialog_Impl {
     fn SetCancelButtonLabel(&self, pszlabel: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -7150,6 +7294,7 @@ impl IFileDialog2_Vtbl {
         iid == &<IFileDialog2 as ::windows::core::Interface>::IID || iid == &<IModalWindow as ::windows::core::Interface>::IID || iid == &<IFileDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFileDialogControlEvents_Impl: Sized {
     fn OnItemSelected(&self, pfdc: &::core::option::Option<IFileDialogCustomize>, dwidctl: u32, dwiditem: u32) -> ::windows::core::Result<()>;
@@ -7194,6 +7339,7 @@ impl IFileDialogControlEvents_Vtbl {
         iid == &<IFileDialogControlEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFileDialogCustomize_Impl: Sized {
     fn EnableOpenDropDown(&self, dwidctl: u32) -> ::windows::core::Result<()>;
@@ -7429,6 +7575,7 @@ impl IFileDialogCustomize_Vtbl {
         iid == &<IFileDialogCustomize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IFileDialogEvents_Impl: Sized {
     fn OnFileOk(&self, pfd: &::core::option::Option<IFileDialog>) -> ::windows::core::Result<()>;
     fn OnFolderChanging(&self, pfd: &::core::option::Option<IFileDialog>, psifolder: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
@@ -7503,6 +7650,7 @@ impl IFileDialogEvents_Vtbl {
         iid == &<IFileDialogEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFileIsInUse_Impl: Sized {
     fn GetAppName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -7578,6 +7726,7 @@ impl IFileIsInUse_Vtbl {
         iid == &<IFileIsInUse as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IFileOpenDialog_Impl: Sized + IFileDialog_Impl {
     fn GetResults(&self) -> ::windows::core::Result<IShellItemArray>;
@@ -7620,6 +7769,7 @@ impl IFileOpenDialog_Vtbl {
         iid == &<IFileOpenDialog as ::windows::core::Interface>::IID || iid == &<IModalWindow as ::windows::core::Interface>::IID || iid == &<IFileDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFileOperation_Impl: Sized {
     fn Advise(&self, pfops: &::core::option::Option<IFileOperationProgressSink>) -> ::windows::core::Result<u32>;
@@ -7788,6 +7938,7 @@ impl IFileOperation_Vtbl {
         iid == &<IFileOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFileOperation2_Impl: Sized + IFileOperation_Impl {
     fn SetOperationFlags2(&self, operationflags2: FILE_OPERATION_FLAGS2) -> ::windows::core::Result<()>;
@@ -7808,6 +7959,7 @@ impl IFileOperation2_Vtbl {
         iid == &<IFileOperation2 as ::windows::core::Interface>::IID || iid == &<IFileOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IFileOperationProgressSink_Impl: Sized {
     fn StartOperations(&self) -> ::windows::core::Result<()>;
     fn FinishOperations(&self, hrresult: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -7933,6 +8085,7 @@ impl IFileOperationProgressSink_Vtbl {
         iid == &<IFileOperationProgressSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFileSaveDialog_Impl: Sized + IFileDialog_Impl {
     fn SetSaveAsItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
@@ -7990,6 +8143,7 @@ impl IFileSaveDialog_Vtbl {
         iid == &<IFileSaveDialog as ::windows::core::Interface>::IID || iid == &<IModalWindow as ::windows::core::Interface>::IID || iid == &<IFileDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFileSearchBand_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetFocus(&self) -> ::windows::core::Result<()>;
@@ -8059,6 +8213,7 @@ impl IFileSearchBand_Vtbl {
         iid == &<IFileSearchBand as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IFileSyncMergeHandler_Impl: Sized {
     fn Merge(&self, localfilepath: &::windows::core::PCWSTR, serverfilepath: &::windows::core::PCWSTR) -> ::windows::core::Result<MERGE_UPDATE_STATUS>;
@@ -8095,6 +8250,7 @@ impl IFileSyncMergeHandler_Vtbl {
         iid == &<IFileSyncMergeHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 pub trait IFileSystemBindData_Impl: Sized {
     fn SetFindData(&self, pfd: *const super::super::Storage::FileSystem::WIN32_FIND_DATAW) -> ::windows::core::Result<()>;
@@ -8131,6 +8287,7 @@ impl IFileSystemBindData_Vtbl {
         iid == &<IFileSystemBindData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem"))]
 pub trait IFileSystemBindData2_Impl: Sized + IFileSystemBindData_Impl {
     fn SetFileID(&self, lifileid: i64) -> ::windows::core::Result<()>;
@@ -8187,6 +8344,7 @@ impl IFileSystemBindData2_Vtbl {
         iid == &<IFileSystemBindData2 as ::windows::core::Interface>::IID || iid == &<IFileSystemBindData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFolderBandPriv_Impl: Sized {
     fn SetCascade(&self, fcascade: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -8231,6 +8389,7 @@ impl IFolderBandPriv_Vtbl {
         iid == &<IFolderBandPriv as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IFolderFilter_Impl: Sized {
     fn ShouldShow(&self, psf: &::core::option::Option<IShellFolder>, pidlfolder: *const Common::ITEMIDLIST, pidlitem: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -8261,6 +8420,7 @@ impl IFolderFilter_Vtbl {
         iid == &<IFolderFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IFolderFilterSite_Impl: Sized {
     fn SetFilter(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -8278,6 +8438,7 @@ impl IFolderFilterSite_Vtbl {
         iid == &<IFolderFilterSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IFolderView_Impl: Sized {
     fn GetCurrentViewMode(&self) -> ::windows::core::Result<u32>;
@@ -8434,6 +8595,7 @@ impl IFolderView_Vtbl {
         iid == &<IFolderView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFolderView2_Impl: Sized + IFolderView_Impl {
     fn SetGroupBy(&self, key: *const PropertiesSystem::PROPERTYKEY, fascending: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -8673,6 +8835,7 @@ impl IFolderView2_Vtbl {
         iid == &<IFolderView2 as ::windows::core::Interface>::IID || iid == &<IFolderView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IFolderViewHost_Impl: Sized {
     fn Initialize(&self, hwndparent: super::super::Foundation::HWND, pdo: &::core::option::Option<super::super::System::Com::IDataObject>, prc: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -8693,6 +8856,7 @@ impl IFolderViewHost_Vtbl {
         iid == &<IFolderViewHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IFolderViewOC_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn SetFolderView(&self, pdisp: &::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows::core::Result<()>;
@@ -8713,6 +8877,7 @@ impl IFolderViewOC_Vtbl {
         iid == &<IFolderViewOC as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IFolderViewOptions_Impl: Sized {
     fn SetFolderViewOptions(&self, fvomask: FOLDERVIEWOPTIONS, fvoflags: FOLDERVIEWOPTIONS) -> ::windows::core::Result<()>;
     fn GetFolderViewOptions(&self) -> ::windows::core::Result<FOLDERVIEWOPTIONS>;
@@ -8746,6 +8911,7 @@ impl IFolderViewOptions_Vtbl {
         iid == &<IFolderViewOptions as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IFolderViewSettings_Impl: Sized {
     fn GetColumnPropertyList(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -8829,6 +8995,7 @@ impl IFolderViewSettings_Vtbl {
         iid == &<IFolderViewSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFrameworkInputPane_Impl: Sized {
     fn Advise(&self, pwindow: &::core::option::Option<::windows::core::IUnknown>, phandler: &::core::option::Option<IFrameworkInputPaneHandler>) -> ::windows::core::Result<u32>;
@@ -8891,6 +9058,7 @@ impl IFrameworkInputPane_Vtbl {
         iid == &<IFrameworkInputPane as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IFrameworkInputPaneHandler_Impl: Sized {
     fn Showing(&self, prcinputpanescreenlocation: *const super::super::Foundation::RECT, fensurefocusedelementinview: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -8921,6 +9089,7 @@ impl IFrameworkInputPaneHandler_Vtbl {
         iid == &<IFrameworkInputPaneHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IGetServiceIds_Impl: Sized {
     fn GetServiceIds(&self, serviceidcount: *mut u32, serviceids: *mut *mut ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -8938,6 +9107,7 @@ impl IGetServiceIds_Vtbl {
         iid == &<IGetServiceIds as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IHWEventHandler_Impl: Sized {
     fn Initialize(&self, pszparams: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -8975,6 +9145,7 @@ impl IHWEventHandler_Vtbl {
         iid == &<IHWEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IHWEventHandler2_Impl: Sized + IHWEventHandler_Impl {
     fn HandleEventWithHWND(&self, pszdeviceid: &::windows::core::PCWSTR, pszaltdeviceid: &::windows::core::PCWSTR, pszeventtype: &::windows::core::PCWSTR, hwndowner: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -8995,6 +9166,7 @@ impl IHWEventHandler2_Vtbl {
         iid == &<IHWEventHandler2 as ::windows::core::Interface>::IID || iid == &<IHWEventHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IHandlerActivationHost_Impl: Sized {
     fn BeforeCoCreateInstance(&self, clsidhandler: *const ::windows::core::GUID, itemsbeingactivated: &::core::option::Option<IShellItemArray>, handlerinfo: &::core::option::Option<IHandlerInfo>) -> ::windows::core::Result<()>;
     fn BeforeCreateProcess(&self, applicationpath: &::windows::core::PCWSTR, commandline: &::windows::core::PCWSTR, handlerinfo: &::core::option::Option<IHandlerInfo>) -> ::windows::core::Result<()>;
@@ -9022,6 +9194,7 @@ impl IHandlerActivationHost_Vtbl {
         iid == &<IHandlerActivationHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IHandlerInfo_Impl: Sized {
     fn GetApplicationDisplayName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetApplicationPublisher(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -9074,6 +9247,7 @@ impl IHandlerInfo_Vtbl {
         iid == &<IHandlerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IHandlerInfo2_Impl: Sized + IHandlerInfo_Impl {
     fn GetApplicationId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -9097,6 +9271,7 @@ impl IHandlerInfo2_Vtbl {
         iid == &<IHandlerInfo2 as ::windows::core::Interface>::IID || iid == &<IHandlerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IHlink_Impl: Sized {
     fn SetHlinkSite(&self, pihlsite: &::core::option::Option<IHlinkSite>, dwsitedata: u32) -> ::windows::core::Result<()>;
@@ -9235,6 +9410,7 @@ impl IHlink_Vtbl {
         iid == &<IHlink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IHlinkBrowseContext_Impl: Sized {
     fn Register(&self, reserved: u32, piunk: &::core::option::Option<::windows::core::IUnknown>, pimk: &::core::option::Option<super::super::System::Com::IMoniker>) -> ::windows::core::Result<u32>;
@@ -9391,6 +9567,7 @@ impl IHlinkBrowseContext_Vtbl {
         iid == &<IHlinkBrowseContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IHlinkFrame_Impl: Sized {
     fn SetBrowseContext(&self, pihlbc: &::core::option::Option<IHlinkBrowseContext>) -> ::windows::core::Result<()>;
@@ -9448,6 +9625,7 @@ impl IHlinkFrame_Vtbl {
         iid == &<IHlinkFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IHlinkSite_Impl: Sized {
     fn QueryService(&self, dwsitedata: u32, guidservice: *const ::windows::core::GUID, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -9504,6 +9682,7 @@ impl IHlinkSite_Vtbl {
         iid == &<IHlinkSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IHlinkTarget_Impl: Sized {
     fn SetBrowseContext(&self, pihlbc: &::core::option::Option<IHlinkBrowseContext>) -> ::windows::core::Result<()>;
@@ -9573,6 +9752,7 @@ impl IHlinkTarget_Vtbl {
         iid == &<IHlinkTarget as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IHomeGroup_Impl: Sized {
     fn IsMember(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -9615,6 +9795,7 @@ impl IHomeGroup_Vtbl {
         iid == &<IHomeGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IIOCancelInformation_Impl: Sized {
     fn SetCancelInformation(&self, dwthreadid: u32, umsgcancel: u32) -> ::windows::core::Result<()>;
     fn GetCancelInformation(&self, pdwthreadid: *mut u32, pumsgcancel: *mut u32) -> ::windows::core::Result<()>;
@@ -9642,6 +9823,7 @@ impl IIOCancelInformation_Vtbl {
         iid == &<IIOCancelInformation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IIdentityName_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -9655,6 +9837,7 @@ impl IIdentityName_Vtbl {
         iid == &<IIdentityName as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IImageRecompress_Impl: Sized {
     fn RecompressImage(&self, psi: &::core::option::Option<IShellItem>, cx: i32, cy: i32, iquality: i32, pstg: &::core::option::Option<super::super::System::Com::StructuredStorage::IStorage>) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -9681,6 +9864,7 @@ impl IImageRecompress_Vtbl {
         iid == &<IImageRecompress as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com_StructuredStorage")]
 pub trait IInitializeCommand_Impl: Sized {
     fn Initialize(&self, pszcommandname: &::windows::core::PCWSTR, ppb: &::core::option::Option<super::super::System::Com::StructuredStorage::IPropertyBag>) -> ::windows::core::Result<()>;
@@ -9701,6 +9885,7 @@ impl IInitializeCommand_Vtbl {
         iid == &<IInitializeCommand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IInitializeNetworkFolder_Impl: Sized {
     fn Initialize(&self, pidl: *const Common::ITEMIDLIST, pidltarget: *const Common::ITEMIDLIST, udisplaytype: u32, pszresname: &::windows::core::PCWSTR, pszprovider: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -9721,6 +9906,7 @@ impl IInitializeNetworkFolder_Vtbl {
         iid == &<IInitializeNetworkFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IInitializeObject_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
 }
@@ -9738,6 +9924,7 @@ impl IInitializeObject_Vtbl {
         iid == &<IInitializeObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IInitializeWithBindCtx_Impl: Sized {
     fn Initialize(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>) -> ::windows::core::Result<()>;
@@ -9758,6 +9945,7 @@ impl IInitializeWithBindCtx_Vtbl {
         iid == &<IInitializeWithBindCtx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IInitializeWithItem_Impl: Sized {
     fn Initialize(&self, psi: &::core::option::Option<IShellItem>, grfmode: u32) -> ::windows::core::Result<()>;
 }
@@ -9775,6 +9963,7 @@ impl IInitializeWithItem_Vtbl {
         iid == &<IInitializeWithItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IInitializeWithPropertyStore_Impl: Sized {
     fn Initialize(&self, pps: &::core::option::Option<PropertiesSystem::IPropertyStore>) -> ::windows::core::Result<()>;
@@ -9795,6 +9984,7 @@ impl IInitializeWithPropertyStore_Vtbl {
         iid == &<IInitializeWithPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInitializeWithWindow_Impl: Sized {
     fn Initialize(&self, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -9815,6 +10005,7 @@ impl IInitializeWithWindow_Vtbl {
         iid == &<IInitializeWithWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IInputObject_Impl: Sized {
     fn UIActivateIO(&self, factivate: super::super::Foundation::BOOL, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
@@ -9852,6 +10043,7 @@ impl IInputObject_Vtbl {
         iid == &<IInputObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IInputObject2_Impl: Sized + IInputObject_Impl {
     fn TranslateAcceleratorGlobal(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
@@ -9872,6 +10064,7 @@ impl IInputObject2_Vtbl {
         iid == &<IInputObject2 as ::windows::core::Interface>::IID || iid == &<IInputObject as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInputObjectSite_Impl: Sized {
     fn OnFocusChangeIS(&self, punkobj: &::core::option::Option<::windows::core::IUnknown>, fsetfocus: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -9892,6 +10085,7 @@ impl IInputObjectSite_Vtbl {
         iid == &<IInputObjectSite as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Graphics_DirectComposition\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_DirectComposition")]
 pub trait IInputPaneAnimationCoordinator_Impl: Sized {
     fn AddAnimation(&self, device: &::core::option::Option<::windows::core::IUnknown>, animation: &::core::option::Option<super::super::Graphics::DirectComposition::IDCompositionAnimation>) -> ::windows::core::Result<()>;
@@ -9912,6 +10106,7 @@ impl IInputPaneAnimationCoordinator_Vtbl {
         iid == &<IInputPaneAnimationCoordinator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IInputPanelConfiguration_Impl: Sized {
     fn EnableFocusTracking(&self) -> ::windows::core::Result<()>;
 }
@@ -9929,6 +10124,7 @@ impl IInputPanelConfiguration_Vtbl {
         iid == &<IInputPanelConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IInputPanelInvocationConfiguration_Impl: Sized {
     fn RequireTouchInEditControl(&self) -> ::windows::core::Result<()>;
 }
@@ -9949,6 +10145,7 @@ impl IInputPanelInvocationConfiguration_Vtbl {
         iid == &<IInputPanelInvocationConfiguration as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IInsertItem_Impl: Sized {
     fn InsertItem(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -9969,6 +10166,7 @@ impl IInsertItem_Vtbl {
         iid == &<IInsertItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IItemNameLimits_Impl: Sized {
     fn GetValidCharacters(&self, ppwszvalidchars: *mut ::windows::core::PWSTR, ppwszinvalidchars: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
     fn GetMaxLength(&self, pszname: &::windows::core::PCWSTR) -> ::windows::core::Result<i32>;
@@ -10002,6 +10200,7 @@ impl IItemNameLimits_Vtbl {
         iid == &<IItemNameLimits as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IKnownFolder_Impl: Sized {
     fn GetId(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -10123,6 +10322,7 @@ impl IKnownFolder_Vtbl {
         iid == &<IKnownFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IKnownFolderManager_Impl: Sized {
     fn FolderIdFromCsidl(&self, ncsidl: i32) -> ::windows::core::Result<::windows::core::GUID>;
@@ -10245,6 +10445,7 @@ impl IKnownFolderManager_Vtbl {
         iid == &<IKnownFolderManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ILaunchSourceAppUserModelId_Impl: Sized {
     fn GetAppUserModelId(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
 }
@@ -10268,6 +10469,7 @@ impl ILaunchSourceAppUserModelId_Vtbl {
         iid == &<ILaunchSourceAppUserModelId as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ILaunchSourceViewSizePreference_Impl: Sized {
     fn GetSourceViewToPosition(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -10310,6 +10512,7 @@ impl ILaunchSourceViewSizePreference_Vtbl {
         iid == &<ILaunchSourceViewSizePreference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait ILaunchTargetMonitor_Impl: Sized {
     fn GetMonitor(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HMONITOR>;
@@ -10336,6 +10539,7 @@ impl ILaunchTargetMonitor_Vtbl {
         iid == &<ILaunchTargetMonitor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ILaunchTargetViewSizePreference_Impl: Sized {
     fn GetTargetViewSizePreference(&self) -> ::windows::core::Result<APPLICATION_VIEW_SIZE_PREFERENCE>;
 }
@@ -10362,6 +10566,7 @@ impl ILaunchTargetViewSizePreference_Vtbl {
         iid == &<ILaunchTargetViewSizePreference as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ILaunchUIContext_Impl: Sized {
     fn SetAssociatedWindow(&self, value: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -10392,6 +10597,7 @@ impl ILaunchUIContext_Vtbl {
         iid == &<ILaunchUIContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ILaunchUIContextProvider_Impl: Sized {
     fn UpdateContext(&self, context: &::core::option::Option<ILaunchUIContext>) -> ::windows::core::Result<()>;
 }
@@ -10409,6 +10615,7 @@ impl ILaunchUIContextProvider_Vtbl {
         iid == &<ILaunchUIContextProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IMenuBand_Impl: Sized {
     fn IsMenuMessage(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
@@ -10439,6 +10646,7 @@ impl IMenuBand_Vtbl {
         iid == &<IMenuBand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
 pub trait IMenuPopup_Impl: Sized + IDeskBar_Impl {
     fn Popup(&self, ppt: *const super::super::Foundation::POINTL, prcexclude: *const super::super::Foundation::RECTL, dwflags: i32) -> ::windows::core::Result<()>;
@@ -10476,6 +10684,7 @@ impl IMenuPopup_Vtbl {
         iid == &<IMenuPopup as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID || iid == &<IDeskBar as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IModalWindow_Impl: Sized {
     fn Show(&self, hwndowner: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -10496,6 +10705,7 @@ impl IModalWindow_Vtbl {
         iid == &<IModalWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INameSpaceTreeAccessible_Impl: Sized {
     fn OnGetDefaultAccessibilityAction(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -10545,6 +10755,7 @@ impl INameSpaceTreeAccessible_Vtbl {
         iid == &<INameSpaceTreeAccessible as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INameSpaceTreeControl_Impl: Sized {
     fn Initialize(&self, hwndparent: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT, nsctsflags: u32) -> ::windows::core::Result<()>;
@@ -10742,6 +10953,7 @@ impl INameSpaceTreeControl_Vtbl {
         iid == &<INameSpaceTreeControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INameSpaceTreeControl2_Impl: Sized + INameSpaceTreeControl_Impl {
     fn SetControlStyle(&self, nstcsmask: u32, nstcsstyle: u32) -> ::windows::core::Result<()>;
@@ -10798,6 +11010,7 @@ impl INameSpaceTreeControl2_Vtbl {
         iid == &<INameSpaceTreeControl2 as ::windows::core::Interface>::IID || iid == &<INameSpaceTreeControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_UI_Controls"))]
 pub trait INameSpaceTreeControlCustomDraw_Impl: Sized {
     fn PrePaint(&self, hdc: super::super::Graphics::Gdi::HDC, prc: *const super::super::Foundation::RECT) -> ::windows::core::Result<super::super::Foundation::LRESULT>;
@@ -10848,6 +11061,7 @@ impl INameSpaceTreeControlCustomDraw_Vtbl {
         iid == &<INameSpaceTreeControlCustomDraw as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INameSpaceTreeControlDropHandler_Impl: Sized {
     fn OnDragEnter(&self, psiover: &::core::option::Option<IShellItem>, psiadata: &::core::option::Option<IShellItemArray>, foutsidesource: super::super::Foundation::BOOL, grfkeystate: u32, pdweffect: *mut u32) -> ::windows::core::Result<()>;
@@ -10906,6 +11120,7 @@ impl INameSpaceTreeControlDropHandler_Vtbl {
         iid == &<INameSpaceTreeControlDropHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INameSpaceTreeControlEvents_Impl: Sized {
     fn OnItemClick(&self, psi: &::core::option::Option<IShellItem>, nstcehittest: u32, nstceclicktype: u32) -> ::windows::core::Result<()>;
@@ -11048,6 +11263,7 @@ impl INameSpaceTreeControlEvents_Vtbl {
         iid == &<INameSpaceTreeControlEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait INameSpaceTreeControlFolderCapabilities_Impl: Sized {
     fn GetFolderCapabilities(&self, nfcmask: NSTCFOLDERCAPABILITIES) -> ::windows::core::Result<NSTCFOLDERCAPABILITIES>;
 }
@@ -11071,6 +11287,7 @@ impl INameSpaceTreeControlFolderCapabilities_Vtbl {
         iid == &<INameSpaceTreeControlFolderCapabilities as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait INamedPropertyBag_Impl: Sized {
     fn ReadPropertyNPB(&self, pszbagname: &::windows::core::PCWSTR, pszpropname: &::windows::core::PCWSTR, pvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()>;
@@ -11108,6 +11325,7 @@ impl INamedPropertyBag_Vtbl {
         iid == &<INamedPropertyBag as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait INamespaceWalk_Impl: Sized {
     fn Walk(&self, punktowalk: &::core::option::Option<::windows::core::IUnknown>, dwflags: u32, cdepth: i32, pnswcb: &::core::option::Option<INamespaceWalkCB>) -> ::windows::core::Result<()>;
@@ -11138,6 +11356,7 @@ impl INamespaceWalk_Vtbl {
         iid == &<INamespaceWalk as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait INamespaceWalkCB_Impl: Sized {
     fn FoundItem(&self, psf: &::core::option::Option<IShellFolder>, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -11182,6 +11401,7 @@ impl INamespaceWalkCB_Vtbl {
         iid == &<INamespaceWalkCB as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait INamespaceWalkCB2_Impl: Sized + INamespaceWalkCB_Impl {
     fn WalkComplete(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -11202,6 +11422,7 @@ impl INamespaceWalkCB2_Vtbl {
         iid == &<INamespaceWalkCB2 as ::windows::core::Interface>::IID || iid == &<INamespaceWalkCB as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait INetworkFolderInternal_Impl: Sized {
     fn GetResourceDisplayType(&self) -> ::windows::core::Result<u32>;
@@ -11251,6 +11472,7 @@ impl INetworkFolderInternal_Vtbl {
         iid == &<INetworkFolderInternal as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait INewMenuClient_Impl: Sized {
     fn IncludeItems(&self) -> ::windows::core::Result<i32>;
@@ -11287,6 +11509,7 @@ impl INewMenuClient_Vtbl {
         iid == &<INewMenuClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INewShortcutHookA_Impl: Sized {
     fn SetReferent(&self, pcszreferent: &::windows::core::PCSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -11345,6 +11568,7 @@ impl INewShortcutHookA_Vtbl {
         iid == &<INewShortcutHookA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INewShortcutHookW_Impl: Sized {
     fn SetReferent(&self, pcszreferent: &::windows::core::PCWSTR, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -11403,6 +11627,7 @@ impl INewShortcutHookW_Vtbl {
         iid == &<INewShortcutHookW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait INewWDEvents_Impl: Sized + IWebWizardHost_Impl {
     fn PassportAuthenticate(&self, bstrsigninurl: &::windows::core::BSTR) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -11429,6 +11654,7 @@ impl INewWDEvents_Vtbl {
         iid == &<INewWDEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWebWizardHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait INewWindowManager_Impl: Sized {
     fn EvaluateNewWindow(&self, pszurl: &::windows::core::PCWSTR, pszname: &::windows::core::PCWSTR, pszurlcontext: &::windows::core::PCWSTR, pszfeatures: &::windows::core::PCWSTR, freplace: super::super::Foundation::BOOL, dwflags: u32, dwuseractiontime: u32) -> ::windows::core::Result<()>;
@@ -11449,6 +11675,7 @@ impl INewWindowManager_Vtbl {
         iid == &<INewWindowManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait INotifyReplica_Impl: Sized {
     fn YouAreAReplica(&self, ulcotherreplicas: u32, rgpmkotherreplicas: *mut ::core::option::Option<super::super::System::Com::IMoniker>) -> ::windows::core::Result<()>;
@@ -11469,6 +11696,7 @@ impl INotifyReplica_Vtbl {
         iid == &<INotifyReplica as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IObjMgr_Impl: Sized {
     fn Append(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn Remove(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -11496,6 +11724,7 @@ impl IObjMgr_Vtbl {
         iid == &<IObjMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IObjectProvider_Impl: Sized {
     fn QueryObject(&self, guidobject: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -11513,6 +11742,7 @@ impl IObjectProvider_Vtbl {
         iid == &<IObjectProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IObjectWithAppUserModelID_Impl: Sized {
     fn SetAppID(&self, pszappid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetAppID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -11546,6 +11776,7 @@ impl IObjectWithAppUserModelID_Vtbl {
         iid == &<IObjectWithAppUserModelID as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IObjectWithBackReferences_Impl: Sized {
     fn RemoveBackReferences(&self) -> ::windows::core::Result<()>;
 }
@@ -11563,6 +11794,7 @@ impl IObjectWithBackReferences_Vtbl {
         iid == &<IObjectWithBackReferences as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IObjectWithCancelEvent_Impl: Sized {
     fn GetCancelEvent(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -11589,6 +11821,7 @@ impl IObjectWithCancelEvent_Vtbl {
         iid == &<IObjectWithCancelEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IObjectWithFolderEnumMode_Impl: Sized {
     fn SetMode(&self, femode: FOLDER_ENUM_MODE) -> ::windows::core::Result<()>;
     fn GetMode(&self) -> ::windows::core::Result<FOLDER_ENUM_MODE>;
@@ -11622,6 +11855,7 @@ impl IObjectWithFolderEnumMode_Vtbl {
         iid == &<IObjectWithFolderEnumMode as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IObjectWithProgID_Impl: Sized {
     fn SetProgID(&self, pszprogid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn GetProgID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -11655,6 +11889,7 @@ impl IObjectWithProgID_Vtbl {
         iid == &<IObjectWithProgID as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IObjectWithSelection_Impl: Sized {
     fn SetSelection(&self, psia: &::core::option::Option<IShellItemArray>) -> ::windows::core::Result<()>;
     fn GetSelection(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -11682,6 +11917,7 @@ impl IObjectWithSelection_Vtbl {
         iid == &<IObjectWithSelection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IOpenControlPanel_Impl: Sized {
     fn Open(&self, pszname: &::windows::core::PCWSTR, pszpage: &::windows::core::PCWSTR, punksite: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetPath(&self, pszname: &::windows::core::PCWSTR, pszpath: ::windows::core::PWSTR, cchpath: u32) -> ::windows::core::Result<()>;
@@ -11722,6 +11958,7 @@ impl IOpenControlPanel_Vtbl {
         iid == &<IOpenControlPanel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IOpenSearchSource_Impl: Sized {
     fn GetResults(&self, hwnd: super::super::Foundation::HWND, pszquery: &::windows::core::PCWSTR, dwstartindex: u32, dwcount: u32, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -11742,6 +11979,7 @@ impl IOpenSearchSource_Vtbl {
         iid == &<IOpenSearchSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IOperationsProgressDialog_Impl: Sized {
     fn StartProgressDialog(&self, hwndowner: super::super::Foundation::HWND, flags: u32) -> ::windows::core::Result<()>;
@@ -11841,6 +12079,7 @@ impl IOperationsProgressDialog_Vtbl {
         iid == &<IOperationsProgressDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IPackageDebugSettings_Impl: Sized {
     fn EnableDebugging(&self, packagefullname: &::windows::core::PCWSTR, debuggercommandline: &::windows::core::PCWSTR, environment: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn DisableDebugging(&self, packagefullname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -11971,6 +12210,7 @@ impl IPackageDebugSettings_Vtbl {
         iid == &<IPackageDebugSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IPackageDebugSettings2_Impl: Sized + IPackageDebugSettings_Impl {
     fn EnumerateApps(&self, packagefullname: &::windows::core::PCWSTR, appcount: *mut u32, appusermodelids: *mut *mut ::windows::core::PWSTR, appdisplaynames: *mut *mut ::windows::core::PWSTR) -> ::windows::core::Result<()>;
 }
@@ -11988,6 +12228,7 @@ impl IPackageDebugSettings2_Vtbl {
         iid == &<IPackageDebugSettings2 as ::windows::core::Interface>::IID || iid == &<IPackageDebugSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IPackageExecutionStateChangeNotification_Impl: Sized {
     fn OnStateChanged(&self, pszpackagefullname: &::windows::core::PCWSTR, pesnewstate: PACKAGE_EXECUTION_STATE) -> ::windows::core::Result<()>;
 }
@@ -12005,6 +12246,7 @@ impl IPackageExecutionStateChangeNotification_Vtbl {
         iid == &<IPackageExecutionStateChangeNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IParentAndItem_Impl: Sized {
     fn SetParentAndItem(&self, pidlparent: *const Common::ITEMIDLIST, psf: &::core::option::Option<IShellFolder>, pidlchild: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -12035,6 +12277,7 @@ impl IParentAndItem_Vtbl {
         iid == &<IParentAndItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IParseAndCreateItem_Impl: Sized {
     fn SetItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
     fn GetItem(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -12062,6 +12305,7 @@ impl IParseAndCreateItem_Vtbl {
         iid == &<IParseAndCreateItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait IPersistFolder_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn Initialize(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -12082,6 +12326,7 @@ impl IPersistFolder_Vtbl {
         iid == &<IPersistFolder as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait IPersistFolder2_Impl: Sized + IPersistFolder_Impl {
     fn GetCurFolder(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
@@ -12108,6 +12353,7 @@ impl IPersistFolder2_Vtbl {
         iid == &<IPersistFolder2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<IPersistFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait IPersistFolder3_Impl: Sized + IPersistFolder2_Impl {
     fn InitializeEx(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, pidlroot: *const Common::ITEMIDLIST, ppfti: *const PERSIST_FOLDER_TARGET_INFO) -> ::windows::core::Result<()>;
@@ -12144,6 +12390,7 @@ impl IPersistFolder3_Vtbl {
         iid == &<IPersistFolder3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID || iid == &<IPersistFolder as ::windows::core::Interface>::IID || iid == &<IPersistFolder2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait IPersistIDList_Impl: Sized + super::super::System::Com::IPersist_Impl {
     fn SetIDList(&self, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -12180,6 +12427,7 @@ impl IPersistIDList_Vtbl {
         iid == &<IPersistIDList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IPersist as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPreviewHandler_Impl: Sized {
     fn SetWindow(&self, hwnd: super::super::Foundation::HWND, prc: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -12251,6 +12499,7 @@ impl IPreviewHandler_Vtbl {
         iid == &<IPreviewHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IPreviewHandlerFrame_Impl: Sized {
     fn GetWindowContext(&self) -> ::windows::core::Result<PREVIEWHANDLERFRAMEINFO>;
@@ -12287,6 +12536,7 @@ impl IPreviewHandlerFrame_Vtbl {
         iid == &<IPreviewHandlerFrame as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IPreviewHandlerVisuals_Impl: Sized {
     fn SetBackgroundColor(&self, color: super::super::Foundation::COLORREF) -> ::windows::core::Result<()>;
@@ -12324,6 +12574,7 @@ impl IPreviewHandlerVisuals_Vtbl {
         iid == &<IPreviewHandlerVisuals as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IPreviewItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -12337,6 +12588,7 @@ impl IPreviewItem_Vtbl {
         iid == &<IPreviewItem as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPreviousVersionsInfo_Impl: Sized {
     fn AreSnapshotsAvailable(&self, pszpath: &::windows::core::PCWSTR, foktobeslow: super::super::Foundation::BOOL) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -12363,6 +12615,7 @@ impl IPreviousVersionsInfo_Vtbl {
         iid == &<IPreviousVersionsInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IProfferService_Impl: Sized {
     fn ProfferService(&self, serviceid: *const ::windows::core::GUID, serviceprovider: &::core::option::Option<super::super::System::Com::IServiceProvider>) -> ::windows::core::Result<u32>;
@@ -12399,6 +12652,7 @@ impl IProfferService_Vtbl {
         iid == &<IProfferService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IProgressDialog_Impl: Sized {
     fn StartProgressDialog(&self, hwndparent: super::super::Foundation::HWND, punkenablemodless: &::core::option::Option<::windows::core::IUnknown>, dwflags: u32, pvresevered: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -12485,6 +12739,7 @@ impl IProgressDialog_Vtbl {
         iid == &<IProgressDialog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IPropertyKeyStore_Impl: Sized {
     fn GetKeyCount(&self) -> ::windows::core::Result<i32>;
@@ -12555,6 +12810,7 @@ impl IPropertyKeyStore_Vtbl {
         iid == &<IPropertyKeyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPublishedApp_Impl: Sized + IShellApp_Impl {
     fn Install(&self, pstinstall: *const super::super::Foundation::SYSTEMTIME) -> ::windows::core::Result<()>;
@@ -12592,6 +12848,7 @@ impl IPublishedApp_Vtbl {
         iid == &<IPublishedApp as ::windows::core::Interface>::IID || iid == &<IShellApp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IPublishedApp2_Impl: Sized + IPublishedApp_Impl {
     fn Install2(&self, pstinstall: *const super::super::Foundation::SYSTEMTIME, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -12612,6 +12869,7 @@ impl IPublishedApp2_Vtbl {
         iid == &<IPublishedApp2 as ::windows::core::Interface>::IID || iid == &<IShellApp as ::windows::core::Interface>::IID || iid == &<IPublishedApp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Data_Xml_MsXml\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Data_Xml_MsXml", feature = "Win32_System_Com", feature = "Win32_UI_Controls"))]
 pub trait IPublishingWizard_Impl: Sized + IWizardExtension_Impl {
     fn Initialize(&self, pdo: &::core::option::Option<super::super::System::Com::IDataObject>, dwoptions: u32, pszservicescope: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -12642,6 +12900,7 @@ impl IPublishingWizard_Vtbl {
         iid == &<IPublishingWizard as ::windows::core::Interface>::IID || iid == &<IWizardExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry"))]
 pub trait IQueryAssociations_Impl: Sized {
     fn Init(&self, flags: ASSOCF, pszassoc: &::windows::core::PCWSTR, hkprogid: super::super::System::Registry::HKEY, hwnd: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -12699,6 +12958,7 @@ impl IQueryAssociations_Vtbl {
         iid == &<IQueryAssociations as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IQueryCancelAutoPlay_Impl: Sized {
     fn AllowAutoPlay(&self, pszpath: &::windows::core::PCWSTR, dwcontenttype: u32, pszlabel: &::windows::core::PCWSTR, dwserialnumber: u32) -> ::windows::core::Result<()>;
 }
@@ -12716,6 +12976,7 @@ impl IQueryCancelAutoPlay_Vtbl {
         iid == &<IQueryCancelAutoPlay as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IQueryCodePage_Impl: Sized {
     fn GetCodePage(&self) -> ::windows::core::Result<u32>;
     fn SetCodePage(&self, uicodepage: u32) -> ::windows::core::Result<()>;
@@ -12749,6 +13010,7 @@ impl IQueryCodePage_Vtbl {
         iid == &<IQueryCodePage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IQueryContinue_Impl: Sized {
     fn QueryContinue(&self) -> ::windows::core::Result<()>;
 }
@@ -12766,6 +13028,7 @@ impl IQueryContinue_Vtbl {
         iid == &<IQueryContinue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IQueryContinueWithStatus_Impl: Sized + IQueryContinue_Impl {
     fn SetStatusMessage(&self, psz: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -12783,6 +13046,7 @@ impl IQueryContinueWithStatus_Vtbl {
         iid == &<IQueryContinueWithStatus as ::windows::core::Interface>::IID || iid == &<IQueryContinue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IQueryInfo_Impl: Sized {
     fn GetInfoTip(&self, dwflags: QITIPF_FLAGS) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetInfoFlags(&self) -> ::windows::core::Result<u32>;
@@ -12822,6 +13086,7 @@ impl IQueryInfo_Vtbl {
         iid == &<IQueryInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRegTreeItem_Impl: Sized {
     fn GetCheckState(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -12858,6 +13123,7 @@ impl IRegTreeItem_Vtbl {
         iid == &<IRegTreeItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IRelatedItem_Impl: Sized {
     fn GetItemIDList(&self) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
@@ -12900,6 +13166,7 @@ impl IRelatedItem_Vtbl {
         iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRemoteComputer_Impl: Sized {
     fn Initialize(&self, pszmachine: &::windows::core::PCWSTR, benumerating: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -12920,6 +13187,7 @@ impl IRemoteComputer_Vtbl {
         iid == &<IRemoteComputer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IResolveShellLink_Impl: Sized {
     fn ResolveShellLink(&self, punklink: &::core::option::Option<::windows::core::IUnknown>, hwnd: super::super::Foundation::HWND, fflags: u32) -> ::windows::core::Result<()>;
@@ -12940,6 +13208,7 @@ impl IResolveShellLink_Vtbl {
         iid == &<IResolveShellLink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IResultsFolder_Impl: Sized {
     fn AddItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
@@ -12991,6 +13260,7 @@ impl IResultsFolder_Vtbl {
         iid == &<IResultsFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRunnableTask_Impl: Sized {
     fn Run(&self) -> ::windows::core::Result<()>;
@@ -13042,6 +13312,7 @@ impl IRunnableTask_Vtbl {
         iid == &<IRunnableTask as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IScriptErrorList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn advanceError(&self) -> ::windows::core::Result<()>;
@@ -13216,6 +13487,7 @@ impl IScriptErrorList_Vtbl {
         iid == &<IScriptErrorList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISearchBoxInfo_Impl: Sized {
     fn GetCondition(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn GetText(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -13249,6 +13521,7 @@ impl ISearchBoxInfo_Vtbl {
         iid == &<ISearchBoxInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISearchContext_Impl: Sized {
     fn GetSearchUrl(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetSearchText(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -13301,6 +13574,7 @@ impl ISearchContext_Vtbl {
         iid == &<ISearchContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_System_Search\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISearchFolderItemFactory_Impl: Sized {
     fn SetDisplayName(&self, pszdisplayname: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -13407,6 +13681,7 @@ impl ISearchFolderItemFactory_Vtbl {
         iid == &<ISearchFolderItemFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ISharedBitmap_Impl: Sized {
     fn GetSharedBitmap(&self) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
@@ -13482,6 +13757,7 @@ impl ISharedBitmap_Vtbl {
         iid == &<ISharedBitmap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISharingConfigurationManager_Impl: Sized {
     fn CreateShare(&self, dsid: DEF_SHARE_ID, role: SHARE_ROLE) -> ::windows::core::Result<()>;
     fn DeleteShare(&self, dsid: DEF_SHARE_ID) -> ::windows::core::Result<()>;
@@ -13550,6 +13826,7 @@ impl ISharingConfigurationManager_Vtbl {
         iid == &<ISharingConfigurationManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IShellApp_Impl: Sized {
     fn GetAppInfo(&self, pai: *mut APPINFODATA) -> ::windows::core::Result<()>;
@@ -13619,6 +13896,7 @@ impl IShellApp_Vtbl {
         iid == &<IShellApp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IShellBrowser_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn InsertMenusSB(&self, hmenushared: super::WindowsAndMessaging::HMENU, lpmenuwidths: *mut super::super::System::Ole::OLEMENUGROUPWIDTHS) -> ::windows::core::Result<()>;
@@ -13744,6 +14022,7 @@ impl IShellBrowser_Vtbl {
         iid == &<IShellBrowser as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IShellChangeNotify_Impl: Sized {
     fn OnChange(&self, levent: i32, pidl1: *const Common::ITEMIDLIST, pidl2: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -13764,6 +14043,7 @@ impl IShellChangeNotify_Vtbl {
         iid == &<IShellChangeNotify as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IShellDetails_Impl: Sized {
     fn GetDetailsOf(&self, pidl: *const Common::ITEMIDLIST, icolumn: u32) -> ::windows::core::Result<Common::SHELLDETAILS>;
@@ -13800,6 +14080,7 @@ impl IShellDetails_Vtbl {
         iid == &<IShellDetails as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellDispatch_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Application(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -14007,6 +14288,7 @@ impl IShellDispatch_Vtbl {
         iid == &<IShellDispatch as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellDispatch2_Impl: Sized + IShellDispatch_Impl {
     fn IsRestricted(&self, group: &::windows::core::BSTR, restriction: &::windows::core::BSTR) -> ::windows::core::Result<i32>;
@@ -14128,6 +14410,7 @@ impl IShellDispatch2_Vtbl {
         iid == &<IShellDispatch2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellDispatch3_Impl: Sized + IShellDispatch2_Impl {
     fn AddToRecent(&self, varfile: &super::super::System::Com::VARIANT, bstrcategory: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -14148,6 +14431,7 @@ impl IShellDispatch3_Vtbl {
         iid == &<IShellDispatch3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellDispatch4_Impl: Sized + IShellDispatch3_Impl {
     fn WindowsSecurity(&self) -> ::windows::core::Result<()>;
@@ -14204,6 +14488,7 @@ impl IShellDispatch4_Vtbl {
         iid == &<IShellDispatch4 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch2 as ::windows::core::Interface>::IID || iid == &<IShellDispatch3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellDispatch5_Impl: Sized + IShellDispatch4_Impl {
     fn WindowSwitcher(&self) -> ::windows::core::Result<()>;
@@ -14224,6 +14509,7 @@ impl IShellDispatch5_Vtbl {
         iid == &<IShellDispatch5 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch2 as ::windows::core::Interface>::IID || iid == &<IShellDispatch3 as ::windows::core::Interface>::IID || iid == &<IShellDispatch4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellDispatch6_Impl: Sized + IShellDispatch5_Impl {
     fn SearchCommand(&self) -> ::windows::core::Result<()>;
@@ -14244,6 +14530,7 @@ impl IShellDispatch6_Vtbl {
         iid == &<IShellDispatch6 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch as ::windows::core::Interface>::IID || iid == &<IShellDispatch2 as ::windows::core::Interface>::IID || iid == &<IShellDispatch3 as ::windows::core::Interface>::IID || iid == &<IShellDispatch4 as ::windows::core::Interface>::IID || iid == &<IShellDispatch5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_System_Registry\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common"))]
 pub trait IShellExtInit_Impl: Sized {
     fn Initialize(&self, pidlfolder: *const Common::ITEMIDLIST, pdtobj: &::core::option::Option<super::super::System::Com::IDataObject>, hkeyprogid: super::super::System::Registry::HKEY) -> ::windows::core::Result<()>;
@@ -14264,6 +14551,7 @@ impl IShellExtInit_Vtbl {
         iid == &<IShellExtInit as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellFavoritesNameSpace_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn MoveSelectionUp(&self) -> ::windows::core::Result<()>;
@@ -14389,6 +14677,7 @@ impl IShellFavoritesNameSpace_Vtbl {
         iid == &<IShellFavoritesNameSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait IShellFolder_Impl: Sized {
     fn ParseDisplayName(&self, hwnd: super::super::Foundation::HWND, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, pszdisplayname: &::windows::core::PCWSTR, pcheaten: *mut u32, ppidl: *mut *mut Common::ITEMIDLIST, pdwattributes: *mut u32) -> ::windows::core::Result<()>;
@@ -14481,6 +14770,7 @@ impl IShellFolder_Vtbl {
         iid == &<IShellFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IShellFolder2_Impl: Sized + IShellFolder_Impl {
     fn GetDefaultSearchGUID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -14582,6 +14872,7 @@ impl IShellFolder2_Vtbl {
         iid == &<IShellFolder2 as ::windows::core::Interface>::IID || iid == &<IShellFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait IShellFolderBand_Impl: Sized {
     fn InitializeSFB(&self, psf: &::core::option::Option<IShellFolder>, pidl: *const Common::ITEMIDLIST) -> ::windows::core::Result<()>;
@@ -14619,6 +14910,7 @@ impl IShellFolderBand_Vtbl {
         iid == &<IShellFolderBand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole", feature = "Win32_UI_Shell_Common"))]
 pub trait IShellFolderView_Impl: Sized {
     fn Rearrange(&self, lparamsort: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -14891,6 +15183,7 @@ impl IShellFolderView_Vtbl {
         iid == &<IShellFolderView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IShellFolderViewCB_Impl: Sized {
     fn MessageSFVCB(&self, umsg: SFVM_MESSAGE_ID, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -14911,6 +15204,7 @@ impl IShellFolderViewCB_Vtbl {
         iid == &<IShellFolderViewCB as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellFolderViewDual_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Application(&self) -> ::windows::core::Result<super::super::System::Com::IDispatch>;
@@ -15038,6 +15332,7 @@ impl IShellFolderViewDual_Vtbl {
         iid == &<IShellFolderViewDual as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellFolderViewDual2_Impl: Sized + IShellFolderViewDual_Impl {
     fn CurrentViewMode(&self) -> ::windows::core::Result<u32>;
@@ -15081,6 +15376,7 @@ impl IShellFolderViewDual2_Vtbl {
         iid == &<IShellFolderViewDual2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellFolderViewDual as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellFolderViewDual3_Impl: Sized + IShellFolderViewDual2_Impl {
     fn GroupBy(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -15184,6 +15480,7 @@ impl IShellFolderViewDual3_Vtbl {
         iid == &<IShellFolderViewDual3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellFolderViewDual as ::windows::core::Interface>::IID || iid == &<IShellFolderViewDual2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IShellIcon_Impl: Sized {
     fn GetIconOf(&self, pidl: *const Common::ITEMIDLIST, flags: u32) -> ::windows::core::Result<i32>;
@@ -15210,6 +15507,7 @@ impl IShellIcon_Vtbl {
         iid == &<IShellIcon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IShellIconOverlay_Impl: Sized {
     fn GetOverlayIndex(&self, pidl: *const Common::ITEMIDLIST, pindex: *mut i32) -> ::windows::core::Result<()>;
@@ -15240,6 +15538,7 @@ impl IShellIconOverlay_Vtbl {
         iid == &<IShellIconOverlay as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IShellIconOverlayIdentifier_Impl: Sized {
     fn IsMemberOf(&self, pwszpath: &::windows::core::PCWSTR, dwattrib: u32) -> ::windows::core::Result<()>;
     fn GetOverlayInfo(&self, pwsziconfile: ::windows::core::PWSTR, cchmax: i32, pindex: *mut i32, pdwflags: *mut u32) -> ::windows::core::Result<()>;
@@ -15280,6 +15579,7 @@ impl IShellIconOverlayIdentifier_Vtbl {
         iid == &<IShellIconOverlayIdentifier as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IShellIconOverlayManager_Impl: Sized {
     fn GetFileOverlayInfo(&self, pwszpath: &::windows::core::PCWSTR, dwattrib: u32, pindex: *mut i32, dwflags: u32) -> ::windows::core::Result<()>;
@@ -15331,6 +15631,7 @@ impl IShellIconOverlayManager_Vtbl {
         iid == &<IShellIconOverlayManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com_StructuredStorage"))]
 pub trait IShellImageData_Impl: Sized {
     fn Decode(&self, dwflags: u32, cxdesired: u32, cydesired: u32) -> ::windows::core::Result<()>;
@@ -15569,6 +15870,7 @@ impl IShellImageData_Vtbl {
         iid == &<IShellImageData as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IShellImageDataAbort_Impl: Sized {
     fn QueryAbort(&self) -> ::windows::core::Result<()>;
 }
@@ -15586,6 +15888,7 @@ impl IShellImageDataAbort_Vtbl {
         iid == &<IShellImageDataAbort as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IShellImageDataFactory_Impl: Sized {
     fn CreateIShellImageData(&self) -> ::windows::core::Result<IShellImageData>;
@@ -15654,6 +15957,7 @@ impl IShellImageDataFactory_Vtbl {
         iid == &<IShellImageDataFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_System_SystemServices\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_SystemServices"))]
 pub trait IShellItem_Impl: Sized {
     fn BindToHandler(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, bhid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -15729,6 +16033,7 @@ impl IShellItem_Vtbl {
         iid == &<IShellItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_System_SystemServices\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_System_SystemServices", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IShellItem2_Impl: Sized + IShellItem_Impl {
     fn GetPropertyStore(&self, flags: PropertiesSystem::GETPROPERTYSTOREFLAGS, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -15884,6 +16189,7 @@ impl IShellItem2_Vtbl {
         iid == &<IShellItem2 as ::windows::core::Interface>::IID || iid == &<IShellItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_System_SystemServices\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_SystemServices", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait IShellItemArray_Impl: Sized {
     fn BindToHandler(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, bhid: *const ::windows::core::GUID, riid: *const ::windows::core::GUID, ppvout: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -15973,6 +16279,7 @@ impl IShellItemArray_Vtbl {
         iid == &<IShellItemArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IShellItemFilter_Impl: Sized {
     fn IncludeItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
     fn GetEnumFlagsForItem(&self, psi: &::core::option::Option<IShellItem>) -> ::windows::core::Result<u32>;
@@ -16006,6 +16313,7 @@ impl IShellItemFilter_Vtbl {
         iid == &<IShellItemFilter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IShellItemImageFactory_Impl: Sized {
     fn GetImage(&self, size: &super::super::Foundation::SIZE, flags: SIIGBF) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
@@ -16032,6 +16340,7 @@ impl IShellItemImageFactory_Vtbl {
         iid == &<IShellItemImageFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IShellItemResources_Impl: Sized {
     fn GetAttributes(&self) -> ::windows::core::Result<u32>;
@@ -16142,6 +16451,7 @@ impl IShellItemResources_Vtbl {
         iid == &<IShellItemResources as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IShellLibrary_Impl: Sized {
     fn LoadLibraryFromItem(&self, psilibrary: &::core::option::Option<IShellItem>, grfmode: u32) -> ::windows::core::Result<()>;
     fn LoadLibraryFromKnownFolder(&self, kfidlibrary: *const ::windows::core::GUID, grfmode: u32) -> ::windows::core::Result<()>;
@@ -16304,6 +16614,7 @@ impl IShellLibrary_Vtbl {
         iid == &<IShellLibrary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_UI_Shell_Common"))]
 pub trait IShellLinkA_Impl: Sized {
     fn GetPath(&self, pszfile: ::windows::core::PSTR, cch: i32, pfd: *mut super::super::Storage::FileSystem::WIN32_FIND_DATAA, fflags: u32) -> ::windows::core::Result<()>;
@@ -16464,6 +16775,7 @@ impl IShellLinkA_Vtbl {
         iid == &<IShellLinkA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IShellLinkDataList_Impl: Sized {
     fn AddDataBlock(&self, pdatablock: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
     fn CopyDataBlock(&self, dwsig: u32, ppdatablock: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -16518,6 +16830,7 @@ impl IShellLinkDataList_Vtbl {
         iid == &<IShellLinkDataList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellLinkDual_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Path(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -16682,6 +16995,7 @@ impl IShellLinkDual_Vtbl {
         iid == &<IShellLinkDual as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellLinkDual2_Impl: Sized + IShellLinkDual_Impl {
     fn Target(&self) -> ::windows::core::Result<FolderItem>;
@@ -16708,6 +17022,7 @@ impl IShellLinkDual2_Vtbl {
         iid == &<IShellLinkDual2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellLinkDual as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_UI_Shell_Common"))]
 pub trait IShellLinkW_Impl: Sized {
     fn GetPath(&self, pszfile: ::windows::core::PWSTR, cch: i32, pfd: *mut super::super::Storage::FileSystem::WIN32_FIND_DATAW, fflags: u32) -> ::windows::core::Result<()>;
@@ -16868,6 +17183,7 @@ impl IShellLinkW_Vtbl {
         iid == &<IShellLinkW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IShellMenu_Impl: Sized {
     fn Initialize(&self, psmc: &::core::option::Option<IShellMenuCallback>, uid: u32, uidancestor: u32, dwflags: u32) -> ::windows::core::Result<()>;
@@ -16953,6 +17269,7 @@ impl IShellMenu_Vtbl {
         iid == &<IShellMenu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IShellMenuCallback_Impl: Sized {
     fn CallbackSM(&self, psmd: *mut SMDATA, umsg: u32, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -16973,6 +17290,7 @@ impl IShellMenuCallback_Vtbl {
         iid == &<IShellMenuCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellNameSpace_Impl: Sized + IShellFavoritesNameSpace_Impl {
     fn EnumOptions(&self) -> ::windows::core::Result<i32>;
@@ -17196,6 +17514,7 @@ impl IShellNameSpace_Vtbl {
         iid == &<IShellNameSpace as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellFavoritesNameSpace as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls"))]
 pub trait IShellPropSheetExt_Impl: Sized {
     fn AddPages(&self, pfnaddpage: super::Controls::LPFNSVADDPROPSHEETPAGE, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -17226,6 +17545,7 @@ impl IShellPropSheetExt_Vtbl {
         iid == &<IShellPropSheetExt as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IShellRunDll_Impl: Sized {
     fn Run(&self, pszargs: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -17243,6 +17563,7 @@ impl IShellRunDll_Vtbl {
         iid == &<IShellRunDll as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IShellService_Impl: Sized {
     fn SetOwner(&self, punkowner: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -17260,6 +17581,7 @@ impl IShellService_Vtbl {
         iid == &<IShellService as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IShellTaskScheduler_Impl: Sized {
     fn AddTask(&self, prt: &::core::option::Option<IRunnableTask>, rtoid: *const ::windows::core::GUID, lparam: usize, dwpriority: u32) -> ::windows::core::Result<()>;
@@ -17304,6 +17626,7 @@ impl IShellTaskScheduler_Vtbl {
         iid == &<IShellTaskScheduler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ResetFirstBootMode(&self) -> ::windows::core::Result<()>;
@@ -17423,6 +17746,7 @@ impl IShellUIHelper_Vtbl {
         iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper2_Impl: Sized + IShellUIHelper_Impl {
     fn AddSearchProvider(&self, url: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -17599,6 +17923,7 @@ impl IShellUIHelper2_Vtbl {
         iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper3_Impl: Sized + IShellUIHelper2_Impl {
     fn AddService(&self, url: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -17724,6 +18049,7 @@ impl IShellUIHelper3_Vtbl {
         iid == &<IShellUIHelper3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper4_Impl: Sized + IShellUIHelper3_Impl {
     fn msIsSiteMode(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -17902,6 +18228,7 @@ impl IShellUIHelper4_Vtbl {
         iid == &<IShellUIHelper4 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper5_Impl: Sized + IShellUIHelper4_Impl {
     fn msProvisionNetworks(&self, bstrprovisioningxml: &::windows::core::BSTR) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -17973,6 +18300,7 @@ impl IShellUIHelper5_Vtbl {
         iid == &<IShellUIHelper5 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper3 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper4 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper6_Impl: Sized + IShellUIHelper5_Impl {
     fn msStopPeriodicTileUpdate(&self) -> ::windows::core::Result<()>;
@@ -18093,6 +18421,7 @@ impl IShellUIHelper6_Vtbl {
         iid == &<IShellUIHelper6 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper3 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper4 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper5 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper7_Impl: Sized + IShellUIHelper6_Impl {
     fn SetExperimentalFlag(&self, bstrflagstring: &::windows::core::BSTR, vfflag: super::super::Foundation::VARIANT_BOOL) -> ::windows::core::Result<()>;
@@ -18196,6 +18525,7 @@ impl IShellUIHelper7_Vtbl {
         iid == &<IShellUIHelper7 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper3 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper4 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper5 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper6 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper8_Impl: Sized + IShellUIHelper7_Impl {
     fn GetCVListData(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -18285,6 +18615,7 @@ impl IShellUIHelper8_Vtbl {
         iid == &<IShellUIHelper8 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper3 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper4 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper5 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper6 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper7 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellUIHelper9_Impl: Sized + IShellUIHelper8_Impl {
     fn GetOSSku(&self) -> ::windows::core::Result<u32>;
@@ -18311,6 +18642,7 @@ impl IShellUIHelper9_Vtbl {
         iid == &<IShellUIHelper9 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IShellUIHelper as ::windows::core::Interface>::IID || iid == &<IShellUIHelper2 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper3 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper4 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper5 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper6 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper7 as ::windows::core::Interface>::IID || iid == &<IShellUIHelper8 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IShellView_Impl: Sized + super::super::System::Ole::IOleWindow_Impl {
     fn TranslateAccelerator(&self, pmsg: *const super::WindowsAndMessaging::MSG) -> ::windows::core::Result<()>;
@@ -18416,6 +18748,7 @@ impl IShellView_Vtbl {
         iid == &<IShellView as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IShellView2_Impl: Sized + IShellView_Impl {
     fn GetView(&self, pvid: *mut ::windows::core::GUID, uview: u32) -> ::windows::core::Result<()>;
@@ -18460,6 +18793,7 @@ impl IShellView2_Vtbl {
         iid == &<IShellView2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID || iid == &<IShellView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole", feature = "Win32_UI_Controls", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait IShellView3_Impl: Sized + IShellView2_Impl {
     fn CreateViewWindow3(&self, psbowner: &::core::option::Option<IShellBrowser>, psvprev: &::core::option::Option<IShellView>, dwviewflags: u32, dwmask: FOLDERFLAGS, dwflags: FOLDERFLAGS, fvmode: FOLDERVIEWMODE, pvid: *const ::windows::core::GUID, prcview: *const super::super::Foundation::RECT) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -18486,6 +18820,7 @@ impl IShellView3_Vtbl {
         iid == &<IShellView3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Ole::IOleWindow as ::windows::core::Interface>::IID || iid == &<IShellView as ::windows::core::Interface>::IID || iid == &<IShellView2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IShellWindows_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -18609,6 +18944,7 @@ impl IShellWindows_Vtbl {
         iid == &<IShellWindows as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait ISortColumnArray_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
@@ -18664,6 +19000,7 @@ impl ISortColumnArray_Vtbl {
         iid == &<ISortColumnArray as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IStartMenuPinnedList_Impl: Sized {
     fn RemoveFromList(&self, pitem: &::core::option::Option<IShellItem>) -> ::windows::core::Result<()>;
 }
@@ -18681,6 +19018,7 @@ impl IStartMenuPinnedList_Vtbl {
         iid == &<IStartMenuPinnedList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IStorageProviderBanners_Impl: Sized {
     fn SetBanner(&self, provideridentity: &::windows::core::PCWSTR, subscriptionid: &::windows::core::PCWSTR, contentid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
     fn ClearBanner(&self, provideridentity: &::windows::core::PCWSTR, subscriptionid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -18728,6 +19066,7 @@ impl IStorageProviderBanners_Vtbl {
         iid == &<IStorageProviderBanners as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IStorageProviderCopyHook_Impl: Sized {
     fn CopyCallback(&self, hwnd: super::super::Foundation::HWND, operation: u32, flags: u32, srcfile: &::windows::core::PCWSTR, srcattribs: u32, destfile: &::windows::core::PCWSTR, destattribs: u32) -> ::windows::core::Result<u32>;
@@ -18754,6 +19093,7 @@ impl IStorageProviderCopyHook_Vtbl {
         iid == &<IStorageProviderCopyHook as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IStorageProviderHandler_Impl: Sized {
     fn GetPropertyHandlerFromPath(&self, path: &::windows::core::PCWSTR) -> ::windows::core::Result<IStorageProviderPropertyHandler>;
     fn GetPropertyHandlerFromUri(&self, uri: &::windows::core::PCWSTR) -> ::windows::core::Result<IStorageProviderPropertyHandler>;
@@ -18806,6 +19146,7 @@ impl IStorageProviderHandler_Vtbl {
         iid == &<IStorageProviderHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IStorageProviderPropertyHandler_Impl: Sized {
     fn RetrieveProperties(&self, propertiestoretrieve: *const PropertiesSystem::PROPERTYKEY, propertiestoretrievecount: u32) -> ::windows::core::Result<PropertiesSystem::IPropertyStore>;
@@ -18842,6 +19183,7 @@ impl IStorageProviderPropertyHandler_Vtbl {
         iid == &<IStorageProviderPropertyHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_IO\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_IO"))]
 pub trait IStreamAsync_Impl: Sized + super::super::System::Com::IStream_Impl {
     fn ReadAsync(&self, pv: *mut ::core::ffi::c_void, cb: u32, pcbread: *mut u32, lpoverlapped: *const super::super::System::IO::OVERLAPPED) -> ::windows::core::Result<()>;
@@ -18886,6 +19228,7 @@ impl IStreamAsync_Vtbl {
         iid == &<IStreamAsync as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::ISequentialStream as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IStream as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IStreamUnbufferedInfo_Impl: Sized {
     fn GetSectorSize(&self) -> ::windows::core::Result<u32>;
 }
@@ -18909,6 +19252,7 @@ impl IStreamUnbufferedInfo_Vtbl {
         iid == &<IStreamUnbufferedInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISuspensionDependencyManager_Impl: Sized {
     fn RegisterAsChild(&self, processhandle: super::super::Foundation::HANDLE) -> ::windows::core::Result<()>;
@@ -18946,6 +19290,7 @@ impl ISuspensionDependencyManager_Vtbl {
         iid == &<ISuspensionDependencyManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
 pub trait ISyncMgrConflict_Impl: Sized {
     fn GetProperty(&self, propkey: *const PropertiesSystem::PROPERTYKEY) -> ::windows::core::Result<super::super::System::Com::StructuredStorage::PROPVARIANT>;
@@ -19015,6 +19360,7 @@ impl ISyncMgrConflict_Vtbl {
         iid == &<ISyncMgrConflict as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait ISyncMgrConflictFolder_Impl: Sized {
     fn GetConflictIDList(&self, pconflict: &::core::option::Option<ISyncMgrConflict>) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
@@ -19041,6 +19387,7 @@ impl ISyncMgrConflictFolder_Vtbl {
         iid == &<ISyncMgrConflictFolder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrConflictItems_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetItem(&self, iindex: u32) -> ::windows::core::Result<CONFIRM_CONFLICT_ITEM>;
@@ -19080,6 +19427,7 @@ impl ISyncMgrConflictItems_Vtbl {
         iid == &<ISyncMgrConflictItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrConflictPresenter_Impl: Sized {
     fn PresentConflict(&self, pconflict: &::core::option::Option<ISyncMgrConflict>, presolveinfo: &::core::option::Option<ISyncMgrConflictResolveInfo>) -> ::windows::core::Result<()>;
 }
@@ -19097,6 +19445,7 @@ impl ISyncMgrConflictPresenter_Vtbl {
         iid == &<ISyncMgrConflictPresenter as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrConflictResolutionItems_Impl: Sized {
     fn GetCount(&self) -> ::windows::core::Result<u32>;
     fn GetItem(&self, iindex: u32) -> ::windows::core::Result<CONFIRM_CONFLICT_RESULT_INFO>;
@@ -19136,6 +19485,7 @@ impl ISyncMgrConflictResolutionItems_Vtbl {
         iid == &<ISyncMgrConflictResolutionItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrConflictResolveInfo_Impl: Sized {
     fn GetIterationInfo(&self, pncurrentconflict: *mut u32, pcconflicts: *mut u32, pcremainingforapplytoall: *mut u32) -> ::windows::core::Result<()>;
@@ -19226,6 +19576,7 @@ impl ISyncMgrConflictResolveInfo_Vtbl {
         iid == &<ISyncMgrConflictResolveInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISyncMgrConflictStore_Impl: Sized {
     fn EnumConflicts(&self, pszhandlerid: &::windows::core::PCWSTR, pszitemid: &::windows::core::PCWSTR) -> ::windows::core::Result<IEnumSyncMgrConflict>;
@@ -19282,6 +19633,7 @@ impl ISyncMgrConflictStore_Vtbl {
         iid == &<ISyncMgrConflictStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrControl_Impl: Sized {
     fn StartHandlerSync(&self, pszhandlerid: &::windows::core::PCWSTR, hwndowner: super::super::Foundation::HWND, punk: &::core::option::Option<::windows::core::IUnknown>, nsynccontrolflags: SYNCMGR_SYNC_CONTROL_FLAGS, presult: &::core::option::Option<ISyncMgrSyncResult>) -> ::windows::core::Result<()>;
@@ -19403,6 +19755,7 @@ impl ISyncMgrControl_Vtbl {
         iid == &<ISyncMgrControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ISyncMgrEnumItems_Impl: Sized {
     fn Next(&self, celt: u32, rgelt: *mut SYNCMGRITEM, pceltfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -19453,6 +19806,7 @@ impl ISyncMgrEnumItems_Vtbl {
         iid == &<ISyncMgrEnumItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrEvent_Impl: Sized {
     fn GetEventID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -19612,6 +19966,7 @@ impl ISyncMgrEvent_Vtbl {
         iid == &<ISyncMgrEvent as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrEventLinkUIOperation_Impl: Sized + ISyncMgrUIOperation_Impl {
     fn Init(&self, rguideventid: *const ::windows::core::GUID, pevent: &::core::option::Option<ISyncMgrEvent>) -> ::windows::core::Result<()>;
@@ -19632,6 +19987,7 @@ impl ISyncMgrEventLinkUIOperation_Vtbl {
         iid == &<ISyncMgrEventLinkUIOperation as ::windows::core::Interface>::IID || iid == &<ISyncMgrUIOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrEventStore_Impl: Sized {
     fn GetEventEnumerator(&self) -> ::windows::core::Result<IEnumSyncMgrEvents>;
     fn GetEventCount(&self) -> ::windows::core::Result<u32>;
@@ -19691,6 +20047,7 @@ impl ISyncMgrEventStore_Vtbl {
         iid == &<ISyncMgrEventStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrHandler_Impl: Sized {
     fn GetName(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -19787,6 +20144,7 @@ impl ISyncMgrHandler_Vtbl {
         iid == &<ISyncMgrHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISyncMgrHandlerCollection_Impl: Sized {
     fn GetHandlerEnumerator(&self) -> ::windows::core::Result<super::super::System::Com::IEnumString>;
@@ -19823,6 +20181,7 @@ impl ISyncMgrHandlerCollection_Vtbl {
         iid == &<ISyncMgrHandlerCollection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrHandlerInfo_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<SYNCMGR_HANDLER_TYPE>;
@@ -19912,6 +20271,7 @@ impl ISyncMgrHandlerInfo_Vtbl {
         iid == &<ISyncMgrHandlerInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrRegister_Impl: Sized {
     fn RegisterSyncMgrHandler(&self, clsidhandler: *const ::windows::core::GUID, pwszdescription: &::windows::core::PCWSTR, dwsyncmgrregisterflags: u32) -> ::windows::core::Result<()>;
     fn UnregisterSyncMgrHandler(&self, clsidhandler: *const ::windows::core::GUID, dwreserved: u32) -> ::windows::core::Result<()>;
@@ -19946,6 +20306,7 @@ impl ISyncMgrRegister_Vtbl {
         iid == &<ISyncMgrRegister as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrResolutionHandler_Impl: Sized {
     fn QueryAbilities(&self) -> ::windows::core::Result<u32>;
     fn KeepOther(&self, psiother: &::core::option::Option<IShellItem>) -> ::windows::core::Result<SYNCMGR_RESOLUTION_FEEDBACK>;
@@ -20024,6 +20385,7 @@ impl ISyncMgrResolutionHandler_Vtbl {
         iid == &<ISyncMgrResolutionHandler as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrScheduleWizardUIOperation_Impl: Sized + ISyncMgrUIOperation_Impl {
     fn InitWizard(&self, pszhandlerid: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -20044,6 +20406,7 @@ impl ISyncMgrScheduleWizardUIOperation_Vtbl {
         iid == &<ISyncMgrScheduleWizardUIOperation as ::windows::core::Interface>::IID || iid == &<ISyncMgrUIOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrSessionCreator_Impl: Sized {
     fn CreateSession(&self, pszhandlerid: &::windows::core::PCWSTR, ppszitemids: *const ::windows::core::PCWSTR, citems: u32) -> ::windows::core::Result<ISyncMgrSyncCallback>;
 }
@@ -20067,6 +20430,7 @@ impl ISyncMgrSessionCreator_Vtbl {
         iid == &<ISyncMgrSessionCreator as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISyncMgrSyncCallback_Impl: Sized {
     fn ReportProgress(&self, pszitemid: &::windows::core::PCWSTR, pszprogresstext: &::windows::core::PCWSTR, nstatus: SYNCMGR_PROGRESS_STATUS, ucurrentstep: u32, umaxstep: u32, pncancelrequest: *mut SYNCMGR_CANCEL_REQUEST) -> ::windows::core::Result<()>;
@@ -20159,6 +20523,7 @@ impl ISyncMgrSyncCallback_Vtbl {
         iid == &<ISyncMgrSyncCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrSyncItem_Impl: Sized {
     fn GetItemID(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -20261,6 +20626,7 @@ impl ISyncMgrSyncItem_Vtbl {
         iid == &<ISyncMgrSyncItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrSyncItemContainer_Impl: Sized {
     fn GetSyncItem(&self, pszitemid: &::windows::core::PCWSTR) -> ::windows::core::Result<ISyncMgrSyncItem>;
     fn GetSyncItemEnumerator(&self) -> ::windows::core::Result<IEnumSyncMgrSyncItems>;
@@ -20313,6 +20679,7 @@ impl ISyncMgrSyncItemContainer_Vtbl {
         iid == &<ISyncMgrSyncItemContainer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrSyncItemInfo_Impl: Sized {
     fn GetTypeLabel(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -20382,6 +20749,7 @@ impl ISyncMgrSyncItemInfo_Vtbl {
         iid == &<ISyncMgrSyncItemInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrSyncResult_Impl: Sized {
     fn Result(&self, nstatus: SYNCMGR_PROGRESS_STATUS, cerror: u32, cconflicts: u32) -> ::windows::core::Result<()>;
 }
@@ -20399,6 +20767,7 @@ impl ISyncMgrSyncResult_Vtbl {
         iid == &<ISyncMgrSyncResult as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ISyncMgrSynchronize_Impl: Sized {
     fn Initialize(&self, dwreserved: u32, dwsyncmgrflags: u32, cbcookie: u32, lpcookie: *const u8) -> ::windows::core::Result<()>;
@@ -20497,6 +20866,7 @@ impl ISyncMgrSynchronize_Vtbl {
         iid == &<ISyncMgrSynchronize as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrSynchronizeCallback_Impl: Sized {
     fn ShowPropertiesCompleted(&self, hr: ::windows::core::HRESULT) -> ::windows::core::Result<()>;
@@ -20576,6 +20946,7 @@ impl ISyncMgrSynchronizeCallback_Vtbl {
         iid == &<ISyncMgrSynchronizeCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ISyncMgrSynchronizeInvoke_Impl: Sized {
     fn UpdateItems(&self, dwinvokeflags: u32, clsid: *const ::windows::core::GUID, cbcookie: u32, pcookie: *const u8) -> ::windows::core::Result<()>;
     fn UpdateAll(&self) -> ::windows::core::Result<()>;
@@ -20603,6 +20974,7 @@ impl ISyncMgrSynchronizeInvoke_Vtbl {
         iid == &<ISyncMgrSynchronizeInvoke as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ISyncMgrUIOperation_Impl: Sized {
     fn Run(&self, hwndowner: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -20623,6 +20995,7 @@ impl ISyncMgrUIOperation_Vtbl {
         iid == &<ISyncMgrUIOperation as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITaskbarList_Impl: Sized {
     fn HrInit(&self) -> ::windows::core::Result<()>;
@@ -20674,6 +21047,7 @@ impl ITaskbarList_Vtbl {
         iid == &<ITaskbarList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITaskbarList2_Impl: Sized + ITaskbarList_Impl {
     fn MarkFullscreenWindow(&self, hwnd: super::super::Foundation::HWND, ffullscreen: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -20694,6 +21068,7 @@ impl ITaskbarList2_Vtbl {
         iid == &<ITaskbarList2 as ::windows::core::Interface>::IID || iid == &<ITaskbarList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITaskbarList3_Impl: Sized + ITaskbarList2_Impl {
     fn SetProgressValue(&self, hwnd: super::super::Foundation::HWND, ullcompleted: u64, ulltotal: u64) -> ::windows::core::Result<()>;
@@ -20794,6 +21169,7 @@ impl ITaskbarList3_Vtbl {
         iid == &<ITaskbarList3 as ::windows::core::Interface>::IID || iid == &<ITaskbarList as ::windows::core::Interface>::IID || iid == &<ITaskbarList2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Controls\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Controls", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITaskbarList4_Impl: Sized + ITaskbarList3_Impl {
     fn SetTabProperties(&self, hwndtab: super::super::Foundation::HWND, stpflags: STPFLAG) -> ::windows::core::Result<()>;
@@ -20814,6 +21190,7 @@ impl ITaskbarList4_Vtbl {
         iid == &<ITaskbarList4 as ::windows::core::Interface>::IID || iid == &<ITaskbarList as ::windows::core::Interface>::IID || iid == &<ITaskbarList2 as ::windows::core::Interface>::IID || iid == &<ITaskbarList3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IThumbnailCache_Impl: Sized {
     fn GetThumbnail(&self, pshellitem: &::core::option::Option<IShellItem>, cxyrequestedthumbsize: u32, flags: WTS_FLAGS, ppvthumb: *mut ::core::option::Option<ISharedBitmap>, poutflags: *mut WTS_CACHEFLAGS, pthumbnailid: *mut WTS_THUMBNAILID) -> ::windows::core::Result<()>;
     fn GetThumbnailByID(&self, thumbnailid: &WTS_THUMBNAILID, cxyrequestedthumbsize: u32, ppvthumb: *mut ::core::option::Option<ISharedBitmap>, poutflags: *mut WTS_CACHEFLAGS) -> ::windows::core::Result<()>;
@@ -20841,6 +21218,7 @@ impl IThumbnailCache_Vtbl {
         iid == &<IThumbnailCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IThumbnailCachePrimer_Impl: Sized {
     fn PageInThumbnail(&self, psi: &::core::option::Option<IShellItem>, wtsflags: WTS_FLAGS, cxyrequestedthumbsize: u32) -> ::windows::core::Result<()>;
 }
@@ -20858,6 +21236,7 @@ impl IThumbnailCachePrimer_Vtbl {
         iid == &<IThumbnailCachePrimer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IThumbnailCapture_Impl: Sized {
     fn CaptureThumbnail(&self, pmaxsize: *const super::super::Foundation::SIZE, phtmldoc2: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<super::super::Graphics::Gdi::HBITMAP>;
@@ -20884,6 +21263,7 @@ impl IThumbnailCapture_Vtbl {
         iid == &<IThumbnailCapture as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait IThumbnailHandlerFactory_Impl: Sized {
     fn GetThumbnailHandler(&self, pidlchild: *const Common::ITEMIDLIST, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
@@ -20904,6 +21284,7 @@ impl IThumbnailHandlerFactory_Vtbl {
         iid == &<IThumbnailHandlerFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait IThumbnailProvider_Impl: Sized {
     fn GetThumbnail(&self, cx: u32, phbmp: *mut super::super::Graphics::Gdi::HBITMAP, pdwalpha: *mut WTS_ALPHATYPE) -> ::windows::core::Result<()>;
@@ -20924,6 +21305,7 @@ impl IThumbnailProvider_Vtbl {
         iid == &<IThumbnailProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IThumbnailSettings_Impl: Sized {
     fn SetContext(&self, dwcontext: WTS_CONTEXTFLAGS) -> ::windows::core::Result<()>;
 }
@@ -20941,6 +21323,7 @@ impl IThumbnailSettings_Vtbl {
         iid == &<IThumbnailSettings as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IThumbnailStreamCache_Impl: Sized {
     fn GetThumbnailStream(&self, path: &::windows::core::PCWSTR, cacheid: u64, options: ThumbnailStreamCacheOptions, requestedthumbnailsize: u32, thumbnailsize: *mut super::super::Foundation::SIZE, thumbnailstream: *mut ::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -20971,6 +21354,7 @@ impl IThumbnailStreamCache_Vtbl {
         iid == &<IThumbnailStreamCache as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Registry\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Registry", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITrackShellMenu_Impl: Sized + IShellMenu_Impl {
     fn SetObscured(&self, hwndtb: super::super::Foundation::HWND, punkband: &::core::option::Option<::windows::core::IUnknown>, dwsmsetflags: u32) -> ::windows::core::Result<()>;
@@ -21001,6 +21385,7 @@ impl ITrackShellMenu_Vtbl {
         iid == &<ITrackShellMenu as ::windows::core::Interface>::IID || iid == &<IShellMenu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITranscodeImage_Impl: Sized {
     fn TranscodeImage(&self, pshellitem: &::core::option::Option<IShellItem>, uimaxwidth: u32, uimaxheight: u32, flags: u32, pvimage: &::core::option::Option<super::super::System::Com::IStream>, puiwidth: *mut u32, puiheight: *mut u32) -> ::windows::core::Result<()>;
@@ -21021,6 +21406,7 @@ impl ITranscodeImage_Vtbl {
         iid == &<ITranscodeImage as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait ITransferAdviseSink_Impl: Sized {
     fn UpdateProgress(&self, ullsizecurrent: u64, ullsizetotal: u64, nfilescurrent: i32, nfilestotal: i32, nfolderscurrent: i32, nfolderstotal: i32) -> ::windows::core::Result<()>;
@@ -21086,6 +21472,7 @@ impl ITransferAdviseSink_Vtbl {
         iid == &<ITransferAdviseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ITransferDestination_Impl: Sized {
     fn Advise(&self, psink: &::core::option::Option<ITransferAdviseSink>) -> ::windows::core::Result<u32>;
     fn Unadvise(&self, dwcookie: u32) -> ::windows::core::Result<()>;
@@ -21126,6 +21513,7 @@ impl ITransferDestination_Vtbl {
         iid == &<ITransferDestination as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait ITransferMediumItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -21139,6 +21527,7 @@ impl ITransferMediumItem_Vtbl {
         iid == &<ITransferMediumItem as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_PropertiesSystem\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait ITransferSource_Impl: Sized {
     fn Advise(&self, psink: &::core::option::Option<ITransferAdviseSink>) -> ::windows::core::Result<u32>;
@@ -21288,6 +21677,7 @@ impl ITransferSource_Vtbl {
         iid == &<ITransferSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common"))]
 pub trait ITravelEntry_Impl: Sized {
     fn Invoke(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -21331,6 +21721,7 @@ impl ITravelEntry_Vtbl {
         iid == &<ITravelEntry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_UI_Shell_Common\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_Shell_Common", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITravelLog_Impl: Sized {
     fn AddEntry(&self, punk: &::core::option::Option<::windows::core::IUnknown>, fislocalanchor: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -21436,6 +21827,7 @@ impl ITravelLog_Vtbl {
         iid == &<ITravelLog as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait ITravelLogClient_Impl: Sized {
     fn FindWindowByIndex(&self, dwid: u32) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -21485,6 +21877,7 @@ impl ITravelLogClient_Vtbl {
         iid == &<ITravelLogClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ITravelLogEntry_Impl: Sized {
     fn GetTitle(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
     fn GetURL(&self) -> ::windows::core::Result<::windows::core::PWSTR>;
@@ -21524,6 +21917,7 @@ impl ITravelLogEntry_Vtbl {
         iid == &<ITravelLogEntry as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITravelLogStg_Impl: Sized {
     fn CreateEntry(&self, pszurl: &::windows::core::PCWSTR, psztitle: &::windows::core::PCWSTR, ptlerelativeto: &::core::option::Option<ITravelLogEntry>, fprepend: super::super::Foundation::BOOL) -> ::windows::core::Result<ITravelLogEntry>;
@@ -21619,6 +22013,7 @@ impl ITravelLogStg_Vtbl {
         iid == &<ITravelLogStg as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait ITrayDeskBand_Impl: Sized {
     fn ShowDeskBand(&self, clsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
     fn HideDeskBand(&self, clsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -21660,6 +22055,7 @@ impl ITrayDeskBand_Vtbl {
         iid == &<ITrayDeskBand as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IURLSearchHook_Impl: Sized {
     fn Translate(&self, pwszsearchurl: ::windows::core::PWSTR, cchbuffersize: u32) -> ::windows::core::Result<()>;
 }
@@ -21677,6 +22073,7 @@ impl IURLSearchHook_Vtbl {
         iid == &<IURLSearchHook as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IURLSearchHook2_Impl: Sized + IURLSearchHook_Impl {
     fn TranslateWithSearchContext(&self, pwszsearchurl: ::windows::core::PWSTR, cchbuffersize: u32, psearchcontext: &::core::option::Option<ISearchContext>) -> ::windows::core::Result<()>;
 }
@@ -21694,6 +22091,7 @@ impl IURLSearchHook2_Vtbl {
         iid == &<IURLSearchHook2 as ::windows::core::Interface>::IID || iid == &<IURLSearchHook as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUniformResourceLocatorA_Impl: Sized {
     fn SetURL(&self, pcszurl: &::windows::core::PCSTR, dwinflags: u32) -> ::windows::core::Result<()>;
@@ -21737,6 +22135,7 @@ impl IUniformResourceLocatorA_Vtbl {
         iid == &<IUniformResourceLocatorA as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUniformResourceLocatorW_Impl: Sized {
     fn SetURL(&self, pcszurl: &::windows::core::PCWSTR, dwinflags: u32) -> ::windows::core::Result<()>;
@@ -21780,6 +22179,7 @@ impl IUniformResourceLocatorW_Vtbl {
         iid == &<IUniformResourceLocatorW as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_System_Com\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_UI_Shell_Common"))]
 pub trait IUpdateIDList_Impl: Sized {
     fn Update(&self, pbc: &::core::option::Option<super::super::System::Com::IBindCtx>, pidlin: *const Common::ITEMIDLIST) -> ::windows::core::Result<*mut Common::ITEMIDLIST>;
@@ -21806,6 +22206,7 @@ impl IUpdateIDList_Vtbl {
         iid == &<IUpdateIDList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IUseToBrowseItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -21819,6 +22220,7 @@ impl IUseToBrowseItem_Vtbl {
         iid == &<IUseToBrowseItem as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"implement\"`*"]
 pub trait IUserAccountChangeCallback_Impl: Sized {
     fn OnPictureChange(&self, pszusername: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
 }
@@ -21836,6 +22238,7 @@ impl IUserAccountChangeCallback_Vtbl {
         iid == &<IUserAccountChangeCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub trait IUserNotification_Impl: Sized {
     fn SetBalloonInfo(&self, psztitle: &::windows::core::PCWSTR, psztext: &::windows::core::PCWSTR, dwinfoflags: u32) -> ::windows::core::Result<()>;
@@ -21887,6 +22290,7 @@ impl IUserNotification_Vtbl {
         iid == &<IUserNotification as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub trait IUserNotification2_Impl: Sized {
     fn SetBalloonInfo(&self, psztitle: &::windows::core::PCWSTR, psztext: &::windows::core::PCWSTR, dwinfoflags: u32) -> ::windows::core::Result<()>;
@@ -21938,6 +22342,7 @@ impl IUserNotification2_Vtbl {
         iid == &<IUserNotification2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUserNotificationCallback_Impl: Sized {
     fn OnBalloonUserClick(&self, pt: *const super::super::Foundation::POINT) -> ::windows::core::Result<()>;
@@ -21975,6 +22380,7 @@ impl IUserNotificationCallback_Vtbl {
         iid == &<IUserNotificationCallback as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Shell_Common\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Shell_Common")]
 pub trait IViewStateIdentityItem_Impl: Sized + IRelatedItem_Impl {}
 #[cfg(feature = "Win32_UI_Shell_Common")]
@@ -21988,6 +22394,7 @@ impl IViewStateIdentityItem_Vtbl {
         iid == &<IViewStateIdentityItem as ::windows::core::Interface>::IID || iid == &<IRelatedItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IVirtualDesktopManager_Impl: Sized {
     fn IsWindowOnCurrentVirtualDesktop(&self, toplevelwindow: super::super::Foundation::HWND) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -22037,6 +22444,7 @@ impl IVirtualDesktopManager_Vtbl {
         iid == &<IVirtualDesktopManager as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait IVisualProperties_Impl: Sized {
     fn SetWatermark(&self, hbmp: super::super::Graphics::Gdi::HBITMAP, vpwf: VPWATERMARKFLAGS) -> ::windows::core::Result<()>;
@@ -22127,6 +22535,7 @@ impl IVisualProperties_Vtbl {
         iid == &<IVisualProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWebBrowser_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GoBack(&self) -> ::windows::core::Result<()>;
@@ -22396,6 +22805,7 @@ impl IWebBrowser_Vtbl {
         iid == &<IWebBrowser as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWebBrowser2_Impl: Sized + IWebBrowserApp_Impl {
     fn Navigate2(&self, url: *const super::super::System::Com::VARIANT, flags: *const super::super::System::Com::VARIANT, targetframename: *const super::super::System::Com::VARIANT, postdata: *const super::super::System::Com::VARIANT, headers: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -22599,6 +23009,7 @@ impl IWebBrowser2_Vtbl {
         iid == &<IWebBrowser2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWebBrowser as ::windows::core::Interface>::IID || iid == &<IWebBrowserApp as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWebBrowserApp_Impl: Sized + IWebBrowser_Impl {
     fn Quit(&self) -> ::windows::core::Result<()>;
@@ -22821,6 +23232,7 @@ impl IWebBrowserApp_Vtbl {
         iid == &<IWebBrowserApp as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWebBrowser as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Controls")]
 pub trait IWebWizardExtension_Impl: Sized + IWizardExtension_Impl {
     fn SetInitialURL(&self, pszurl: &::windows::core::PCWSTR) -> ::windows::core::Result<()>;
@@ -22851,6 +23263,7 @@ impl IWebWizardExtension_Vtbl {
         iid == &<IWebWizardExtension as ::windows::core::Interface>::IID || iid == &<IWizardExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWebWizardHost_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn FinalBack(&self) -> ::windows::core::Result<()>;
@@ -22942,6 +23355,7 @@ impl IWebWizardHost_Vtbl {
         iid == &<IWebWizardHost as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IWebWizardHost2_Impl: Sized + IWebWizardHost_Impl {
     fn SignString(&self, value: &::windows::core::BSTR) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -22968,6 +23382,7 @@ impl IWebWizardHost2_Vtbl {
         iid == &<IWebWizardHost2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID || iid == &<IWebWizardHost as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Controls")]
 pub trait IWizardExtension_Impl: Sized {
     fn AddPages(&self, apages: *mut super::Controls::HPROPSHEETPAGE, cpages: u32, pnpagesadded: *mut u32) -> ::windows::core::Result<()>;
@@ -23017,6 +23432,7 @@ impl IWizardExtension_Vtbl {
         iid == &<IWizardExtension as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_Controls\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_Controls")]
 pub trait IWizardSite_Impl: Sized {
     fn GetPreviousPage(&self) -> ::windows::core::Result<super::Controls::HPROPSHEETPAGE>;

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IDynamicRenderer_Impl: Sized {
     fn Enabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -155,6 +156,7 @@ impl IDynamicRenderer_Vtbl {
         iid == &<IDynamicRenderer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IGestureRecognizer_Impl: Sized {
     fn Enabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -225,6 +227,7 @@ impl IGestureRecognizer_Vtbl {
         iid == &<IGestureRecognizer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IHandwrittenTextInsertion_Impl: Sized {
     fn InsertRecognitionResultsArray(&self, psaalternates: *const super::super::System::Com::SAFEARRAY, locale: u32, falternatecontainsautospacinginformation: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -255,6 +258,7 @@ impl IHandwrittenTextInsertion_Vtbl {
         iid == &<IHandwrittenTextInsertion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInk_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -268,6 +272,7 @@ impl IInk_Vtbl {
         iid == &<IInk as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkCollector_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn hWnd(&self) -> ::windows::core::Result<isize>;
@@ -678,6 +683,7 @@ impl IInkCollector_Vtbl {
         iid == &<IInkCollector as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkCursor_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -779,6 +785,7 @@ impl IInkCursor_Vtbl {
         iid == &<IInkCursor as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkCursorButton_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -834,6 +841,7 @@ impl IInkCursorButton_Vtbl {
         iid == &<IInkCursorButton as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkCursorButtons_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -889,6 +897,7 @@ impl IInkCursorButtons_Vtbl {
         iid == &<IInkCursorButtons as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkCursors_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -944,6 +953,7 @@ impl IInkCursors_Vtbl {
         iid == &<IInkCursors as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkCustomStrokes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1020,6 +1030,7 @@ impl IInkCustomStrokes_Vtbl {
         iid == &<IInkCustomStrokes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkDisp_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Strokes(&self) -> ::windows::core::Result<IInkStrokes>;
@@ -1313,6 +1324,7 @@ impl IInkDisp_Vtbl {
         iid == &<IInkDisp as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkDivider_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Strokes(&self) -> ::windows::core::Result<IInkStrokes>;
@@ -1402,6 +1414,7 @@ impl IInkDivider_Vtbl {
         iid == &<IInkDivider as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkDivisionResult_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Strokes(&self) -> ::windows::core::Result<IInkStrokes>;
@@ -1444,6 +1457,7 @@ impl IInkDivisionResult_Vtbl {
         iid == &<IInkDivisionResult as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkDivisionUnit_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Strokes(&self) -> ::windows::core::Result<IInkStrokes>;
@@ -1512,6 +1526,7 @@ impl IInkDivisionUnit_Vtbl {
         iid == &<IInkDivisionUnit as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkDivisionUnits_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -1567,6 +1582,7 @@ impl IInkDivisionUnits_Vtbl {
         iid == &<IInkDivisionUnits as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkDrawingAttributes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Color(&self) -> ::windows::core::Result<i32>;
@@ -1789,6 +1805,7 @@ impl IInkDrawingAttributes_Vtbl {
         iid == &<IInkDrawingAttributes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkEdit_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Status(&self) -> ::windows::core::Result<InkEditStatus>;
@@ -2572,6 +2589,7 @@ impl IInkEdit_Vtbl {
         iid == &<IInkEdit as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkExtendedProperties_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -2667,6 +2685,7 @@ impl IInkExtendedProperties_Vtbl {
         iid == &<IInkExtendedProperties as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkExtendedProperty_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Guid(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -2716,6 +2735,7 @@ impl IInkExtendedProperty_Vtbl {
         iid == &<IInkExtendedProperty as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkGesture_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Confidence(&self) -> ::windows::core::Result<InkRecognitionConfidence>;
@@ -2765,6 +2785,7 @@ impl IInkGesture_Vtbl {
         iid == &<IInkGesture as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IInkLineInfo_Impl: Sized {
     fn SetFormat(&self, pim: *const INKMETRIC) -> ::windows::core::Result<()>;
@@ -2823,6 +2844,7 @@ impl IInkLineInfo_Vtbl {
         iid == &<IInkLineInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkOverlay_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn hWnd(&self) -> ::windows::core::Result<isize>;
@@ -3373,6 +3395,7 @@ impl IInkOverlay_Vtbl {
         iid == &<IInkOverlay as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkPicture_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn hWnd(&self) -> ::windows::core::Result<isize>;
@@ -3976,6 +3999,7 @@ impl IInkPicture_Vtbl {
         iid == &<IInkPicture as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognitionAlternate_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn String(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4175,6 +4199,7 @@ impl IInkRecognitionAlternate_Vtbl {
         iid == &<IInkRecognitionAlternate as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognitionAlternates_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4243,6 +4268,7 @@ impl IInkRecognitionAlternates_Vtbl {
         iid == &<IInkRecognitionAlternates as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognitionResult_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn TopString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4338,6 +4364,7 @@ impl IInkRecognitionResult_Vtbl {
         iid == &<IInkRecognitionResult as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognizer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4445,6 +4472,7 @@ impl IInkRecognizer_Vtbl {
         iid == &<IInkRecognizer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognizer2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Id(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4487,6 +4515,7 @@ impl IInkRecognizer2_Vtbl {
         iid == &<IInkRecognizer2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognizerContext_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Strokes(&self) -> ::windows::core::Result<IInkStrokes>;
@@ -4737,6 +4766,7 @@ impl IInkRecognizerContext_Vtbl {
         iid == &<IInkRecognizerContext as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognizerContext2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn EnabledUnicodeRanges(&self) -> ::windows::core::Result<super::super::System::Com::VARIANT>;
@@ -4773,6 +4803,7 @@ impl IInkRecognizerContext2_Vtbl {
         iid == &<IInkRecognizerContext2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognizerGuide_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn WritingBox(&self) -> ::windows::core::Result<IInkRectangle>;
@@ -4909,6 +4940,7 @@ impl IInkRecognizerGuide_Vtbl {
         iid == &<IInkRecognizerGuide as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRecognizers_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -4977,6 +5009,7 @@ impl IInkRecognizers_Vtbl {
         iid == &<IInkRecognizers as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRectangle_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Top(&self) -> ::windows::core::Result<i32>;
@@ -5107,6 +5140,7 @@ impl IInkRectangle_Vtbl {
         iid == &<IInkRectangle as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkRenderer_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn GetViewTransform(&self, viewtransform: &::core::option::Option<IInkTransform>) -> ::windows::core::Result<()>;
@@ -5240,6 +5274,7 @@ impl IInkRenderer_Vtbl {
         iid == &<IInkRenderer as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkStrokeDisp_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn ID(&self) -> ::windows::core::Result<i32>;
@@ -5625,6 +5660,7 @@ impl IInkStrokeDisp_Vtbl {
         iid == &<IInkStrokeDisp as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkStrokes_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -5823,6 +5859,7 @@ impl IInkStrokes_Vtbl {
         iid == &<IInkStrokes as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkTablet_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Name(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -5911,6 +5948,7 @@ impl IInkTablet_Vtbl {
         iid == &<IInkTablet as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkTablet2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn DeviceKind(&self) -> ::windows::core::Result<TabletDeviceKind>;
@@ -5937,6 +5975,7 @@ impl IInkTablet2_Vtbl {
         iid == &<IInkTablet2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkTablet3_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn IsMultiTouch(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -5979,6 +6018,7 @@ impl IInkTablet3_Vtbl {
         iid == &<IInkTablet3 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkTablets_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Count(&self) -> ::windows::core::Result<i32>;
@@ -6060,6 +6100,7 @@ impl IInkTablets_Vtbl {
         iid == &<IInkTablets as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkTransform_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Reset(&self) -> ::windows::core::Result<()>;
@@ -6272,6 +6313,7 @@ impl IInkTransform_Vtbl {
         iid == &<IInkTransform as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkWordList_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AddWord(&self, newword: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6309,6 +6351,7 @@ impl IInkWordList_Vtbl {
         iid == &<IInkWordList as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IInkWordList2_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn AddWords(&self, newwords: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -6329,6 +6372,7 @@ impl IInkWordList2_Vtbl {
         iid == &<IInkWordList2 as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"implement\"`*"]
 pub trait IInputPanelWindowHandle_Impl: Sized {
     fn AttachedEditWindow32(&self) -> ::windows::core::Result<i32>;
     fn SetAttachedEditWindow32(&self, attachededitwindow: i32) -> ::windows::core::Result<()>;
@@ -6382,6 +6426,7 @@ impl IInputPanelWindowHandle_Vtbl {
         iid == &<IInputPanelWindowHandle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IMathInputControl_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Show(&self) -> ::windows::core::Result<()>;
@@ -6535,6 +6580,7 @@ impl IMathInputControl_Vtbl {
         iid == &<IMathInputControl as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IPenInputPanel_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn Busy(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -6804,6 +6850,7 @@ impl IPenInputPanel_Vtbl {
         iid == &<IPenInputPanel as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IRealTimeStylus_Impl: Sized {
     fn Enabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -7115,6 +7162,7 @@ impl IRealTimeStylus_Vtbl {
         iid == &<IRealTimeStylus as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRealTimeStylus2_Impl: Sized {
     fn FlicksEnabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -7151,6 +7199,7 @@ impl IRealTimeStylus2_Vtbl {
         iid == &<IRealTimeStylus2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IRealTimeStylus3_Impl: Sized {
     fn MultiTouchEnabled(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -7187,6 +7236,7 @@ impl IRealTimeStylus3_Vtbl {
         iid == &<IRealTimeStylus3 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"implement\"`*"]
 pub trait IRealTimeStylusSynchronization_Impl: Sized {
     fn AcquireLock(&self, lock: RealTimeStylusLockType) -> ::windows::core::Result<()>;
     fn ReleaseLock(&self, lock: RealTimeStylusLockType) -> ::windows::core::Result<()>;
@@ -7214,6 +7264,7 @@ impl IRealTimeStylusSynchronization_Vtbl {
         iid == &<IRealTimeStylusSynchronization as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ISketchInk_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7227,6 +7278,7 @@ impl ISketchInk_Vtbl {
         iid == &<ISketchInk as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStrokeBuilder_Impl: Sized {
     fn CreateStroke(&self, cpktbufflength: u32, ppackets: *const i32, cpacketproperties: u32, ppacketproperties: *const PACKET_PROPERTY, finktodevicescalex: f32, finktodevicescaley: f32, ppiinkstroke: *mut ::core::option::Option<IInkStrokeDisp>) -> ::windows::core::Result<()>;
@@ -7291,6 +7343,7 @@ impl IStrokeBuilder_Vtbl {
         iid == &<IStrokeBuilder as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStylusAsyncPlugin_Impl: Sized + IStylusPlugin_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -7304,6 +7357,7 @@ impl IStylusAsyncPlugin_Vtbl {
         iid == &<IStylusAsyncPlugin as ::windows::core::Interface>::IID || iid == &<IStylusPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStylusPlugin_Impl: Sized {
     fn RealTimeStylusEnabled(&self, pirtssrc: &::core::option::Option<IRealTimeStylus>, ctcidcount: u32, ptcids: *const u32) -> ::windows::core::Result<()>;
@@ -7445,6 +7499,7 @@ impl IStylusPlugin_Vtbl {
         iid == &<IStylusPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IStylusSyncPlugin_Impl: Sized + IStylusPlugin_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
@@ -7458,6 +7513,7 @@ impl IStylusSyncPlugin_Vtbl {
         iid == &<IStylusSyncPlugin as ::windows::core::Interface>::IID || iid == &<IStylusPlugin as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITextInputPanel_Impl: Sized {
     fn AttachedEditWindow(&self) -> ::windows::core::Result<super::super::Foundation::HWND>;
@@ -7727,6 +7783,7 @@ impl ITextInputPanel_Vtbl {
         iid == &<ITextInputPanel as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITextInputPanelEventSink_Impl: Sized {
     fn InPlaceStateChanging(&self, oldinplacestate: InPlaceState, newinplacestate: InPlaceState) -> ::windows::core::Result<()>;
@@ -7827,6 +7884,7 @@ impl ITextInputPanelEventSink_Vtbl {
         iid == &<ITextInputPanelEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITextInputPanelRunInfo_Impl: Sized {
     fn IsTipRunning(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -7853,6 +7911,7 @@ impl ITextInputPanelRunInfo_Vtbl {
         iid == &<ITextInputPanelRunInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITipAutoCompleteClient_Impl: Sized {
     fn AdviseProvider(&self, hwndfield: super::super::Foundation::HWND, piprovider: &::core::option::Option<ITipAutoCompleteProvider>) -> ::windows::core::Result<()>;
@@ -7910,6 +7969,7 @@ impl ITipAutoCompleteClient_Vtbl {
         iid == &<ITipAutoCompleteClient as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITipAutoCompleteProvider_Impl: Sized {
     fn UpdatePendingText(&self, bstrpendingtext: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -7940,6 +8000,7 @@ impl ITipAutoCompleteProvider_Vtbl {
         iid == &<ITipAutoCompleteProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkCollectorEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7953,6 +8014,7 @@ impl _IInkCollectorEvents_Vtbl {
         iid == &<_IInkCollectorEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkEditEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7966,6 +8028,7 @@ impl _IInkEditEvents_Vtbl {
         iid == &<_IInkEditEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7979,6 +8042,7 @@ impl _IInkEvents_Vtbl {
         iid == &<_IInkEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkOverlayEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -7992,6 +8056,7 @@ impl _IInkOverlayEvents_Vtbl {
         iid == &<_IInkOverlayEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkPictureEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -8005,6 +8070,7 @@ impl _IInkPictureEvents_Vtbl {
         iid == &<_IInkPictureEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkRecognitionEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -8018,6 +8084,7 @@ impl _IInkRecognitionEvents_Vtbl {
         iid == &<_IInkRecognitionEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IInkStrokesEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -8031,6 +8098,7 @@ impl _IInkStrokesEvents_Vtbl {
         iid == &<_IInkStrokesEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IMathInputControlEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -8044,6 +8112,7 @@ impl _IMathInputControlEvents_Vtbl {
         iid == &<_IMathInputControlEvents as ::windows::core::Interface>::IID || iid == &<super::super::System::Com::IDispatch as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TabletPC\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait _IPenInputPanelEvents_Impl: Sized + super::super::System::Com::IDispatch_Impl {}
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAccClientDocMgr_Impl: Sized {
     fn GetDocuments(&self) -> ::windows::core::Result<super::super::System::Com::IEnumUnknown>;
@@ -66,6 +67,7 @@ impl IAccClientDocMgr_Vtbl {
         iid == &<IAccClientDocMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IAccDictionary_Impl: Sized {
     fn GetLocalizedString(&self, term: *const ::windows::core::GUID, lcid: u32, presult: *mut ::windows::core::BSTR, plcid: *mut u32) -> ::windows::core::Result<()>;
@@ -135,6 +137,7 @@ impl IAccDictionary_Vtbl {
         iid == &<IAccDictionary as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IAccServerDocMgr_Impl: Sized {
     fn NewDocument(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn RevokeDocument(&self, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -169,6 +172,7 @@ impl IAccServerDocMgr_Vtbl {
         iid == &<IAccServerDocMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait IAccStore_Impl: Sized {
     fn Register(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
@@ -258,6 +262,7 @@ impl IAccStore_Vtbl {
         iid == &<IAccStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IAnchor_Impl: Sized {
     fn SetGravity(&self, gravity: TsGravity) -> ::windows::core::Result<()>;
@@ -387,6 +392,7 @@ impl IAnchor_Vtbl {
         iid == &<IAnchor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IClonableWrapper_Impl: Sized {
     fn CloneNewWrapper(&self, riid: *const ::windows::core::GUID, ppv: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
 }
@@ -404,6 +410,7 @@ impl IClonableWrapper_Vtbl {
         iid == &<IClonableWrapper as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICoCreateLocally_Impl: Sized {
     fn CoCreateLocally(&self, rclsid: *const ::windows::core::GUID, dwclscontext: u32, riid: *const ::windows::core::GUID, punk: *mut ::core::option::Option<::windows::core::IUnknown>, riidparam: *const ::windows::core::GUID, punkparam: &::core::option::Option<::windows::core::IUnknown>, varparam: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -424,6 +431,7 @@ impl ICoCreateLocally_Vtbl {
         iid == &<ICoCreateLocally as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ICoCreatedLocally_Impl: Sized {
     fn LocalInit(&self, punklocalobject: &::core::option::Option<::windows::core::IUnknown>, riidparam: *const ::windows::core::GUID, punkparam: &::core::option::Option<::windows::core::IUnknown>, varparam: &super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -444,6 +452,7 @@ impl ICoCreatedLocally_Vtbl {
         iid == &<ICoCreatedLocally as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IDocWrap_Impl: Sized {
     fn SetDoc(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn GetWrappedDoc(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::IUnknown>;
@@ -477,6 +486,7 @@ impl IDocWrap_Vtbl {
         iid == &<IDocWrap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumITfCompositionView_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumITfCompositionView>;
     fn Next(&self, ulcount: u32, rgcompositionview: *mut ::core::option::Option<ITfCompositionView>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -524,6 +534,7 @@ impl IEnumITfCompositionView_Vtbl {
         iid == &<IEnumITfCompositionView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumSpeechCommands_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumSpeechCommands>;
     fn Next(&self, ulcount: u32, pspcmds: *mut *mut u16, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -571,6 +582,7 @@ impl IEnumSpeechCommands_Vtbl {
         iid == &<IEnumSpeechCommands as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfCandidates_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfCandidates>;
     fn Next(&self, ulcount: u32, ppcand: *mut ::core::option::Option<ITfCandidateString>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -618,6 +630,7 @@ impl IEnumTfCandidates_Vtbl {
         iid == &<IEnumTfCandidates as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfContextViews_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfContextViews>;
     fn Next(&self, ulcount: u32, rgviews: *mut ::core::option::Option<ITfContextView>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -665,6 +678,7 @@ impl IEnumTfContextViews_Vtbl {
         iid == &<IEnumTfContextViews as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfContexts_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfContexts>;
     fn Next(&self, ulcount: u32, rgcontext: *mut ::core::option::Option<ITfContext>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -712,6 +726,7 @@ impl IEnumTfContexts_Vtbl {
         iid == &<IEnumTfContexts as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfDisplayAttributeInfo_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfDisplayAttributeInfo>;
     fn Next(&self, ulcount: u32, rginfo: *mut ::core::option::Option<ITfDisplayAttributeInfo>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -759,6 +774,7 @@ impl IEnumTfDisplayAttributeInfo_Vtbl {
         iid == &<IEnumTfDisplayAttributeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfDocumentMgrs_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfDocumentMgrs>;
     fn Next(&self, ulcount: u32, rgdocumentmgr: *mut ::core::option::Option<ITfDocumentMgr>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -806,6 +822,7 @@ impl IEnumTfDocumentMgrs_Vtbl {
         iid == &<IEnumTfDocumentMgrs as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfFunctionProviders_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfFunctionProviders>;
     fn Next(&self, ulcount: u32, ppcmdobj: *mut ::core::option::Option<ITfFunctionProvider>, pcfetch: *mut u32) -> ::windows::core::Result<()>;
@@ -853,6 +870,7 @@ impl IEnumTfFunctionProviders_Vtbl {
         iid == &<IEnumTfFunctionProviders as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfInputProcessorProfiles_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfInputProcessorProfiles>;
     fn Next(&self, ulcount: u32, pprofile: *mut TF_INPUTPROCESSORPROFILE, pcfetch: *mut u32) -> ::windows::core::Result<()>;
@@ -900,6 +918,7 @@ impl IEnumTfInputProcessorProfiles_Vtbl {
         iid == &<IEnumTfInputProcessorProfiles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfLangBarItems_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfLangBarItems>;
     fn Next(&self, ulcount: u32, ppitem: *mut ::core::option::Option<ITfLangBarItem>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -947,6 +966,7 @@ impl IEnumTfLangBarItems_Vtbl {
         iid == &<IEnumTfLangBarItems as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IEnumTfLanguageProfiles_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfLanguageProfiles>;
@@ -997,6 +1017,7 @@ impl IEnumTfLanguageProfiles_Vtbl {
         iid == &<IEnumTfLanguageProfiles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfLatticeElements_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfLatticeElements>;
     fn Next(&self, ulcount: u32, rgselements: *mut TF_LMLATTELEMENT, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1044,6 +1065,7 @@ impl IEnumTfLatticeElements_Vtbl {
         iid == &<IEnumTfLatticeElements as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfProperties_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfProperties>;
     fn Next(&self, ulcount: u32, ppprop: *mut ::core::option::Option<ITfProperty>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1091,6 +1113,7 @@ impl IEnumTfProperties_Vtbl {
         iid == &<IEnumTfProperties as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait IEnumTfPropertyValue_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfPropertyValue>;
@@ -1141,6 +1164,7 @@ impl IEnumTfPropertyValue_Vtbl {
         iid == &<IEnumTfPropertyValue as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfRanges_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfRanges>;
     fn Next(&self, ulcount: u32, pprange: *mut ::core::option::Option<ITfRange>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1188,6 +1212,7 @@ impl IEnumTfRanges_Vtbl {
         iid == &<IEnumTfRanges as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IEnumTfUIElements_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<IEnumTfUIElements>;
     fn Next(&self, ulcount: u32, ppelement: *mut ::core::option::Option<ITfUIElement>, pcfetched: *mut u32) -> ::windows::core::Result<()>;
@@ -1235,6 +1260,7 @@ impl IEnumTfUIElements_Vtbl {
         iid == &<IEnumTfUIElements as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IInternalDocWrap_Impl: Sized {
     fn NotifyRevoke(&self) -> ::windows::core::Result<()>;
 }
@@ -1252,6 +1278,7 @@ impl IInternalDocWrap_Vtbl {
         iid == &<IInternalDocWrap as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ISpeechCommandProvider_Impl: Sized {
     fn EnumSpeechCommands(&self, langid: u16) -> ::windows::core::Result<IEnumSpeechCommands>;
     fn ProcessCommand(&self, pszcommand: &::windows::core::PCWSTR, cch: u32, langid: u16) -> ::windows::core::Result<()>;
@@ -1285,6 +1312,7 @@ impl ISpeechCommandProvider_Vtbl {
         iid == &<ISpeechCommandProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextStoreACP_Impl: Sized {
     fn AdviseSink(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>, dwmask: u32) -> ::windows::core::Result<()>;
@@ -1555,6 +1583,7 @@ impl ITextStoreACP_Vtbl {
         iid == &<ITextStoreACP as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextStoreACP2_Impl: Sized {
     fn AdviseSink(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>, dwmask: u32) -> ::windows::core::Result<()>;
@@ -1812,6 +1841,7 @@ impl ITextStoreACP2_Vtbl {
         iid == &<ITextStoreACP2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITextStoreACPEx_Impl: Sized {
     fn ScrollToRect(&self, acpstart: i32, acpend: i32, rc: &super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::Result<()>;
@@ -1832,6 +1862,7 @@ impl ITextStoreACPEx_Vtbl {
         iid == &<ITextStoreACPEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITextStoreACPServices_Impl: Sized {
     fn Serialize(&self, pprop: &::core::option::Option<ITfProperty>, prange: &::core::option::Option<ITfRange>, phdr: *mut TF_PERSISTENT_PROPERTY_HEADER_ACP, pstream: &::core::option::Option<super::super::System::Com::IStream>) -> ::windows::core::Result<()>;
@@ -1882,6 +1913,7 @@ impl ITextStoreACPServices_Vtbl {
         iid == &<ITextStoreACPServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITextStoreACPSink_Impl: Sized {
     fn OnTextChange(&self, dwflags: TEXT_STORE_TEXT_CHANGE_FLAGS, pchange: *const TS_TEXTCHANGE) -> ::windows::core::Result<()>;
     fn OnSelectionChange(&self) -> ::windows::core::Result<()>;
@@ -1951,6 +1983,7 @@ impl ITextStoreACPSink_Vtbl {
         iid == &<ITextStoreACPSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITextStoreACPSinkEx_Impl: Sized + ITextStoreACPSink_Impl {
     fn OnDisconnect(&self) -> ::windows::core::Result<()>;
 }
@@ -1968,6 +2001,7 @@ impl ITextStoreACPSinkEx_Vtbl {
         iid == &<ITextStoreACPSinkEx as ::windows::core::Interface>::IID || iid == &<ITextStoreACPSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITextStoreAnchor_Impl: Sized {
     fn AdviseSink(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>, dwmask: u32) -> ::windows::core::Result<()>;
@@ -2239,6 +2273,7 @@ impl ITextStoreAnchor_Vtbl {
         iid == &<ITextStoreAnchor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITextStoreAnchorEx_Impl: Sized {
     fn ScrollToRect(&self, pstart: &::core::option::Option<IAnchor>, pend: &::core::option::Option<IAnchor>, rc: &super::super::Foundation::RECT, dwposition: u32) -> ::windows::core::Result<()>;
@@ -2259,6 +2294,7 @@ impl ITextStoreAnchorEx_Vtbl {
         iid == &<ITextStoreAnchorEx as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITextStoreAnchorSink_Impl: Sized {
     fn OnTextChange(&self, dwflags: TEXT_STORE_CHANGE_FLAGS, pastart: &::core::option::Option<IAnchor>, paend: &::core::option::Option<IAnchor>) -> ::windows::core::Result<()>;
     fn OnSelectionChange(&self) -> ::windows::core::Result<()>;
@@ -2328,6 +2364,7 @@ impl ITextStoreAnchorSink_Vtbl {
         iid == &<ITextStoreAnchorSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITextStoreSinkAnchorEx_Impl: Sized + ITextStoreAnchorSink_Impl {
     fn OnDisconnect(&self) -> ::windows::core::Result<()>;
 }
@@ -2345,6 +2382,7 @@ impl ITextStoreSinkAnchorEx_Vtbl {
         iid == &<ITextStoreSinkAnchorEx as ::windows::core::Interface>::IID || iid == &<ITextStoreAnchorSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfActiveLanguageProfileNotifySink_Impl: Sized {
     fn OnActivated(&self, clsid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, factivated: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -2365,6 +2403,7 @@ impl ITfActiveLanguageProfileNotifySink_Vtbl {
         iid == &<ITfActiveLanguageProfileNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfCandidateList_Impl: Sized {
     fn EnumCandidates(&self) -> ::windows::core::Result<IEnumTfCandidates>;
     fn GetCandidate(&self, nindex: u32) -> ::windows::core::Result<ITfCandidateString>;
@@ -2424,6 +2463,7 @@ impl ITfCandidateList_Vtbl {
         iid == &<ITfCandidateList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfCandidateListUIElement_Impl: Sized + ITfUIElement_Impl {
     fn GetUpdatedFlags(&self) -> ::windows::core::Result<u32>;
@@ -2532,6 +2572,7 @@ impl ITfCandidateListUIElement_Vtbl {
         iid == &<ITfCandidateListUIElement as ::windows::core::Interface>::IID || iid == &<ITfUIElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfCandidateListUIElementBehavior_Impl: Sized + ITfCandidateListUIElement_Impl {
     fn SetSelection(&self, nindex: u32) -> ::windows::core::Result<()>;
@@ -2569,6 +2610,7 @@ impl ITfCandidateListUIElementBehavior_Vtbl {
         iid == &<ITfCandidateListUIElementBehavior as ::windows::core::Interface>::IID || iid == &<ITfUIElement as ::windows::core::Interface>::IID || iid == &<ITfCandidateListUIElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfCandidateString_Impl: Sized {
     fn GetString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
     fn GetIndex(&self) -> ::windows::core::Result<u32>;
@@ -2608,6 +2650,7 @@ impl ITfCandidateString_Vtbl {
         iid == &<ITfCandidateString as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITfCategoryMgr_Impl: Sized {
     fn RegisterCategory(&self, rclsid: *const ::windows::core::GUID, rcatid: *const ::windows::core::GUID, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -2764,6 +2807,7 @@ impl ITfCategoryMgr_Vtbl {
         iid == &<ITfCategoryMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfCleanupContextDurationSink_Impl: Sized {
     fn OnStartCleanupContext(&self) -> ::windows::core::Result<()>;
     fn OnEndCleanupContext(&self) -> ::windows::core::Result<()>;
@@ -2791,6 +2835,7 @@ impl ITfCleanupContextDurationSink_Vtbl {
         iid == &<ITfCleanupContextDurationSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfCleanupContextSink_Impl: Sized {
     fn OnCleanupContext(&self, ecwrite: u32, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
 }
@@ -2808,6 +2853,7 @@ impl ITfCleanupContextSink_Vtbl {
         iid == &<ITfCleanupContextSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfClientId_Impl: Sized {
     fn GetClientId(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
 }
@@ -2831,6 +2877,7 @@ impl ITfClientId_Vtbl {
         iid == &<ITfClientId as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITfCompartment_Impl: Sized {
     fn SetValue(&self, tid: u32, pvarvalue: *const super::super::System::Com::VARIANT) -> ::windows::core::Result<()>;
@@ -2867,6 +2914,7 @@ impl ITfCompartment_Vtbl {
         iid == &<ITfCompartment as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfCompartmentEventSink_Impl: Sized {
     fn OnChange(&self, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
 }
@@ -2884,6 +2932,7 @@ impl ITfCompartmentEventSink_Vtbl {
         iid == &<ITfCompartmentEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITfCompartmentMgr_Impl: Sized {
     fn GetCompartment(&self, rguid: *const ::windows::core::GUID) -> ::windows::core::Result<ITfCompartment>;
@@ -2933,6 +2982,7 @@ impl ITfCompartmentMgr_Vtbl {
         iid == &<ITfCompartmentMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfComposition_Impl: Sized {
     fn GetRange(&self) -> ::windows::core::Result<ITfRange>;
     fn ShiftStart(&self, ecwrite: u32, pnewstart: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
@@ -2980,6 +3030,7 @@ impl ITfComposition_Vtbl {
         iid == &<ITfComposition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfCompositionSink_Impl: Sized {
     fn OnCompositionTerminated(&self, ecwrite: u32, pcomposition: &::core::option::Option<ITfComposition>) -> ::windows::core::Result<()>;
 }
@@ -2997,6 +3048,7 @@ impl ITfCompositionSink_Vtbl {
         iid == &<ITfCompositionSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfCompositionView_Impl: Sized {
     fn GetOwnerClsid(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetRange(&self) -> ::windows::core::Result<ITfRange>;
@@ -3036,6 +3088,7 @@ impl ITfCompositionView_Vtbl {
         iid == &<ITfCompositionView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfConfigureSystemKeystrokeFeed_Impl: Sized {
     fn DisableSystemKeystrokeFeed(&self) -> ::windows::core::Result<()>;
     fn EnableSystemKeystrokeFeed(&self) -> ::windows::core::Result<()>;
@@ -3063,6 +3116,7 @@ impl ITfConfigureSystemKeystrokeFeed_Vtbl {
         iid == &<ITfConfigureSystemKeystrokeFeed as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfContext_Impl: Sized {
     fn RequestEditSession(&self, tid: u32, pes: &::core::option::Option<ITfEditSession>, dwflags: TF_CONTEXT_EDIT_CONTEXT_FLAGS) -> ::windows::core::Result<::windows::core::HRESULT>;
@@ -3262,6 +3316,7 @@ impl ITfContext_Vtbl {
         iid == &<ITfContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfContextComposition_Impl: Sized {
     fn StartComposition(&self, ecwrite: u32, pcompositionrange: &::core::option::Option<ITfRange>, psink: &::core::option::Option<ITfCompositionSink>) -> ::windows::core::Result<ITfComposition>;
     fn EnumCompositions(&self) -> ::windows::core::Result<IEnumITfCompositionView>;
@@ -3327,6 +3382,7 @@ impl ITfContextComposition_Vtbl {
         iid == &<ITfContextComposition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfContextKeyEventSink_Impl: Sized {
     fn OnKeyDown(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3395,6 +3451,7 @@ impl ITfContextKeyEventSink_Vtbl {
         iid == &<ITfContextKeyEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITfContextOwner_Impl: Sized {
     fn GetACPFromPoint(&self, ptscreen: *const super::super::Foundation::POINT, dwflags: u32) -> ::windows::core::Result<i32>;
@@ -3483,6 +3540,7 @@ impl ITfContextOwner_Vtbl {
         iid == &<ITfContextOwner as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfContextOwnerCompositionServices_Impl: Sized + ITfContextComposition_Impl {
     fn TerminateComposition(&self, pcomposition: &::core::option::Option<ITfCompositionView>) -> ::windows::core::Result<()>;
 }
@@ -3500,6 +3558,7 @@ impl ITfContextOwnerCompositionServices_Vtbl {
         iid == &<ITfContextOwnerCompositionServices as ::windows::core::Interface>::IID || iid == &<ITfContextComposition as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfContextOwnerCompositionSink_Impl: Sized {
     fn OnStartComposition(&self, pcomposition: &::core::option::Option<ITfCompositionView>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3543,6 +3602,7 @@ impl ITfContextOwnerCompositionSink_Vtbl {
         iid == &<ITfContextOwnerCompositionSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITfContextOwnerServices_Impl: Sized {
     fn OnLayoutChange(&self) -> ::windows::core::Result<()>;
@@ -3614,6 +3674,7 @@ impl ITfContextOwnerServices_Vtbl {
         iid == &<ITfContextOwnerServices as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfContextView_Impl: Sized {
     fn GetRangeFromPoint(&self, ec: u32, ppt: *const super::super::Foundation::POINT, dwflags: u32) -> ::windows::core::Result<ITfRange>;
@@ -3676,6 +3737,7 @@ impl ITfContextView_Vtbl {
         iid == &<ITfContextView as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITfCreatePropertyStore_Impl: Sized {
     fn IsStoreSerializable(&self, guidprop: *const ::windows::core::GUID, prange: &::core::option::Option<ITfRange>, ppropstore: &::core::option::Option<ITfPropertyStore>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3718,6 +3780,7 @@ impl ITfCreatePropertyStore_Vtbl {
         iid == &<ITfCreatePropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfDisplayAttributeInfo_Impl: Sized {
     fn GetGUID(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -3787,6 +3850,7 @@ impl ITfDisplayAttributeInfo_Vtbl {
         iid == &<ITfDisplayAttributeInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfDisplayAttributeMgr_Impl: Sized {
     fn OnUpdateInfo(&self) -> ::windows::core::Result<()>;
     fn EnumDisplayAttributeInfo(&self) -> ::windows::core::Result<IEnumTfDisplayAttributeInfo>;
@@ -3827,6 +3891,7 @@ impl ITfDisplayAttributeMgr_Vtbl {
         iid == &<ITfDisplayAttributeMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfDisplayAttributeNotifySink_Impl: Sized {
     fn OnUpdateInfo(&self) -> ::windows::core::Result<()>;
 }
@@ -3844,6 +3909,7 @@ impl ITfDisplayAttributeNotifySink_Vtbl {
         iid == &<ITfDisplayAttributeNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfDisplayAttributeProvider_Impl: Sized {
     fn EnumDisplayAttributeInfo(&self) -> ::windows::core::Result<IEnumTfDisplayAttributeInfo>;
     fn GetDisplayAttributeInfo(&self, guid: *const ::windows::core::GUID) -> ::windows::core::Result<ITfDisplayAttributeInfo>;
@@ -3883,6 +3949,7 @@ impl ITfDisplayAttributeProvider_Vtbl {
         iid == &<ITfDisplayAttributeProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfDocumentMgr_Impl: Sized {
     fn CreateContext(&self, tidowner: u32, dwflags: u32, punk: &::core::option::Option<::windows::core::IUnknown>, ppic: *mut ::core::option::Option<ITfContext>, pectextstore: *mut u32) -> ::windows::core::Result<()>;
     fn Push(&self, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
@@ -3956,6 +4023,7 @@ impl ITfDocumentMgr_Vtbl {
         iid == &<ITfDocumentMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfEditRecord_Impl: Sized {
     fn GetSelectionStatus(&self) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -3998,6 +4066,7 @@ impl ITfEditRecord_Vtbl {
         iid == &<ITfEditRecord as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfEditSession_Impl: Sized {
     fn DoEditSession(&self, ec: u32) -> ::windows::core::Result<()>;
 }
@@ -4015,6 +4084,7 @@ impl ITfEditSession_Vtbl {
         iid == &<ITfEditSession as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfEditTransactionSink_Impl: Sized {
     fn OnStartEditTransaction(&self, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
     fn OnEndEditTransaction(&self, pic: &::core::option::Option<ITfContext>) -> ::windows::core::Result<()>;
@@ -4042,6 +4112,7 @@ impl ITfEditTransactionSink_Vtbl {
         iid == &<ITfEditTransactionSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnAdviseText_Impl: Sized + ITfFunction_Impl {
     fn OnTextUpdate(&self, prange: &::core::option::Option<ITfRange>, pchtext: &::windows::core::PCWSTR, cch: i32) -> ::windows::core::Result<()>;
     fn OnLatticeUpdate(&self, prange: &::core::option::Option<ITfRange>, plattice: &::core::option::Option<ITfLMLattice>) -> ::windows::core::Result<()>;
@@ -4069,6 +4140,7 @@ impl ITfFnAdviseText_Vtbl {
         iid == &<ITfFnAdviseText as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnBalloon_Impl: Sized {
     fn UpdateBalloon(&self, style: TfLBBalloonStyle, pch: &::windows::core::PCWSTR, cch: u32) -> ::windows::core::Result<()>;
 }
@@ -4086,6 +4158,7 @@ impl ITfFnBalloon_Vtbl {
         iid == &<ITfFnBalloon as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnConfigure_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND, langid: u16, rguidprofile: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -4106,6 +4179,7 @@ impl ITfFnConfigure_Vtbl {
         iid == &<ITfFnConfigure as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnConfigureRegisterEudc_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND, langid: u16, rguidprofile: *const ::windows::core::GUID, bstrregistered: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4126,6 +4200,7 @@ impl ITfFnConfigureRegisterEudc_Vtbl {
         iid == &<ITfFnConfigureRegisterEudc as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnConfigureRegisterWord_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND, langid: u16, rguidprofile: *const ::windows::core::GUID, bstrregistered: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4146,6 +4221,7 @@ impl ITfFnConfigureRegisterWord_Vtbl {
         iid == &<ITfFnConfigureRegisterWord as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnCustomSpeechCommand_Impl: Sized + ITfFunction_Impl {
     fn SetSpeechCommandProvider(&self, pspcmdprovider: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
 }
@@ -4163,6 +4239,7 @@ impl ITfFnCustomSpeechCommand_Vtbl {
         iid == &<ITfFnCustomSpeechCommand as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnGetLinguisticAlternates_Impl: Sized + ITfFunction_Impl {
     fn GetAlternates(&self, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<ITfCandidateList>;
 }
@@ -4186,6 +4263,7 @@ impl ITfFnGetLinguisticAlternates_Vtbl {
         iid == &<ITfFnGetLinguisticAlternates as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnGetPreferredTouchKeyboardLayout_Impl: Sized + ITfFunction_Impl {
     fn GetLayout(&self, ptkblayouttype: *mut TKBLayoutType, pwpreferredlayoutid: *const u16) -> ::windows::core::Result<()>;
 }
@@ -4203,6 +4281,7 @@ impl ITfFnGetPreferredTouchKeyboardLayout_Vtbl {
         iid == &<ITfFnGetPreferredTouchKeyboardLayout as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnGetSAPIObject_Impl: Sized + ITfFunction_Impl {
     fn Get(&self, sobj: TfSapiObject) -> ::windows::core::Result<::windows::core::IUnknown>;
 }
@@ -4226,6 +4305,7 @@ impl ITfFnGetSAPIObject_Vtbl {
         iid == &<ITfFnGetSAPIObject as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnLMInternal_Impl: Sized + ITfFnLMProcessor_Impl {
     fn ProcessLattice(&self, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
@@ -4246,6 +4326,7 @@ impl ITfFnLMInternal_Vtbl {
         iid == &<ITfFnLMInternal as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID || iid == &<ITfFnLMProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnLMProcessor_Impl: Sized + ITfFunction_Impl {
     fn QueryRange(&self, prange: &::core::option::Option<ITfRange>, ppnewrange: *mut ::core::option::Option<ITfRange>, pfaccepted: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4329,6 +4410,7 @@ impl ITfFnLMProcessor_Vtbl {
         iid == &<ITfFnLMProcessor as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnLangProfileUtil_Impl: Sized + ITfFunction_Impl {
     fn RegisterActiveProfiles(&self) -> ::windows::core::Result<()>;
@@ -4365,6 +4447,7 @@ impl ITfFnLangProfileUtil_Vtbl {
         iid == &<ITfFnLangProfileUtil as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnPlayBack_Impl: Sized + ITfFunction_Impl {
     fn QueryRange(&self, prange: &::core::option::Option<ITfRange>, ppnewrange: *mut ::core::option::Option<ITfRange>, pfplayable: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4395,6 +4478,7 @@ impl ITfFnPlayBack_Vtbl {
         iid == &<ITfFnPlayBack as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnPropertyUIStatus_Impl: Sized + ITfFunction_Impl {
     fn GetStatus(&self, refguidprop: *const ::windows::core::GUID) -> ::windows::core::Result<u32>;
     fn SetStatus(&self, refguidprop: *const ::windows::core::GUID, dw: u32) -> ::windows::core::Result<()>;
@@ -4428,6 +4512,7 @@ impl ITfFnPropertyUIStatus_Vtbl {
         iid == &<ITfFnPropertyUIStatus as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnReconversion_Impl: Sized + ITfFunction_Impl {
     fn QueryRange(&self, prange: &::core::option::Option<ITfRange>, ppnewrange: *mut ::core::option::Option<ITfRange>, pfconvertable: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -4471,6 +4556,7 @@ impl ITfFnReconversion_Vtbl {
         iid == &<ITfFnReconversion as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFnSearchCandidateProvider_Impl: Sized + ITfFunction_Impl {
     fn GetSearchCandidates(&self, bstrquery: &::windows::core::BSTR, bstrapplicationid: &::windows::core::BSTR) -> ::windows::core::Result<ITfCandidateList>;
     fn SetResult(&self, bstrquery: &::windows::core::BSTR, bstrapplicationid: &::windows::core::BSTR, bstrresult: &::windows::core::BSTR) -> ::windows::core::Result<()>;
@@ -4504,6 +4590,7 @@ impl ITfFnSearchCandidateProvider_Vtbl {
         iid == &<ITfFnSearchCandidateProvider as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfFnShowHelp_Impl: Sized + ITfFunction_Impl {
     fn Show(&self, hwndparent: super::super::Foundation::HWND) -> ::windows::core::Result<()>;
@@ -4524,6 +4611,7 @@ impl ITfFnShowHelp_Vtbl {
         iid == &<ITfFnShowHelp as ::windows::core::Interface>::IID || iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFunction_Impl: Sized {
     fn GetDisplayName(&self) -> ::windows::core::Result<::windows::core::BSTR>;
 }
@@ -4547,6 +4635,7 @@ impl ITfFunction_Vtbl {
         iid == &<ITfFunction as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfFunctionProvider_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -4599,6 +4688,7 @@ impl ITfFunctionProvider_Vtbl {
         iid == &<ITfFunctionProvider as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfInputProcessorProfileActivationSink_Impl: Sized {
     fn OnActivated(&self, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, catid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -4616,6 +4706,7 @@ impl ITfInputProcessorProfileActivationSink_Vtbl {
         iid == &<ITfInputProcessorProfileActivationSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfInputProcessorProfileMgr_Impl: Sized {
     fn ActivateProfile(&self, dwprofiletype: u32, langid: u16, clsid: *const ::windows::core::GUID, guidprofile: *const ::windows::core::GUID, hkl: HKL, dwflags: u32) -> ::windows::core::Result<()>;
@@ -4720,6 +4811,7 @@ impl ITfInputProcessorProfileMgr_Vtbl {
         iid == &<ITfInputProcessorProfileMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfInputProcessorProfileSubstituteLayout_Impl: Sized {
     fn GetSubstituteKeyboardLayout(&self, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID) -> ::windows::core::Result<HKL>;
 }
@@ -4746,6 +4838,7 @@ impl ITfInputProcessorProfileSubstituteLayout_Vtbl {
         iid == &<ITfInputProcessorProfileSubstituteLayout as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITfInputProcessorProfiles_Impl: Sized {
     fn Register(&self, rclsid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -4918,6 +5011,7 @@ impl ITfInputProcessorProfiles_Vtbl {
         iid == &<ITfInputProcessorProfiles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITfInputProcessorProfilesEx_Impl: Sized + ITfInputProcessorProfiles_Impl {
     fn SetLanguageProfileDisplayName(&self, rclsid: *const ::windows::core::GUID, langid: u16, guidprofile: *const ::windows::core::GUID, pchfile: &::windows::core::PCWSTR, cchfile: u32, uresid: u32) -> ::windows::core::Result<()>;
@@ -4941,6 +5035,7 @@ impl ITfInputProcessorProfilesEx_Vtbl {
         iid == &<ITfInputProcessorProfilesEx as ::windows::core::Interface>::IID || iid == &<ITfInputProcessorProfiles as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfInputScope_Impl: Sized {
     fn GetInputScopes(&self, pprginputscopes: *mut *mut InputScope, pccount: *mut u32) -> ::windows::core::Result<()>;
     fn GetPhrase(&self, ppbstrphrases: *mut *mut ::windows::core::BSTR, pccount: *mut u32) -> ::windows::core::Result<()>;
@@ -5007,6 +5102,7 @@ impl ITfInputScope_Vtbl {
         iid == &<ITfInputScope as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITfInputScope2_Impl: Sized + ITfInputScope_Impl {
     fn EnumWordList(&self) -> ::windows::core::Result<super::super::System::Com::IEnumString>;
@@ -5033,6 +5129,7 @@ impl ITfInputScope2_Vtbl {
         iid == &<ITfInputScope2 as ::windows::core::Interface>::IID || iid == &<ITfInputScope as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITfInsertAtSelection_Impl: Sized {
     fn InsertTextAtSelection(&self, ec: u32, dwflags: INSERT_TEXT_AT_SELECTION_FLAGS, pchtext: &::windows::core::PCWSTR, cch: i32) -> ::windows::core::Result<ITfRange>;
@@ -5075,6 +5172,7 @@ impl ITfInsertAtSelection_Vtbl {
         iid == &<ITfInsertAtSelection as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfIntegratableCandidateListUIElement_Impl: Sized {
     fn SetIntegrationStyle(&self, guidintegrationstyle: &::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -5144,6 +5242,7 @@ impl ITfIntegratableCandidateListUIElement_Vtbl {
         iid == &<ITfIntegratableCandidateListUIElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfKeyEventSink_Impl: Sized {
     fn OnSetFocus(&self, fforeground: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5232,6 +5331,7 @@ impl ITfKeyEventSink_Vtbl {
         iid == &<ITfKeyEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfKeyTraceEventSink_Impl: Sized {
     fn OnKeyTraceDown(&self, wparam: super::super::Foundation::WPARAM, lparam: super::super::Foundation::LPARAM) -> ::windows::core::Result<()>;
@@ -5262,6 +5362,7 @@ impl ITfKeyTraceEventSink_Vtbl {
         iid == &<ITfKeyTraceEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfKeystrokeMgr_Impl: Sized {
     fn AdviseKeyEventSink(&self, tid: u32, psink: &::core::option::Option<ITfKeyEventSink>, fforeground: super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -5430,6 +5531,7 @@ impl ITfKeystrokeMgr_Vtbl {
         iid == &<ITfKeystrokeMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfLMLattice_Impl: Sized {
     fn QueryType(&self, rguidtype: *const ::windows::core::GUID) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -5472,6 +5574,7 @@ impl ITfLMLattice_Vtbl {
         iid == &<ITfLMLattice as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfLangBarEventSink_Impl: Sized {
     fn OnSetFocus(&self, dwthreadid: u32) -> ::windows::core::Result<()>;
@@ -5536,6 +5639,7 @@ impl ITfLangBarEventSink_Vtbl {
         iid == &<ITfLangBarEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfLangBarItem_Impl: Sized {
     fn GetInfo(&self) -> ::windows::core::Result<TF_LANGBARITEMINFO>;
@@ -5598,6 +5702,7 @@ impl ITfLangBarItem_Vtbl {
         iid == &<ITfLangBarItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfLangBarItemBalloon_Impl: Sized + ITfLangBarItem_Impl {
     fn OnClick(&self, click: TfLBIClick, pt: &super::super::Foundation::POINT, prcarea: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -5647,6 +5752,7 @@ impl ITfLangBarItemBalloon_Vtbl {
         iid == &<ITfLangBarItemBalloon as ::windows::core::Interface>::IID || iid == &<ITfLangBarItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ITfLangBarItemBitmap_Impl: Sized + ITfLangBarItem_Impl {
     fn OnClick(&self, click: TfLBIClick, pt: &super::super::Foundation::POINT, prcarea: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -5690,6 +5796,7 @@ impl ITfLangBarItemBitmap_Vtbl {
         iid == &<ITfLangBarItemBitmap as ::windows::core::Interface>::IID || iid == &<ITfLangBarItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub trait ITfLangBarItemBitmapButton_Impl: Sized + ITfLangBarItem_Impl {
     fn OnClick(&self, click: TfLBIClick, pt: &super::super::Foundation::POINT, prcarea: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -5760,6 +5867,7 @@ impl ITfLangBarItemBitmapButton_Vtbl {
         iid == &<ITfLangBarItemBitmapButton as ::windows::core::Interface>::IID || iid == &<ITfLangBarItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITfLangBarItemButton_Impl: Sized + ITfLangBarItem_Impl {
     fn OnClick(&self, click: TfLBIClick, pt: &super::super::Foundation::POINT, prcarea: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -5823,6 +5931,7 @@ impl ITfLangBarItemButton_Vtbl {
         iid == &<ITfLangBarItemButton as ::windows::core::Interface>::IID || iid == &<ITfLangBarItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfLangBarItemMgr_Impl: Sized {
     fn EnumItems(&self) -> ::windows::core::Result<IEnumTfLangBarItems>;
@@ -5947,6 +6056,7 @@ impl ITfLangBarItemMgr_Vtbl {
         iid == &<ITfLangBarItemMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfLangBarItemSink_Impl: Sized {
     fn OnUpdate(&self, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -5964,6 +6074,7 @@ impl ITfLangBarItemSink_Vtbl {
         iid == &<ITfLangBarItemSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfLangBarMgr_Impl: Sized {
     fn AdviseEventSink(&self, psink: &::core::option::Option<ITfLangBarEventSink>, hwnd: super::super::Foundation::HWND, dwflags: u32, pdwcookie: *const u32) -> ::windows::core::Result<()>;
@@ -6055,6 +6166,7 @@ impl ITfLangBarMgr_Vtbl {
         iid == &<ITfLangBarMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfLanguageProfileNotifySink_Impl: Sized {
     fn OnLanguageChange(&self, langid: u16) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -6091,6 +6203,7 @@ impl ITfLanguageProfileNotifySink_Vtbl {
         iid == &<ITfLanguageProfileNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfMSAAControl_Impl: Sized {
     fn SystemEnableMSAA(&self) -> ::windows::core::Result<()>;
     fn SystemDisableMSAA(&self) -> ::windows::core::Result<()>;
@@ -6118,6 +6231,7 @@ impl ITfMSAAControl_Vtbl {
         iid == &<ITfMSAAControl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Graphics_Gdi\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 pub trait ITfMenu_Impl: Sized {
     fn AddMenuItem(&self, uid: u32, dwflags: u32, hbmp: super::super::Graphics::Gdi::HBITMAP, hbmpmask: super::super::Graphics::Gdi::HBITMAP, pch: &::windows::core::PCWSTR, cch: u32, ppmenu: *mut ::core::option::Option<ITfMenu>) -> ::windows::core::Result<()>;
@@ -6138,6 +6252,7 @@ impl ITfMenu_Vtbl {
         iid == &<ITfMenu as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 pub trait ITfMessagePump_Impl: Sized {
     fn PeekMessageA(&self, pmsg: *mut super::WindowsAndMessaging::MSG, hwnd: super::super::Foundation::HWND, wmsgfiltermin: u32, wmsgfiltermax: u32, wremovemsg: u32, pfresult: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -6182,6 +6297,7 @@ impl ITfMessagePump_Vtbl {
         iid == &<ITfMessagePump as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfMouseSink_Impl: Sized {
     fn OnMouseEvent(&self, uedge: u32, uquadrant: u32, dwbtnstatus: u32) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -6208,6 +6324,7 @@ impl ITfMouseSink_Vtbl {
         iid == &<ITfMouseSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfMouseTracker_Impl: Sized {
     fn AdviseMouseSink(&self, range: &::core::option::Option<ITfRange>, psink: &::core::option::Option<ITfMouseSink>) -> ::windows::core::Result<u32>;
     fn UnadviseMouseSink(&self, dwcookie: u32) -> ::windows::core::Result<()>;
@@ -6241,6 +6358,7 @@ impl ITfMouseTracker_Vtbl {
         iid == &<ITfMouseTracker as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfMouseTrackerACP_Impl: Sized {
     fn AdviseMouseSink(&self, range: &::core::option::Option<ITfRangeACP>, psink: &::core::option::Option<ITfMouseSink>) -> ::windows::core::Result<u32>;
     fn UnadviseMouseSink(&self, dwcookie: u32) -> ::windows::core::Result<()>;
@@ -6274,6 +6392,7 @@ impl ITfMouseTrackerACP_Vtbl {
         iid == &<ITfMouseTrackerACP as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITfPersistentPropertyLoaderACP_Impl: Sized {
     fn LoadProperty(&self, phdr: *const TF_PERSISTENT_PROPERTY_HEADER_ACP) -> ::windows::core::Result<super::super::System::Com::IStream>;
@@ -6300,6 +6419,7 @@ impl ITfPersistentPropertyLoaderACP_Vtbl {
         iid == &<ITfPersistentPropertyLoaderACP as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfPreservedKeyNotifySink_Impl: Sized {
     fn OnUpdated(&self, pprekey: *const TF_PRESERVEDKEY) -> ::windows::core::Result<()>;
 }
@@ -6317,6 +6437,7 @@ impl ITfPreservedKeyNotifySink_Vtbl {
         iid == &<ITfPreservedKeyNotifySink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITfProperty_Impl: Sized + ITfReadOnlyProperty_Impl {
     fn FindRange(&self, ec: u32, prange: &::core::option::Option<ITfRange>, pprange: *mut ::core::option::Option<ITfRange>, apos: TfAnchor) -> ::windows::core::Result<()>;
@@ -6361,6 +6482,7 @@ impl ITfProperty_Vtbl {
         iid == &<ITfProperty as ::windows::core::Interface>::IID || iid == &<ITfReadOnlyProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITfPropertyStore_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -6494,6 +6616,7 @@ impl ITfPropertyStore_Vtbl {
         iid == &<ITfPropertyStore as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITfQueryEmbedded_Impl: Sized {
     fn QueryInsertEmbedded(&self, pguidservice: *const ::windows::core::GUID, pformatetc: *const super::super::System::Com::FORMATETC) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -6520,6 +6643,7 @@ impl ITfQueryEmbedded_Vtbl {
         iid == &<ITfQueryEmbedded as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITfRange_Impl: Sized {
     fn GetText(&self, ec: u32, dwflags: u32, pchtext: ::windows::core::PWSTR, cchmax: u32, pcch: *mut u32) -> ::windows::core::Result<()>;
@@ -6762,6 +6886,7 @@ impl ITfRange_Vtbl {
         iid == &<ITfRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 pub trait ITfRangeACP_Impl: Sized + ITfRange_Impl {
     fn GetExtent(&self, pacpanchor: *mut i32, pcch: *mut i32) -> ::windows::core::Result<()>;
@@ -6792,6 +6917,7 @@ impl ITfRangeACP_Vtbl {
         iid == &<ITfRangeACP as ::windows::core::Interface>::IID || iid == &<ITfRange as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfRangeBackup_Impl: Sized {
     fn Restore(&self, ec: u32, prange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<()>;
 }
@@ -6809,6 +6935,7 @@ impl ITfRangeBackup_Vtbl {
         iid == &<ITfRangeBackup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub trait ITfReadOnlyProperty_Impl: Sized {
     fn GetType(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -6871,6 +6998,7 @@ impl ITfReadOnlyProperty_Vtbl {
         iid == &<ITfReadOnlyProperty as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfReadingInformationUIElement_Impl: Sized + ITfUIElement_Impl {
     fn GetUpdatedFlags(&self) -> ::windows::core::Result<u32>;
@@ -6965,6 +7093,7 @@ impl ITfReadingInformationUIElement_Vtbl {
         iid == &<ITfReadingInformationUIElement as ::windows::core::Interface>::IID || iid == &<ITfUIElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfReverseConversion_Impl: Sized {
     fn DoReverseConversion(&self, lpstr: &::windows::core::PCWSTR) -> ::windows::core::Result<ITfReverseConversionList>;
 }
@@ -6988,6 +7117,7 @@ impl ITfReverseConversion_Vtbl {
         iid == &<ITfReverseConversion as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfReverseConversionList_Impl: Sized {
     fn GetLength(&self) -> ::windows::core::Result<u32>;
     fn GetString(&self, uindex: u32) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7027,6 +7157,7 @@ impl ITfReverseConversionList_Vtbl {
         iid == &<ITfReverseConversionList as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfReverseConversionMgr_Impl: Sized {
     fn GetReverseConversion(&self, langid: u16, guidprofile: *const ::windows::core::GUID, dwflag: u32) -> ::windows::core::Result<ITfReverseConversion>;
 }
@@ -7050,6 +7181,7 @@ impl ITfReverseConversionMgr_Vtbl {
         iid == &<ITfReverseConversionMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfSource_Impl: Sized {
     fn AdviseSink(&self, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<u32>;
     fn UnadviseSink(&self, dwcookie: u32) -> ::windows::core::Result<()>;
@@ -7083,6 +7215,7 @@ impl ITfSource_Vtbl {
         iid == &<ITfSource as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfSourceSingle_Impl: Sized {
     fn AdviseSingleSink(&self, tid: u32, riid: *const ::windows::core::GUID, punk: &::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()>;
     fn UnadviseSingleSink(&self, tid: u32, riid: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -7110,6 +7243,7 @@ impl ITfSourceSingle_Vtbl {
         iid == &<ITfSourceSingle as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfSpeechUIServer_Impl: Sized {
     fn Initialize(&self) -> ::windows::core::Result<()>;
@@ -7147,6 +7281,7 @@ impl ITfSpeechUIServer_Vtbl {
         iid == &<ITfSpeechUIServer as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfStatusSink_Impl: Sized {
     fn OnStatusChange(&self, pic: &::core::option::Option<ITfContext>, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -7164,6 +7299,7 @@ impl ITfStatusSink_Vtbl {
         iid == &<ITfStatusSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfSystemDeviceTypeLangBarItem_Impl: Sized {
     fn SetIconMode(&self, dwflags: LANG_BAR_ITEM_ICON_MODE_FLAGS) -> ::windows::core::Result<()>;
     fn GetIconMode(&self) -> ::windows::core::Result<u32>;
@@ -7197,6 +7333,7 @@ impl ITfSystemDeviceTypeLangBarItem_Vtbl {
         iid == &<ITfSystemDeviceTypeLangBarItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_UI_WindowsAndMessaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
 pub trait ITfSystemLangBarItem_Impl: Sized {
     fn SetIcon(&self, hicon: super::WindowsAndMessaging::HICON) -> ::windows::core::Result<()>;
@@ -7227,6 +7364,7 @@ impl ITfSystemLangBarItem_Vtbl {
         iid == &<ITfSystemLangBarItem as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfSystemLangBarItemSink_Impl: Sized {
     fn InitMenu(&self, pmenu: &::core::option::Option<ITfMenu>) -> ::windows::core::Result<()>;
     fn OnMenuSelect(&self, wid: u32) -> ::windows::core::Result<()>;
@@ -7254,6 +7392,7 @@ impl ITfSystemLangBarItemSink_Vtbl {
         iid == &<ITfSystemLangBarItemSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfSystemLangBarItemText_Impl: Sized {
     fn SetItemText(&self, pch: &::windows::core::PCWSTR, cch: u32) -> ::windows::core::Result<()>;
     fn GetItemText(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7287,6 +7426,7 @@ impl ITfSystemLangBarItemText_Vtbl {
         iid == &<ITfSystemLangBarItemText as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfTextEditSink_Impl: Sized {
     fn OnEndEdit(&self, pic: &::core::option::Option<ITfContext>, ecreadonly: u32, peditrecord: &::core::option::Option<ITfEditRecord>) -> ::windows::core::Result<()>;
 }
@@ -7304,6 +7444,7 @@ impl ITfTextEditSink_Vtbl {
         iid == &<ITfTextEditSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfTextInputProcessor_Impl: Sized {
     fn Activate(&self, ptim: &::core::option::Option<ITfThreadMgr>, tid: u32) -> ::windows::core::Result<()>;
     fn Deactivate(&self) -> ::windows::core::Result<()>;
@@ -7331,6 +7472,7 @@ impl ITfTextInputProcessor_Vtbl {
         iid == &<ITfTextInputProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfTextInputProcessorEx_Impl: Sized + ITfTextInputProcessor_Impl {
     fn ActivateEx(&self, ptim: &::core::option::Option<ITfThreadMgr>, tid: u32, dwflags: u32) -> ::windows::core::Result<()>;
 }
@@ -7348,6 +7490,7 @@ impl ITfTextInputProcessorEx_Vtbl {
         iid == &<ITfTextInputProcessorEx as ::windows::core::Interface>::IID || iid == &<ITfTextInputProcessor as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfTextLayoutSink_Impl: Sized {
     fn OnLayoutChange(&self, pic: &::core::option::Option<ITfContext>, lcode: TfLayoutCode, pview: &::core::option::Option<ITfContextView>) -> ::windows::core::Result<()>;
 }
@@ -7365,6 +7508,7 @@ impl ITfTextLayoutSink_Vtbl {
         iid == &<ITfTextLayoutSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfThreadFocusSink_Impl: Sized {
     fn OnSetThreadFocus(&self) -> ::windows::core::Result<()>;
     fn OnKillThreadFocus(&self) -> ::windows::core::Result<()>;
@@ -7392,6 +7536,7 @@ impl ITfThreadFocusSink_Vtbl {
         iid == &<ITfThreadFocusSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfThreadMgr_Impl: Sized {
     fn Activate(&self) -> ::windows::core::Result<u32>;
@@ -7539,6 +7684,7 @@ impl ITfThreadMgr_Vtbl {
         iid == &<ITfThreadMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfThreadMgr2_Impl: Sized {
     fn Activate(&self) -> ::windows::core::Result<u32>;
@@ -7707,6 +7853,7 @@ impl ITfThreadMgr2_Vtbl {
         iid == &<ITfThreadMgr2 as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait ITfThreadMgrEventSink_Impl: Sized {
     fn OnInitDocumentMgr(&self, pdim: &::core::option::Option<ITfDocumentMgr>) -> ::windows::core::Result<()>;
     fn OnUninitDocumentMgr(&self, pdim: &::core::option::Option<ITfDocumentMgr>) -> ::windows::core::Result<()>;
@@ -7755,6 +7902,7 @@ impl ITfThreadMgrEventSink_Vtbl {
         iid == &<ITfThreadMgrEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfThreadMgrEx_Impl: Sized + ITfThreadMgr_Impl {
     fn ActivateEx(&self, ptid: *mut u32, dwflags: u32) -> ::windows::core::Result<()>;
@@ -7791,6 +7939,7 @@ impl ITfThreadMgrEx_Vtbl {
         iid == &<ITfThreadMgrEx as ::windows::core::Interface>::IID || iid == &<ITfThreadMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfToolTipUIElement_Impl: Sized + ITfUIElement_Impl {
     fn GetString(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7817,6 +7966,7 @@ impl ITfToolTipUIElement_Vtbl {
         iid == &<ITfToolTipUIElement as ::windows::core::Interface>::IID || iid == &<ITfUIElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfTransitoryExtensionSink_Impl: Sized {
     fn OnTransitoryExtensionUpdated(&self, pic: &::core::option::Option<ITfContext>, ecreadonly: u32, presultrange: &::core::option::Option<ITfRange>, pcompositionrange: &::core::option::Option<ITfRange>) -> ::windows::core::Result<super::super::Foundation::BOOL>;
@@ -7846,6 +7996,7 @@ impl ITfTransitoryExtensionSink_Vtbl {
         iid == &<ITfTransitoryExtensionSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfTransitoryExtensionUIElement_Impl: Sized + ITfUIElement_Impl {
     fn GetDocumentMgr(&self) -> ::windows::core::Result<ITfDocumentMgr>;
@@ -7872,6 +8023,7 @@ impl ITfTransitoryExtensionUIElement_Vtbl {
         iid == &<ITfTransitoryExtensionUIElement as ::windows::core::Interface>::IID || iid == &<ITfUIElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfUIElement_Impl: Sized {
     fn GetDescription(&self) -> ::windows::core::Result<::windows::core::BSTR>;
@@ -7934,6 +8086,7 @@ impl ITfUIElement_Vtbl {
         iid == &<ITfUIElement as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfUIElementMgr_Impl: Sized {
     fn BeginUIElement(&self, pelement: &::core::option::Option<ITfUIElement>, pbshow: *mut super::super::Foundation::BOOL, pdwuielementid: *mut u32) -> ::windows::core::Result<()>;
@@ -7997,6 +8150,7 @@ impl ITfUIElementMgr_Vtbl {
         iid == &<ITfUIElementMgr as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait ITfUIElementSink_Impl: Sized {
     fn BeginUIElement(&self, dwuielementid: u32, pbshow: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()>;
@@ -8034,6 +8188,7 @@ impl ITfUIElementSink_Vtbl {
         iid == &<ITfUIElementSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IUIManagerEventSink_Impl: Sized {
     fn OnWindowOpening(&self, prcbounds: *const super::super::Foundation::RECT) -> ::windows::core::Result<()>;
@@ -8092,6 +8247,7 @@ impl IUIManagerEventSink_Vtbl {
         iid == &<IUIManagerEventSink as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_TextServices\"`, `\"implement\"`*"]
 pub trait IVersionInfo_Impl: Sized {
     fn GetSubcomponentCount(&self, ulsub: u32) -> ::windows::core::Result<u32>;
     fn GetImplementationID(&self, ulsub: u32) -> ::windows::core::Result<::windows::core::GUID>;

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
@@ -1,3 +1,4 @@
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Graphics_Imaging")]
 pub trait IMILBitmapEffect_Impl: Sized {
     fn GetOutput(&self, uiindex: u32, pcontext: &::core::option::Option<IMILBitmapEffectRenderContext>) -> ::windows::core::Result<super::super::Graphics::Imaging::IWICBitmapSource>;
@@ -47,6 +48,7 @@ impl IMILBitmapEffect_Vtbl {
         iid == &<IMILBitmapEffect as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectConnections_Impl: Sized {
     fn GetInputConnector(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectInputConnector>;
     fn GetOutputConnector(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectOutputConnector>;
@@ -86,6 +88,7 @@ impl IMILBitmapEffectConnections_Vtbl {
         iid == &<IMILBitmapEffectConnections as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectConnectionsInfo_Impl: Sized {
     fn GetNumberInputs(&self) -> ::windows::core::Result<u32>;
     fn GetNumberOutputs(&self) -> ::windows::core::Result<u32>;
@@ -151,6 +154,7 @@ impl IMILBitmapEffectConnectionsInfo_Vtbl {
         iid == &<IMILBitmapEffectConnectionsInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMILBitmapEffectConnector_Impl: Sized + IMILBitmapEffectConnectorInfo_Impl {
     fn IsConnected(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -193,6 +197,7 @@ impl IMILBitmapEffectConnector_Vtbl {
         iid == &<IMILBitmapEffectConnector as ::windows::core::Interface>::IID || iid == &<IMILBitmapEffectConnectorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectConnectorInfo_Impl: Sized {
     fn GetIndex(&self) -> ::windows::core::Result<u32>;
     fn GetOptimalFormat(&self) -> ::windows::core::Result<::windows::core::GUID>;
@@ -258,6 +263,7 @@ impl IMILBitmapEffectConnectorInfo_Vtbl {
         iid == &<IMILBitmapEffectConnectorInfo as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectEvents_Impl: Sized {
     fn PropertyChange(&self, peffect: &::core::option::Option<IMILBitmapEffect>, bstrpropertyname: &::windows::core::BSTR) -> ::windows::core::Result<()>;
     fn DirtyRegion(&self, peffect: &::core::option::Option<IMILBitmapEffect>, prect: *const MilRectD) -> ::windows::core::Result<()>;
@@ -285,6 +291,7 @@ impl IMILBitmapEffectEvents_Vtbl {
         iid == &<IMILBitmapEffectEvents as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectFactory_Impl: Sized {
     fn CreateEffect(&self, pguideffect: *const ::windows::core::GUID) -> ::windows::core::Result<IMILBitmapEffect>;
     fn CreateContext(&self) -> ::windows::core::Result<IMILBitmapEffectRenderContext>;
@@ -337,6 +344,7 @@ impl IMILBitmapEffectFactory_Vtbl {
         iid == &<IMILBitmapEffectFactory as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectGroup_Impl: Sized {
     fn GetInteriorInputConnector(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectOutputConnector>;
     fn GetInteriorOutputConnector(&self, uiindex: u32) -> ::windows::core::Result<IMILBitmapEffectInputConnector>;
@@ -383,6 +391,7 @@ impl IMILBitmapEffectGroup_Vtbl {
         iid == &<IMILBitmapEffectGroup as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectGroupImpl_Impl: Sized {
     fn Preprocess(&self, pcontext: &::core::option::Option<IMILBitmapEffectRenderContext>) -> ::windows::core::Result<()>;
     fn GetNumberChildren(&self) -> ::windows::core::Result<u32>;
@@ -429,6 +438,7 @@ impl IMILBitmapEffectGroupImpl_Vtbl {
         iid == &<IMILBitmapEffectGroupImpl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Imaging"))]
 pub trait IMILBitmapEffectImpl_Impl: Sized {
     fn IsInPlaceModificationAllowed(&self, poutputconnector: &::core::option::Option<IMILBitmapEffectOutputConnector>) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -512,6 +522,7 @@ impl IMILBitmapEffectImpl_Vtbl {
         iid == &<IMILBitmapEffectImpl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMILBitmapEffectInputConnector_Impl: Sized + IMILBitmapEffectConnector_Impl {
     fn ConnectTo(&self, pconnector: &::core::option::Option<IMILBitmapEffectOutputConnector>) -> ::windows::core::Result<()>;
@@ -548,6 +559,7 @@ impl IMILBitmapEffectInputConnector_Vtbl {
         iid == &<IMILBitmapEffectInputConnector as ::windows::core::Interface>::IID || iid == &<IMILBitmapEffectConnectorInfo as ::windows::core::Interface>::IID || iid == &<IMILBitmapEffectConnector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectInteriorInputConnector_Impl: Sized {
     fn GetInputConnector(&self) -> ::windows::core::Result<IMILBitmapEffectInputConnector>;
 }
@@ -571,6 +583,7 @@ impl IMILBitmapEffectInteriorInputConnector_Vtbl {
         iid == &<IMILBitmapEffectInteriorInputConnector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectInteriorOutputConnector_Impl: Sized {
     fn GetOutputConnector(&self) -> ::windows::core::Result<IMILBitmapEffectOutputConnector>;
 }
@@ -594,6 +607,7 @@ impl IMILBitmapEffectInteriorOutputConnector_Vtbl {
         iid == &<IMILBitmapEffectInteriorOutputConnector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMILBitmapEffectOutputConnector_Impl: Sized + IMILBitmapEffectConnector_Impl {
     fn GetNumberConnections(&self) -> ::windows::core::Result<u32>;
@@ -636,6 +650,7 @@ impl IMILBitmapEffectOutputConnector_Vtbl {
         iid == &<IMILBitmapEffectOutputConnector as ::windows::core::Interface>::IID || iid == &<IMILBitmapEffectConnectorInfo as ::windows::core::Interface>::IID || iid == &<IMILBitmapEffectConnector as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffectOutputConnectorImpl_Impl: Sized {
     fn AddBackLink(&self, pconnection: &::core::option::Option<IMILBitmapEffectInputConnector>) -> ::windows::core::Result<()>;
     fn RemoveBackLink(&self, pconnection: &::core::option::Option<IMILBitmapEffectInputConnector>) -> ::windows::core::Result<()>;
@@ -663,6 +678,7 @@ impl IMILBitmapEffectOutputConnectorImpl_Vtbl {
         iid == &<IMILBitmapEffectOutputConnectorImpl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Dwm\"`, `\"Win32_Graphics_Imaging\"`, `\"implement\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Dwm", feature = "Win32_Graphics_Imaging"))]
 pub trait IMILBitmapEffectPrimitive_Impl: Sized {
     fn GetOutput(&self, uiindex: u32, pcontext: &::core::option::Option<IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows::core::Result<()>;
@@ -733,6 +749,7 @@ impl IMILBitmapEffectPrimitive_Vtbl {
         iid == &<IMILBitmapEffectPrimitive as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMILBitmapEffectPrimitiveImpl_Impl: Sized {
     fn IsDirty(&self, uioutputindex: u32, pfdirty: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows::core::HRESULT;
@@ -769,6 +786,7 @@ impl IMILBitmapEffectPrimitiveImpl_Vtbl {
         iid == &<IMILBitmapEffectPrimitiveImpl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMILBitmapEffectRenderContext_Impl: Sized {
     fn SetOutputPixelFormat(&self, format: *const ::windows::core::GUID) -> ::windows::core::Result<()>;
@@ -853,6 +871,7 @@ impl IMILBitmapEffectRenderContext_Vtbl {
         iid == &<IMILBitmapEffectRenderContext as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"Win32_Foundation\"`, `\"implement\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub trait IMILBitmapEffectRenderContextImpl_Impl: Sized {
     fn GetUseSoftwareRenderer(&self) -> ::windows::core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -910,6 +929,7 @@ impl IMILBitmapEffectRenderContextImpl_Vtbl {
         iid == &<IMILBitmapEffectRenderContextImpl as ::windows::core::Interface>::IID
     }
 }
+#[doc = "*Required features: `\"Win32_UI_Wpf\"`, `\"implement\"`*"]
 pub trait IMILBitmapEffects_Impl: Sized {
     fn _NewEnum(&self) -> ::windows::core::Result<::windows::core::IUnknown>;
     fn Parent(&self) -> ::windows::core::Result<IMILBitmapEffectGroup>;


### PR DESCRIPTION
While investigating #2236 I was reminded that the implementation traits don't include a doc comment clearly indicating what features are required to access the trait. This is a little tricky to deduce so I made it explicit. Take for example the `IDispatch` interface from #2236 and you'll notice the type itself only requires `Win32_System_Com` but notice that one of its methods also requires two more features. This avoids aggresively including features that the dependent crate may not need when only calling a subset of methods.

<img width="752" alt="image" src="https://user-images.githubusercontent.com/9845234/206785433-ee64ba53-88c6-4420-be84-283f950dae1d.png">

Of course, when you're implementing `IDispatch` you'll need all features to able to implement the interface so a complete list of features is now documented there:

<img width="750" alt="image" src="https://user-images.githubusercontent.com/9845234/206785868-db766f95-556c-4529-aca4-49b3ce862142.png">

