### PR TITLE
Version 0.45

### DIFF
--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/sys/src/core/mod.rs
+++ b/crates/libs/sys/src/core/mod.rs
@@ -72,4 +72,5 @@ macro_rules! link {
     )
 }
 
+#[doc(hidden)]
 pub use crate::link;

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -167,4 +167,5 @@ macro_rules! link {
     )
 }
 
+#[doc(hidden)]
 pub use crate::link;

--- a/crates/samples/readme.md
+++ b/crates/samples/readme.md
@@ -3,6 +3,6 @@ Many of the samples were inspired or originally appeared in Kenny's [articles](h
 The samples in the repo compile with the latest, usually pre-release, version of the `windows` or `windows-sys` crate. 
 To find the samples for a particular release you can use a specific release tag. For example:
 
-https://github.com/microsoft/windows-rs/tree/0.42.0/crates/samples
+https://github.com/microsoft/windows-rs/tree/0.45.0/crates/samples
 
-That will give you the samples that compile with version 0.42.0 of the `windows` and `windows-sys` crates.
+That will give you the samples that compile with version 0.45.0 of the `windows` and `windows-sys` crates.

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -73,7 +73,7 @@ fn main() {
         r#"
 [package]
 name = "windows-sys"
-version = "0.42.0"
+version = "0.45.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -3,7 +3,7 @@
 The [windows](https://crates.io/crates/windows) and [windows-sys](https://crates.io/crates/windows-sys) crates let you call any Windows API past, present, and future using code generated on the fly directly from the [metadata describing the API](https://github.com/microsoft/windows-rs/tree/master/crates/libs/metadata/default) and right into your Rust package where you can call them as if they were just another Rust module. The Rust language projection follows in the tradition established by [C++/WinRT](https://github.com/microsoft/cppwinrt) of building language projections for Windows using standard languages and compilers, providing a natural and idiomatic way for Rust developers to call Windows APIs.
 
 * [Getting started](https://kennykerr.ca/rust-getting-started/)
-* [Samples](https://github.com/microsoft/windows-rs/tree/0.44.0/crates/samples)
+* [Samples](https://github.com/microsoft/windows-rs/tree/0.45.0/crates/samples)
 * [Releases](https://github.com/microsoft/windows-rs/releases)
 
 Start by adding the following to your Cargo.toml file:
@@ -58,7 +58,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-sys]
-version = "0.42.0"
+version = "0.45.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",


### PR DESCRIPTION
Bumps the version in anticipation of the 0.45 release of the `windows-sys` crate.

Fixes: #2298
