### PR TITLE
Fix test component re-build reliability

### DIFF
--- a/crates/tests/component/build.rs
+++ b/crates/tests/component/build.rs
@@ -6,7 +6,12 @@ fn main() -> std::io::Result<()> {
     let metadata_dir = format!("{}\\System32\\WinMetadata", env!("windir"));
     std::fs::create_dir_all(".windows/winmd")?;
 
-    Command::new("midlrt.exe").arg("/winrt").arg("/nomidl").arg("/h").arg("nul").arg("/metadata_dir").arg(&metadata_dir).arg("/reference").arg(format!("{metadata_dir}\\Windows.Foundation.winmd")).arg("/winmd").arg(".windows/winmd/component.winmd").arg("src/component.idl").status()?;
+    let mut command = Command::new("midlrt.exe");
+    command.arg("/winrt").arg("/nomidl").arg("/h").arg("nul").arg("/metadata_dir").arg(&metadata_dir).arg("/reference").arg(format!("{metadata_dir}\\Windows.Foundation.winmd")).arg("/winmd").arg(".windows/winmd/component.winmd").arg("src/component.idl");
+
+    if !command.status()?.success() {
+        panic!();
+    }
 
     let files = metadata::reader::File::with_default(&[".windows/winmd/component.winmd"])?;
     write("src/bindings.rs", bindgen::component("test_component", &files))?;


### PR DESCRIPTION
The build script wasn't reliably detecting when the MIDL compiler failed, leading cargo to cache the last successful result and seemingly ignoring IDL changes. 