### PR TITLE
Add link from docs.rs to full API documentation

### DIFF
--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = "1.64"
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
+rustc-args = ["--cfg", "docsrs"]
 
 [target.'cfg(not(windows_raw_dylib))'.dependencies]
 windows-targets = { path = "../targets",  version = "0.42.1" }

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(docsrs, doc = "This is a stub. The latest API documentation is here: <https://microsoft.github.io/windows-docs-rs/>")]
+#![cfg_attr(docsrs, doc = "")]
 /*!
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -55,6 +55,7 @@ rust-version = "1.64"
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
+rustc-args = ["--cfg", "docsrs"]
 
 [target.'cfg(not(windows_raw_dylib))'.dependencies]
 windows-targets = { path = "../targets",  version = "0.42.1" }


### PR DESCRIPTION
This attempts to help with discovery for people who find Rust documentation directly via docs.rs and not the crates.io readme. The wording chosen hopefully makes it clear that it's not necessarily the same version as the doc.rs page (note that old versions on crates.io have the same issue). I guess we could have something about building old docs locally for that case but that's probably better left to the FAQ if it's desired.

The docs.rs documentation can be generated locally by setting `$env:RUSTDOCFLAGS = "--cfg docsrs"`. Though obviously testing properly would require actually publishing it, unfortunately.

Fixes: #2296
