### PR TITLE
Verify alignment for `DEVMODEA`/`DEVMODEW` structs

### DIFF
--- a/crates/tests/metadata/tests/struct_size.rs
+++ b/crates/tests/metadata/tests/struct_size.rs
@@ -4,6 +4,9 @@ fn test_windows() {
 
     assert_eq!(156, std::mem::size_of::<DEVMODEA>());
     assert_eq!(220, std::mem::size_of::<DEVMODEW>());
+
+    assert_eq!(4, std::mem::align_of::<DEVMODEA>());
+    assert_eq!(4, std::mem::align_of::<DEVMODEW>());
 }
 
 #[test]
@@ -12,4 +15,7 @@ fn test_sys() {
 
     assert_eq!(156, std::mem::size_of::<DEVMODEA>());
     assert_eq!(220, std::mem::size_of::<DEVMODEW>());
+
+    assert_eq!(4, std::mem::align_of::<DEVMODEA>());
+    assert_eq!(4, std::mem::align_of::<DEVMODEW>());
 }


### PR DESCRIPTION
Previously, this struct had field size issues that have since been fixed (https://github.com/microsoft/win32metadata/issues/1325). This update just additionally confirms the alignment is also consistent with MSVC.

Fixes: #2257