### PR TITLE
Provide option to use default metadata for code generation

### DIFF
--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
-exclude = ["/default"]
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/libs/metadata/src/reader/file.rs
+++ b/crates/libs/metadata/src/reader/file.rs
@@ -52,6 +52,19 @@ fn error_invalid_winmd() -> Error {
 }
 
 impl File {
+    pub fn with_default(paths: &[&str]) -> Result<Vec<Self>> {
+        let mut files = Vec::new();
+        files.push(Self::from_buffer(std::include_bytes!("../../default/Windows.winmd").to_vec(), "Windows.winmd".to_string())?);
+        files.push(Self::from_buffer(std::include_bytes!("../../default/Windows.Win32.winmd").to_vec(), "Windows.Win32.winmd".to_string())?);
+        files.push(Self::from_buffer(std::include_bytes!("../../default/Windows.Win32.Interop.winmd").to_vec(), "Windows.Win32.Interop.winmd".to_string())?);
+
+        for path in paths {
+            files.push(Self::new(path)?);
+        }
+
+        Ok(files)
+    }
+
     pub fn new(path: &str) -> Result<Self> {
         let path = std::path::Path::new(path);
 

--- a/crates/tests/component/build.rs
+++ b/crates/tests/component/build.rs
@@ -8,7 +8,7 @@ fn main() -> std::io::Result<()> {
 
     Command::new("midlrt.exe").arg("/winrt").arg("/nomidl").arg("/h").arg("nul").arg("/metadata_dir").arg(&metadata_dir).arg("/reference").arg(format!("{metadata_dir}\\Windows.Foundation.winmd")).arg("/winmd").arg(".windows/winmd/component.winmd").arg("src/component.idl").status()?;
 
-    let files = vec![metadata::reader::File::new("../../libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new(".windows/winmd/component.winmd").unwrap()];
+    let files = metadata::reader::File::with_default(&[".windows/winmd/component.winmd"])?;
     write("src/bindings.rs", bindgen::component("test_component", &files))?;
     Command::new("rustfmt").arg("src/bindings.rs").status()?;
 

--- a/crates/tests/component_client/build.rs
+++ b/crates/tests/component_client/build.rs
@@ -5,7 +5,7 @@ fn main() -> std::io::Result<()> {
     create_dir_all(".windows/winmd")?;
     copy("../component/.windows/winmd/component.winmd", ".windows/winmd/component.winmd")?;
 
-    let files = vec![metadata::reader::File::new("../../libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new(".windows/winmd/component.winmd").unwrap()];
+    let files = metadata::reader::File::with_default(&[".windows/winmd/component.winmd"])?;
     write("src/bindings.rs", bindgen::component("test_component", &files))?;
     Command::new("rustfmt").arg("src/bindings.rs").status()?;
     Ok(())

--- a/crates/tests/metadata/tests/fn_call_size.rs
+++ b/crates/tests/metadata/tests/fn_call_size.rs
@@ -3,7 +3,7 @@ fn size() {
     // Note: you can double check these export names from a Visual Studio x86 command prompt as follows:
     // dumpbin /exports kernel32.lib | findstr /i RtmConvertIpv6AddressAndLengthToNetAddress
 
-    let files = vec![metadata::reader::File::new("../../libs/metadata/default/Windows.Win32.winmd").unwrap()];
+    let files = metadata::reader::File::with_default(&[]).unwrap();
     let reader = &metadata::reader::Reader::new(&files);
 
     assert_eq!(struct_size(reader, "Windows.Win32.System.Com", "VARIANT"), 16);

--- a/crates/tests/metadata/tests/writer.rs
+++ b/crates/tests/metadata/tests/writer.rs
@@ -37,7 +37,7 @@ fn writer() {
     {
         use metadata::reader::*;
 
-        let files = vec![File::new(temp_file.to_str().unwrap()).unwrap()];
+        let files = metadata::reader::File::with_default(&[temp_file.to_str().unwrap()]).unwrap();
         let reader = &Reader::new(&files);
         let def = reader.get(TypeName::new("TestWindows.Foundation", "IStringable")).next().unwrap();
         assert_eq!(reader.type_def_kind(def), TypeKind::Interface);

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -28,7 +28,7 @@ pub fn rustfmt(name: &str, tokens: &mut String) {
 
 /// Returns the libraries and their function and stack sizes used by the gnu and msvc tools to build the umbrella libs.
 pub fn libraries() -> BTreeMap<String, BTreeMap<String, CallingConvention>> {
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
+    let files = metadata::reader::File::with_default(&[]).unwrap();
     let reader = &metadata::reader::Reader::new(&files);
     let mut libraries = BTreeMap::<String, BTreeMap<String, CallingConvention>>::new();
     let root = reader.tree("Windows.Win32", &[]).expect("`Windows` namespace not found");

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
         let _ = std::fs::remove_dir_all(&output);
     }
     output.pop();
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
+    let files = metadata::reader::File::with_default(&[]).unwrap();
     let reader = &metadata::reader::Reader::new(&files);
     if !namespace.is_empty() {
         let tree = reader.tree(&namespace, &[]).expect("Namespace not found");

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
         let _ = std::fs::remove_dir_all(&output);
     }
     output.pop();
-    let files = vec![metadata::reader::File::new("crates/libs/metadata/default/Windows.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.winmd").unwrap(), metadata::reader::File::new("crates/libs/metadata/default/Windows.Win32.Interop.winmd").unwrap()];
+    let files = metadata::reader::File::with_default(&[]).unwrap();
     let reader = &metadata::reader::Reader::new(&files);
     if !namespace.is_empty() {
         let tree = reader.tree(&namespace, &[]).expect("Namespace not found");


### PR DESCRIPTION
The new `with_default` method will produce a `File` set that includes the winmd files used to generate the current version of the windows-rs project. This should make it easier for projects generating their own bindings to stay in sync and target a specific version of the `windows` crate without needing to manage their own winmd dependencies. 

Fixes: #2211