### PR TITLE
Only show visible windows and include x/y in output

### DIFF
--- a/crates/samples/windows/enum_windows/src/main.rs
+++ b/crates/samples/windows/enum_windows/src/main.rs
@@ -1,6 +1,8 @@
 use windows::{
     Win32::Foundation::{BOOL, HWND, LPARAM},
-    Win32::UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW},
+    Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowInfo, GetWindowTextW, WINDOWINFO, WS_VISIBLE,
+    },
 };
 
 fn main() -> windows::core::Result<()> {
@@ -13,8 +15,14 @@ extern "system" fn enum_window(window: HWND, _: LPARAM) -> BOOL {
         let len = GetWindowTextW(window, &mut text);
         let text = String::from_utf16_lossy(&text[..len as usize]);
 
-        if !text.is_empty() {
-            println!("{text}");
+        let mut info = WINDOWINFO {
+            cbSize: core::mem::size_of::<WINDOWINFO>() as u32,
+            ..Default::default()
+        };
+        GetWindowInfo(window, &mut info).unwrap();
+
+        if !text.is_empty() && info.dwStyle & WS_VISIBLE.0 != 0 {
+            println!("{} ({}, {})", text, info.rcWindow.left, info.rcWindow.top);
         }
 
         true.into()


### PR DESCRIPTION
I'm not sure if contributes to the samples are welcome... I wanted an example that showed passing a struct to a Win32 function and working with bit masks, so I added one.