### PR TITLE
Generate `contains` method for enum flags

### DIFF
--- a/crates/libs/bindgen/src/enums.rs
+++ b/crates/libs/bindgen/src/enums.rs
@@ -132,6 +132,12 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
         if gen.reader.type_def_is_flags(def) {
             tokens.combine(&quote! {
                 #features
+                impl #ident {
+                    pub const fn contains(&self, other: Self) -> bool {
+                        self.0 & other.0 == other.0
+                    }
+                }
+                #features
                 impl ::core::ops::BitOr for #ident {
                     type Output = Self;
 

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
@@ -3775,6 +3775,11 @@ impl ::core::fmt::Debug for AppointmentDaysOfWeek {
         f.debug_tuple("AppointmentDaysOfWeek").field(&self.0).finish()
     }
 }
+impl AppointmentDaysOfWeek {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AppointmentDaysOfWeek {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4158,6 +4163,11 @@ unsafe impl ::windows::core::Abi for FindAppointmentCalendarsOptions {
 impl ::core::fmt::Debug for FindAppointmentCalendarsOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FindAppointmentCalendarsOptions").field(&self.0).finish()
+    }
+}
+impl FindAppointmentCalendarsOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FindAppointmentCalendarsOptions {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
@@ -697,6 +697,11 @@ impl ::core::fmt::Debug for PhoneLineProperties {
         f.debug_tuple("PhoneLineProperties").field(&self.0).finish()
     }
 }
+impl PhoneLineProperties {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PhoneLineProperties {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
@@ -4562,6 +4562,11 @@ impl ::core::fmt::Debug for PhoneCallHistoryEntryQueryDesiredMedia {
         f.debug_tuple("PhoneCallHistoryEntryQueryDesiredMedia").field(&self.0).finish()
     }
 }
+impl PhoneCallHistoryEntryQueryDesiredMedia {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PhoneCallHistoryEntryQueryDesiredMedia {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5130,6 +5135,11 @@ unsafe impl ::windows::core::Abi for VoipPhoneCallMedia {
 impl ::core::fmt::Debug for VoipPhoneCallMedia {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoipPhoneCallMedia").field(&self.0).finish()
+    }
+}
+impl VoipPhoneCallMedia {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for VoipPhoneCallMedia {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
@@ -7681,6 +7681,11 @@ impl ::core::fmt::Debug for ContactAnnotationOperations {
         f.debug_tuple("ContactAnnotationOperations").field(&self.0).finish()
     }
 }
+impl ContactAnnotationOperations {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ContactAnnotationOperations {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8298,6 +8303,11 @@ impl ::core::fmt::Debug for ContactQueryDesiredFields {
         f.debug_tuple("ContactQueryDesiredFields").field(&self.0).finish()
     }
 }
+impl ContactQueryDesiredFields {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ContactQueryDesiredFields {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8361,6 +8371,11 @@ unsafe impl ::windows::core::Abi for ContactQuerySearchFields {
 impl ::core::fmt::Debug for ContactQuerySearchFields {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactQuerySearchFields").field(&self.0).finish()
+    }
+}
+impl ContactQuerySearchFields {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for ContactQuerySearchFields {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
@@ -679,6 +679,11 @@ impl ::core::fmt::Debug for CoreDragUIContentMode {
         f.debug_tuple("CoreDragUIContentMode").field(&self.0).finish()
     }
 }
+impl CoreDragUIContentMode {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CoreDragUIContentMode {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/mod.rs
@@ -32,6 +32,11 @@ impl ::core::fmt::Debug for DragDropModifiers {
         f.debug_tuple("DragDropModifiers").field(&self.0).finish()
     }
 }
+impl DragDropModifiers {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DragDropModifiers {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -3556,6 +3556,11 @@ impl ::core::fmt::Debug for DataPackageOperation {
         f.debug_tuple("DataPackageOperation").field(&self.0).finish()
     }
 }
+impl DataPackageOperation {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DataPackageOperation {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
@@ -6355,6 +6355,11 @@ impl ::core::fmt::Debug for EmailQuerySearchFields {
         f.debug_tuple("EmailQuerySearchFields").field(&self.0).finish()
     }
 }
+impl EmailQuerySearchFields {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for EmailQuerySearchFields {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
@@ -1029,6 +1029,11 @@ impl ::core::fmt::Debug for StoreLogOptions {
         f.debug_tuple("StoreLogOptions").field(&self.0).finish()
     }
 }
+impl StoreLogOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for StoreLogOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
@@ -815,6 +815,11 @@ impl ::core::fmt::Debug for UserDataAccountContentKinds {
         f.debug_tuple("UserDataAccountContentKinds").field(&self.0).finish()
     }
 }
+impl UserDataAccountContentKinds {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for UserDataAccountContentKinds {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
@@ -1647,6 +1647,11 @@ impl ::core::fmt::Debug for UserDataTaskDaysOfWeek {
         f.debug_tuple("UserDataTaskDaysOfWeek").field(&self.0).finish()
     }
 }
+impl UserDataTaskDaysOfWeek {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for UserDataTaskDaysOfWeek {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
@@ -4399,6 +4399,11 @@ impl ::core::fmt::Debug for AddResourcePackageOptions {
         f.debug_tuple("AddResourcePackageOptions").field(&self.0).finish()
     }
 }
+impl AddResourcePackageOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AddResourcePackageOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -1308,6 +1308,11 @@ impl ::core::fmt::Debug for TextPredictionOptions {
         f.debug_tuple("TextPredictionOptions").field(&self.0).finish()
     }
 }
+impl TextPredictionOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TextPredictionOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
@@ -1701,6 +1701,11 @@ impl ::core::fmt::Debug for BluetoothLEAdvertisementFlags {
         f.debug_tuple("BluetoothLEAdvertisementFlags").field(&self.0).finish()
     }
 }
+impl BluetoothLEAdvertisementFlags {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for BluetoothLEAdvertisementFlags {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
@@ -5508,6 +5508,11 @@ impl ::core::fmt::Debug for GattCharacteristicProperties {
         f.debug_tuple("GattCharacteristicProperties").field(&self.0).finish()
     }
 }
+impl GattCharacteristicProperties {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GattCharacteristicProperties {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
@@ -3096,6 +3096,11 @@ impl ::core::fmt::Debug for BluetoothServiceCapabilities {
         f.debug_tuple("BluetoothServiceCapabilities").field(&self.0).finish()
     }
 }
+impl BluetoothServiceCapabilities {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for BluetoothServiceCapabilities {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
@@ -2999,6 +2999,11 @@ impl ::core::fmt::Debug for DisplayBitsPerChannel {
         f.debug_tuple("DisplayBitsPerChannel").field(&self.0).finish()
     }
 }
+impl DisplayBitsPerChannel {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DisplayBitsPerChannel {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3093,6 +3098,11 @@ unsafe impl ::windows::core::Abi for DisplayManagerOptions {
 impl ::core::fmt::Debug for DisplayManagerOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayManagerOptions").field(&self.0).finish()
+    }
+}
+impl DisplayManagerOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DisplayManagerOptions {
@@ -3192,6 +3202,11 @@ unsafe impl ::windows::core::Abi for DisplayModeQueryOptions {
 impl ::core::fmt::Debug for DisplayModeQueryOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayModeQueryOptions").field(&self.0).finish()
+    }
+}
+impl DisplayModeQueryOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DisplayModeQueryOptions {
@@ -3406,6 +3421,11 @@ impl ::core::fmt::Debug for DisplayScanoutOptions {
         f.debug_tuple("DisplayScanoutOptions").field(&self.0).finish()
     }
 }
+impl DisplayScanoutOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DisplayScanoutOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3507,6 +3527,11 @@ impl ::core::fmt::Debug for DisplayStateApplyOptions {
         f.debug_tuple("DisplayStateApplyOptions").field(&self.0).finish()
     }
 }
+impl DisplayStateApplyOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DisplayStateApplyOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3568,6 +3593,11 @@ unsafe impl ::windows::core::Abi for DisplayStateFunctionalizeOptions {
 impl ::core::fmt::Debug for DisplayStateFunctionalizeOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayStateFunctionalizeOptions").field(&self.0).finish()
+    }
+}
+impl DisplayStateFunctionalizeOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DisplayStateFunctionalizeOptions {

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
@@ -3072,6 +3072,11 @@ impl ::core::fmt::Debug for DevicePairingKinds {
         f.debug_tuple("DevicePairingKinds").field(&self.0).finish()
     }
 }
+impl DevicePairingKinds {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DevicePairingKinds {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3222,6 +3227,11 @@ unsafe impl ::windows::core::Abi for DevicePickerDisplayStatusOptions {
 impl ::core::fmt::Debug for DevicePickerDisplayStatusOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DevicePickerDisplayStatusOptions").field(&self.0).finish()
+    }
+}
+impl DevicePickerDisplayStatusOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DevicePickerDisplayStatusOptions {

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
@@ -551,6 +551,11 @@ impl ::core::fmt::Debug for GeofenceState {
         f.debug_tuple("GeofenceState").field(&self.0).finish()
     }
 }
+impl GeofenceState {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GeofenceState {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -613,6 +618,11 @@ unsafe impl ::windows::core::Abi for MonitoredGeofenceStates {
 impl ::core::fmt::Debug for MonitoredGeofenceStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MonitoredGeofenceStates").field(&self.0).finish()
+    }
+}
+impl MonitoredGeofenceStates {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MonitoredGeofenceStates {

--- a/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
@@ -848,6 +848,11 @@ impl ::core::fmt::Debug for LampPurposes {
         f.debug_tuple("LampPurposes").field(&self.0).finish()
     }
 }
+impl LampPurposes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LampPurposes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
@@ -12669,6 +12669,11 @@ impl ::core::fmt::Debug for PosConnectionTypes {
         f.debug_tuple("PosConnectionTypes").field(&self.0).finish()
     }
 }
+impl PosConnectionTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PosConnectionTypes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12804,6 +12809,11 @@ impl ::core::fmt::Debug for PosPrinterCartridgeSensors {
         f.debug_tuple("PosPrinterCartridgeSensors").field(&self.0).finish()
     }
 }
+impl PosPrinterCartridgeSensors {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PosPrinterCartridgeSensors {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12874,6 +12884,11 @@ unsafe impl ::windows::core::Abi for PosPrinterColorCapabilities {
 impl ::core::fmt::Debug for PosPrinterColorCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterColorCapabilities").field(&self.0).finish()
+    }
+}
+impl PosPrinterColorCapabilities {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PosPrinterColorCapabilities {
@@ -13090,6 +13105,11 @@ impl ::core::fmt::Debug for PosPrinterMarkFeedCapabilities {
         f.debug_tuple("PosPrinterMarkFeedCapabilities").field(&self.0).finish()
     }
 }
+impl PosPrinterMarkFeedCapabilities {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PosPrinterMarkFeedCapabilities {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13258,6 +13278,11 @@ unsafe impl ::windows::core::Abi for PosPrinterRuledLineCapabilities {
 impl ::core::fmt::Debug for PosPrinterRuledLineCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterRuledLineCapabilities").field(&self.0).finish()
+    }
+}
+impl PosPrinterRuledLineCapabilities {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PosPrinterRuledLineCapabilities {

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -4509,6 +4509,11 @@ impl ::core::fmt::Debug for SmartCardCryptogramPlacementOptions {
         f.debug_tuple("SmartCardCryptogramPlacementOptions").field(&self.0).finish()
     }
 }
+impl SmartCardCryptogramPlacementOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SmartCardCryptogramPlacementOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4604,6 +4609,11 @@ unsafe impl ::windows::core::Abi for SmartCardCryptogramStorageKeyCapabilities {
 impl ::core::fmt::Debug for SmartCardCryptogramStorageKeyCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramStorageKeyCapabilities").field(&self.0).finish()
+    }
+}
+impl SmartCardCryptogramStorageKeyCapabilities {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SmartCardCryptogramStorageKeyCapabilities {

--- a/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
@@ -2669,6 +2669,11 @@ impl ::core::fmt::Debug for UsbReadOptions {
         f.debug_tuple("UsbReadOptions").field(&self.0).finish()
     }
 }
+impl UsbReadOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for UsbReadOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2764,6 +2769,11 @@ unsafe impl ::windows::core::Abi for UsbWriteOptions {
 impl ::core::fmt::Debug for UsbWriteOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UsbWriteOptions").field(&self.0).finish()
+    }
+}
+impl UsbWriteOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for UsbWriteOptions {

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
@@ -2840,6 +2840,11 @@ impl ::core::fmt::Debug for ErrorOptions {
         f.debug_tuple("ErrorOptions").field(&self.0).finish()
     }
 }
+impl ErrorOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ErrorOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
@@ -132,6 +132,11 @@ impl ::core::fmt::Debug for AttributeTargets {
         f.debug_tuple("AttributeTargets").field(&self.0).finish()
     }
 }
+impl AttributeTargets {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AttributeTargets {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
@@ -861,6 +861,11 @@ impl ::core::fmt::Debug for ForceFeedbackEffectAxes {
         f.debug_tuple("ForceFeedbackEffectAxes").field(&self.0).finish()
     }
 }
+impl ForceFeedbackEffectAxes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ForceFeedbackEffectAxes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
@@ -2221,6 +2221,11 @@ impl ::core::fmt::Debug for ArcadeStickButtons {
         f.debug_tuple("ArcadeStickButtons").field(&self.0).finish()
     }
 }
+impl ArcadeStickButtons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ArcadeStickButtons {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2282,6 +2287,11 @@ unsafe impl ::windows::core::Abi for FlightStickButtons {
 impl ::core::fmt::Debug for FlightStickButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FlightStickButtons").field(&self.0).finish()
+    }
+}
+impl FlightStickButtons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FlightStickButtons {
@@ -2540,6 +2550,11 @@ impl ::core::fmt::Debug for GamepadButtons {
         f.debug_tuple("GamepadButtons").field(&self.0).finish()
     }
 }
+impl GamepadButtons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GamepadButtons {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2611,6 +2626,11 @@ unsafe impl ::windows::core::Abi for OptionalUINavigationButtons {
 impl ::core::fmt::Debug for OptionalUINavigationButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OptionalUINavigationButtons").field(&self.0).finish()
+    }
+}
+impl OptionalUINavigationButtons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for OptionalUINavigationButtons {
@@ -2696,6 +2716,11 @@ impl ::core::fmt::Debug for RacingWheelButtons {
         f.debug_tuple("RacingWheelButtons").field(&self.0).finish()
     }
 }
+impl RacingWheelButtons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RacingWheelButtons {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2763,6 +2788,11 @@ unsafe impl ::windows::core::Abi for RequiredUINavigationButtons {
 impl ::core::fmt::Debug for RequiredUINavigationButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RequiredUINavigationButtons").field(&self.0).finish()
+    }
+}
+impl RequiredUINavigationButtons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RequiredUINavigationButtons {

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
@@ -182,6 +182,11 @@ impl ::core::fmt::Debug for Direct3DBindings {
         f.debug_tuple("Direct3DBindings").field(&self.0).finish()
     }
 }
+impl Direct3DBindings {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for Direct3DBindings {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -1705,6 +1705,11 @@ impl ::core::fmt::Debug for DisplayBrightnessOverrideOptions {
         f.debug_tuple("DisplayBrightnessOverrideOptions").field(&self.0).finish()
     }
 }
+impl DisplayBrightnessOverrideOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DisplayBrightnessOverrideOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1872,6 +1877,11 @@ unsafe impl ::windows::core::Abi for DisplayOrientations {
 impl ::core::fmt::Debug for DisplayOrientations {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayOrientations").field(&self.0).finish()
+    }
+}
+impl DisplayOrientations {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DisplayOrientations {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
@@ -3960,6 +3960,11 @@ impl ::core::fmt::Debug for PrintOptionStates {
         f.debug_tuple("PrintOptionStates").field(&self.0).finish()
     }
 }
+impl PrintOptionStates {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PrintOptionStates {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
@@ -2807,6 +2807,11 @@ impl ::core::fmt::Debug for PdlConversionHostBasedProcessingOperations {
         f.debug_tuple("PdlConversionHostBasedProcessingOperations").field(&self.0).finish()
     }
 }
+impl PdlConversionHostBasedProcessingOperations {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PdlConversionHostBasedProcessingOperations {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
@@ -3878,6 +3878,11 @@ impl ::core::fmt::Debug for AddPackageByAppInstallerOptions {
         f.debug_tuple("AddPackageByAppInstallerOptions").field(&self.0).finish()
     }
 }
+impl AddPackageByAppInstallerOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AddPackageByAppInstallerOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3945,6 +3950,11 @@ unsafe impl ::windows::core::Abi for DeploymentOptions {
 impl ::core::fmt::Debug for DeploymentOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeploymentOptions").field(&self.0).finish()
+    }
+}
+impl DeploymentOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DeploymentOptions {
@@ -4118,6 +4128,11 @@ impl ::core::fmt::Debug for PackageStatus {
         f.debug_tuple("PackageStatus").field(&self.0).finish()
     }
 }
+impl PackageStatus {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PackageStatus {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4220,6 +4235,11 @@ impl ::core::fmt::Debug for PackageTypes {
         f.debug_tuple("PackageTypes").field(&self.0).finish()
     }
 }
+impl PackageTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PackageTypes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4282,6 +4302,11 @@ unsafe impl ::windows::core::Abi for RemovalOptions {
 impl ::core::fmt::Debug for RemovalOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemovalOptions").field(&self.0).finish()
+    }
+}
+impl RemovalOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RemovalOptions {

--- a/crates/libs/windows/src/Windows/Management/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Update/mod.rs
@@ -2054,6 +2054,11 @@ impl ::core::fmt::Debug for WindowsUpdateAdministratorOptions {
         f.debug_tuple("WindowsUpdateAdministratorOptions").field(&self.0).finish()
     }
 }
+impl WindowsUpdateAdministratorOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WindowsUpdateAdministratorOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/mod.rs
@@ -7481,6 +7481,11 @@ impl ::core::fmt::Debug for AudioNodeEmitterSettings {
         f.debug_tuple("AudioNodeEmitterSettings").field(&self.0).finish()
     }
 }
+impl AudioNodeEmitterSettings {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AudioNodeEmitterSettings {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Media/Casting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Casting/mod.rs
@@ -920,6 +920,11 @@ impl ::core::fmt::Debug for CastingPlaybackTypes {
         f.debug_tuple("CastingPlaybackTypes").field(&self.0).finish()
     }
 }
+impl CastingPlaybackTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CastingPlaybackTypes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
@@ -2615,6 +2615,11 @@ impl ::core::fmt::Debug for MediaMirroringOptions {
         f.debug_tuple("MediaMirroringOptions").field(&self.0).finish()
     }
 }
+impl MediaMirroringOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MediaMirroringOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -1162,6 +1162,11 @@ impl ::core::fmt::Debug for RevocationAndRenewalReasons {
         f.debug_tuple("RevocationAndRenewalReasons").field(&self.0).finish()
     }
 }
+impl RevocationAndRenewalReasons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RevocationAndRenewalReasons {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -3181,6 +3181,11 @@ impl ::core::fmt::Debug for NetworkTypes {
         f.debug_tuple("NetworkTypes").field(&self.0).finish()
     }
 }
+impl NetworkTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NetworkTypes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3242,6 +3247,11 @@ unsafe impl ::windows::core::Abi for RoamingStates {
 impl ::core::fmt::Debug for RoamingStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RoamingStates").field(&self.0).finish()
+    }
+}
+impl RoamingStates {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RoamingStates {
@@ -3352,6 +3362,11 @@ unsafe impl ::windows::core::Abi for WwanDataClass {
 impl ::core::fmt::Debug for WwanDataClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WwanDataClass").field(&self.0).finish()
+    }
+}
+impl WwanDataClass {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WwanDataClass {

--- a/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
@@ -8996,6 +8996,11 @@ impl ::core::fmt::Debug for DataClasses {
         f.debug_tuple("DataClasses").field(&self.0).finish()
     }
 }
+impl DataClasses {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DataClasses {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -1063,6 +1063,11 @@ impl ::core::fmt::Debug for PeerDiscoveryTypes {
         f.debug_tuple("PeerDiscoveryTypes").field(&self.0).finish()
     }
 }
+impl PeerDiscoveryTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PeerDiscoveryTypes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
@@ -5568,6 +5568,11 @@ impl ::core::fmt::Debug for VpnChannelRequestCredentialsOptions {
         f.debug_tuple("VpnChannelRequestCredentialsOptions").field(&self.0).finish()
     }
 }
+impl VpnChannelRequestCredentialsOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for VpnChannelRequestCredentialsOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
@@ -1334,6 +1334,11 @@ impl ::core::fmt::Debug for XboxLiveEndpointPairCreationBehaviors {
         f.debug_tuple("XboxLiveEndpointPairCreationBehaviors").field(&self.0).finish()
     }
 }
+impl XboxLiveEndpointPairCreationBehaviors {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for XboxLiveEndpointPairCreationBehaviors {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Networking/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/mod.rs
@@ -399,6 +399,11 @@ impl ::core::fmt::Debug for HostNameSortOptions {
         f.debug_tuple("HostNameSortOptions").field(&self.0).finish()
     }
 }
+impl HostNameSortOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HostNameSortOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Phone/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/ApplicationModel/mod.rs
@@ -58,6 +58,11 @@ impl ::core::fmt::Debug for ApplicationProfileModes {
         f.debug_tuple("ApplicationProfileModes").field(&self.0).finish()
     }
 }
+impl ApplicationProfileModes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ApplicationProfileModes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
@@ -191,6 +191,11 @@ impl ::core::fmt::Debug for AvailableAudioRoutingEndpoints {
         f.debug_tuple("AvailableAudioRoutingEndpoints").field(&self.0).finish()
     }
 }
+impl AvailableAudioRoutingEndpoints {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AvailableAudioRoutingEndpoints {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
@@ -2940,6 +2940,11 @@ impl ::core::fmt::Debug for AccessoryNotificationType {
         f.debug_tuple("AccessoryNotificationType").field(&self.0).finish()
     }
 }
+impl AccessoryNotificationType {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AccessoryNotificationType {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3294,6 +3299,11 @@ unsafe impl ::windows::core::Abi for PlaybackCapability {
 impl ::core::fmt::Debug for PlaybackCapability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlaybackCapability").field(&self.0).finish()
+    }
+}
+impl PlaybackCapability {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PlaybackCapability {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
@@ -2538,6 +2538,11 @@ impl ::core::fmt::Debug for WebAccountSelectionOptions {
         f.debug_tuple("WebAccountSelectionOptions").field(&self.0).finish()
     }
 }
+impl WebAccountSelectionOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WebAccountSelectionOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
@@ -275,6 +275,11 @@ impl ::core::fmt::Debug for WebAuthenticationOptions {
         f.debug_tuple("WebAuthenticationOptions").field(&self.0).finish()
     }
 }
+impl WebAuthenticationOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WebAuthenticationOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
@@ -3364,6 +3364,11 @@ impl ::core::fmt::Debug for EnrollKeyUsages {
         f.debug_tuple("EnrollKeyUsages").field(&self.0).finish()
     }
 }
+impl EnrollKeyUsages {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for EnrollKeyUsages {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3458,6 +3463,11 @@ unsafe impl ::windows::core::Abi for InstallOptions {
 impl ::core::fmt::Debug for InstallOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InstallOptions").field(&self.0).finish()
+    }
+}
+impl InstallOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for InstallOptions {

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -2016,6 +2016,11 @@ impl ::core::fmt::Debug for IsolatedWindowsEnvironmentAllowedClipboardFormats {
         f.debug_tuple("IsolatedWindowsEnvironmentAllowedClipboardFormats").field(&self.0).finish()
     }
 }
+impl IsolatedWindowsEnvironmentAllowedClipboardFormats {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IsolatedWindowsEnvironmentAllowedClipboardFormats {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2081,6 +2086,11 @@ impl ::core::fmt::Debug for IsolatedWindowsEnvironmentAvailablePrinters {
         f.debug_tuple("IsolatedWindowsEnvironmentAvailablePrinters").field(&self.0).finish()
     }
 }
+impl IsolatedWindowsEnvironmentAvailablePrinters {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IsolatedWindowsEnvironmentAvailablePrinters {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2142,6 +2152,11 @@ unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentClipboardCopyPast
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentClipboardCopyPasteDirections").field(&self.0).finish()
+    }
+}
+impl IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {

--- a/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
@@ -1715,6 +1715,11 @@ impl ::core::fmt::Debug for GuidanceAudioNotifications {
         f.debug_tuple("GuidanceAudioNotifications").field(&self.0).finish()
     }
 }
+impl GuidanceAudioNotifications {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GuidanceAudioNotifications {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1784,6 +1789,11 @@ unsafe impl ::windows::core::Abi for GuidanceLaneMarkers {
 impl ::core::fmt::Debug for GuidanceLaneMarkers {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GuidanceLaneMarkers").field(&self.0).finish()
+    }
+}
+impl GuidanceLaneMarkers {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GuidanceLaneMarkers {

--- a/crates/libs/windows/src/Windows/Services/Maps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/mod.rs
@@ -2344,6 +2344,11 @@ impl ::core::fmt::Debug for MapManeuverNotices {
         f.debug_tuple("MapManeuverNotices").field(&self.0).finish()
     }
 }
+impl MapManeuverNotices {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MapManeuverNotices {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2544,6 +2549,11 @@ unsafe impl ::windows::core::Abi for MapRouteRestrictions {
 impl ::core::fmt::Debug for MapRouteRestrictions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapRouteRestrictions").field(&self.0).finish()
+    }
+}
+impl MapRouteRestrictions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MapRouteRestrictions {

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
@@ -993,6 +993,11 @@ impl ::core::fmt::Debug for AccessCacheOptions {
         f.debug_tuple("AccessCacheOptions").field(&self.0).finish()
     }
 }
+impl AccessCacheOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AccessCacheOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
@@ -1899,6 +1899,11 @@ impl ::core::fmt::Debug for PropertyPrefetchOptions {
         f.debug_tuple("PropertyPrefetchOptions").field(&self.0).finish()
     }
 }
+impl PropertyPrefetchOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PropertyPrefetchOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1999,6 +2004,11 @@ unsafe impl ::windows::core::Abi for ThumbnailOptions {
 impl ::core::fmt::Debug for ThumbnailOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ThumbnailOptions").field(&self.0).finish()
+    }
+}
+impl ThumbnailOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for ThumbnailOptions {

--- a/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
@@ -2182,6 +2182,11 @@ impl ::core::fmt::Debug for CachedFileOptions {
         f.debug_tuple("CachedFileOptions").field(&self.0).finish()
     }
 }
+impl CachedFileOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CachedFileOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2350,6 +2355,11 @@ impl ::core::fmt::Debug for StorageProviderHardlinkPolicy {
         f.debug_tuple("StorageProviderHardlinkPolicy").field(&self.0).finish()
     }
 }
+impl StorageProviderHardlinkPolicy {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for StorageProviderHardlinkPolicy {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2451,6 +2461,11 @@ impl ::core::fmt::Debug for StorageProviderHydrationPolicyModifier {
         f.debug_tuple("StorageProviderHydrationPolicyModifier").field(&self.0).finish()
     }
 }
+impl StorageProviderHydrationPolicyModifier {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for StorageProviderHydrationPolicyModifier {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2521,6 +2536,11 @@ unsafe impl ::windows::core::Abi for StorageProviderInSyncPolicy {
 impl ::core::fmt::Debug for StorageProviderInSyncPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderInSyncPolicy").field(&self.0).finish()
+    }
+}
+impl StorageProviderInSyncPolicy {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for StorageProviderInSyncPolicy {

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -4025,6 +4025,11 @@ impl ::core::fmt::Debug for InputStreamOptions {
         f.debug_tuple("InputStreamOptions").field(&self.0).finish()
     }
 }
+impl InputStreamOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for InputStreamOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -7668,6 +7668,11 @@ impl ::core::fmt::Debug for FileAttributes {
         f.debug_tuple("FileAttributes").field(&self.0).finish()
     }
 }
+impl FileAttributes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FileAttributes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7923,6 +7928,11 @@ impl ::core::fmt::Debug for StorageItemTypes {
         f.debug_tuple("StorageItemTypes").field(&self.0).finish()
     }
 }
+impl StorageItemTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for StorageItemTypes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8026,6 +8036,11 @@ unsafe impl ::windows::core::Abi for StorageOpenOptions {
 impl ::core::fmt::Debug for StorageOpenOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageOpenOptions").field(&self.0).finish()
+    }
+}
+impl StorageOpenOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for StorageOpenOptions {

--- a/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
@@ -368,6 +368,11 @@ impl ::core::fmt::Debug for PlatformDiagnosticEventBufferLatencies {
         f.debug_tuple("PlatformDiagnosticEventBufferLatencies").field(&self.0).finish()
     }
 }
+impl PlatformDiagnosticEventBufferLatencies {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PlatformDiagnosticEventBufferLatencies {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/System/Profile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/mod.rs
@@ -1224,6 +1224,11 @@ impl ::core::fmt::Debug for UnsupportedAppRequirementReasons {
         f.debug_tuple("UnsupportedAppRequirementReasons").field(&self.0).finish()
     }
 }
+impl UnsupportedAppRequirementReasons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for UnsupportedAppRequirementReasons {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -241,6 +241,11 @@ impl ::core::fmt::Debug for WorkItemOptions {
         f.debug_tuple("WorkItemOptions").field(&self.0).finish()
     }
 }
+impl WorkItemOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WorkItemOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -6670,6 +6670,11 @@ impl ::core::fmt::Debug for VirtualKeyModifiers {
         f.debug_tuple("VirtualKeyModifiers").field(&self.0).finish()
     }
 }
+impl VirtualKeyModifiers {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for VirtualKeyModifiers {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -1354,6 +1354,11 @@ impl ::core::fmt::Debug for SupportedWebAccountActions {
         f.debug_tuple("SupportedWebAccountActions").field(&self.0).finish()
     }
 }
+impl SupportedWebAccountActions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SupportedWebAccountActions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
@@ -206,6 +206,11 @@ impl ::core::fmt::Debug for CompositionDebugOverdrawContentKinds {
         f.debug_tuple("CompositionDebugOverdrawContentKinds").field(&self.0).finish()
     }
 }
+impl CompositionDebugOverdrawContentKinds {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CompositionDebugOverdrawContentKinds {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
@@ -4508,6 +4508,11 @@ impl ::core::fmt::Debug for InteractionBindingAxisModes {
         f.debug_tuple("InteractionBindingAxisModes").field(&self.0).finish()
     }
 }
+impl InteractionBindingAxisModes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for InteractionBindingAxisModes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/mod.rs
@@ -38126,6 +38126,11 @@ impl ::core::fmt::Debug for CompositionBatchTypes {
         f.debug_tuple("CompositionBatchTypes").field(&self.0).finish()
     }
 }
+impl CompositionBatchTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CompositionBatchTypes {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -5895,6 +5895,11 @@ impl ::core::fmt::Debug for CoreIndependentInputFilters {
         f.debug_tuple("CoreIndependentInputFilters").field(&self.0).finish()
     }
 }
+impl CoreIndependentInputFilters {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CoreIndependentInputFilters {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5957,6 +5962,11 @@ unsafe impl ::windows::core::Abi for CoreInputDeviceTypes {
 impl ::core::fmt::Debug for CoreInputDeviceTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreInputDeviceTypes").field(&self.0).finish()
+    }
+}
+impl CoreInputDeviceTypes {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CoreInputDeviceTypes {
@@ -6090,6 +6100,11 @@ unsafe impl ::windows::core::Abi for CoreVirtualKeyStates {
 impl ::core::fmt::Debug for CoreVirtualKeyStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreVirtualKeyStates").field(&self.0).finish()
+    }
+}
+impl CoreVirtualKeyStates {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CoreVirtualKeyStates {

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
@@ -963,6 +963,11 @@ impl ::core::fmt::Debug for InjectedInputKeyOptions {
         f.debug_tuple("InjectedInputKeyOptions").field(&self.0).finish()
     }
 }
+impl InjectedInputKeyOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for InjectedInputKeyOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1038,6 +1043,11 @@ impl ::core::fmt::Debug for InjectedInputMouseOptions {
         f.debug_tuple("InjectedInputMouseOptions").field(&self.0).finish()
     }
 }
+impl InjectedInputMouseOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for InjectedInputMouseOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1100,6 +1110,11 @@ unsafe impl ::windows::core::Abi for InjectedInputPenButtons {
 impl ::core::fmt::Debug for InjectedInputPenButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputPenButtons").field(&self.0).finish()
+    }
+}
+impl InjectedInputPenButtons {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for InjectedInputPenButtons {
@@ -1165,6 +1180,11 @@ unsafe impl ::windows::core::Abi for InjectedInputPenParameters {
 impl ::core::fmt::Debug for InjectedInputPenParameters {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputPenParameters").field(&self.0).finish()
+    }
+}
+impl InjectedInputPenParameters {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for InjectedInputPenParameters {
@@ -1238,6 +1258,11 @@ unsafe impl ::windows::core::Abi for InjectedInputPointerOptions {
 impl ::core::fmt::Debug for InjectedInputPointerOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputPointerOptions").field(&self.0).finish()
+    }
+}
+impl InjectedInputPointerOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for InjectedInputPointerOptions {
@@ -1337,6 +1362,11 @@ unsafe impl ::windows::core::Abi for InjectedInputTouchParameters {
 impl ::core::fmt::Debug for InjectedInputTouchParameters {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputTouchParameters").field(&self.0).finish()
+    }
+}
+impl InjectedInputTouchParameters {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for InjectedInputTouchParameters {

--- a/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
@@ -3243,6 +3243,11 @@ impl ::core::fmt::Debug for SpatialGestureSettings {
         f.debug_tuple("SpatialGestureSettings").field(&self.0).finish()
     }
 }
+impl SpatialGestureSettings {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SpatialGestureSettings {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/mod.rs
@@ -5507,6 +5507,11 @@ impl ::core::fmt::Debug for GestureSettings {
         f.debug_tuple("GestureSettings").field(&self.0).finish()
     }
 }
+impl GestureSettings {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GestureSettings {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
@@ -4538,6 +4538,11 @@ impl ::core::fmt::Debug for NotificationKinds {
         f.debug_tuple("NotificationKinds").field(&self.0).finish()
     }
 }
+impl NotificationKinds {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NotificationKinds {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -641,6 +641,11 @@ impl ::core::fmt::Debug for MessageDialogOptions {
         f.debug_tuple("MessageDialogOptions").field(&self.0).finish()
     }
 }
+impl MessageDialogOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MessageDialogOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
@@ -1958,6 +1958,11 @@ impl ::core::fmt::Debug for TileOptions {
         f.debug_tuple("TileOptions").field(&self.0).finish()
     }
 }
+impl TileOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TileOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/UI/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/mod.rs
@@ -3055,6 +3055,11 @@ impl ::core::fmt::Debug for FindOptions {
         f.debug_tuple("FindOptions").field(&self.0).finish()
     }
 }
+impl FindOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FindOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3599,6 +3604,11 @@ impl ::core::fmt::Debug for PointOptions {
         f.debug_tuple("PointOptions").field(&self.0).finish()
     }
 }
+impl PointOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PointOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3733,6 +3743,11 @@ unsafe impl ::windows::core::Abi for SelectionOptions {
 impl ::core::fmt::Debug for SelectionOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SelectionOptions").field(&self.0).finish()
+    }
+}
+impl SelectionOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SelectionOptions {
@@ -3910,6 +3925,11 @@ impl ::core::fmt::Debug for TextDecorations {
         f.debug_tuple("TextDecorations").field(&self.0).finish()
     }
 }
+impl TextDecorations {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TextDecorations {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3977,6 +3997,11 @@ unsafe impl ::windows::core::Abi for TextGetOptions {
 impl ::core::fmt::Debug for TextGetOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextGetOptions").field(&self.0).finish()
+    }
+}
+impl TextGetOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TextGetOptions {
@@ -4205,6 +4230,11 @@ unsafe impl ::windows::core::Abi for TextSetOptions {
 impl ::core::fmt::Debug for TextSetOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextSetOptions").field(&self.0).finish()
+    }
+}
+impl TextSetOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TextSetOptions {

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
@@ -3504,6 +3504,11 @@ impl ::core::fmt::Debug for ApplicationViewSwitchingOptions {
         f.debug_tuple("ApplicationViewSwitchingOptions").field(&self.0).finish()
     }
 }
+impl ApplicationViewSwitchingOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ApplicationViewSwitchingOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/DirectML/mod.rs
@@ -1025,6 +1025,11 @@ impl ::core::fmt::Debug for DML_CREATE_DEVICE_FLAGS {
         f.debug_tuple("DML_CREATE_DEVICE_FLAGS").field(&self.0).finish()
     }
 }
+impl DML_CREATE_DEVICE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DML_CREATE_DEVICE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1109,6 +1114,11 @@ unsafe impl ::windows::core::Abi for DML_EXECUTION_FLAGS {
 impl ::core::fmt::Debug for DML_EXECUTION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DML_EXECUTION_FLAGS").field(&self.0).finish()
+    }
+}
+impl DML_EXECUTION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DML_EXECUTION_FLAGS {
@@ -1900,6 +1910,11 @@ unsafe impl ::windows::core::Abi for DML_TENSOR_FLAGS {
 impl ::core::fmt::Debug for DML_TENSOR_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DML_TENSOR_FLAGS").field(&self.0).finish()
+    }
+}
+impl DML_TENSOR_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DML_TENSOR_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
@@ -1075,6 +1075,11 @@ impl ::core::fmt::Debug for MLOperatorKernelOptions {
         f.debug_tuple("MLOperatorKernelOptions").field(&self.0).finish()
     }
 }
+impl MLOperatorKernelOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MLOperatorKernelOptions {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1129,6 +1134,11 @@ unsafe impl ::windows::core::Abi for MLOperatorParameterOptions {
 impl ::core::fmt::Debug for MLOperatorParameterOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorParameterOptions").field(&self.0).finish()
+    }
+}
+impl MLOperatorParameterOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MLOperatorParameterOptions {

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -1430,6 +1430,11 @@ impl ::core::fmt::Debug for WORD_WHEEL_OPEN_FLAGS {
         f.debug_tuple("WORD_WHEEL_OPEN_FLAGS").field(&self.0).finish()
     }
 }
+impl WORD_WHEEL_OPEN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WORD_WHEEL_OPEN_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
@@ -511,6 +511,11 @@ impl ::core::fmt::Debug for CLEAR_COMM_ERROR_FLAGS {
         f.debug_tuple("CLEAR_COMM_ERROR_FLAGS").field(&self.0).finish()
     }
 }
+impl CLEAR_COMM_ERROR_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CLEAR_COMM_ERROR_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -576,6 +581,11 @@ unsafe impl ::windows::core::Abi for COMMPROP_STOP_PARITY {
 impl ::core::fmt::Debug for COMMPROP_STOP_PARITY {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("COMMPROP_STOP_PARITY").field(&self.0).finish()
+    }
+}
+impl COMMPROP_STOP_PARITY {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for COMMPROP_STOP_PARITY {
@@ -653,6 +663,11 @@ unsafe impl ::windows::core::Abi for COMM_EVENT_MASK {
 impl ::core::fmt::Debug for COMM_EVENT_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("COMM_EVENT_MASK").field(&self.0).finish()
+    }
+}
+impl COMM_EVENT_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for COMM_EVENT_MASK {
@@ -813,6 +828,11 @@ impl ::core::fmt::Debug for MODEMDEVCAPS_DIAL_OPTIONS {
         f.debug_tuple("MODEMDEVCAPS_DIAL_OPTIONS").field(&self.0).finish()
     }
 }
+impl MODEMDEVCAPS_DIAL_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MODEMDEVCAPS_DIAL_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -872,6 +892,11 @@ impl ::core::fmt::Debug for MODEMDEVCAPS_SPEAKER_MODE {
         f.debug_tuple("MODEMDEVCAPS_SPEAKER_MODE").field(&self.0).finish()
     }
 }
+impl MODEMDEVCAPS_SPEAKER_MODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MODEMDEVCAPS_SPEAKER_MODE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -927,6 +952,11 @@ unsafe impl ::windows::core::Abi for MODEMDEVCAPS_SPEAKER_VOLUME {
 impl ::core::fmt::Debug for MODEMDEVCAPS_SPEAKER_VOLUME {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MODEMDEVCAPS_SPEAKER_VOLUME").field(&self.0).finish()
+    }
+}
+impl MODEMDEVCAPS_SPEAKER_VOLUME {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MODEMDEVCAPS_SPEAKER_VOLUME {
@@ -1048,6 +1078,11 @@ impl ::core::fmt::Debug for MODEM_STATUS_FLAGS {
         f.debug_tuple("MODEM_STATUS_FLAGS").field(&self.0).finish()
     }
 }
+impl MODEM_STATUS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MODEM_STATUS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1105,6 +1140,11 @@ unsafe impl ::windows::core::Abi for PURGE_COMM_FLAGS {
 impl ::core::fmt::Debug for PURGE_COMM_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PURGE_COMM_FLAGS").field(&self.0).finish()
+    }
+}
+impl PURGE_COMM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PURGE_COMM_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -8504,6 +8504,11 @@ impl ::core::fmt::Debug for SP_COPY_STYLE {
         f.debug_tuple("SP_COPY_STYLE").field(&self.0).finish()
     }
 }
+impl SP_COPY_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SP_COPY_STYLE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceQuery/mod.rs
@@ -282,6 +282,11 @@ impl ::core::fmt::Debug for DEVPROP_OPERATOR {
         f.debug_tuple("DEVPROP_OPERATOR").field(&self.0).finish()
     }
 }
+impl DEVPROP_OPERATOR {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DEVPROP_OPERATOR {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -3608,6 +3608,11 @@ impl ::core::fmt::Debug for QUERY_DISPLAY_CONFIG_FLAGS {
         f.debug_tuple("QUERY_DISPLAY_CONFIG_FLAGS").field(&self.0).finish()
     }
 }
+impl QUERY_DISPLAY_CONFIG_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for QUERY_DISPLAY_CONFIG_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3691,6 +3696,11 @@ unsafe impl ::windows::core::Abi for SET_DISPLAY_CONFIG_FLAGS {
 impl ::core::fmt::Debug for SET_DISPLAY_CONFIG_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SET_DISPLAY_CONFIG_FLAGS").field(&self.0).finish()
+    }
+}
+impl SET_DISPLAY_CONFIG_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SET_DISPLAY_CONFIG_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -13214,6 +13214,11 @@ impl ::core::fmt::Debug for DUPLICATE_HANDLE_OPTIONS {
         f.debug_tuple("DUPLICATE_HANDLE_OPTIONS").field(&self.0).finish()
     }
 }
+impl DUPLICATE_HANDLE_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DUPLICATE_HANDLE_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13267,6 +13272,11 @@ unsafe impl ::windows::core::Abi for HANDLE_FLAGS {
 impl ::core::fmt::Debug for HANDLE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HANDLE_FLAGS").field(&self.0).finish()
+    }
+}
+impl HANDLE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for HANDLE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -12264,6 +12264,11 @@ impl ::core::fmt::Debug for COMPARE_STRING_FLAGS {
         f.debug_tuple("COMPARE_STRING_FLAGS").field(&self.0).finish()
     }
 }
+impl COMPARE_STRING_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for COMPARE_STRING_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12449,6 +12454,11 @@ impl ::core::fmt::Debug for FOLD_STRING_MAP_FLAGS {
         f.debug_tuple("FOLD_STRING_MAP_FLAGS").field(&self.0).finish()
     }
 }
+impl FOLD_STRING_MAP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FOLD_STRING_MAP_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12528,6 +12538,11 @@ unsafe impl ::windows::core::Abi for IS_TEXT_UNICODE_RESULT {
 impl ::core::fmt::Debug for IS_TEXT_UNICODE_RESULT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IS_TEXT_UNICODE_RESULT").field(&self.0).finish()
+    }
+}
+impl IS_TEXT_UNICODE_RESULT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IS_TEXT_UNICODE_RESULT {
@@ -12801,6 +12816,11 @@ unsafe impl ::windows::core::Abi for MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
 impl ::core::fmt::Debug for MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MULTI_BYTE_TO_WIDE_CHAR_FLAGS").field(&self.0).finish()
+    }
+}
+impl MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MULTI_BYTE_TO_WIDE_CHAR_FLAGS {
@@ -13234,6 +13254,11 @@ unsafe impl ::windows::core::Abi for TIME_FORMAT_FLAGS {
 impl ::core::fmt::Debug for TIME_FORMAT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TIME_FORMAT_FLAGS").field(&self.0).finish()
+    }
+}
+impl TIME_FORMAT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TIME_FORMAT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/Common/mod.rs
@@ -435,6 +435,11 @@ impl ::core::fmt::Debug for D2D1_PATH_SEGMENT {
         f.debug_tuple("D2D1_PATH_SEGMENT").field(&self.0).finish()
     }
 }
+impl D2D1_PATH_SEGMENT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D2D1_PATH_SEGMENT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -17780,6 +17780,11 @@ impl ::core::fmt::Debug for D2D1_BITMAP_OPTIONS {
         f.debug_tuple("D2D1_BITMAP_OPTIONS").field(&self.0).finish()
     }
 }
+impl D2D1_BITMAP_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D2D1_BITMAP_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -18111,6 +18116,11 @@ unsafe impl ::windows::core::Abi for D2D1_CHANGE_TYPE {
 impl ::core::fmt::Debug for D2D1_CHANGE_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_CHANGE_TYPE").field(&self.0).finish()
+    }
+}
+impl D2D1_CHANGE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_CHANGE_TYPE {
@@ -18581,6 +18591,11 @@ impl ::core::fmt::Debug for D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS {
         f.debug_tuple("D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS").field(&self.0).finish()
     }
 }
+impl D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D2D1_COMPATIBLE_RENDER_TARGET_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -18931,6 +18946,11 @@ unsafe impl ::windows::core::Abi for D2D1_DEVICE_CONTEXT_OPTIONS {
 impl ::core::fmt::Debug for D2D1_DEVICE_CONTEXT_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_DEVICE_CONTEXT_OPTIONS").field(&self.0).finish()
+    }
+}
+impl D2D1_DEVICE_CONTEXT_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_DEVICE_CONTEXT_OPTIONS {
@@ -19354,6 +19374,11 @@ unsafe impl ::windows::core::Abi for D2D1_DRAW_TEXT_OPTIONS {
 impl ::core::fmt::Debug for D2D1_DRAW_TEXT_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_DRAW_TEXT_OPTIONS").field(&self.0).finish()
+    }
+}
+impl D2D1_DRAW_TEXT_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_DRAW_TEXT_OPTIONS {
@@ -20206,6 +20231,11 @@ impl ::core::fmt::Debug for D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS {
         f.debug_tuple("D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS").field(&self.0).finish()
     }
 }
+impl D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D2D1_IMAGE_SOURCE_FROM_DXGI_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -20263,6 +20293,11 @@ unsafe impl ::windows::core::Abi for D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
 impl ::core::fmt::Debug for D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_IMAGE_SOURCE_LOADING_OPTIONS").field(&self.0).finish()
+    }
+}
+impl D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_IMAGE_SOURCE_LOADING_OPTIONS {
@@ -20427,6 +20462,11 @@ impl ::core::fmt::Debug for D2D1_LAYER_OPTIONS {
         f.debug_tuple("D2D1_LAYER_OPTIONS").field(&self.0).finish()
     }
 }
+impl D2D1_LAYER_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D2D1_LAYER_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -20484,6 +20524,11 @@ unsafe impl ::windows::core::Abi for D2D1_LAYER_OPTIONS1 {
 impl ::core::fmt::Debug for D2D1_LAYER_OPTIONS1 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_LAYER_OPTIONS1").field(&self.0).finish()
+    }
+}
+impl D2D1_LAYER_OPTIONS1 {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_LAYER_OPTIONS1 {
@@ -20658,6 +20703,11 @@ unsafe impl ::windows::core::Abi for D2D1_MAP_OPTIONS {
 impl ::core::fmt::Debug for D2D1_MAP_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_MAP_OPTIONS").field(&self.0).finish()
+    }
+}
+impl D2D1_MAP_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_MAP_OPTIONS {
@@ -20934,6 +20984,11 @@ impl ::core::fmt::Debug for D2D1_PIXEL_OPTIONS {
         f.debug_tuple("D2D1_PIXEL_OPTIONS").field(&self.0).finish()
     }
 }
+impl D2D1_PIXEL_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D2D1_PIXEL_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -21172,6 +21227,11 @@ unsafe impl ::windows::core::Abi for D2D1_PRESENT_OPTIONS {
 impl ::core::fmt::Debug for D2D1_PRESENT_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_PRESENT_OPTIONS").field(&self.0).finish()
+    }
+}
+impl D2D1_PRESENT_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_PRESENT_OPTIONS {
@@ -21465,6 +21525,11 @@ unsafe impl ::windows::core::Abi for D2D1_RENDER_TARGET_USAGE {
 impl ::core::fmt::Debug for D2D1_RENDER_TARGET_USAGE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_RENDER_TARGET_USAGE").field(&self.0).finish()
+    }
+}
+impl D2D1_RENDER_TARGET_USAGE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_RENDER_TARGET_USAGE {
@@ -21959,6 +22024,11 @@ unsafe impl ::windows::core::Abi for D2D1_SPRITE_OPTIONS {
 impl ::core::fmt::Debug for D2D1_SPRITE_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_SPRITE_OPTIONS").field(&self.0).finish()
+    }
+}
+impl D2D1_SPRITE_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_SPRITE_OPTIONS {
@@ -22838,6 +22908,11 @@ impl ::core::fmt::Debug for D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS {
         f.debug_tuple("D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS").field(&self.0).finish()
     }
 }
+impl D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D2D1_TRANSFORMED_IMAGE_SOURCE_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -22965,6 +23040,11 @@ unsafe impl ::windows::core::Abi for D2D1_VERTEX_OPTIONS {
 impl ::core::fmt::Debug for D2D1_VERTEX_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_VERTEX_OPTIONS").field(&self.0).finish()
+    }
+}
+impl D2D1_VERTEX_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_VERTEX_OPTIONS {
@@ -23111,6 +23191,11 @@ unsafe impl ::windows::core::Abi for D2D1_WINDOW_STATE {
 impl ::core::fmt::Debug for D2D1_WINDOW_STATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D2D1_WINDOW_STATE").field(&self.0).finish()
+    }
+}
+impl D2D1_WINDOW_STATE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D2D1_WINDOW_STATE {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -14941,6 +14941,11 @@ impl ::core::fmt::Debug for D3D11_BIND_FLAG {
         f.debug_tuple("D3D11_BIND_FLAG").field(&self.0).finish()
     }
 }
+impl D3D11_BIND_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D11_BIND_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15208,6 +15213,11 @@ unsafe impl ::windows::core::Abi for D3D11_CLEAR_FLAG {
 impl ::core::fmt::Debug for D3D11_CLEAR_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D11_CLEAR_FLAG").field(&self.0).finish()
+    }
+}
+impl D3D11_CLEAR_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D11_CLEAR_FLAG {
@@ -15566,6 +15576,11 @@ impl ::core::fmt::Debug for D3D11_CPU_ACCESS_FLAG {
         f.debug_tuple("D3D11_CPU_ACCESS_FLAG").field(&self.0).finish()
     }
 }
+impl D3D11_CPU_ACCESS_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D11_CPU_ACCESS_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15635,6 +15650,11 @@ impl ::core::fmt::Debug for D3D11_CREATE_DEVICE_FLAG {
         f.debug_tuple("D3D11_CREATE_DEVICE_FLAG").field(&self.0).finish()
     }
 }
+impl D3D11_CREATE_DEVICE_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D11_CREATE_DEVICE_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15686,6 +15706,11 @@ unsafe impl ::windows::core::Abi for D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
 impl ::core::fmt::Debug for D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D11_CRYPTO_SESSION_KEY_EXCHANGE_FLAGS {
@@ -16011,6 +16036,11 @@ unsafe impl ::windows::core::Abi for D3D11_FENCE_FLAG {
 impl ::core::fmt::Debug for D3D11_FENCE_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D11_FENCE_FLAG").field(&self.0).finish()
+    }
+}
+impl D3D11_FENCE_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D11_FENCE_FLAG {
@@ -19465,6 +19495,11 @@ impl ::core::fmt::Debug for D3D11_RESOURCE_MISC_FLAG {
         f.debug_tuple("D3D11_RESOURCE_MISC_FLAG").field(&self.0).finish()
     }
 }
+impl D3D11_RESOURCE_MISC_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D11_RESOURCE_MISC_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -20464,6 +20499,11 @@ unsafe impl ::windows::core::Abi for D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLA
 impl ::core::fmt::Debug for D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D11_VIDEO_DECODER_HISTOGRAM_COMPONENT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -14993,6 +14993,11 @@ impl ::core::fmt::Debug for D3D12_BARRIER_ACCESS {
         f.debug_tuple("D3D12_BARRIER_ACCESS").field(&self.0).finish()
     }
 }
+impl D3D12_BARRIER_ACCESS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_BARRIER_ACCESS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15181,6 +15186,11 @@ impl ::core::fmt::Debug for D3D12_BARRIER_SYNC {
         f.debug_tuple("D3D12_BARRIER_SYNC").field(&self.0).finish()
     }
 }
+impl D3D12_BARRIER_SYNC {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_BARRIER_SYNC {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15359,6 +15369,11 @@ impl ::core::fmt::Debug for D3D12_BUFFER_SRV_FLAGS {
         f.debug_tuple("D3D12_BUFFER_SRV_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_BUFFER_SRV_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_BUFFER_SRV_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15414,6 +15429,11 @@ impl ::core::fmt::Debug for D3D12_BUFFER_UAV_FLAGS {
         f.debug_tuple("D3D12_BUFFER_UAV_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_BUFFER_UAV_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_BUFFER_UAV_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15467,6 +15487,11 @@ unsafe impl ::windows::core::Abi for D3D12_CLEAR_FLAGS {
 impl ::core::fmt::Debug for D3D12_CLEAR_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_CLEAR_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_CLEAR_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_CLEAR_FLAGS {
@@ -15555,6 +15580,11 @@ impl ::core::fmt::Debug for D3D12_COMMAND_LIST_FLAGS {
         f.debug_tuple("D3D12_COMMAND_LIST_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_COMMAND_LIST_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_COMMAND_LIST_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15620,6 +15650,11 @@ unsafe impl ::windows::core::Abi for D3D12_COMMAND_LIST_SUPPORT_FLAGS {
 impl ::core::fmt::Debug for D3D12_COMMAND_LIST_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_COMMAND_LIST_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_COMMAND_LIST_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_COMMAND_LIST_SUPPORT_FLAGS {
@@ -15714,6 +15749,11 @@ impl ::core::fmt::Debug for D3D12_COMMAND_POOL_FLAGS {
         f.debug_tuple("D3D12_COMMAND_POOL_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_COMMAND_POOL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_COMMAND_POOL_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15767,6 +15807,11 @@ unsafe impl ::windows::core::Abi for D3D12_COMMAND_QUEUE_FLAGS {
 impl ::core::fmt::Debug for D3D12_COMMAND_QUEUE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_COMMAND_QUEUE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_COMMAND_QUEUE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_COMMAND_QUEUE_FLAGS {
@@ -15849,6 +15894,11 @@ unsafe impl ::windows::core::Abi for D3D12_COMMAND_RECORDER_FLAGS {
 impl ::core::fmt::Debug for D3D12_COMMAND_RECORDER_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_COMMAND_RECORDER_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_COMMAND_RECORDER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_COMMAND_RECORDER_FLAGS {
@@ -16212,6 +16262,11 @@ impl ::core::fmt::Debug for D3D12_DESCRIPTOR_HEAP_FLAGS {
         f.debug_tuple("D3D12_DESCRIPTOR_HEAP_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_DESCRIPTOR_HEAP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_DESCRIPTOR_HEAP_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -16308,6 +16363,11 @@ impl ::core::fmt::Debug for D3D12_DESCRIPTOR_RANGE_FLAGS {
         f.debug_tuple("D3D12_DESCRIPTOR_RANGE_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_DESCRIPTOR_RANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_DESCRIPTOR_RANGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -16398,6 +16458,11 @@ impl ::core::fmt::Debug for D3D12_DEVICE_FACTORY_FLAGS {
         f.debug_tuple("D3D12_DEVICE_FACTORY_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_DEVICE_FACTORY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_DEVICE_FACTORY_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -16471,6 +16536,11 @@ unsafe impl ::windows::core::Abi for D3D12_DEVICE_FLAGS {
 impl ::core::fmt::Debug for D3D12_DEVICE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_DEVICE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_DEVICE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_DEVICE_FLAGS {
@@ -16671,6 +16741,11 @@ impl ::core::fmt::Debug for D3D12_DRED_FLAGS {
         f.debug_tuple("D3D12_DRED_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_DRED_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_DRED_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -16722,6 +16797,11 @@ unsafe impl ::windows::core::Abi for D3D12_DRED_PAGE_FAULT_FLAGS {
 impl ::core::fmt::Debug for D3D12_DRED_PAGE_FAULT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_DRED_PAGE_FAULT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_DRED_PAGE_FAULT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_DRED_PAGE_FAULT_FLAGS {
@@ -16882,6 +16962,11 @@ impl ::core::fmt::Debug for D3D12_DSV_FLAGS {
         f.debug_tuple("D3D12_DSV_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_DSV_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_DSV_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -16960,6 +17045,11 @@ unsafe impl ::windows::core::Abi for D3D12_EXPORT_FLAGS {
 impl ::core::fmt::Debug for D3D12_EXPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_EXPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_EXPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_EXPORT_FLAGS {
@@ -17114,6 +17204,11 @@ unsafe impl ::windows::core::Abi for D3D12_FENCE_FLAGS {
 impl ::core::fmt::Debug for D3D12_FENCE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_FENCE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_FENCE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_FENCE_FLAGS {
@@ -17407,6 +17502,11 @@ impl ::core::fmt::Debug for D3D12_FORMAT_SUPPORT1 {
         f.debug_tuple("D3D12_FORMAT_SUPPORT1").field(&self.0).finish()
     }
 }
+impl D3D12_FORMAT_SUPPORT1 {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_FORMAT_SUPPORT1 {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -17482,6 +17582,11 @@ unsafe impl ::windows::core::Abi for D3D12_FORMAT_SUPPORT2 {
 impl ::core::fmt::Debug for D3D12_FORMAT_SUPPORT2 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_FORMAT_SUPPORT2").field(&self.0).finish()
+    }
+}
+impl D3D12_FORMAT_SUPPORT2 {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_FORMAT_SUPPORT2 {
@@ -17664,6 +17769,11 @@ impl ::core::fmt::Debug for D3D12_GRAPHICS_STATES {
         f.debug_tuple("D3D12_GRAPHICS_STATES").field(&self.0).finish()
     }
 }
+impl D3D12_GRAPHICS_STATES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_GRAPHICS_STATES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -17745,6 +17855,11 @@ unsafe impl ::windows::core::Abi for D3D12_HEAP_FLAGS {
 impl ::core::fmt::Debug for D3D12_HEAP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_HEAP_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_HEAP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_HEAP_FLAGS {
@@ -20178,6 +20293,11 @@ impl ::core::fmt::Debug for D3D12_META_COMMAND_PARAMETER_FLAGS {
         f.debug_tuple("D3D12_META_COMMAND_PARAMETER_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_META_COMMAND_PARAMETER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_META_COMMAND_PARAMETER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -20297,6 +20417,11 @@ impl ::core::fmt::Debug for D3D12_MULTIPLE_FENCE_WAIT_FLAGS {
         f.debug_tuple("D3D12_MULTIPLE_FENCE_WAIT_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_MULTIPLE_FENCE_WAIT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_MULTIPLE_FENCE_WAIT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -20350,6 +20475,11 @@ unsafe impl ::windows::core::Abi for D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
 impl ::core::fmt::Debug for D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_MULTISAMPLE_QUALITY_LEVEL_FLAGS {
@@ -20409,6 +20539,11 @@ unsafe impl ::windows::core::Abi for D3D12_PIPELINE_STATE_FLAGS {
 impl ::core::fmt::Debug for D3D12_PIPELINE_STATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_PIPELINE_STATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_PIPELINE_STATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_PIPELINE_STATE_FLAGS {
@@ -20632,6 +20767,11 @@ impl ::core::fmt::Debug for D3D12_PROTECTED_RESOURCE_SESSION_FLAGS {
         f.debug_tuple("D3D12_PROTECTED_RESOURCE_SESSION_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_PROTECTED_RESOURCE_SESSION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_PROTECTED_RESOURCE_SESSION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -20685,6 +20825,11 @@ unsafe impl ::windows::core::Abi for D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FL
 impl ::core::fmt::Debug for D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_PROTECTED_RESOURCE_SESSION_SUPPORT_FLAGS {
@@ -20859,6 +21004,11 @@ impl ::core::fmt::Debug for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS 
         f.debug_tuple("D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_RAYTRACING_ACCELERATION_STRUCTURE_BUILD_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -21007,6 +21157,11 @@ impl ::core::fmt::Debug for D3D12_RAYTRACING_GEOMETRY_FLAGS {
         f.debug_tuple("D3D12_RAYTRACING_GEOMETRY_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_RAYTRACING_GEOMETRY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_RAYTRACING_GEOMETRY_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -21095,6 +21250,11 @@ impl ::core::fmt::Debug for D3D12_RAYTRACING_INSTANCE_FLAGS {
         f.debug_tuple("D3D12_RAYTRACING_INSTANCE_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_RAYTRACING_INSTANCE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_RAYTRACING_INSTANCE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -21150,6 +21310,11 @@ unsafe impl ::windows::core::Abi for D3D12_RAYTRACING_PIPELINE_FLAGS {
 impl ::core::fmt::Debug for D3D12_RAYTRACING_PIPELINE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_RAYTRACING_PIPELINE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_RAYTRACING_PIPELINE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_RAYTRACING_PIPELINE_FLAGS {
@@ -21252,6 +21417,11 @@ unsafe impl ::windows::core::Abi for D3D12_RAY_FLAGS {
 impl ::core::fmt::Debug for D3D12_RAY_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_RAY_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_RAY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_RAY_FLAGS {
@@ -21375,6 +21545,11 @@ impl ::core::fmt::Debug for D3D12_RENDER_PASS_FLAGS {
         f.debug_tuple("D3D12_RENDER_PASS_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_RENDER_PASS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_RENDER_PASS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -21457,6 +21632,11 @@ unsafe impl ::windows::core::Abi for D3D12_RESIDENCY_FLAGS {
 impl ::core::fmt::Debug for D3D12_RESIDENCY_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_RESIDENCY_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_RESIDENCY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_RESIDENCY_FLAGS {
@@ -21582,6 +21762,11 @@ unsafe impl ::windows::core::Abi for D3D12_RESOURCE_BARRIER_FLAGS {
 impl ::core::fmt::Debug for D3D12_RESOURCE_BARRIER_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_RESOURCE_BARRIER_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_RESOURCE_BARRIER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_RESOURCE_BARRIER_FLAGS {
@@ -21746,6 +21931,11 @@ impl ::core::fmt::Debug for D3D12_RESOURCE_FLAGS {
         f.debug_tuple("D3D12_RESOURCE_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_RESOURCE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_RESOURCE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -21878,6 +22068,11 @@ impl ::core::fmt::Debug for D3D12_RESOURCE_STATES {
         f.debug_tuple("D3D12_RESOURCE_STATES").field(&self.0).finish()
     }
 }
+impl D3D12_RESOURCE_STATES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_RESOURCE_STATES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -21966,6 +22161,11 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_DESCRIPTOR_FLAGS {
 impl ::core::fmt::Debug for D3D12_ROOT_DESCRIPTOR_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_ROOT_DESCRIPTOR_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_ROOT_DESCRIPTOR_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_ROOT_DESCRIPTOR_FLAGS {
@@ -22076,6 +22276,11 @@ unsafe impl ::windows::core::Abi for D3D12_ROOT_SIGNATURE_FLAGS {
 impl ::core::fmt::Debug for D3D12_ROOT_SIGNATURE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_ROOT_SIGNATURE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_ROOT_SIGNATURE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_ROOT_SIGNATURE_FLAGS {
@@ -22203,6 +22408,11 @@ impl ::core::fmt::Debug for D3D12_SAMPLER_FLAGS {
         f.debug_tuple("D3D12_SAMPLER_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_SAMPLER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_SAMPLER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -22285,6 +22495,11 @@ impl ::core::fmt::Debug for D3D12_SHADER_CACHE_CONTROL_FLAGS {
         f.debug_tuple("D3D12_SHADER_CACHE_CONTROL_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_SHADER_CACHE_CONTROL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_SHADER_CACHE_CONTROL_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -22340,6 +22555,11 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_CACHE_FLAGS {
 impl ::core::fmt::Debug for D3D12_SHADER_CACHE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_SHADER_CACHE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_SHADER_CACHE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_SHADER_CACHE_FLAGS {
@@ -22399,6 +22619,11 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_CACHE_KIND_FLAGS {
 impl ::core::fmt::Debug for D3D12_SHADER_CACHE_KIND_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_SHADER_CACHE_KIND_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_SHADER_CACHE_KIND_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_SHADER_CACHE_KIND_FLAGS {
@@ -22495,6 +22720,11 @@ impl ::core::fmt::Debug for D3D12_SHADER_CACHE_SUPPORT_FLAGS {
         f.debug_tuple("D3D12_SHADER_CACHE_SUPPORT_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_SHADER_CACHE_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_SHADER_CACHE_SUPPORT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -22585,6 +22815,11 @@ unsafe impl ::windows::core::Abi for D3D12_SHADER_MIN_PRECISION_SUPPORT {
 impl ::core::fmt::Debug for D3D12_SHADER_MIN_PRECISION_SUPPORT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_SHADER_MIN_PRECISION_SUPPORT").field(&self.0).finish()
+    }
+}
+impl D3D12_SHADER_MIN_PRECISION_SUPPORT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_SHADER_MIN_PRECISION_SUPPORT {
@@ -22886,6 +23121,11 @@ impl ::core::fmt::Debug for D3D12_STATE_OBJECT_FLAGS {
         f.debug_tuple("D3D12_STATE_OBJECT_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_STATE_OBJECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_STATE_OBJECT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -23122,6 +23362,11 @@ impl ::core::fmt::Debug for D3D12_TEXTURE_BARRIER_FLAGS {
         f.debug_tuple("D3D12_TEXTURE_BARRIER_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_TEXTURE_BARRIER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_TEXTURE_BARRIER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -23272,6 +23517,11 @@ impl ::core::fmt::Debug for D3D12_TILE_COPY_FLAGS {
         f.debug_tuple("D3D12_TILE_COPY_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_TILE_COPY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_TILE_COPY_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -23325,6 +23575,11 @@ unsafe impl ::windows::core::Abi for D3D12_TILE_MAPPING_FLAGS {
 impl ::core::fmt::Debug for D3D12_TILE_MAPPING_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_TILE_MAPPING_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_TILE_MAPPING_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_TILE_MAPPING_FLAGS {
@@ -23510,6 +23765,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIEW_INSTANCING_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIEW_INSTANCING_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIEW_INSTANCING_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIEW_INSTANCING_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIEW_INSTANCING_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -11615,6 +11615,11 @@ impl ::core::fmt::Debug for DWRITE_AUTOMATIC_FONT_AXES {
         f.debug_tuple("DWRITE_AUTOMATIC_FONT_AXES").field(&self.0).finish()
     }
 }
+impl DWRITE_AUTOMATIC_FONT_AXES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DWRITE_AUTOMATIC_FONT_AXES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11829,6 +11834,11 @@ unsafe impl ::windows::core::Abi for DWRITE_FONT_AXIS_ATTRIBUTES {
 impl ::core::fmt::Debug for DWRITE_FONT_AXIS_ATTRIBUTES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DWRITE_FONT_AXIS_ATTRIBUTES").field(&self.0).finish()
+    }
+}
+impl DWRITE_FONT_AXIS_ATTRIBUTES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DWRITE_FONT_AXIS_ATTRIBUTES {
@@ -12305,6 +12315,11 @@ impl ::core::fmt::Debug for DWRITE_FONT_SIMULATIONS {
         f.debug_tuple("DWRITE_FONT_SIMULATIONS").field(&self.0).finish()
     }
 }
+impl DWRITE_FONT_SIMULATIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DWRITE_FONT_SIMULATIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12536,6 +12551,11 @@ unsafe impl ::windows::core::Abi for DWRITE_GLYPH_IMAGE_FORMATS {
 impl ::core::fmt::Debug for DWRITE_GLYPH_IMAGE_FORMATS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DWRITE_GLYPH_IMAGE_FORMATS").field(&self.0).finish()
+    }
+}
+impl DWRITE_GLYPH_IMAGE_FORMATS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DWRITE_GLYPH_IMAGE_FORMATS {
@@ -14216,6 +14236,11 @@ unsafe impl ::windows::core::Abi for DWRITE_SCRIPT_SHAPES {
 impl ::core::fmt::Debug for DWRITE_SCRIPT_SHAPES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DWRITE_SCRIPT_SHAPES").field(&self.0).finish()
+    }
+}
+impl DWRITE_SCRIPT_SHAPES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DWRITE_SCRIPT_SHAPES {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
@@ -514,6 +514,11 @@ impl ::core::fmt::Debug for DWM_SHOWCONTACT {
         f.debug_tuple("DWM_SHOWCONTACT").field(&self.0).finish()
     }
 }
+impl DWM_SHOWCONTACT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DWM_SHOWCONTACT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -614,6 +619,11 @@ unsafe impl ::windows::core::Abi for DWM_TAB_WINDOW_REQUIREMENTS {
 impl ::core::fmt::Debug for DWM_TAB_WINDOW_REQUIREMENTS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DWM_TAB_WINDOW_REQUIREMENTS").field(&self.0).finish()
+    }
+}
+impl DWM_TAB_WINDOW_REQUIREMENTS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DWM_TAB_WINDOW_REQUIREMENTS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -6048,6 +6048,11 @@ impl ::core::fmt::Debug for DXGI_ADAPTER_FLAG {
         f.debug_tuple("DXGI_ADAPTER_FLAG").field(&self.0).finish()
     }
 }
+impl DXGI_ADAPTER_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DXGI_ADAPTER_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6113,6 +6118,11 @@ unsafe impl ::windows::core::Abi for DXGI_ADAPTER_FLAG3 {
 impl ::core::fmt::Debug for DXGI_ADAPTER_FLAG3 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DXGI_ADAPTER_FLAG3").field(&self.0).finish()
+    }
+}
+impl DXGI_ADAPTER_FLAG3 {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DXGI_ADAPTER_FLAG3 {
@@ -6205,6 +6215,11 @@ unsafe impl ::windows::core::Abi for DXGI_DEBUG_RLO_FLAGS {
 impl ::core::fmt::Debug for DXGI_DEBUG_RLO_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DXGI_DEBUG_RLO_FLAGS").field(&self.0).finish()
+    }
+}
+impl DXGI_DEBUG_RLO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DXGI_DEBUG_RLO_FLAGS {
@@ -6380,6 +6395,11 @@ unsafe impl ::windows::core::Abi for DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
 impl ::core::fmt::Debug for DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DXGI_HARDWARE_COMPOSITION_SUPPORT_FLAGS {
@@ -7680,6 +7700,11 @@ unsafe impl ::windows::core::Abi for DXGI_USAGE {
 impl ::core::fmt::Debug for DXGI_USAGE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DXGI_USAGE").field(&self.0).finish()
+    }
+}
+impl DXGI_USAGE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DXGI_USAGE {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
@@ -5649,6 +5649,11 @@ impl ::core::fmt::Debug for CDS_TYPE {
         f.debug_tuple("CDS_TYPE").field(&self.0).finish()
     }
 }
+impl CDS_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CDS_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5785,6 +5790,11 @@ unsafe impl ::windows::core::Abi for DC_LAYOUT {
 impl ::core::fmt::Debug for DC_LAYOUT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DC_LAYOUT").field(&self.0).finish()
+    }
+}
+impl DC_LAYOUT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DC_LAYOUT {
@@ -6061,6 +6071,11 @@ impl ::core::fmt::Debug for DEVMODE_FIELD_FLAGS {
         f.debug_tuple("DEVMODE_FIELD_FLAGS").field(&self.0).finish()
     }
 }
+impl DEVMODE_FIELD_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DEVMODE_FIELD_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6201,6 +6216,11 @@ unsafe impl ::windows::core::Abi for DFCS_STATE {
 impl ::core::fmt::Debug for DFCS_STATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DFCS_STATE").field(&self.0).finish()
+    }
+}
+impl DFCS_STATE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DFCS_STATE {
@@ -6412,6 +6432,11 @@ impl ::core::fmt::Debug for DRAWEDGE_FLAGS {
         f.debug_tuple("DRAWEDGE_FLAGS").field(&self.0).finish()
     }
 }
+impl DRAWEDGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DRAWEDGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6487,6 +6512,11 @@ impl ::core::fmt::Debug for DRAWSTATE_FLAGS {
         f.debug_tuple("DRAWSTATE_FLAGS").field(&self.0).finish()
     }
 }
+impl DRAWSTATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DRAWSTATE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6550,6 +6580,11 @@ unsafe impl ::windows::core::Abi for DRAW_CAPTION_FLAGS {
 impl ::core::fmt::Debug for DRAW_CAPTION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DRAW_CAPTION_FLAGS").field(&self.0).finish()
+    }
+}
+impl DRAW_CAPTION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DRAW_CAPTION_FLAGS {
@@ -6639,6 +6674,11 @@ unsafe impl ::windows::core::Abi for DRAW_EDGE_FLAGS {
 impl ::core::fmt::Debug for DRAW_EDGE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DRAW_EDGE_FLAGS").field(&self.0).finish()
+    }
+}
+impl DRAW_EDGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DRAW_EDGE_FLAGS {
@@ -6738,6 +6778,11 @@ unsafe impl ::windows::core::Abi for DRAW_TEXT_FORMAT {
 impl ::core::fmt::Debug for DRAW_TEXT_FORMAT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DRAW_TEXT_FORMAT").field(&self.0).finish()
+    }
+}
+impl DRAW_TEXT_FORMAT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DRAW_TEXT_FORMAT {
@@ -7122,6 +7167,11 @@ impl ::core::fmt::Debug for ENUM_DISPLAY_SETTINGS_FLAGS {
         f.debug_tuple("ENUM_DISPLAY_SETTINGS_FLAGS").field(&self.0).finish()
     }
 }
+impl ENUM_DISPLAY_SETTINGS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ENUM_DISPLAY_SETTINGS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7216,6 +7266,11 @@ unsafe impl ::windows::core::Abi for ETO_OPTIONS {
 impl ::core::fmt::Debug for ETO_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ETO_OPTIONS").field(&self.0).finish()
+    }
+}
+impl ETO_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for ETO_OPTIONS {
@@ -7375,6 +7430,11 @@ unsafe impl ::windows::core::Abi for FONT_CLIP_PRECISION {
 impl ::core::fmt::Debug for FONT_CLIP_PRECISION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FONT_CLIP_PRECISION").field(&self.0).finish()
+    }
+}
+impl FONT_CLIP_PRECISION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FONT_CLIP_PRECISION {
@@ -7746,6 +7806,11 @@ impl ::core::fmt::Debug for GET_CHARACTER_PLACEMENT_FLAGS {
         f.debug_tuple("GET_CHARACTER_PLACEMENT_FLAGS").field(&self.0).finish()
     }
 }
+impl GET_CHARACTER_PLACEMENT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GET_CHARACTER_PLACEMENT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7817,6 +7882,11 @@ unsafe impl ::windows::core::Abi for GET_DCX_FLAGS {
 impl ::core::fmt::Debug for GET_DCX_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GET_DCX_FLAGS").field(&self.0).finish()
+    }
+}
+impl GET_DCX_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GET_DCX_FLAGS {
@@ -8822,6 +8892,11 @@ impl ::core::fmt::Debug for PEN_STYLE {
         f.debug_tuple("PEN_STYLE").field(&self.0).finish()
     }
 }
+impl PEN_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PEN_STYLE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8954,6 +9029,11 @@ impl ::core::fmt::Debug for REDRAW_WINDOW_FLAGS {
         f.debug_tuple("REDRAW_WINDOW_FLAGS").field(&self.0).finish()
     }
 }
+impl REDRAW_WINDOW_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for REDRAW_WINDOW_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9074,6 +9154,11 @@ unsafe impl ::windows::core::Abi for ROP_CODE {
 impl ::core::fmt::Debug for ROP_CODE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ROP_CODE").field(&self.0).finish()
+    }
+}
+impl ROP_CODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for ROP_CODE {
@@ -9353,6 +9438,11 @@ impl ::core::fmt::Debug for TEXT_ALIGN_OPTIONS {
         f.debug_tuple("TEXT_ALIGN_OPTIONS").field(&self.0).finish()
     }
 }
+impl TEXT_ALIGN_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TEXT_ALIGN_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9410,6 +9500,11 @@ unsafe impl ::windows::core::Abi for TMPF_FLAGS {
 impl ::core::fmt::Debug for TMPF_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TMPF_FLAGS").field(&self.0).finish()
+    }
+}
+impl TMPF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TMPF_FLAGS {
@@ -9471,6 +9566,11 @@ impl ::core::fmt::Debug for TTEMBED_FLAGS {
         f.debug_tuple("TTEMBED_FLAGS").field(&self.0).finish()
     }
 }
+impl TTEMBED_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TTEMBED_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9524,6 +9624,11 @@ unsafe impl ::windows::core::Abi for TTLOAD_EMBEDDED_FONT_STATUS {
 impl ::core::fmt::Debug for TTLOAD_EMBEDDED_FONT_STATUS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TTLOAD_EMBEDDED_FONT_STATUS").field(&self.0).finish()
+    }
+}
+impl TTLOAD_EMBEDDED_FONT_STATUS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TTLOAD_EMBEDDED_FONT_STATUS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
@@ -4032,6 +4032,11 @@ impl ::core::fmt::Debug for PFD_FLAGS {
         f.debug_tuple("PFD_FLAGS").field(&self.0).finish()
     }
 }
+impl PFD_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PFD_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
@@ -12455,6 +12455,11 @@ impl ::core::fmt::Debug for PRINTER_ACCESS_RIGHTS {
         f.debug_tuple("PRINTER_ACCESS_RIGHTS").field(&self.0).finish()
     }
 }
+impl PRINTER_ACCESS_RIGHTS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PRINTER_ACCESS_RIGHTS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -6698,6 +6698,11 @@ impl ::core::fmt::Debug for AUDCLNT_STREAMOPTIONS {
         f.debug_tuple("AUDCLNT_STREAMOPTIONS").field(&self.0).finish()
     }
 }
+impl AUDCLNT_STREAMOPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AUDCLNT_STREAMOPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6778,6 +6783,11 @@ unsafe impl ::windows::core::Abi for AUDIO_DUCKING_OPTIONS {
 impl ::core::fmt::Debug for AUDIO_DUCKING_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AUDIO_DUCKING_OPTIONS").field(&self.0).finish()
+    }
+}
+impl AUDIO_DUCKING_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for AUDIO_DUCKING_OPTIONS {
@@ -6976,6 +6986,11 @@ unsafe impl ::windows::core::Abi for AudioObjectType {
 impl ::core::fmt::Debug for AudioObjectType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioObjectType").field(&self.0).finish()
+    }
+}
+impl AudioObjectType {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for AudioObjectType {
@@ -7317,6 +7332,11 @@ impl ::core::fmt::Debug for MIDI_WAVE_OPEN_TYPE {
         f.debug_tuple("MIDI_WAVE_OPEN_TYPE").field(&self.0).finish()
     }
 }
+impl MIDI_WAVE_OPEN_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MIDI_WAVE_OPEN_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7515,6 +7535,11 @@ impl ::core::fmt::Debug for SND_FLAGS {
         f.debug_tuple("SND_FLAGS").field(&self.0).finish()
     }
 }
+impl SND_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SND_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7568,6 +7593,11 @@ unsafe impl ::windows::core::Abi for SPATIAL_AUDIO_STREAM_OPTIONS {
 impl ::core::fmt::Debug for SPATIAL_AUDIO_STREAM_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SPATIAL_AUDIO_STREAM_OPTIONS").field(&self.0).finish()
+    }
+}
+impl SPATIAL_AUDIO_STREAM_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SPATIAL_AUDIO_STREAM_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/mod.rs
@@ -50888,6 +50888,11 @@ impl ::core::fmt::Debug for ADVISE_TYPE {
         f.debug_tuple("ADVISE_TYPE").field(&self.0).finish()
     }
 }
+impl ADVISE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ADVISE_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -50978,6 +50983,11 @@ impl ::core::fmt::Debug for AMMSF_MMS_INIT_FLAGS {
         f.debug_tuple("AMMSF_MMS_INIT_FLAGS").field(&self.0).finish()
     }
 }
+impl AMMSF_MMS_INIT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AMMSF_MMS_INIT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -51035,6 +51045,11 @@ unsafe impl ::windows::core::Abi for AMMSF_MS_FLAGS {
 impl ::core::fmt::Debug for AMMSF_MS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AMMSF_MS_FLAGS").field(&self.0).finish()
+    }
+}
+impl AMMSF_MS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for AMMSF_MS_FLAGS {
@@ -51098,6 +51113,11 @@ unsafe impl ::windows::core::Abi for AMMSF_RENDER_FLAGS {
 impl ::core::fmt::Debug for AMMSF_RENDER_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AMMSF_RENDER_FLAGS").field(&self.0).finish()
+    }
+}
+impl AMMSF_RENDER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for AMMSF_RENDER_FLAGS {
@@ -54355,6 +54375,11 @@ unsafe impl ::windows::core::Abi for DDSFF_FLAGS {
 impl ::core::fmt::Debug for DDSFF_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DDSFF_FLAGS").field(&self.0).finish()
+    }
+}
+impl DDSFF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DDSFF_FLAGS {
@@ -57967,6 +57992,11 @@ impl ::core::fmt::Debug for KSPROPERTY_IPSINK {
         f.debug_tuple("KSPROPERTY_IPSINK").field(&self.0).finish()
     }
 }
+impl KSPROPERTY_IPSINK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for KSPROPERTY_IPSINK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -58148,6 +58178,11 @@ unsafe impl ::windows::core::Abi for MMSSF_GET_INFORMATION_FLAGS {
 impl ::core::fmt::Debug for MMSSF_GET_INFORMATION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MMSSF_GET_INFORMATION_FLAGS").field(&self.0).finish()
+    }
+}
+impl MMSSF_GET_INFORMATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MMSSF_GET_INFORMATION_FLAGS {
@@ -58887,6 +58922,11 @@ impl ::core::fmt::Debug for OUTPUT_STATE {
         f.debug_tuple("OUTPUT_STATE").field(&self.0).finish()
     }
 }
+impl OUTPUT_STATE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for OUTPUT_STATE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -59238,6 +59278,11 @@ unsafe impl ::windows::core::Abi for REG_PINFLAG {
 impl ::core::fmt::Debug for REG_PINFLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("REG_PINFLAG").field(&self.0).finish()
+    }
+}
+impl REG_PINFLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for REG_PINFLAG {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -35120,6 +35120,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS {
         f.debug_tuple("D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_DECODE_CONFIGURATION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -35173,6 +35178,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS
 impl ::core::fmt::Debug for D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_DECODE_CONVERSION_SUPPORT_FLAGS {
@@ -35279,6 +35289,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS {
         f.debug_tuple("D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_DECODE_HISTOGRAM_COMPONENT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -35365,6 +35380,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_DECODE_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_DECODE_SUPPORT_FLAGS {
@@ -35515,6 +35535,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS {
         f.debug_tuple("D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -35619,6 +35644,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_
         f.debug_tuple("D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_DEBLOCKING_MODE_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_DEBLOCKING_MODE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_H264_SLICES_DEBLOCKING_MODE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -35715,6 +35745,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEV
 impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_HEVC_FLAGS {
@@ -35815,6 +35850,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264
         f.debug_tuple("D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_H264_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -35886,6 +35926,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC
         f.debug_tuple("D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_CODEC_CONFIGURATION_SUPPORT_HEVC_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -35949,6 +35994,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS {
         f.debug_tuple("D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_ENCODE_ERROR_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -36000,6 +36050,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_ENCODER_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_ENCODER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_FLAGS {
@@ -36148,6 +36203,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_HEAP_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_HEAP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_ENCODER_HEAP_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_ENCODER_HEAP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_HEAP_FLAGS {
@@ -36375,6 +36435,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_
         f.debug_tuple("D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_H264_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -36430,6 +36495,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_
         f.debug_tuple("D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_CODEC_DATA_HEVC_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -36483,6 +36553,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_PICTURE_CONTROL_FLAGS {
@@ -36606,6 +36681,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS {
         f.debug_tuple("D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_RATE_CONTROL_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -36702,6 +36782,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS {
         f.debug_tuple("D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_SEQUENCE_CONTROL_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -36779,6 +36864,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_ENCODER_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_SUPPORT_FLAGS {
@@ -36879,6 +36969,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_ENCODER_VALIDATION_FLAGS {
         f.debug_tuple("D3D12_VIDEO_ENCODER_VALIDATION_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_ENCODER_VALIDATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_ENCODER_VALIDATION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -36934,6 +37029,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLA
 impl ::core::fmt::Debug for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_EXTENSION_COMMAND_PARAMETER_FLAGS {
@@ -37191,6 +37291,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS
         f.debug_tuple("D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_MOTION_ESTIMATOR_SEARCH_BLOCK_SIZE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -37269,6 +37374,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISI
 impl ::core::fmt::Debug for D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_MOTION_ESTIMATOR_VECTOR_PRECISION_FLAGS {
@@ -37373,6 +37483,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS {
         f.debug_tuple("D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_PROCESS_AUTO_PROCESSING_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -37428,6 +37543,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_PROCESS_DEINTERLACE_FLAGS {
@@ -37495,6 +37615,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_PROCESS_FEATURE_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_PROCESS_FEATURE_FLAGS {
@@ -37605,6 +37730,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_PROCESS_FILTER_FLAGS {
         f.debug_tuple("D3D12_VIDEO_PROCESS_FILTER_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_PROCESS_FILTER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_PROCESS_FILTER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -37660,6 +37790,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_PROCESS_INPUT_STREAM_FLAGS {
@@ -37756,6 +37891,11 @@ impl ::core::fmt::Debug for D3D12_VIDEO_PROCESS_SUPPORT_FLAGS {
         f.debug_tuple("D3D12_VIDEO_PROCESS_SUPPORT_FLAGS").field(&self.0).finish()
     }
 }
+impl D3D12_VIDEO_PROCESS_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for D3D12_VIDEO_PROCESS_SUPPORT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -37809,6 +37949,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAG
 impl ::core::fmt::Debug for D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_PROTECTED_RESOURCE_SUPPORT_FLAGS {
@@ -37866,6 +38011,11 @@ unsafe impl ::windows::core::Abi for D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
 impl ::core::fmt::Debug for D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("D3D12_VIDEO_SCALE_SUPPORT_FLAGS").field(&self.0).finish()
+    }
+}
+impl D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for D3D12_VIDEO_SCALE_SUPPORT_FLAGS {
@@ -41422,6 +41572,11 @@ impl ::core::fmt::Debug for MFT_ENUM_FLAG {
         f.debug_tuple("MFT_ENUM_FLAG").field(&self.0).finish()
     }
 }
+impl MFT_ENUM_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MFT_ENUM_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -44446,6 +44601,11 @@ impl ::core::fmt::Debug for MF_RESOLUTION_FLAGS {
         f.debug_tuple("MF_RESOLUTION_FLAGS").field(&self.0).finish()
     }
 }
+impl MF_RESOLUTION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MF_RESOLUTION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -45617,6 +45777,11 @@ impl ::core::fmt::Debug for MPEG2VIDEOINFO_FLAGS {
         f.debug_tuple("MPEG2VIDEOINFO_FLAGS").field(&self.0).finish()
     }
 }
+impl MPEG2VIDEOINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MPEG2VIDEOINFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -45902,6 +46067,11 @@ unsafe impl ::windows::core::Abi for OPM_HDCP_FLAGS {
 impl ::core::fmt::Debug for OPM_HDCP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OPM_HDCP_FLAGS").field(&self.0).finish()
+    }
+}
+impl OPM_HDCP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for OPM_HDCP_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/mod.rs
@@ -465,6 +465,11 @@ impl ::core::fmt::Debug for TIMECODE_SAMPLE_FLAGS {
         f.debug_tuple("TIMECODE_SAMPLE_FLAGS").field(&self.0).finish()
     }
 }
+impl TIMECODE_SAMPLE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TIMECODE_SAMPLE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
@@ -1294,6 +1294,11 @@ impl ::core::fmt::Debug for DNS_QUERY_OPTIONS {
         f.debug_tuple("DNS_QUERY_OPTIONS").field(&self.0).finish()
     }
 }
+impl DNS_QUERY_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DNS_QUERY_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/IpHelper/mod.rs
@@ -2370,6 +2370,11 @@ impl ::core::fmt::Debug for GET_ADAPTERS_ADDRESSES_FLAGS {
         f.debug_tuple("GET_ADAPTERS_ADDRESSES_FLAGS").field(&self.0).finish()
     }
 }
+impl GET_ADAPTERS_ADDRESSES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GET_ADAPTERS_ADDRESSES_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
@@ -7256,6 +7256,11 @@ impl ::core::fmt::Debug for AF_OP {
         f.debug_tuple("AF_OP").field(&self.0).finish()
     }
 }
+impl AF_OP {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AF_OP {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7705,6 +7710,11 @@ impl ::core::fmt::Debug for NETSETUP_PROVISION {
         f.debug_tuple("NETSETUP_PROVISION").field(&self.0).finish()
     }
 }
+impl NETSETUP_PROVISION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NETSETUP_PROVISION {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7883,6 +7893,11 @@ impl ::core::fmt::Debug for NET_JOIN_DOMAIN_JOIN_OPTIONS {
         f.debug_tuple("NET_JOIN_DOMAIN_JOIN_OPTIONS").field(&self.0).finish()
     }
 }
+impl NET_JOIN_DOMAIN_JOIN_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NET_JOIN_DOMAIN_JOIN_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7967,6 +7982,11 @@ unsafe impl ::windows::core::Abi for NET_REQUEST_PROVISION_OPTIONS {
 impl ::core::fmt::Debug for NET_REQUEST_PROVISION_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NET_REQUEST_PROVISION_OPTIONS").field(&self.0).finish()
+    }
+}
+impl NET_REQUEST_PROVISION_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NET_REQUEST_PROVISION_OPTIONS {
@@ -8086,6 +8106,11 @@ impl ::core::fmt::Debug for NET_SERVER_TYPE {
         f.debug_tuple("NET_SERVER_TYPE").field(&self.0).finish()
     }
 }
+impl NET_SERVER_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NET_SERVER_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8145,6 +8170,11 @@ unsafe impl ::windows::core::Abi for NET_USER_ENUM_FILTER_FLAGS {
 impl ::core::fmt::Debug for NET_USER_ENUM_FILTER_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NET_USER_ENUM_FILTER_FLAGS").field(&self.0).finish()
+    }
+}
+impl NET_USER_ENUM_FILTER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NET_USER_ENUM_FILTER_FLAGS {
@@ -8449,6 +8479,11 @@ unsafe impl ::windows::core::Abi for USER_ACCOUNT_FLAGS {
 impl ::core::fmt::Debug for USER_ACCOUNT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("USER_ACCOUNT_FLAGS").field(&self.0).finish()
+    }
+}
+impl USER_ACCOUNT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for USER_ACCOUNT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
@@ -4339,6 +4339,11 @@ impl ::core::fmt::Debug for RASIKEV_PROJECTION_INFO_FLAGS {
         f.debug_tuple("RASIKEV_PROJECTION_INFO_FLAGS").field(&self.0).finish()
     }
 }
+impl RASIKEV_PROJECTION_INFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RASIKEV_PROJECTION_INFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WNet/mod.rs
@@ -779,6 +779,11 @@ impl ::core::fmt::Debug for CONNECTDLGSTRUCT_FLAGS {
         f.debug_tuple("CONNECTDLGSTRUCT_FLAGS").field(&self.0).finish()
     }
 }
+impl CONNECTDLGSTRUCT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CONNECTDLGSTRUCT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -832,6 +837,11 @@ unsafe impl ::windows::core::Abi for DISCDLGSTRUCT_FLAGS {
 impl ::core::fmt::Debug for DISCDLGSTRUCT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DISCDLGSTRUCT_FLAGS").field(&self.0).finish()
+    }
+}
+impl DISCDLGSTRUCT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DISCDLGSTRUCT_FLAGS {
@@ -889,6 +899,11 @@ unsafe impl ::windows::core::Abi for NETINFOSTRUCT_CHARACTERISTICS {
 impl ::core::fmt::Debug for NETINFOSTRUCT_CHARACTERISTICS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NETINFOSTRUCT_CHARACTERISTICS").field(&self.0).finish()
+    }
+}
+impl NETINFOSTRUCT_CHARACTERISTICS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NETINFOSTRUCT_CHARACTERISTICS {
@@ -1006,6 +1021,11 @@ impl ::core::fmt::Debug for NET_RESOURCE_TYPE {
         f.debug_tuple("NET_RESOURCE_TYPE").field(&self.0).finish()
     }
 }
+impl NET_RESOURCE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NET_RESOURCE_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1073,6 +1093,11 @@ unsafe impl ::windows::core::Abi for NET_USE_CONNECT_FLAGS {
 impl ::core::fmt::Debug for NET_USE_CONNECT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NET_USE_CONNECT_FLAGS").field(&self.0).finish()
+    }
+}
+impl NET_USE_CONNECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NET_USE_CONNECT_FLAGS {
@@ -1219,6 +1244,11 @@ unsafe impl ::windows::core::Abi for WNET_OPEN_ENUM_USAGE {
 impl ::core::fmt::Debug for WNET_OPEN_ENUM_USAGE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WNET_OPEN_ENUM_USAGE").field(&self.0).finish()
+    }
+}
+impl WNET_OPEN_ENUM_USAGE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WNET_OPEN_ENUM_USAGE {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
@@ -3274,6 +3274,11 @@ impl ::core::fmt::Debug for FWPM_FILTER_FLAGS {
         f.debug_tuple("FWPM_FILTER_FLAGS").field(&self.0).finish()
     }
 }
+impl FWPM_FILTER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FWPM_FILTER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3984,6 +3989,11 @@ impl ::core::fmt::Debug for IKEEXT_CERT_AUTH {
         f.debug_tuple("IKEEXT_CERT_AUTH").field(&self.0).finish()
     }
 }
+impl IKEEXT_CERT_AUTH {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IKEEXT_CERT_AUTH {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4125,6 +4135,11 @@ impl ::core::fmt::Debug for IKEEXT_CERT_FLAGS {
         f.debug_tuple("IKEEXT_CERT_FLAGS").field(&self.0).finish()
     }
 }
+impl IKEEXT_CERT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IKEEXT_CERT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4260,6 +4275,11 @@ impl ::core::fmt::Debug for IKEEXT_EAP_AUTHENTICATION_FLAGS {
         f.debug_tuple("IKEEXT_EAP_AUTHENTICATION_FLAGS").field(&self.0).finish()
     }
 }
+impl IKEEXT_EAP_AUTHENTICATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IKEEXT_EAP_AUTHENTICATION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4383,6 +4403,11 @@ unsafe impl ::windows::core::Abi for IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
 impl ::core::fmt::Debug for IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IKEEXT_KERBEROS_AUTHENTICATION_FLAGS").field(&self.0).finish()
+    }
+}
+impl IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IKEEXT_KERBEROS_AUTHENTICATION_FLAGS {
@@ -4512,6 +4537,11 @@ impl ::core::fmt::Debug for IKEEXT_POLICY_FLAG {
         f.debug_tuple("IKEEXT_POLICY_FLAG").field(&self.0).finish()
     }
 }
+impl IKEEXT_POLICY_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IKEEXT_POLICY_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4565,6 +4595,11 @@ unsafe impl ::windows::core::Abi for IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
 impl ::core::fmt::Debug for IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS").field(&self.0).finish()
+    }
+}
+impl IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IKEEXT_PRESHARED_KEY_AUTHENTICATION_FLAGS {
@@ -4651,6 +4686,11 @@ unsafe impl ::windows::core::Abi for IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
 impl ::core::fmt::Debug for IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IKEEXT_RESERVED_AUTHENTICATION_FLAGS").field(&self.0).finish()
+    }
+}
+impl IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IKEEXT_RESERVED_AUTHENTICATION_FLAGS {
@@ -4817,6 +4857,11 @@ impl ::core::fmt::Debug for IPSEC_DOSP_FLAGS {
         f.debug_tuple("IPSEC_DOSP_FLAGS").field(&self.0).finish()
     }
 }
+impl IPSEC_DOSP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IPSEC_DOSP_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4968,6 +5013,11 @@ impl ::core::fmt::Debug for IPSEC_POLICY_FLAG {
         f.debug_tuple("IPSEC_POLICY_FLAG").field(&self.0).finish()
     }
 }
+impl IPSEC_POLICY_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IPSEC_POLICY_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5037,6 +5087,11 @@ unsafe impl ::windows::core::Abi for IPSEC_SA_BUNDLE_FLAGS {
 impl ::core::fmt::Debug for IPSEC_SA_BUNDLE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IPSEC_SA_BUNDLE_FLAGS").field(&self.0).finish()
+    }
+}
+impl IPSEC_SA_BUNDLE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IPSEC_SA_BUNDLE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFirewall/mod.rs
@@ -4311,6 +4311,11 @@ impl ::core::fmt::Debug for FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS {
         f.debug_tuple("FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS").field(&self.0).finish()
     }
 }
+impl FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FW_DYNAMIC_KEYWORD_ADDRESS_ENUM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4362,6 +4367,11 @@ unsafe impl ::windows::core::Abi for FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {
 impl ::core::fmt::Debug for FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS").field(&self.0).finish()
+    }
+}
+impl FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FW_DYNAMIC_KEYWORD_ADDRESS_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/HttpServer/mod.rs
@@ -1003,6 +1003,11 @@ impl ::core::fmt::Debug for HTTP_INITIALIZE {
         f.debug_tuple("HTTP_INITIALIZE").field(&self.0).finish()
     }
 }
+impl HTTP_INITIALIZE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HTTP_INITIALIZE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
@@ -1451,6 +1451,11 @@ impl ::core::fmt::Debug for WINHTTP_OPEN_REQUEST_FLAGS {
         f.debug_tuple("WINHTTP_OPEN_REQUEST_FLAGS").field(&self.0).finish()
     }
 }
+impl WINHTTP_OPEN_REQUEST_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WINHTTP_OPEN_REQUEST_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -5039,6 +5039,11 @@ impl ::core::fmt::Debug for HTTP_ADDREQ_FLAG {
         f.debug_tuple("HTTP_ADDREQ_FLAG").field(&self.0).finish()
     }
 }
+impl HTTP_ADDREQ_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HTTP_ADDREQ_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5360,6 +5365,11 @@ impl ::core::fmt::Debug for INTERNET_CONNECTION {
         f.debug_tuple("INTERNET_CONNECTION").field(&self.0).finish()
     }
 }
+impl INTERNET_CONNECTION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for INTERNET_CONNECTION {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5608,6 +5618,11 @@ unsafe impl ::windows::core::Abi for PROXY_AUTO_DETECT_TYPE {
 impl ::core::fmt::Debug for PROXY_AUTO_DETECT_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROXY_AUTO_DETECT_TYPE").field(&self.0).finish()
+    }
+}
+impl PROXY_AUTO_DETECT_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROXY_AUTO_DETECT_TYPE {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -5628,6 +5628,11 @@ impl ::core::fmt::Debug for SEND_RECV_FLAGS {
         f.debug_tuple("SEND_RECV_FLAGS").field(&self.0).finish()
     }
 }
+impl SEND_RECV_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SEND_RECV_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/AppLocker/mod.rs
@@ -202,6 +202,11 @@ impl ::core::fmt::Debug for SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS {
         f.debug_tuple("SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS").field(&self.0).finish()
     }
 }
+impl SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SAFER_COMPUTE_TOKEN_FROM_LEVEL_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
@@ -1213,6 +1213,11 @@ impl ::core::fmt::Debug for IdentityUpdateEvent {
         f.debug_tuple("IdentityUpdateEvent").field(&self.0).finish()
     }
 }
+impl IdentityUpdateEvent {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IdentityUpdateEvent {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -4694,6 +4694,11 @@ impl ::core::fmt::Debug for ASC_REQ_FLAGS {
         f.debug_tuple("ASC_REQ_FLAGS").field(&self.0).finish()
     }
 }
+impl ASC_REQ_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ASC_REQ_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4745,6 +4750,11 @@ unsafe impl ::windows::core::Abi for ASC_REQ_HIGH_FLAGS {
 impl ::core::fmt::Debug for ASC_REQ_HIGH_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ASC_REQ_HIGH_FLAGS").field(&self.0).finish()
+    }
+}
+impl ASC_REQ_HIGH_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for ASC_REQ_HIGH_FLAGS {
@@ -4839,6 +4849,11 @@ impl ::core::fmt::Debug for DOMAIN_PASSWORD_PROPERTIES {
         f.debug_tuple("DOMAIN_PASSWORD_PROPERTIES").field(&self.0).finish()
     }
 }
+impl DOMAIN_PASSWORD_PROPERTIES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DOMAIN_PASSWORD_PROPERTIES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4894,6 +4909,11 @@ unsafe impl ::windows::core::Abi for EXPORT_SECURITY_CONTEXT_FLAGS {
 impl ::core::fmt::Debug for EXPORT_SECURITY_CONTEXT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EXPORT_SECURITY_CONTEXT_FLAGS").field(&self.0).finish()
+    }
+}
+impl EXPORT_SECURITY_CONTEXT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for EXPORT_SECURITY_CONTEXT_FLAGS {
@@ -5048,6 +5068,11 @@ impl ::core::fmt::Debug for ISC_REQ_FLAGS {
         f.debug_tuple("ISC_REQ_FLAGS").field(&self.0).finish()
     }
 }
+impl ISC_REQ_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ISC_REQ_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5101,6 +5126,11 @@ unsafe impl ::windows::core::Abi for ISC_REQ_HIGH_FLAGS {
 impl ::core::fmt::Debug for ISC_REQ_HIGH_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ISC_REQ_HIGH_FLAGS").field(&self.0).finish()
+    }
+}
+impl ISC_REQ_HIGH_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for ISC_REQ_HIGH_FLAGS {
@@ -5471,6 +5501,11 @@ unsafe impl ::windows::core::Abi for KERB_TICKET_FLAGS {
 impl ::core::fmt::Debug for KERB_TICKET_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KERB_TICKET_FLAGS").field(&self.0).finish()
+    }
+}
+impl KERB_TICKET_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for KERB_TICKET_FLAGS {
@@ -5968,6 +6003,11 @@ impl ::core::fmt::Debug for MSV_SUBAUTH_LOGON_PARAMETER_CONTROL {
         f.debug_tuple("MSV_SUBAUTH_LOGON_PARAMETER_CONTROL").field(&self.0).finish()
     }
 }
+impl MSV_SUBAUTH_LOGON_PARAMETER_CONTROL {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MSV_SUBAUTH_LOGON_PARAMETER_CONTROL {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6064,6 +6104,11 @@ unsafe impl ::windows::core::Abi for MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
 impl ::core::fmt::Debug for MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS").field(&self.0).finish()
+    }
+}
+impl MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MSV_SUPPLEMENTAL_CREDENTIAL_FLAGS {
@@ -6489,6 +6534,11 @@ unsafe impl ::windows::core::Abi for SCHANNEL_CRED_FLAGS {
 impl ::core::fmt::Debug for SCHANNEL_CRED_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SCHANNEL_CRED_FLAGS").field(&self.0).finish()
+    }
+}
+impl SCHANNEL_CRED_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SCHANNEL_CRED_FLAGS {
@@ -7373,6 +7423,11 @@ unsafe impl ::windows::core::Abi for SchGetExtensionsOptions {
 impl ::core::fmt::Debug for SchGetExtensionsOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SchGetExtensionsOptions").field(&self.0).finish()
+    }
+}
+impl SchGetExtensionsOptions {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SchGetExtensionsOptions {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
@@ -525,6 +525,11 @@ impl ::core::fmt::Debug for SECURITY_INFO_PAGE_FLAGS {
         f.debug_tuple("SECURITY_INFO_PAGE_FLAGS").field(&self.0).finish()
     }
 }
+impl SECURITY_INFO_PAGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SECURITY_INFO_PAGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -602,6 +607,11 @@ unsafe impl ::windows::core::Abi for SI_OBJECT_INFO_FLAGS {
 impl ::core::fmt::Debug for SI_OBJECT_INFO_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SI_OBJECT_INFO_FLAGS").field(&self.0).finish()
+    }
+}
+impl SI_OBJECT_INFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SI_OBJECT_INFO_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/mod.rs
@@ -8269,6 +8269,11 @@ impl ::core::fmt::Debug for AUTHZ_RESOURCE_MANAGER_FLAGS {
         f.debug_tuple("AUTHZ_RESOURCE_MANAGER_FLAGS").field(&self.0).finish()
     }
 }
+impl AUTHZ_RESOURCE_MANAGER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for AUTHZ_RESOURCE_MANAGER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8322,6 +8327,11 @@ unsafe impl ::windows::core::Abi for AUTHZ_SECURITY_ATTRIBUTE_FLAGS {
 impl ::core::fmt::Debug for AUTHZ_SECURITY_ATTRIBUTE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AUTHZ_SECURITY_ATTRIBUTE_FLAGS").field(&self.0).finish()
+    }
+}
+impl AUTHZ_SECURITY_ATTRIBUTE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for AUTHZ_SECURITY_ATTRIBUTE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
@@ -1490,6 +1490,11 @@ impl ::core::fmt::Debug for CREDUIWIN_FLAGS {
         f.debug_tuple("CREDUIWIN_FLAGS").field(&self.0).finish()
     }
 }
+impl CREDUIWIN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CREDUIWIN_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1575,6 +1580,11 @@ impl ::core::fmt::Debug for CREDUI_FLAGS {
         f.debug_tuple("CREDUI_FLAGS").field(&self.0).finish()
     }
 }
+impl CREDUI_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CREDUI_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1626,6 +1636,11 @@ unsafe impl ::windows::core::Abi for CRED_ENUMERATE_FLAGS {
 impl ::core::fmt::Debug for CRED_ENUMERATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRED_ENUMERATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRED_ENUMERATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRED_ENUMERATE_FLAGS {
@@ -1697,6 +1712,11 @@ unsafe impl ::windows::core::Abi for CRED_FLAGS {
 impl ::core::fmt::Debug for CRED_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRED_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRED_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRED_FLAGS {
@@ -1789,6 +1809,11 @@ unsafe impl ::windows::core::Abi for CRED_PACK_FLAGS {
 impl ::core::fmt::Debug for CRED_PACK_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRED_PACK_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRED_PACK_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRED_PACK_FLAGS {
@@ -1957,6 +1982,11 @@ unsafe impl ::windows::core::Abi for KeyCredentialManagerOperationErrorStates {
 impl ::core::fmt::Debug for KeyCredentialManagerOperationErrorStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyCredentialManagerOperationErrorStates").field(&self.0).finish()
+    }
+}
+impl KeyCredentialManagerOperationErrorStates {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for KeyCredentialManagerOperationErrorStates {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Catalog/mod.rs
@@ -413,6 +413,11 @@ impl ::core::fmt::Debug for CRYPTCAT_OPEN_FLAGS {
         f.debug_tuple("CRYPTCAT_OPEN_FLAGS").field(&self.0).finish()
     }
 }
+impl CRYPTCAT_OPEN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CRYPTCAT_OPEN_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
@@ -22676,6 +22676,11 @@ impl ::core::fmt::Debug for CERTADMIN_GET_ROLES_FLAGS {
         f.debug_tuple("CERTADMIN_GET_ROLES_FLAGS").field(&self.0).finish()
     }
 }
+impl CERTADMIN_GET_ROLES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CERTADMIN_GET_ROLES_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -23956,6 +23961,11 @@ unsafe impl ::windows::core::Abi for CERT_EXIT_EVENT_MASK {
 impl ::core::fmt::Debug for CERT_EXIT_EVENT_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CERT_EXIT_EVENT_MASK").field(&self.0).finish()
+    }
+}
+impl CERT_EXIT_EVENT_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CERT_EXIT_EVENT_MASK {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/UI/mod.rs
@@ -284,6 +284,11 @@ impl ::core::fmt::Debug for CERT_SELECT_STRUCT_FLAGS {
         f.debug_tuple("CERT_SELECT_STRUCT_FLAGS").field(&self.0).finish()
     }
 }
+impl CERT_SELECT_STRUCT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CERT_SELECT_STRUCT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -353,6 +358,11 @@ unsafe impl ::windows::core::Abi for CERT_VIEWPROPERTIES_STRUCT_FLAGS {
 impl ::core::fmt::Debug for CERT_VIEWPROPERTIES_STRUCT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CERT_VIEWPROPERTIES_STRUCT_FLAGS").field(&self.0).finish()
+    }
+}
+impl CERT_VIEWPROPERTIES_STRUCT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CERT_VIEWPROPERTIES_STRUCT_FLAGS {
@@ -444,6 +454,11 @@ unsafe impl ::windows::core::Abi for CRYPTUI_VIEWCERTIFICATE_FLAGS {
 impl ::core::fmt::Debug for CRYPTUI_VIEWCERTIFICATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRYPTUI_VIEWCERTIFICATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRYPTUI_VIEWCERTIFICATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRYPTUI_VIEWCERTIFICATE_FLAGS {
@@ -730,6 +745,11 @@ unsafe impl ::windows::core::Abi for CRYPTUI_WIZ_FLAGS {
 impl ::core::fmt::Debug for CRYPTUI_WIZ_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRYPTUI_WIZ_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRYPTUI_WIZ_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRYPTUI_WIZ_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -10078,6 +10078,11 @@ impl ::core::fmt::Debug for BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS {
         f.debug_tuple("BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS").field(&self.0).finish()
     }
 }
+impl BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for BCRYPT_OPEN_ALGORITHM_PROVIDER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10139,6 +10144,11 @@ unsafe impl ::windows::core::Abi for BCRYPT_OPERATION {
 impl ::core::fmt::Debug for BCRYPT_OPERATION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BCRYPT_OPERATION").field(&self.0).finish()
+    }
+}
+impl BCRYPT_OPERATION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for BCRYPT_OPERATION {
@@ -10225,6 +10235,11 @@ unsafe impl ::windows::core::Abi for BCRYPT_RESOLVE_PROVIDERS_FLAGS {
 impl ::core::fmt::Debug for BCRYPT_RESOLVE_PROVIDERS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BCRYPT_RESOLVE_PROVIDERS_FLAGS").field(&self.0).finish()
+    }
+}
+impl BCRYPT_RESOLVE_PROVIDERS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for BCRYPT_RESOLVE_PROVIDERS_FLAGS {
@@ -10543,6 +10558,11 @@ impl ::core::fmt::Debug for CERT_CREATE_SELFSIGN_FLAGS {
         f.debug_tuple("CERT_CREATE_SELFSIGN_FLAGS").field(&self.0).finish()
     }
 }
+impl CERT_CREATE_SELFSIGN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CERT_CREATE_SELFSIGN_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10604,6 +10624,11 @@ unsafe impl ::windows::core::Abi for CERT_FIND_CHAIN_IN_STORE_FLAGS {
 impl ::core::fmt::Debug for CERT_FIND_CHAIN_IN_STORE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CERT_FIND_CHAIN_IN_STORE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CERT_FIND_CHAIN_IN_STORE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CERT_FIND_CHAIN_IN_STORE_FLAGS {
@@ -10739,6 +10764,11 @@ unsafe impl ::windows::core::Abi for CERT_FIND_FLAGS {
 impl ::core::fmt::Debug for CERT_FIND_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CERT_FIND_FLAGS").field(&self.0).finish()
+    }
+}
+impl CERT_FIND_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CERT_FIND_FLAGS {
@@ -11127,6 +11157,11 @@ impl ::core::fmt::Debug for CERT_QUERY_ENCODING_TYPE {
         f.debug_tuple("CERT_QUERY_ENCODING_TYPE").field(&self.0).finish()
     }
 }
+impl CERT_QUERY_ENCODING_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CERT_QUERY_ENCODING_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11369,6 +11404,11 @@ impl ::core::fmt::Debug for CERT_ROOT_PROGRAM_FLAGS {
         f.debug_tuple("CERT_ROOT_PROGRAM_FLAGS").field(&self.0).finish()
     }
 }
+impl CERT_ROOT_PROGRAM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CERT_ROOT_PROGRAM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11473,6 +11513,11 @@ unsafe impl ::windows::core::Abi for CERT_STORE_PROV_FLAGS {
 impl ::core::fmt::Debug for CERT_STORE_PROV_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CERT_STORE_PROV_FLAGS").field(&self.0).finish()
+    }
+}
+impl CERT_STORE_PROV_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CERT_STORE_PROV_FLAGS {
@@ -11617,6 +11662,11 @@ unsafe impl ::windows::core::Abi for CERT_STRONG_SIGN_FLAGS {
 impl ::core::fmt::Debug for CERT_STRONG_SIGN_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CERT_STRONG_SIGN_FLAGS").field(&self.0).finish()
+    }
+}
+impl CERT_STRONG_SIGN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CERT_STRONG_SIGN_FLAGS {
@@ -11798,6 +11848,11 @@ impl ::core::fmt::Debug for CRYPT_ACQUIRE_FLAGS {
         f.debug_tuple("CRYPT_ACQUIRE_FLAGS").field(&self.0).finish()
     }
 }
+impl CRYPT_ACQUIRE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CRYPT_ACQUIRE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11853,6 +11908,11 @@ impl ::core::fmt::Debug for CRYPT_CONTEXT_CONFIG_FLAGS {
         f.debug_tuple("CRYPT_CONTEXT_CONFIG_FLAGS").field(&self.0).finish()
     }
 }
+impl CRYPT_CONTEXT_CONFIG_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CRYPT_CONTEXT_CONFIG_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11906,6 +11966,11 @@ unsafe impl ::windows::core::Abi for CRYPT_DEFAULT_CONTEXT_FLAGS {
 impl ::core::fmt::Debug for CRYPT_DEFAULT_CONTEXT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRYPT_DEFAULT_CONTEXT_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRYPT_DEFAULT_CONTEXT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRYPT_DEFAULT_CONTEXT_FLAGS {
@@ -11996,6 +12061,11 @@ impl ::core::fmt::Debug for CRYPT_ENCODE_OBJECT_FLAGS {
         f.debug_tuple("CRYPT_ENCODE_OBJECT_FLAGS").field(&self.0).finish()
     }
 }
+impl CRYPT_ENCODE_OBJECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CRYPT_ENCODE_OBJECT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12084,6 +12154,11 @@ impl ::core::fmt::Debug for CRYPT_GET_URL_FLAGS {
         f.debug_tuple("CRYPT_GET_URL_FLAGS").field(&self.0).finish()
     }
 }
+impl CRYPT_GET_URL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CRYPT_GET_URL_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12139,6 +12214,11 @@ impl ::core::fmt::Debug for CRYPT_IMAGE_REF_FLAGS {
         f.debug_tuple("CRYPT_IMAGE_REF_FLAGS").field(&self.0).finish()
     }
 }
+impl CRYPT_IMAGE_REF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CRYPT_IMAGE_REF_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12192,6 +12272,11 @@ unsafe impl ::windows::core::Abi for CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
 impl ::core::fmt::Debug for CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRYPT_IMPORT_PUBLIC_KEY_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRYPT_IMPORT_PUBLIC_KEY_FLAGS {
@@ -12305,6 +12390,11 @@ unsafe impl ::windows::core::Abi for CRYPT_KEY_FLAGS {
 impl ::core::fmt::Debug for CRYPT_KEY_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CRYPT_KEY_FLAGS").field(&self.0).finish()
+    }
+}
+impl CRYPT_KEY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CRYPT_KEY_FLAGS {
@@ -12974,6 +13064,11 @@ impl ::core::fmt::Debug for CRYPT_XML_TRANSFORM_FLAGS {
         f.debug_tuple("CRYPT_XML_TRANSFORM_FLAGS").field(&self.0).finish()
     }
 }
+impl CRYPT_XML_TRANSFORM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CRYPT_XML_TRANSFORM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13410,6 +13505,11 @@ impl ::core::fmt::Debug for NCRYPT_FLAGS {
         f.debug_tuple("NCRYPT_FLAGS").field(&self.0).finish()
     }
 }
+impl NCRYPT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NCRYPT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13469,6 +13569,11 @@ unsafe impl ::windows::core::Abi for NCRYPT_OPERATION {
 impl ::core::fmt::Debug for NCRYPT_OPERATION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NCRYPT_OPERATION").field(&self.0).finish()
+    }
+}
+impl NCRYPT_OPERATION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NCRYPT_OPERATION {

--- a/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/EnterpriseData/mod.rs
@@ -438,6 +438,11 @@ impl ::core::fmt::Debug for ENTERPRISE_DATA_POLICIES {
         f.debug_tuple("ENTERPRISE_DATA_POLICIES").field(&self.0).finish()
     }
 }
+impl ENTERPRISE_DATA_POLICIES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ENTERPRISE_DATA_POLICIES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/WinTrust/mod.rs
@@ -519,6 +519,11 @@ impl ::core::fmt::Debug for WINTRUST_DATA_PROVIDER_FLAGS {
         f.debug_tuple("WINTRUST_DATA_PROVIDER_FLAGS").field(&self.0).finish()
     }
 }
+impl WINTRUST_DATA_PROVIDER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WINTRUST_DATA_PROVIDER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -768,6 +773,11 @@ unsafe impl ::windows::core::Abi for WINTRUST_POLICY_FLAGS {
 impl ::core::fmt::Debug for WINTRUST_POLICY_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WINTRUST_POLICY_FLAGS").field(&self.0).finish()
+    }
+}
+impl WINTRUST_POLICY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WINTRUST_POLICY_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Security/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/mod.rs
@@ -1598,6 +1598,11 @@ impl ::core::fmt::Debug for ACE_FLAGS {
         f.debug_tuple("ACE_FLAGS").field(&self.0).finish()
     }
 }
+impl ACE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ACE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1742,6 +1747,11 @@ impl ::core::fmt::Debug for CLAIM_SECURITY_ATTRIBUTE_FLAGS {
         f.debug_tuple("CLAIM_SECURITY_ATTRIBUTE_FLAGS").field(&self.0).finish()
     }
 }
+impl CLAIM_SECURITY_ATTRIBUTE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CLAIM_SECURITY_ATTRIBUTE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1836,6 +1846,11 @@ unsafe impl ::windows::core::Abi for CREATE_RESTRICTED_TOKEN_FLAGS {
 impl ::core::fmt::Debug for CREATE_RESTRICTED_TOKEN_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CREATE_RESTRICTED_TOKEN_FLAGS").field(&self.0).finish()
+    }
+}
+impl CREATE_RESTRICTED_TOKEN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CREATE_RESTRICTED_TOKEN_FLAGS {
@@ -2055,6 +2070,11 @@ impl ::core::fmt::Debug for OBJECT_SECURITY_INFORMATION {
         f.debug_tuple("OBJECT_SECURITY_INFORMATION").field(&self.0).finish()
     }
 }
+impl OBJECT_SECURITY_INFORMATION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for OBJECT_SECURITY_INFORMATION {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2126,6 +2146,11 @@ unsafe impl ::windows::core::Abi for SECURITY_AUTO_INHERIT_FLAGS {
 impl ::core::fmt::Debug for SECURITY_AUTO_INHERIT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SECURITY_AUTO_INHERIT_FLAGS").field(&self.0).finish()
+    }
+}
+impl SECURITY_AUTO_INHERIT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SECURITY_AUTO_INHERIT_FLAGS {
@@ -2205,6 +2230,11 @@ unsafe impl ::windows::core::Abi for SECURITY_DESCRIPTOR_CONTROL {
 impl ::core::fmt::Debug for SECURITY_DESCRIPTOR_CONTROL {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SECURITY_DESCRIPTOR_CONTROL").field(&self.0).finish()
+    }
+}
+impl SECURITY_DESCRIPTOR_CONTROL {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SECURITY_DESCRIPTOR_CONTROL {
@@ -2338,6 +2368,11 @@ impl ::core::fmt::Debug for SYSTEM_AUDIT_OBJECT_ACE_FLAGS {
         f.debug_tuple("SYSTEM_AUDIT_OBJECT_ACE_FLAGS").field(&self.0).finish()
     }
 }
+impl SYSTEM_AUDIT_OBJECT_ACE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SYSTEM_AUDIT_OBJECT_ACE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2429,6 +2464,11 @@ unsafe impl ::windows::core::Abi for TOKEN_ACCESS_MASK {
 impl ::core::fmt::Debug for TOKEN_ACCESS_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TOKEN_ACCESS_MASK").field(&self.0).finish()
+    }
+}
+impl TOKEN_ACCESS_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TOKEN_ACCESS_MASK {
@@ -2667,6 +2707,11 @@ unsafe impl ::windows::core::Abi for TOKEN_PRIVILEGES_ATTRIBUTES {
 impl ::core::fmt::Debug for TOKEN_PRIVILEGES_ATTRIBUTES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TOKEN_PRIVILEGES_ATTRIBUTES").field(&self.0).finish()
+    }
+}
+impl TOKEN_PRIVILEGES_ATTRIBUTES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TOKEN_PRIVILEGES_ATTRIBUTES {

--- a/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/CloudFilters/mod.rs
@@ -379,6 +379,11 @@ impl ::core::fmt::Debug for CF_CALLBACK_CANCEL_FLAGS {
         f.debug_tuple("CF_CALLBACK_CANCEL_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_CALLBACK_CANCEL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_CALLBACK_CANCEL_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -432,6 +437,11 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
 impl ::core::fmt::Debug for CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CALLBACK_CLOSE_COMPLETION_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CALLBACK_CLOSE_COMPLETION_FLAGS {
@@ -491,6 +501,11 @@ impl ::core::fmt::Debug for CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS {
         f.debug_tuple("CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_CALLBACK_DEHYDRATE_COMPLETION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -544,6 +559,11 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_DEHYDRATE_FLAGS {
 impl ::core::fmt::Debug for CF_CALLBACK_DEHYDRATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CALLBACK_DEHYDRATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CALLBACK_DEHYDRATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CALLBACK_DEHYDRATE_FLAGS {
@@ -632,6 +652,11 @@ impl ::core::fmt::Debug for CF_CALLBACK_DELETE_COMPLETION_FLAGS {
         f.debug_tuple("CF_CALLBACK_DELETE_COMPLETION_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_CALLBACK_DELETE_COMPLETION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_CALLBACK_DELETE_COMPLETION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -687,6 +712,11 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_DELETE_FLAGS {
 impl ::core::fmt::Debug for CF_CALLBACK_DELETE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CALLBACK_DELETE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CALLBACK_DELETE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CALLBACK_DELETE_FLAGS {
@@ -746,6 +776,11 @@ impl ::core::fmt::Debug for CF_CALLBACK_FETCH_DATA_FLAGS {
         f.debug_tuple("CF_CALLBACK_FETCH_DATA_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_CALLBACK_FETCH_DATA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_CALLBACK_FETCH_DATA_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -797,6 +832,11 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
 impl ::core::fmt::Debug for CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CALLBACK_FETCH_PLACEHOLDERS_FLAGS {
@@ -856,6 +896,11 @@ impl ::core::fmt::Debug for CF_CALLBACK_OPEN_COMPLETION_FLAGS {
         f.debug_tuple("CF_CALLBACK_OPEN_COMPLETION_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_CALLBACK_OPEN_COMPLETION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_CALLBACK_OPEN_COMPLETION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -907,6 +952,11 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_RENAME_COMPLETION_FLAGS {
 impl ::core::fmt::Debug for CF_CALLBACK_RENAME_COMPLETION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CALLBACK_RENAME_COMPLETION_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CALLBACK_RENAME_COMPLETION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CALLBACK_RENAME_COMPLETION_FLAGS {
@@ -966,6 +1016,11 @@ unsafe impl ::windows::core::Abi for CF_CALLBACK_RENAME_FLAGS {
 impl ::core::fmt::Debug for CF_CALLBACK_RENAME_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CALLBACK_RENAME_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CALLBACK_RENAME_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CALLBACK_RENAME_FLAGS {
@@ -1074,6 +1129,11 @@ impl ::core::fmt::Debug for CF_CALLBACK_VALIDATE_DATA_FLAGS {
         f.debug_tuple("CF_CALLBACK_VALIDATE_DATA_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_CALLBACK_VALIDATE_DATA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_CALLBACK_VALIDATE_DATA_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1131,6 +1191,11 @@ unsafe impl ::windows::core::Abi for CF_CONNECT_FLAGS {
 impl ::core::fmt::Debug for CF_CONNECT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CONNECT_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CONNECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CONNECT_FLAGS {
@@ -1196,6 +1261,11 @@ impl ::core::fmt::Debug for CF_CONVERT_FLAGS {
         f.debug_tuple("CF_CONVERT_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_CONVERT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_CONVERT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1249,6 +1319,11 @@ unsafe impl ::windows::core::Abi for CF_CREATE_FLAGS {
 impl ::core::fmt::Debug for CF_CREATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_CREATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_CREATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_CREATE_FLAGS {
@@ -1306,6 +1381,11 @@ impl ::core::fmt::Debug for CF_DEHYDRATE_FLAGS {
         f.debug_tuple("CF_DEHYDRATE_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_DEHYDRATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_DEHYDRATE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1361,6 +1441,11 @@ impl ::core::fmt::Debug for CF_HARDLINK_POLICY {
         f.debug_tuple("CF_HARDLINK_POLICY").field(&self.0).finish()
     }
 }
+impl CF_HARDLINK_POLICY {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_HARDLINK_POLICY {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1412,6 +1497,11 @@ unsafe impl ::windows::core::Abi for CF_HYDRATE_FLAGS {
 impl ::core::fmt::Debug for CF_HYDRATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_HYDRATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_HYDRATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_HYDRATE_FLAGS {
@@ -1473,6 +1563,11 @@ unsafe impl ::windows::core::Abi for CF_HYDRATION_POLICY_MODIFIER {
 impl ::core::fmt::Debug for CF_HYDRATION_POLICY_MODIFIER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_HYDRATION_POLICY_MODIFIER").field(&self.0).finish()
+    }
+}
+impl CF_HYDRATION_POLICY_MODIFIER {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_HYDRATION_POLICY_MODIFIER {
@@ -1587,6 +1682,11 @@ impl ::core::fmt::Debug for CF_INSYNC_POLICY {
         f.debug_tuple("CF_INSYNC_POLICY").field(&self.0).finish()
     }
 }
+impl CF_INSYNC_POLICY {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_INSYNC_POLICY {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1675,6 +1775,11 @@ impl ::core::fmt::Debug for CF_OPEN_FILE_FLAGS {
         f.debug_tuple("CF_OPEN_FILE_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_OPEN_FILE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_OPEN_FILE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1726,6 +1831,11 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_ACK_DATA_FLAGS {
 impl ::core::fmt::Debug for CF_OPERATION_ACK_DATA_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_OPERATION_ACK_DATA_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_OPERATION_ACK_DATA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_OPERATION_ACK_DATA_FLAGS {
@@ -1781,6 +1891,11 @@ impl ::core::fmt::Debug for CF_OPERATION_ACK_DEHYDRATE_FLAGS {
         f.debug_tuple("CF_OPERATION_ACK_DEHYDRATE_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_OPERATION_ACK_DEHYDRATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_OPERATION_ACK_DEHYDRATE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1834,6 +1949,11 @@ impl ::core::fmt::Debug for CF_OPERATION_ACK_DELETE_FLAGS {
         f.debug_tuple("CF_OPERATION_ACK_DELETE_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_OPERATION_ACK_DELETE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_OPERATION_ACK_DELETE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1885,6 +2005,11 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_ACK_RENAME_FLAGS {
 impl ::core::fmt::Debug for CF_OPERATION_ACK_RENAME_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_OPERATION_ACK_RENAME_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_OPERATION_ACK_RENAME_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_OPERATION_ACK_RENAME_FLAGS {
@@ -1942,6 +2067,11 @@ impl ::core::fmt::Debug for CF_OPERATION_RESTART_HYDRATION_FLAGS {
         f.debug_tuple("CF_OPERATION_RESTART_HYDRATION_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_OPERATION_RESTART_HYDRATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_OPERATION_RESTART_HYDRATION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1995,6 +2125,11 @@ impl ::core::fmt::Debug for CF_OPERATION_RETRIEVE_DATA_FLAGS {
         f.debug_tuple("CF_OPERATION_RETRIEVE_DATA_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_OPERATION_RETRIEVE_DATA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_OPERATION_RETRIEVE_DATA_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2046,6 +2181,11 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_TRANSFER_DATA_FLAGS {
 impl ::core::fmt::Debug for CF_OPERATION_TRANSFER_DATA_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_OPERATION_TRANSFER_DATA_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_OPERATION_TRANSFER_DATA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_OPERATION_TRANSFER_DATA_FLAGS {
@@ -2103,6 +2243,11 @@ unsafe impl ::windows::core::Abi for CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
 impl ::core::fmt::Debug for CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_OPERATION_TRANSFER_PLACEHOLDERS_FLAGS {
@@ -2236,6 +2381,11 @@ unsafe impl ::windows::core::Abi for CF_PLACEHOLDER_CREATE_FLAGS {
 impl ::core::fmt::Debug for CF_PLACEHOLDER_CREATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_PLACEHOLDER_CREATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_PLACEHOLDER_CREATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_PLACEHOLDER_CREATE_FLAGS {
@@ -2392,6 +2542,11 @@ impl ::core::fmt::Debug for CF_PLACEHOLDER_STATE {
         f.debug_tuple("CF_PLACEHOLDER_STATE").field(&self.0).finish()
     }
 }
+impl CF_PLACEHOLDER_STATE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_PLACEHOLDER_STATE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2443,6 +2598,11 @@ unsafe impl ::windows::core::Abi for CF_POPULATION_POLICY_MODIFIER {
 impl ::core::fmt::Debug for CF_POPULATION_POLICY_MODIFIER {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_POPULATION_POLICY_MODIFIER").field(&self.0).finish()
+    }
+}
+impl CF_POPULATION_POLICY_MODIFIER {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_POPULATION_POLICY_MODIFIER {
@@ -2533,6 +2693,11 @@ impl ::core::fmt::Debug for CF_REGISTER_FLAGS {
         f.debug_tuple("CF_REGISTER_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_REGISTER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_REGISTER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2586,6 +2751,11 @@ impl ::core::fmt::Debug for CF_REVERT_FLAGS {
         f.debug_tuple("CF_REVERT_FLAGS").field(&self.0).finish()
     }
 }
+impl CF_REVERT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CF_REVERT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2637,6 +2807,11 @@ unsafe impl ::windows::core::Abi for CF_SET_IN_SYNC_FLAGS {
 impl ::core::fmt::Debug for CF_SET_IN_SYNC_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_SET_IN_SYNC_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_SET_IN_SYNC_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_SET_IN_SYNC_FLAGS {
@@ -2696,6 +2871,11 @@ unsafe impl ::windows::core::Abi for CF_SET_PIN_FLAGS {
 impl ::core::fmt::Debug for CF_SET_PIN_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_SET_PIN_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_SET_PIN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_SET_PIN_FLAGS {
@@ -2769,6 +2949,11 @@ unsafe impl ::windows::core::Abi for CF_SYNC_PROVIDER_STATUS {
 impl ::core::fmt::Debug for CF_SYNC_PROVIDER_STATUS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_SYNC_PROVIDER_STATUS").field(&self.0).finish()
+    }
+}
+impl CF_SYNC_PROVIDER_STATUS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_SYNC_PROVIDER_STATUS {
@@ -2873,6 +3058,11 @@ unsafe impl ::windows::core::Abi for CF_UPDATE_FLAGS {
 impl ::core::fmt::Debug for CF_UPDATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CF_UPDATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CF_UPDATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CF_UPDATE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -5036,6 +5036,11 @@ impl ::core::fmt::Debug for CLFS_FLAG {
         f.debug_tuple("CLFS_FLAG").field(&self.0).finish()
     }
 }
+impl CLFS_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CLFS_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5495,6 +5500,11 @@ impl ::core::fmt::Debug for DEFINE_DOS_DEVICE_FLAGS {
         f.debug_tuple("DEFINE_DOS_DEVICE_FLAGS").field(&self.0).finish()
     }
 }
+impl DEFINE_DOS_DEVICE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DEFINE_DOS_DEVICE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5658,6 +5668,11 @@ unsafe impl ::windows::core::Abi for FILE_ACCESS_FLAGS {
 impl ::core::fmt::Debug for FILE_ACCESS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FILE_ACCESS_FLAGS").field(&self.0).finish()
+    }
+}
+impl FILE_ACCESS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FILE_ACCESS_FLAGS {
@@ -5898,6 +5913,11 @@ impl ::core::fmt::Debug for FILE_FLAGS_AND_ATTRIBUTES {
         f.debug_tuple("FILE_FLAGS_AND_ATTRIBUTES").field(&self.0).finish()
     }
 }
+impl FILE_FLAGS_AND_ATTRIBUTES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FILE_FLAGS_AND_ATTRIBUTES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6061,6 +6081,11 @@ impl ::core::fmt::Debug for FILE_INFO_FLAGS_PERMISSIONS {
         f.debug_tuple("FILE_INFO_FLAGS_PERMISSIONS").field(&self.0).finish()
     }
 }
+impl FILE_INFO_FLAGS_PERMISSIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FILE_INFO_FLAGS_PERMISSIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6155,6 +6180,11 @@ impl ::core::fmt::Debug for FILE_NOTIFY_CHANGE {
         f.debug_tuple("FILE_NOTIFY_CHANGE").field(&self.0).finish()
     }
 }
+impl FILE_NOTIFY_CHANGE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FILE_NOTIFY_CHANGE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6212,6 +6242,11 @@ unsafe impl ::windows::core::Abi for FILE_SHARE_MODE {
 impl ::core::fmt::Debug for FILE_SHARE_MODE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FILE_SHARE_MODE").field(&self.0).finish()
+    }
+}
+impl FILE_SHARE_MODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FILE_SHARE_MODE {
@@ -6364,6 +6399,11 @@ impl ::core::fmt::Debug for FIND_FIRST_EX_FLAGS {
         f.debug_tuple("FIND_FIRST_EX_FLAGS").field(&self.0).finish()
     }
 }
+impl FIND_FIRST_EX_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FIND_FIRST_EX_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6446,6 +6486,11 @@ unsafe impl ::windows::core::Abi for GET_FILE_VERSION_INFO_FLAGS {
 impl ::core::fmt::Debug for GET_FILE_VERSION_INFO_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GET_FILE_VERSION_INFO_FLAGS").field(&self.0).finish()
+    }
+}
+impl GET_FILE_VERSION_INFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GET_FILE_VERSION_INFO_FLAGS {
@@ -6721,6 +6766,11 @@ impl ::core::fmt::Debug for LOCK_FILE_FLAGS {
         f.debug_tuple("LOCK_FILE_FLAGS").field(&self.0).finish()
     }
 }
+impl LOCK_FILE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LOCK_FILE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6831,6 +6881,11 @@ impl ::core::fmt::Debug for LZOPENFILE_STYLE {
         f.debug_tuple("LZOPENFILE_STYLE").field(&self.0).finish()
     }
 }
+impl LZOPENFILE_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LZOPENFILE_STYLE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6892,6 +6947,11 @@ unsafe impl ::windows::core::Abi for MOVE_FILE_FLAGS {
 impl ::core::fmt::Debug for MOVE_FILE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MOVE_FILE_FLAGS").field(&self.0).finish()
+    }
+}
+impl MOVE_FILE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MOVE_FILE_FLAGS {
@@ -8459,6 +8519,11 @@ impl ::core::fmt::Debug for REPLACE_FILE_FLAGS {
         f.debug_tuple("REPLACE_FILE_FLAGS").field(&self.0).finish()
     }
 }
+impl REPLACE_FILE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for REPLACE_FILE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8644,6 +8709,11 @@ impl ::core::fmt::Debug for SHARE_TYPE {
         f.debug_tuple("SHARE_TYPE").field(&self.0).finish()
     }
 }
+impl SHARE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SHARE_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8791,6 +8861,11 @@ unsafe impl ::windows::core::Abi for SYMBOLIC_LINK_FLAGS {
 impl ::core::fmt::Debug for SYMBOLIC_LINK_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SYMBOLIC_LINK_FLAGS").field(&self.0).finish()
+    }
+}
+impl SYMBOLIC_LINK_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SYMBOLIC_LINK_FLAGS {
@@ -9088,6 +9163,11 @@ impl ::core::fmt::Debug for VER_FIND_FILE_STATUS {
         f.debug_tuple("VER_FIND_FILE_STATUS").field(&self.0).finish()
     }
 }
+impl VER_FIND_FILE_STATUS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for VER_FIND_FILE_STATUS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9208,6 +9288,11 @@ impl ::core::fmt::Debug for VER_INSTALL_FILE_STATUS {
         f.debug_tuple("VER_INSTALL_FILE_STATUS").field(&self.0).finish()
     }
 }
+impl VER_INSTALL_FILE_STATUS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for VER_INSTALL_FILE_STATUS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9269,6 +9354,11 @@ unsafe impl ::windows::core::Abi for VS_FIXEDFILEINFO_FILE_FLAGS {
 impl ::core::fmt::Debug for VS_FIXEDFILEINFO_FILE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VS_FIXEDFILEINFO_FILE_FLAGS").field(&self.0).finish()
+    }
+}
+impl VS_FIXEDFILEINFO_FILE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for VS_FIXEDFILEINFO_FILE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/OperationRecorder/mod.rs
@@ -37,6 +37,11 @@ impl ::core::fmt::Debug for OPERATION_END_PARAMETERS_FLAGS {
         f.debug_tuple("OPERATION_END_PARAMETERS_FLAGS").field(&self.0).finish()
     }
 }
+impl OPERATION_END_PARAMETERS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for OPERATION_END_PARAMETERS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -88,6 +93,11 @@ unsafe impl ::windows::core::Abi for OPERATION_START_FLAGS {
 impl ::core::fmt::Debug for OPERATION_START_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OPERATION_START_FLAGS").field(&self.0).finish()
+    }
+}
+impl OPERATION_START_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for OPERATION_START_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -5364,6 +5364,11 @@ impl ::core::fmt::Debug for APPX_CAPABILITIES {
         f.debug_tuple("APPX_CAPABILITIES").field(&self.0).finish()
     }
 }
+impl APPX_CAPABILITIES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for APPX_CAPABILITIES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5487,6 +5492,11 @@ unsafe impl ::windows::core::Abi for APPX_ENCRYPTED_PACKAGE_OPTIONS {
 impl ::core::fmt::Debug for APPX_ENCRYPTED_PACKAGE_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("APPX_ENCRYPTED_PACKAGE_OPTIONS").field(&self.0).finish()
+    }
+}
+impl APPX_ENCRYPTED_PACKAGE_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for APPX_ENCRYPTED_PACKAGE_OPTIONS {
@@ -5647,6 +5657,11 @@ unsafe impl ::windows::core::Abi for APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST
 impl ::core::fmt::Debug for APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS").field(&self.0).finish()
+    }
+}
+impl APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for APPX_PACKAGE_EDITOR_UPDATE_PACKAGE_MANIFEST_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Opc/mod.rs
@@ -2825,6 +2825,11 @@ impl ::core::fmt::Debug for OPC_READ_FLAGS {
         f.debug_tuple("OPC_READ_FLAGS").field(&self.0).finish()
     }
 }
+impl OPC_READ_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for OPC_READ_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3048,6 +3053,11 @@ unsafe impl ::windows::core::Abi for OPC_WRITE_FLAGS {
 impl ::core::fmt::Debug for OPC_WRITE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OPC_WRITE_FLAGS").field(&self.0).finish()
+    }
+}
+impl OPC_WRITE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for OPC_WRITE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/ProjectedFileSystem/mod.rs
@@ -297,6 +297,11 @@ impl ::core::fmt::Debug for PRJ_FILE_STATE {
         f.debug_tuple("PRJ_FILE_STATE").field(&self.0).finish()
     }
 }
+impl PRJ_FILE_STATE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PRJ_FILE_STATE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -425,6 +430,11 @@ impl ::core::fmt::Debug for PRJ_NOTIFY_TYPES {
         f.debug_tuple("PRJ_NOTIFY_TYPES").field(&self.0).finish()
     }
 }
+impl PRJ_NOTIFY_TYPES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PRJ_NOTIFY_TYPES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -505,6 +515,11 @@ impl ::core::fmt::Debug for PRJ_STARTVIRTUALIZING_FLAGS {
         f.debug_tuple("PRJ_STARTVIRTUALIZING_FLAGS").field(&self.0).finish()
     }
 }
+impl PRJ_STARTVIRTUALIZING_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PRJ_STARTVIRTUALIZING_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -564,6 +579,11 @@ unsafe impl ::windows::core::Abi for PRJ_UPDATE_FAILURE_CAUSES {
 impl ::core::fmt::Debug for PRJ_UPDATE_FAILURE_CAUSES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PRJ_UPDATE_FAILURE_CAUSES").field(&self.0).finish()
+    }
+}
+impl PRJ_UPDATE_FAILURE_CAUSES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PRJ_UPDATE_FAILURE_CAUSES {
@@ -631,6 +651,11 @@ unsafe impl ::windows::core::Abi for PRJ_UPDATE_TYPES {
 impl ::core::fmt::Debug for PRJ_UPDATE_TYPES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PRJ_UPDATE_TYPES").field(&self.0).finish()
+    }
+}
+impl PRJ_UPDATE_TYPES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PRJ_UPDATE_TYPES {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
@@ -340,6 +340,11 @@ impl ::core::fmt::Debug for APPLY_SNAPSHOT_VHDSET_FLAG {
         f.debug_tuple("APPLY_SNAPSHOT_VHDSET_FLAG").field(&self.0).finish()
     }
 }
+impl APPLY_SNAPSHOT_VHDSET_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for APPLY_SNAPSHOT_VHDSET_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -440,6 +445,11 @@ impl ::core::fmt::Debug for ATTACH_VIRTUAL_DISK_FLAG {
         f.debug_tuple("ATTACH_VIRTUAL_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl ATTACH_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ATTACH_VIRTUAL_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -524,6 +534,11 @@ unsafe impl ::windows::core::Abi for COMPACT_VIRTUAL_DISK_FLAG {
 impl ::core::fmt::Debug for COMPACT_VIRTUAL_DISK_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("COMPACT_VIRTUAL_DISK_FLAG").field(&self.0).finish()
+    }
+}
+impl COMPACT_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for COMPACT_VIRTUAL_DISK_FLAG {
@@ -628,6 +643,11 @@ impl ::core::fmt::Debug for CREATE_VIRTUAL_DISK_FLAG {
         f.debug_tuple("CREATE_VIRTUAL_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl CREATE_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CREATE_VIRTUAL_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -714,6 +734,11 @@ unsafe impl ::windows::core::Abi for DELETE_SNAPSHOT_VHDSET_FLAG {
 impl ::core::fmt::Debug for DELETE_SNAPSHOT_VHDSET_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DELETE_SNAPSHOT_VHDSET_FLAG").field(&self.0).finish()
+    }
+}
+impl DELETE_SNAPSHOT_VHDSET_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DELETE_SNAPSHOT_VHDSET_FLAG {
@@ -824,6 +849,11 @@ impl ::core::fmt::Debug for DEPENDENT_DISK_FLAG {
         f.debug_tuple("DEPENDENT_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl DEPENDENT_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DEPENDENT_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -875,6 +905,11 @@ unsafe impl ::windows::core::Abi for DETACH_VIRTUAL_DISK_FLAG {
 impl ::core::fmt::Debug for DETACH_VIRTUAL_DISK_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DETACH_VIRTUAL_DISK_FLAG").field(&self.0).finish()
+    }
+}
+impl DETACH_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DETACH_VIRTUAL_DISK_FLAG {
@@ -930,6 +965,11 @@ unsafe impl ::windows::core::Abi for EXPAND_VIRTUAL_DISK_FLAG {
 impl ::core::fmt::Debug for EXPAND_VIRTUAL_DISK_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EXPAND_VIRTUAL_DISK_FLAG").field(&self.0).finish()
+    }
+}
+impl EXPAND_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for EXPAND_VIRTUAL_DISK_FLAG {
@@ -1014,6 +1054,11 @@ impl ::core::fmt::Debug for FORK_VIRTUAL_DISK_FLAG {
         f.debug_tuple("FORK_VIRTUAL_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl FORK_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FORK_VIRTUAL_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1096,6 +1141,11 @@ unsafe impl ::windows::core::Abi for GET_STORAGE_DEPENDENCY_FLAG {
 impl ::core::fmt::Debug for GET_STORAGE_DEPENDENCY_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GET_STORAGE_DEPENDENCY_FLAG").field(&self.0).finish()
+    }
+}
+impl GET_STORAGE_DEPENDENCY_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GET_STORAGE_DEPENDENCY_FLAG {
@@ -1206,6 +1256,11 @@ impl ::core::fmt::Debug for MERGE_VIRTUAL_DISK_FLAG {
         f.debug_tuple("MERGE_VIRTUAL_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl MERGE_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MERGE_VIRTUAL_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1296,6 +1351,11 @@ impl ::core::fmt::Debug for MIRROR_VIRTUAL_DISK_FLAG {
         f.debug_tuple("MIRROR_VIRTUAL_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl MIRROR_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MIRROR_VIRTUAL_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1376,6 +1436,11 @@ unsafe impl ::windows::core::Abi for MODIFY_VHDSET_FLAG {
 impl ::core::fmt::Debug for MODIFY_VHDSET_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MODIFY_VHDSET_FLAG").field(&self.0).finish()
+    }
+}
+impl MODIFY_VHDSET_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MODIFY_VHDSET_FLAG {
@@ -1486,6 +1551,11 @@ impl ::core::fmt::Debug for OPEN_VIRTUAL_DISK_FLAG {
         f.debug_tuple("OPEN_VIRTUAL_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl OPEN_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for OPEN_VIRTUAL_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1570,6 +1640,11 @@ impl ::core::fmt::Debug for QUERY_CHANGES_VIRTUAL_DISK_FLAG {
         f.debug_tuple("QUERY_CHANGES_VIRTUAL_DISK_FLAG").field(&self.0).finish()
     }
 }
+impl QUERY_CHANGES_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for QUERY_CHANGES_VIRTUAL_DISK_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1621,6 +1696,11 @@ unsafe impl ::windows::core::Abi for RAW_SCSI_VIRTUAL_DISK_FLAG {
 impl ::core::fmt::Debug for RAW_SCSI_VIRTUAL_DISK_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RAW_SCSI_VIRTUAL_DISK_FLAG").field(&self.0).finish()
+    }
+}
+impl RAW_SCSI_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RAW_SCSI_VIRTUAL_DISK_FLAG {
@@ -1705,6 +1785,11 @@ unsafe impl ::windows::core::Abi for RESIZE_VIRTUAL_DISK_FLAG {
 impl ::core::fmt::Debug for RESIZE_VIRTUAL_DISK_FLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RESIZE_VIRTUAL_DISK_FLAG").field(&self.0).finish()
+    }
+}
+impl RESIZE_VIRTUAL_DISK_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RESIZE_VIRTUAL_DISK_FLAG {
@@ -1857,6 +1942,11 @@ impl ::core::fmt::Debug for TAKE_SNAPSHOT_VHDSET_FLAG {
         f.debug_tuple("TAKE_SNAPSHOT_VHDSET_FLAG").field(&self.0).finish()
     }
 }
+impl TAKE_SNAPSHOT_VHDSET_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TAKE_SNAPSHOT_VHDSET_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1953,6 +2043,11 @@ unsafe impl ::windows::core::Abi for VIRTUAL_DISK_ACCESS_MASK {
 impl ::core::fmt::Debug for VIRTUAL_DISK_ACCESS_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VIRTUAL_DISK_ACCESS_MASK").field(&self.0).finish()
+    }
+}
+impl VIRTUAL_DISK_ACCESS_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for VIRTUAL_DISK_ACCESS_MASK {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -7968,6 +7968,11 @@ impl ::core::fmt::Debug for PSINJECT_POINT {
         f.debug_tuple("PSINJECT_POINT").field(&self.0).finish()
     }
 }
+impl PSINJECT_POINT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PSINJECT_POINT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -7778,6 +7778,11 @@ impl ::core::fmt::Debug for ASM_BIND_FLAGS {
         f.debug_tuple("ASM_BIND_FLAGS").field(&self.0).finish()
     }
 }
+impl ASM_BIND_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ASM_BIND_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9814,6 +9819,11 @@ unsafe impl ::windows::core::Abi for QUERYASMINFO_FLAGS {
 impl ::core::fmt::Debug for QUERYASMINFO_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("QUERYASMINFO_FLAGS").field(&self.0).finish()
+    }
+}
+impl QUERYASMINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for QUERYASMINFO_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationVerifier/mod.rs
@@ -37,6 +37,11 @@ impl ::core::fmt::Debug for VERIFIER_ENUM_RESOURCE_FLAGS {
         f.debug_tuple("VERIFIER_ENUM_RESOURCE_FLAGS").field(&self.0).finish()
     }
 }
+impl VERIFIER_ENUM_RESOURCE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for VERIFIER_ENUM_RESOURCE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -7694,6 +7694,11 @@ impl ::core::fmt::Debug for ADVANCED_FEATURE_FLAGS {
         f.debug_tuple("ADVANCED_FEATURE_FLAGS").field(&self.0).finish()
     }
 }
+impl ADVANCED_FEATURE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ADVANCED_FEATURE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8071,6 +8076,11 @@ impl ::core::fmt::Debug for CLSCTX {
         f.debug_tuple("CLSCTX").field(&self.0).finish()
     }
 }
+impl CLSCTX {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CLSCTX {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8128,6 +8138,11 @@ unsafe impl ::windows::core::Abi for COINIT {
 impl ::core::fmt::Debug for COINIT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("COINIT").field(&self.0).finish()
+    }
+}
+impl COINIT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for COINIT {
@@ -8459,6 +8474,11 @@ unsafe impl ::windows::core::Abi for DISPATCH_FLAGS {
 impl ::core::fmt::Debug for DISPATCH_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DISPATCH_FLAGS").field(&self.0).finish()
+    }
+}
+impl DISPATCH_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DISPATCH_FLAGS {
@@ -8894,6 +8914,11 @@ impl ::core::fmt::Debug for IDLFLAGS {
         f.debug_tuple("IDLFLAGS").field(&self.0).finish()
     }
 }
+impl IDLFLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IDLFLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8951,6 +8976,11 @@ unsafe impl ::windows::core::Abi for IMPLTYPEFLAGS {
 impl ::core::fmt::Debug for IMPLTYPEFLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IMPLTYPEFLAGS").field(&self.0).finish()
+    }
+}
+impl IMPLTYPEFLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IMPLTYPEFLAGS {
@@ -9340,6 +9370,11 @@ impl ::core::fmt::Debug for ROT_FLAGS {
         f.debug_tuple("ROT_FLAGS").field(&self.0).finish()
     }
 }
+impl ROT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ROT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9593,6 +9628,11 @@ impl ::core::fmt::Debug for STGC {
         f.debug_tuple("STGC").field(&self.0).finish()
     }
 }
+impl STGC {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for STGC {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -9678,6 +9718,11 @@ unsafe impl ::windows::core::Abi for STGM {
 impl ::core::fmt::Debug for STGM {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("STGM").field(&self.0).finish()
+    }
+}
+impl STGM {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for STGM {
@@ -10027,6 +10072,11 @@ unsafe impl ::windows::core::Abi for URI_CREATE_FLAGS {
 impl ::core::fmt::Debug for URI_CREATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("URI_CREATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl URI_CREATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for URI_CREATE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Console/mod.rs
@@ -1006,6 +1006,11 @@ impl ::core::fmt::Debug for CONSOLE_CHARACTER_ATTRIBUTES {
         f.debug_tuple("CONSOLE_CHARACTER_ATTRIBUTES").field(&self.0).finish()
     }
 }
+impl CONSOLE_CHARACTER_ATTRIBUTES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CONSOLE_CHARACTER_ATTRIBUTES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1085,6 +1090,11 @@ unsafe impl ::windows::core::Abi for CONSOLE_MODE {
 impl ::core::fmt::Debug for CONSOLE_MODE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CONSOLE_MODE").field(&self.0).finish()
+    }
+}
+impl CONSOLE_MODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CONSOLE_MODE {

--- a/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DataExchange/mod.rs
@@ -908,6 +908,11 @@ impl ::core::fmt::Debug for CONVINFO_STATUS {
         f.debug_tuple("CONVINFO_STATUS").field(&self.0).finish()
     }
 }
+impl CONVINFO_STATUS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CONVINFO_STATUS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1087,6 +1092,11 @@ unsafe impl ::windows::core::Abi for DDE_INITIALIZE_COMMAND {
 impl ::core::fmt::Debug for DDE_INITIALIZE_COMMAND {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DDE_INITIALIZE_COMMAND").field(&self.0).finish()
+    }
+}
+impl DDE_INITIALIZE_COMMAND {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DDE_INITIALIZE_COMMAND {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -36388,6 +36388,11 @@ impl ::core::fmt::Debug for DBGPROP_ATTRIB_FLAGS {
         f.debug_tuple("DBGPROP_ATTRIB_FLAGS").field(&self.0).finish()
     }
 }
+impl DBGPROP_ATTRIB_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DBGPROP_ATTRIB_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -36455,6 +36460,11 @@ unsafe impl ::windows::core::Abi for DBGPROP_INFO {
 impl ::core::fmt::Debug for DBGPROP_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DBGPROP_INFO").field(&self.0).finish()
+    }
+}
+impl DBGPROP_INFO {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DBGPROP_INFO {
@@ -37178,6 +37188,11 @@ impl ::core::fmt::Debug for FORMAT_MESSAGE_OPTIONS {
         f.debug_tuple("FORMAT_MESSAGE_OPTIONS").field(&self.0).finish()
     }
 }
+impl FORMAT_MESSAGE_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FORMAT_MESSAGE_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -37668,6 +37683,11 @@ impl ::core::fmt::Debug for IMAGE_DLL_CHARACTERISTICS {
         f.debug_tuple("IMAGE_DLL_CHARACTERISTICS").field(&self.0).finish()
     }
 }
+impl IMAGE_DLL_CHARACTERISTICS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IMAGE_DLL_CHARACTERISTICS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -37749,6 +37769,11 @@ impl ::core::fmt::Debug for IMAGE_FILE_CHARACTERISTICS {
         f.debug_tuple("IMAGE_FILE_CHARACTERISTICS").field(&self.0).finish()
     }
 }
+impl IMAGE_FILE_CHARACTERISTICS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IMAGE_FILE_CHARACTERISTICS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -37828,6 +37853,11 @@ unsafe impl ::windows::core::Abi for IMAGE_FILE_CHARACTERISTICS2 {
 impl ::core::fmt::Debug for IMAGE_FILE_CHARACTERISTICS2 {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IMAGE_FILE_CHARACTERISTICS2").field(&self.0).finish()
+    }
+}
+impl IMAGE_FILE_CHARACTERISTICS2 {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IMAGE_FILE_CHARACTERISTICS2 {
@@ -37988,6 +38018,11 @@ unsafe impl ::windows::core::Abi for IMAGE_SECTION_CHARACTERISTICS {
 impl ::core::fmt::Debug for IMAGE_SECTION_CHARACTERISTICS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IMAGE_SECTION_CHARACTERISTICS").field(&self.0).finish()
+    }
+}
+impl IMAGE_SECTION_CHARACTERISTICS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IMAGE_SECTION_CHARACTERISTICS {
@@ -38455,6 +38490,11 @@ impl ::core::fmt::Debug for MINIDUMP_MISC_INFO_FLAGS {
         f.debug_tuple("MINIDUMP_MISC_INFO_FLAGS").field(&self.0).finish()
     }
 }
+impl MINIDUMP_MISC_INFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MINIDUMP_MISC_INFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -38721,6 +38761,11 @@ unsafe impl ::windows::core::Abi for MINIDUMP_TYPE {
 impl ::core::fmt::Debug for MINIDUMP_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MINIDUMP_TYPE").field(&self.0).finish()
+    }
+}
+impl MINIDUMP_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MINIDUMP_TYPE {
@@ -39042,6 +39087,11 @@ impl ::core::fmt::Debug for PROFILER_EVENT_MASK {
         f.debug_tuple("PROFILER_EVENT_MASK").field(&self.0).finish()
     }
 }
+impl PROFILER_EVENT_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROFILER_EVENT_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -39099,6 +39149,11 @@ unsafe impl ::windows::core::Abi for PROFILER_HEAP_ENUM_FLAGS {
 impl ::core::fmt::Debug for PROFILER_HEAP_ENUM_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROFILER_HEAP_ENUM_FLAGS").field(&self.0).finish()
+    }
+}
+impl PROFILER_HEAP_ENUM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROFILER_HEAP_ENUM_FLAGS {
@@ -39176,6 +39231,11 @@ unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_FLAGS {
 impl ::core::fmt::Debug for PROFILER_HEAP_OBJECT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROFILER_HEAP_OBJECT_FLAGS").field(&self.0).finish()
+    }
+}
+impl PROFILER_HEAP_OBJECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROFILER_HEAP_OBJECT_FLAGS {
@@ -39288,6 +39348,11 @@ unsafe impl ::windows::core::Abi for PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
 impl ::core::fmt::Debug for PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS").field(&self.0).finish()
+    }
+}
+impl PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROFILER_HEAP_OBJECT_RELATIONSHIP_FLAGS {
@@ -39996,6 +40061,11 @@ impl ::core::fmt::Debug for SYMBOL_INFO_FLAGS {
         f.debug_tuple("SYMBOL_INFO_FLAGS").field(&self.0).finish()
     }
 }
+impl SYMBOL_INFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SYMBOL_INFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -40082,6 +40152,11 @@ unsafe impl ::windows::core::Abi for SYM_LOAD_FLAGS {
 impl ::core::fmt::Debug for SYM_LOAD_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SYM_LOAD_FLAGS").field(&self.0).finish()
+    }
+}
+impl SYM_LOAD_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SYM_LOAD_FLAGS {
@@ -40471,6 +40546,11 @@ unsafe impl ::windows::core::Abi for THREAD_ERROR_MODE {
 impl ::core::fmt::Debug for THREAD_ERROR_MODE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("THREAD_ERROR_MODE").field(&self.0).finish()
+    }
+}
+impl THREAD_ERROR_MODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for THREAD_ERROR_MODE {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -2225,6 +2225,11 @@ impl ::core::fmt::Debug for EVENT_TRACE_FLAG {
         f.debug_tuple("EVENT_TRACE_FLAG").field(&self.0).finish()
     }
 }
+impl EVENT_TRACE_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for EVENT_TRACE_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2502,6 +2507,11 @@ unsafe impl ::windows::core::Abi for TRACE_MESSAGE_FLAGS {
 impl ::core::fmt::Debug for TRACE_MESSAGE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TRACE_MESSAGE_FLAGS").field(&self.0).finish()
+    }
+}
+impl TRACE_MESSAGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TRACE_MESSAGE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ProcessSnapshotting/mod.rs
@@ -161,6 +161,11 @@ impl ::core::fmt::Debug for PSS_CAPTURE_FLAGS {
         f.debug_tuple("PSS_CAPTURE_FLAGS").field(&self.0).finish()
     }
 }
+impl PSS_CAPTURE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PSS_CAPTURE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -214,6 +219,11 @@ unsafe impl ::windows::core::Abi for PSS_DUPLICATE_FLAGS {
 impl ::core::fmt::Debug for PSS_DUPLICATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PSS_DUPLICATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl PSS_DUPLICATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PSS_DUPLICATE_FLAGS {
@@ -275,6 +285,11 @@ unsafe impl ::windows::core::Abi for PSS_HANDLE_FLAGS {
 impl ::core::fmt::Debug for PSS_HANDLE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PSS_HANDLE_FLAGS").field(&self.0).finish()
+    }
+}
+impl PSS_HANDLE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PSS_HANDLE_FLAGS {
@@ -377,6 +392,11 @@ impl ::core::fmt::Debug for PSS_PROCESS_FLAGS {
         f.debug_tuple("PSS_PROCESS_FLAGS").field(&self.0).finish()
     }
 }
+impl PSS_PROCESS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PSS_PROCESS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -469,6 +489,11 @@ unsafe impl ::windows::core::Abi for PSS_THREAD_FLAGS {
 impl ::core::fmt::Debug for PSS_THREAD_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PSS_THREAD_FLAGS").field(&self.0).finish()
+    }
+}
+impl PSS_THREAD_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PSS_THREAD_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/ToolHelp/mod.rs
@@ -190,6 +190,11 @@ impl ::core::fmt::Debug for CREATE_TOOLHELP_SNAPSHOT_FLAGS {
         f.debug_tuple("CREATE_TOOLHELP_SNAPSHOT_FLAGS").field(&self.0).finish()
     }
 }
+impl CREATE_TOOLHELP_SNAPSHOT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CREATE_TOOLHELP_SNAPSHOT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ErrorReporting/mod.rs
@@ -634,6 +634,11 @@ impl ::core::fmt::Debug for WER_FAULT_REPORTING {
         f.debug_tuple("WER_FAULT_REPORTING").field(&self.0).finish()
     }
 }
+impl WER_FAULT_REPORTING {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WER_FAULT_REPORTING {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -687,6 +692,11 @@ unsafe impl ::windows::core::Abi for WER_FILE {
 impl ::core::fmt::Debug for WER_FILE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WER_FILE").field(&self.0).finish()
+    }
+}
+impl WER_FILE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WER_FILE {
@@ -918,6 +928,11 @@ unsafe impl ::windows::core::Abi for WER_SUBMIT_FLAGS {
 impl ::core::fmt::Debug for WER_SUBMIT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WER_SUBMIT_FLAGS").field(&self.0).finish()
+    }
+}
+impl WER_SUBMIT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WER_SUBMIT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/HostComputeSystem/mod.rs
@@ -698,6 +698,11 @@ impl ::core::fmt::Debug for HCS_EVENT_OPTIONS {
         f.debug_tuple("HCS_EVENT_OPTIONS").field(&self.0).finish()
     }
 }
+impl HCS_EVENT_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HCS_EVENT_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -1269,6 +1269,11 @@ impl ::core::fmt::Debug for HDV_MMIO_MAPPING_FLAGS {
         f.debug_tuple("HDV_MMIO_MAPPING_FLAGS").field(&self.0).finish()
     }
 }
+impl HDV_MMIO_MAPPING_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HDV_MMIO_MAPPING_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1855,6 +1860,11 @@ impl ::core::fmt::Debug for WHV_ALLOCATE_VPCI_RESOURCE_FLAGS {
         f.debug_tuple("WHV_ALLOCATE_VPCI_RESOURCE_FLAGS").field(&self.0).finish()
     }
 }
+impl WHV_ALLOCATE_VPCI_RESOURCE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WHV_ALLOCATE_VPCI_RESOURCE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1998,6 +2008,11 @@ unsafe impl ::windows::core::Abi for WHV_CREATE_VPCI_DEVICE_FLAGS {
 impl ::core::fmt::Debug for WHV_CREATE_VPCI_DEVICE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WHV_CREATE_VPCI_DEVICE_FLAGS").field(&self.0).finish()
+    }
+}
+impl WHV_CREATE_VPCI_DEVICE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WHV_CREATE_VPCI_DEVICE_FLAGS {
@@ -2205,6 +2220,11 @@ unsafe impl ::windows::core::Abi for WHV_MAP_GPA_RANGE_FLAGS {
 impl ::core::fmt::Debug for WHV_MAP_GPA_RANGE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WHV_MAP_GPA_RANGE_FLAGS").field(&self.0).finish()
+    }
+}
+impl WHV_MAP_GPA_RANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WHV_MAP_GPA_RANGE_FLAGS {
@@ -3117,6 +3137,11 @@ impl ::core::fmt::Debug for WHV_TRANSLATE_GVA_FLAGS {
         f.debug_tuple("WHV_TRANSLATE_GVA_FLAGS").field(&self.0).finish()
     }
 }
+impl WHV_TRANSLATE_GVA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WHV_TRANSLATE_GVA_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3395,6 +3420,11 @@ impl ::core::fmt::Debug for WHV_VPCI_INTERRUPT_TARGET_FLAGS {
         f.debug_tuple("WHV_VPCI_INTERRUPT_TARGET_FLAGS").field(&self.0).finish()
     }
 }
+impl WHV_VPCI_INTERRUPT_TARGET_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WHV_VPCI_INTERRUPT_TARGET_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3448,6 +3478,11 @@ unsafe impl ::windows::core::Abi for WHV_VPCI_MMIO_RANGE_FLAGS {
 impl ::core::fmt::Debug for WHV_VPCI_MMIO_RANGE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WHV_VPCI_MMIO_RANGE_FLAGS").field(&self.0).finish()
+    }
+}
+impl WHV_VPCI_MMIO_RANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WHV_VPCI_MMIO_RANGE_FLAGS {
@@ -3536,6 +3571,11 @@ unsafe impl ::windows::core::Abi for WHV_X64_CPUID_RESULT2_FLAGS {
 impl ::core::fmt::Debug for WHV_X64_CPUID_RESULT2_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WHV_X64_CPUID_RESULT2_FLAGS").field(&self.0).finish()
+    }
+}
+impl WHV_X64_CPUID_RESULT2_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WHV_X64_CPUID_RESULT2_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
@@ -2187,6 +2187,11 @@ impl ::core::fmt::Debug for CHANGER_ELEMENT_STATUS_FLAGS {
         f.debug_tuple("CHANGER_ELEMENT_STATUS_FLAGS").field(&self.0).finish()
     }
 }
+impl CHANGER_ELEMENT_STATUS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CHANGER_ELEMENT_STATUS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2294,6 +2299,11 @@ unsafe impl ::windows::core::Abi for CHANGER_FEATURES {
 impl ::core::fmt::Debug for CHANGER_FEATURES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CHANGER_FEATURES").field(&self.0).finish()
+    }
+}
+impl CHANGER_FEATURES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CHANGER_FEATURES {
@@ -2722,6 +2732,11 @@ impl ::core::fmt::Debug for FILE_STORAGE_TIER_FLAGS {
         f.debug_tuple("FILE_STORAGE_TIER_FLAGS").field(&self.0).finish()
     }
 }
+impl FILE_STORAGE_TIER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FILE_STORAGE_TIER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2929,6 +2944,11 @@ impl ::core::fmt::Debug for GET_CHANGER_PARAMETERS_FEATURES1 {
         f.debug_tuple("GET_CHANGER_PARAMETERS_FEATURES1").field(&self.0).finish()
     }
 }
+impl GET_CHANGER_PARAMETERS_FEATURES1 {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GET_CHANGER_PARAMETERS_FEATURES1 {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2988,6 +3008,11 @@ unsafe impl ::windows::core::Abi for GPT_ATTRIBUTES {
 impl ::core::fmt::Debug for GPT_ATTRIBUTES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GPT_ATTRIBUTES").field(&self.0).finish()
+    }
+}
+impl GPT_ATTRIBUTES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GPT_ATTRIBUTES {
@@ -5256,6 +5281,11 @@ impl ::core::fmt::Debug for TXFS_RMF_LAGS {
         f.debug_tuple("TXFS_RMF_LAGS").field(&self.0).finish()
     }
 }
+impl TXFS_RMF_LAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TXFS_RMF_LAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5309,6 +5339,11 @@ unsafe impl ::windows::core::Abi for USN_DELETE_FLAGS {
 impl ::core::fmt::Debug for USN_DELETE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("USN_DELETE_FLAGS").field(&self.0).finish()
+    }
+}
+impl USN_DELETE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for USN_DELETE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/JobObjects/mod.rs
@@ -383,6 +383,11 @@ impl ::core::fmt::Debug for JOB_OBJECT_CPU_RATE_CONTROL {
         f.debug_tuple("JOB_OBJECT_CPU_RATE_CONTROL").field(&self.0).finish()
     }
 }
+impl JOB_OBJECT_CPU_RATE_CONTROL {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for JOB_OBJECT_CPU_RATE_CONTROL {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -521,6 +526,11 @@ impl ::core::fmt::Debug for JOB_OBJECT_LIMIT {
         f.debug_tuple("JOB_OBJECT_LIMIT").field(&self.0).finish()
     }
 }
+impl JOB_OBJECT_LIMIT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for JOB_OBJECT_LIMIT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -578,6 +588,11 @@ unsafe impl ::windows::core::Abi for JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
 impl ::core::fmt::Debug for JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JOB_OBJECT_NET_RATE_CONTROL_FLAGS").field(&self.0).finish()
+    }
+}
+impl JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for JOB_OBJECT_NET_RATE_CONTROL_FLAGS {
@@ -639,6 +654,11 @@ unsafe impl ::windows::core::Abi for JOB_OBJECT_SECURITY {
 impl ::core::fmt::Debug for JOB_OBJECT_SECURITY {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JOB_OBJECT_SECURITY").field(&self.0).finish()
+    }
+}
+impl JOB_OBJECT_SECURITY {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for JOB_OBJECT_SECURITY {
@@ -735,6 +755,11 @@ unsafe impl ::windows::core::Abi for JOB_OBJECT_UILIMIT {
 impl ::core::fmt::Debug for JOB_OBJECT_UILIMIT {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JOB_OBJECT_UILIMIT").field(&self.0).finish()
+    }
+}
+impl JOB_OBJECT_UILIMIT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for JOB_OBJECT_UILIMIT {

--- a/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/LibraryLoader/mod.rs
@@ -588,6 +588,11 @@ impl ::core::fmt::Debug for LOAD_LIBRARY_FLAGS {
         f.debug_tuple("LOAD_LIBRARY_FLAGS").field(&self.0).finish()
     }
 }
+impl LOAD_LIBRARY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LOAD_LIBRARY_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Memory/mod.rs
@@ -942,6 +942,11 @@ impl ::core::fmt::Debug for FILE_MAP {
         f.debug_tuple("FILE_MAP").field(&self.0).finish()
     }
 }
+impl FILE_MAP {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FILE_MAP {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1001,6 +1006,11 @@ unsafe impl ::windows::core::Abi for GLOBAL_ALLOC_FLAGS {
 impl ::core::fmt::Debug for GLOBAL_ALLOC_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GLOBAL_ALLOC_FLAGS").field(&self.0).finish()
+    }
+}
+impl GLOBAL_ALLOC_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GLOBAL_ALLOC_FLAGS {
@@ -1086,6 +1096,11 @@ unsafe impl ::windows::core::Abi for HEAP_FLAGS {
 impl ::core::fmt::Debug for HEAP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HEAP_FLAGS").field(&self.0).finish()
+    }
+}
+impl HEAP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for HEAP_FLAGS {
@@ -1182,6 +1197,11 @@ unsafe impl ::windows::core::Abi for LOCAL_ALLOC_FLAGS {
 impl ::core::fmt::Debug for LOCAL_ALLOC_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LOCAL_ALLOC_FLAGS").field(&self.0).finish()
+    }
+}
+impl LOCAL_ALLOC_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LOCAL_ALLOC_FLAGS {
@@ -1410,6 +1430,11 @@ impl ::core::fmt::Debug for PAGE_PROTECTION_FLAGS {
         f.debug_tuple("PAGE_PROTECTION_FLAGS").field(&self.0).finish()
     }
 }
+impl PAGE_PROTECTION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PAGE_PROTECTION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1465,6 +1490,11 @@ unsafe impl ::windows::core::Abi for PAGE_TYPE {
 impl ::core::fmt::Debug for PAGE_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PAGE_TYPE").field(&self.0).finish()
+    }
+}
+impl PAGE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PAGE_TYPE {
@@ -1561,6 +1591,11 @@ unsafe impl ::windows::core::Abi for VIRTUAL_ALLOCATION_TYPE {
 impl ::core::fmt::Debug for VIRTUAL_ALLOCATION_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VIRTUAL_ALLOCATION_TYPE").field(&self.0).finish()
+    }
+}
+impl VIRTUAL_ALLOCATION_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for VIRTUAL_ALLOCATION_TYPE {

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -12005,6 +12005,11 @@ impl ::core::fmt::Debug for ACTIVEOBJECT_FLAGS {
         f.debug_tuple("ACTIVEOBJECT_FLAGS").field(&self.0).finish()
     }
 }
+impl ACTIVEOBJECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ACTIVEOBJECT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12091,6 +12096,11 @@ unsafe impl ::windows::core::Abi for BUSY_DIALOG_FLAGS {
 impl ::core::fmt::Debug for BUSY_DIALOG_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BUSY_DIALOG_FLAGS").field(&self.0).finish()
+    }
+}
+impl BUSY_DIALOG_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for BUSY_DIALOG_FLAGS {
@@ -12193,6 +12203,11 @@ impl ::core::fmt::Debug for CHANGE_ICON_FLAGS {
         f.debug_tuple("CHANGE_ICON_FLAGS").field(&self.0).finish()
     }
 }
+impl CHANGE_ICON_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CHANGE_ICON_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12250,6 +12265,11 @@ unsafe impl ::windows::core::Abi for CHANGE_SOURCE_FLAGS {
 impl ::core::fmt::Debug for CHANGE_SOURCE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CHANGE_SOURCE_FLAGS").field(&self.0).finish()
+    }
+}
+impl CHANGE_SOURCE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CHANGE_SOURCE_FLAGS {
@@ -12475,6 +12495,11 @@ impl ::core::fmt::Debug for DROPEFFECT {
         f.debug_tuple("DROPEFFECT").field(&self.0).finish()
     }
 }
+impl DROPEFFECT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DROPEFFECT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12588,6 +12613,11 @@ impl ::core::fmt::Debug for EDIT_LINKS_FLAGS {
         f.debug_tuple("EDIT_LINKS_FLAGS").field(&self.0).finish()
     }
 }
+impl EDIT_LINKS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for EDIT_LINKS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12645,6 +12675,11 @@ unsafe impl ::windows::core::Abi for EMBDHLP_FLAGS {
 impl ::core::fmt::Debug for EMBDHLP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EMBDHLP_FLAGS").field(&self.0).finish()
+    }
+}
+impl EMBDHLP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for EMBDHLP_FLAGS {
@@ -12763,6 +12798,11 @@ unsafe impl ::windows::core::Abi for FDEX_PROP_FLAGS {
 impl ::core::fmt::Debug for FDEX_PROP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FDEX_PROP_FLAGS").field(&self.0).finish()
+    }
+}
+impl FDEX_PROP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FDEX_PROP_FLAGS {
@@ -12927,6 +12967,11 @@ impl ::core::fmt::Debug for INSERT_OBJECT_FLAGS {
         f.debug_tuple("INSERT_OBJECT_FLAGS").field(&self.0).finish()
     }
 }
+impl INSERT_OBJECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for INSERT_OBJECT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12982,6 +13027,11 @@ unsafe impl ::windows::core::Abi for KEYMODIFIERS {
 impl ::core::fmt::Debug for KEYMODIFIERS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KEYMODIFIERS").field(&self.0).finish()
+    }
+}
+impl KEYMODIFIERS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for KEYMODIFIERS {
@@ -13072,6 +13122,11 @@ unsafe impl ::windows::core::Abi for LOAD_PICTURE_FLAGS {
 impl ::core::fmt::Debug for LOAD_PICTURE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LOAD_PICTURE_FLAGS").field(&self.0).finish()
+    }
+}
+impl LOAD_PICTURE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LOAD_PICTURE_FLAGS {
@@ -13219,6 +13274,11 @@ impl ::core::fmt::Debug for NUMPARSE_FLAGS {
         f.debug_tuple("NUMPARSE_FLAGS").field(&self.0).finish()
     }
 }
+impl NUMPARSE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NUMPARSE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13276,6 +13336,11 @@ unsafe impl ::windows::core::Abi for OBJECT_PROPERTIES_FLAGS {
 impl ::core::fmt::Debug for OBJECT_PROPERTIES_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OBJECT_PROPERTIES_FLAGS").field(&self.0).finish()
+    }
+}
+impl OBJECT_PROPERTIES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for OBJECT_PROPERTIES_FLAGS {
@@ -14416,6 +14481,11 @@ impl ::core::fmt::Debug for PARAMFLAGS {
         f.debug_tuple("PARAMFLAGS").field(&self.0).finish()
     }
 }
+impl PARAMFLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PARAMFLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -14481,6 +14551,11 @@ unsafe impl ::windows::core::Abi for PASTE_SPECIAL_FLAGS {
 impl ::core::fmt::Debug for PASTE_SPECIAL_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PASTE_SPECIAL_FLAGS").field(&self.0).finish()
+    }
+}
+impl PASTE_SPECIAL_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PASTE_SPECIAL_FLAGS {
@@ -14637,6 +14712,11 @@ unsafe impl ::windows::core::Abi for PRINTFLAG {
 impl ::core::fmt::Debug for PRINTFLAG {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PRINTFLAG").field(&self.0).finish()
+    }
+}
+impl PRINTFLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PRINTFLAG {
@@ -15004,6 +15084,11 @@ impl ::core::fmt::Debug for UI_CONVERT_FLAGS {
         f.debug_tuple("UI_CONVERT_FLAGS").field(&self.0).finish()
     }
 }
+impl UI_CONVERT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for UI_CONVERT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -15071,6 +15156,11 @@ unsafe impl ::windows::core::Abi for UPDFCACHE_FLAGS {
 impl ::core::fmt::Debug for UPDFCACHE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UPDFCACHE_FLAGS").field(&self.0).finish()
+    }
+}
+impl UPDFCACHE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for UPDFCACHE_FLAGS {
@@ -15413,6 +15503,11 @@ unsafe impl ::windows::core::Abi for VIEW_OBJECT_PROPERTIES_FLAGS {
 impl ::core::fmt::Debug for VIEW_OBJECT_PROPERTIES_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VIEW_OBJECT_PROPERTIES_FLAGS").field(&self.0).finish()
+    }
+}
+impl VIEW_OBJECT_PROPERTIES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for VIEW_OBJECT_PROPERTIES_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/Pipes/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Pipes/mod.rs
@@ -267,6 +267,11 @@ impl ::core::fmt::Debug for NAMED_PIPE_MODE {
         f.debug_tuple("NAMED_PIPE_MODE").field(&self.0).finish()
     }
 }
+impl NAMED_PIPE_MODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NAMED_PIPE_MODE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
@@ -1351,6 +1351,11 @@ impl ::core::fmt::Debug for EXECUTION_STATE {
         f.debug_tuple("EXECUTION_STATE").field(&self.0).finish()
     }
 }
+impl EXECUTION_STATE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for EXECUTION_STATE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1480,6 +1485,11 @@ unsafe impl ::windows::core::Abi for POWER_ACTION_POLICY_EVENT_CODE {
 impl ::core::fmt::Debug for POWER_ACTION_POLICY_EVENT_CODE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("POWER_ACTION_POLICY_EVENT_CODE").field(&self.0).finish()
+    }
+}
+impl POWER_ACTION_POLICY_EVENT_CODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for POWER_ACTION_POLICY_EVENT_CODE {

--- a/crates/libs/windows/src/Windows/Win32/System/Recovery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Recovery/mod.rs
@@ -95,6 +95,11 @@ impl ::core::fmt::Debug for REGISTER_APPLICATION_RESTART_FLAGS {
         f.debug_tuple("REGISTER_APPLICATION_RESTART_FLAGS").field(&self.0).finish()
     }
 }
+impl REGISTER_APPLICATION_RESTART_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for REGISTER_APPLICATION_RESTART_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Registry/mod.rs
@@ -2813,6 +2813,11 @@ impl ::core::fmt::Debug for REG_NOTIFY_FILTER {
         f.debug_tuple("REG_NOTIFY_FILTER").field(&self.0).finish()
     }
 }
+impl REG_NOTIFY_FILTER {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for REG_NOTIFY_FILTER {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2876,6 +2881,11 @@ unsafe impl ::windows::core::Abi for REG_OPEN_CREATE_OPTIONS {
 impl ::core::fmt::Debug for REG_OPEN_CREATE_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("REG_OPEN_CREATE_OPTIONS").field(&self.0).finish()
+    }
+}
+impl REG_OPEN_CREATE_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for REG_OPEN_CREATE_OPTIONS {
@@ -2986,6 +2996,11 @@ impl ::core::fmt::Debug for REG_ROUTINE_FLAGS {
         f.debug_tuple("REG_ROUTINE_FLAGS").field(&self.0).finish()
     }
 }
+impl REG_ROUTINE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for REG_ROUTINE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3061,6 +3076,11 @@ unsafe impl ::windows::core::Abi for REG_SAM_FLAGS {
 impl ::core::fmt::Debug for REG_SAM_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("REG_SAM_FLAGS").field(&self.0).finish()
+    }
+}
+impl REG_SAM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for REG_SAM_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -9382,6 +9382,11 @@ impl ::core::fmt::Debug for WTS_SECURITY_FLAGS {
         f.debug_tuple("WTS_SECURITY_FLAGS").field(&self.0).finish()
     }
 }
+impl WTS_SECURITY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WTS_SECURITY_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
@@ -4050,6 +4050,11 @@ impl ::core::fmt::Debug for RPC_BINDING_HANDLE_OPTIONS_FLAGS {
         f.debug_tuple("RPC_BINDING_HANDLE_OPTIONS_FLAGS").field(&self.0).finish()
     }
 }
+impl RPC_BINDING_HANDLE_OPTIONS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RPC_BINDING_HANDLE_OPTIONS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4132,6 +4137,11 @@ impl ::core::fmt::Debug for RPC_C_HTTP_AUTHN_TARGET {
         f.debug_tuple("RPC_C_HTTP_AUTHN_TARGET").field(&self.0).finish()
     }
 }
+impl RPC_C_HTTP_AUTHN_TARGET {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RPC_C_HTTP_AUTHN_TARGET {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4189,6 +4199,11 @@ unsafe impl ::windows::core::Abi for RPC_C_HTTP_FLAGS {
 impl ::core::fmt::Debug for RPC_C_HTTP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RPC_C_HTTP_FLAGS").field(&self.0).finish()
+    }
+}
+impl RPC_C_HTTP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RPC_C_HTTP_FLAGS {
@@ -4254,6 +4269,11 @@ unsafe impl ::windows::core::Abi for RPC_C_QOS_CAPABILITIES {
 impl ::core::fmt::Debug for RPC_C_QOS_CAPABILITIES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RPC_C_QOS_CAPABILITIES").field(&self.0).finish()
+    }
+}
+impl RPC_C_QOS_CAPABILITIES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RPC_C_QOS_CAPABILITIES {

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -20069,6 +20069,11 @@ impl ::core::fmt::Debug for CONDITION_CREATION_OPTIONS {
         f.debug_tuple("CONDITION_CREATION_OPTIONS").field(&self.0).finish()
     }
 }
+impl CONDITION_CREATION_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CONDITION_CREATION_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -24481,6 +24486,11 @@ unsafe impl ::windows::core::Abi for STRUCTURED_QUERY_RESOLVE_OPTION {
 impl ::core::fmt::Debug for STRUCTURED_QUERY_RESOLVE_OPTION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("STRUCTURED_QUERY_RESOLVE_OPTION").field(&self.0).finish()
+    }
+}
+impl STRUCTURED_QUERY_RESOLVE_OPTION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for STRUCTURED_QUERY_RESOLVE_OPTION {

--- a/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
@@ -928,6 +928,11 @@ impl ::core::fmt::Debug for ENUM_SERVICE_TYPE {
         f.debug_tuple("ENUM_SERVICE_TYPE").field(&self.0).finish()
     }
 }
+impl ENUM_SERVICE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ENUM_SERVICE_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1210,6 +1215,11 @@ unsafe impl ::windows::core::Abi for SERVICE_NOTIFY {
 impl ::core::fmt::Debug for SERVICE_NOTIFY {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SERVICE_NOTIFY").field(&self.0).finish()
+    }
+}
+impl SERVICE_NOTIFY {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SERVICE_NOTIFY {

--- a/crates/libs/windows/src/Windows/Win32/System/Shutdown/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Shutdown/mod.rs
@@ -263,6 +263,11 @@ impl ::core::fmt::Debug for SHUTDOWN_FLAGS {
         f.debug_tuple("SHUTDOWN_FLAGS").field(&self.0).finish()
     }
 }
+impl SHUTDOWN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SHUTDOWN_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -414,6 +419,11 @@ unsafe impl ::windows::core::Abi for SHUTDOWN_REASON {
 impl ::core::fmt::Debug for SHUTDOWN_REASON {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SHUTDOWN_REASON").field(&self.0).finish()
+    }
+}
+impl SHUTDOWN_REASON {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SHUTDOWN_REASON {

--- a/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/StationsAndDesktops/mod.rs
@@ -373,6 +373,11 @@ impl ::core::fmt::Debug for BROADCAST_SYSTEM_MESSAGE_FLAGS {
         f.debug_tuple("BROADCAST_SYSTEM_MESSAGE_FLAGS").field(&self.0).finish()
     }
 }
+impl BROADCAST_SYSTEM_MESSAGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for BROADCAST_SYSTEM_MESSAGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -428,6 +433,11 @@ unsafe impl ::windows::core::Abi for BROADCAST_SYSTEM_MESSAGE_INFO {
 impl ::core::fmt::Debug for BROADCAST_SYSTEM_MESSAGE_INFO {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BROADCAST_SYSTEM_MESSAGE_INFO").field(&self.0).finish()
+    }
+}
+impl BROADCAST_SYSTEM_MESSAGE_INFO {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for BROADCAST_SYSTEM_MESSAGE_INFO {

--- a/crates/libs/windows/src/Windows/Win32/System/SubsystemForLinux/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SubsystemForLinux/mod.rs
@@ -105,6 +105,11 @@ impl ::core::fmt::Debug for WSL_DISTRIBUTION_FLAGS {
         f.debug_tuple("WSL_DISTRIBUTION_FLAGS").field(&self.0).finish()
     }
 }
+impl WSL_DISTRIBUTION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WSL_DISTRIBUTION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemInformation/mod.rs
@@ -1533,6 +1533,11 @@ impl ::core::fmt::Debug for VER_FLAGS {
         f.debug_tuple("VER_FLAGS").field(&self.0).finish()
     }
 }
+impl VER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for VER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -6709,6 +6709,11 @@ impl ::core::fmt::Debug for ATF_FLAGS {
         f.debug_tuple("ATF_FLAGS").field(&self.0).finish()
     }
 }
+impl ATF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ATF_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6800,6 +6805,11 @@ unsafe impl ::windows::core::Abi for CFE_UNDERLINE {
 impl ::core::fmt::Debug for CFE_UNDERLINE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CFE_UNDERLINE").field(&self.0).finish()
+    }
+}
+impl CFE_UNDERLINE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CFE_UNDERLINE {
@@ -6962,6 +6972,11 @@ unsafe impl ::windows::core::Abi for GESTURECONFIG_FLAGS {
 impl ::core::fmt::Debug for GESTURECONFIG_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GESTURECONFIG_FLAGS").field(&self.0).finish()
+    }
+}
+impl GESTURECONFIG_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GESTURECONFIG_FLAGS {
@@ -7391,6 +7406,11 @@ impl ::core::fmt::Debug for MODIFIERKEYS_FLAGS {
         f.debug_tuple("MODIFIERKEYS_FLAGS").field(&self.0).finish()
     }
 }
+impl MODIFIERKEYS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MODIFIERKEYS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7711,6 +7731,11 @@ impl ::core::fmt::Debug for RECO_FLAGS {
         f.debug_tuple("RECO_FLAGS").field(&self.0).finish()
     }
 }
+impl RECO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RECO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7903,6 +7928,11 @@ unsafe impl ::windows::core::Abi for SECTION_FLAGS {
 impl ::core::fmt::Debug for SECTION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SECTION_FLAGS").field(&self.0).finish()
+    }
+}
+impl SECTION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SECTION_FLAGS {
@@ -8228,6 +8258,11 @@ impl ::core::fmt::Debug for SFGAO_FLAGS {
         f.debug_tuple("SFGAO_FLAGS").field(&self.0).finish()
     }
 }
+impl SFGAO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SFGAO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8533,6 +8568,11 @@ unsafe impl ::windows::core::Abi for TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {
 impl ::core::fmt::Debug for TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH").field(&self.0).finish()
+    }
+}
+impl TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TAPE_GET_DRIVE_PARAMETERS_FEATURES_HIGH {

--- a/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
@@ -2758,6 +2758,11 @@ impl ::core::fmt::Debug for CREATE_EVENT {
         f.debug_tuple("CREATE_EVENT").field(&self.0).finish()
     }
 }
+impl CREATE_EVENT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CREATE_EVENT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -2871,6 +2876,11 @@ unsafe impl ::windows::core::Abi for MACHINE_ATTRIBUTES {
 impl ::core::fmt::Debug for MACHINE_ATTRIBUTES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MACHINE_ATTRIBUTES").field(&self.0).finish()
+    }
+}
+impl MACHINE_ATTRIBUTES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MACHINE_ATTRIBUTES {
@@ -3138,6 +3148,11 @@ impl ::core::fmt::Debug for PROCESS_ACCESS_RIGHTS {
         f.debug_tuple("PROCESS_ACCESS_RIGHTS").field(&self.0).finish()
     }
 }
+impl PROCESS_ACCESS_RIGHTS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROCESS_ACCESS_RIGHTS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3278,6 +3293,11 @@ impl ::core::fmt::Debug for PROCESS_CREATION_FLAGS {
         f.debug_tuple("PROCESS_CREATION_FLAGS").field(&self.0).finish()
     }
 }
+impl PROCESS_CREATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROCESS_CREATION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3333,6 +3353,11 @@ unsafe impl ::windows::core::Abi for PROCESS_DEP_FLAGS {
 impl ::core::fmt::Debug for PROCESS_DEP_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROCESS_DEP_FLAGS").field(&self.0).finish()
+    }
+}
+impl PROCESS_DEP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROCESS_DEP_FLAGS {
@@ -3744,6 +3769,11 @@ impl ::core::fmt::Debug for STARTUPINFOW_FLAGS {
         f.debug_tuple("STARTUPINFOW_FLAGS").field(&self.0).finish()
     }
 }
+impl STARTUPINFOW_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for STARTUPINFOW_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3821,6 +3851,11 @@ unsafe impl ::windows::core::Abi for SYNCHRONIZATION_ACCESS_RIGHTS {
 impl ::core::fmt::Debug for SYNCHRONIZATION_ACCESS_RIGHTS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SYNCHRONIZATION_ACCESS_RIGHTS").field(&self.0).finish()
+    }
+}
+impl SYNCHRONIZATION_ACCESS_RIGHTS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SYNCHRONIZATION_ACCESS_RIGHTS {
@@ -3939,6 +3974,11 @@ impl ::core::fmt::Debug for THREAD_ACCESS_RIGHTS {
         f.debug_tuple("THREAD_ACCESS_RIGHTS").field(&self.0).finish()
     }
 }
+impl THREAD_ACCESS_RIGHTS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for THREAD_ACCESS_RIGHTS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3994,6 +4034,11 @@ unsafe impl ::windows::core::Abi for THREAD_CREATION_FLAGS {
 impl ::core::fmt::Debug for THREAD_CREATION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("THREAD_CREATION_FLAGS").field(&self.0).finish()
+    }
+}
+impl THREAD_CREATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for THREAD_CREATION_FLAGS {
@@ -4170,6 +4215,11 @@ unsafe impl ::windows::core::Abi for WORKER_THREAD_FLAGS {
 impl ::core::fmt::Debug for WORKER_THREAD_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WORKER_THREAD_FLAGS").field(&self.0).finish()
+    }
+}
+impl WORKER_THREAD_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WORKER_THREAD_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Storage/mod.rs
@@ -281,6 +281,11 @@ impl ::core::fmt::Debug for HANDLE_ACCESS_OPTIONS {
         f.debug_tuple("HANDLE_ACCESS_OPTIONS").field(&self.0).finish()
     }
 }
+impl HANDLE_ACCESS_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HANDLE_ACCESS_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -381,6 +386,11 @@ impl ::core::fmt::Debug for HANDLE_OPTIONS {
         f.debug_tuple("HANDLE_OPTIONS").field(&self.0).finish()
     }
 }
+impl HANDLE_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HANDLE_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -438,6 +448,11 @@ unsafe impl ::windows::core::Abi for HANDLE_SHARING_OPTIONS {
 impl ::core::fmt::Debug for HANDLE_SHARING_OPTIONS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HANDLE_SHARING_OPTIONS").field(&self.0).finish()
+    }
+}
+impl HANDLE_SHARING_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for HANDLE_SHARING_OPTIONS {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -2694,6 +2694,11 @@ impl ::core::fmt::Debug for RO_ERROR_REPORTING_FLAGS {
         f.debug_tuple("RO_ERROR_REPORTING_FLAGS").field(&self.0).finish()
     }
 }
+impl RO_ERROR_REPORTING_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RO_ERROR_REPORTING_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -8159,6 +8159,11 @@ impl ::core::fmt::Debug for WBEM_GENERIC_FLAG_TYPE {
         f.debug_tuple("WBEM_GENERIC_FLAG_TYPE").field(&self.0).finish()
     }
 }
+impl WBEM_GENERIC_FLAG_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WBEM_GENERIC_FLAG_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -18281,6 +18281,11 @@ impl ::core::fmt::Debug for ACC_UTILITY_STATE_FLAGS {
         f.debug_tuple("ACC_UTILITY_STATE_FLAGS").field(&self.0).finish()
     }
 }
+impl ACC_UTILITY_STATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ACC_UTILITY_STATE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -18934,6 +18939,11 @@ impl ::core::fmt::Debug for HIGHCONTRASTW_FLAGS {
         f.debug_tuple("HIGHCONTRASTW_FLAGS").field(&self.0).finish()
     }
 }
+impl HIGHCONTRASTW_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HIGHCONTRASTW_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -19369,6 +19379,11 @@ impl ::core::fmt::Debug for SERIALKEYS_FLAGS {
         f.debug_tuple("SERIALKEYS_FLAGS").field(&self.0).finish()
     }
 }
+impl SERIALKEYS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SERIALKEYS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -19424,6 +19439,11 @@ unsafe impl ::windows::core::Abi for SOUNDSENTRY_FLAGS {
 impl ::core::fmt::Debug for SOUNDSENTRY_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SOUNDSENTRY_FLAGS").field(&self.0).finish()
+    }
+}
+impl SOUNDSENTRY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SOUNDSENTRY_FLAGS {
@@ -19616,6 +19636,11 @@ unsafe impl ::windows::core::Abi for STICKYKEYS_FLAGS {
 impl ::core::fmt::Debug for STICKYKEYS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("STICKYKEYS_FLAGS").field(&self.0).finish()
+    }
+}
+impl STICKYKEYS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for STICKYKEYS_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
@@ -2221,6 +2221,11 @@ impl ::core::fmt::Debug for UI_ANIMATION_DEPENDENCIES {
         f.debug_tuple("UI_ANIMATION_DEPENDENCIES").field(&self.0).finish()
     }
 }
+impl UI_ANIMATION_DEPENDENCIES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for UI_ANIMATION_DEPENDENCIES {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/Dialogs/mod.rs
@@ -486,6 +486,11 @@ impl ::core::fmt::Debug for CHOOSECOLOR_FLAGS {
         f.debug_tuple("CHOOSECOLOR_FLAGS").field(&self.0).finish()
     }
 }
+impl CHOOSECOLOR_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CHOOSECOLOR_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -595,6 +600,11 @@ impl ::core::fmt::Debug for CHOOSEFONT_FLAGS {
         f.debug_tuple("CHOOSEFONT_FLAGS").field(&self.0).finish()
     }
 }
+impl CHOOSEFONT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CHOOSEFONT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -656,6 +666,11 @@ unsafe impl ::windows::core::Abi for CHOOSEFONT_FONT_TYPE {
 impl ::core::fmt::Debug for CHOOSEFONT_FONT_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CHOOSEFONT_FONT_TYPE").field(&self.0).finish()
+    }
+}
+impl CHOOSEFONT_FONT_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CHOOSEFONT_FONT_TYPE {
@@ -883,6 +898,11 @@ impl ::core::fmt::Debug for FINDREPLACE_FLAGS {
         f.debug_tuple("FINDREPLACE_FLAGS").field(&self.0).finish()
     }
 }
+impl FINDREPLACE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FINDREPLACE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -986,6 +1006,11 @@ impl ::core::fmt::Debug for OPEN_FILENAME_FLAGS {
         f.debug_tuple("OPEN_FILENAME_FLAGS").field(&self.0).finish()
     }
 }
+impl OPEN_FILENAME_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for OPEN_FILENAME_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1039,6 +1064,11 @@ unsafe impl ::windows::core::Abi for OPEN_FILENAME_FLAGS_EX {
 impl ::core::fmt::Debug for OPEN_FILENAME_FLAGS_EX {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OPEN_FILENAME_FLAGS_EX").field(&self.0).finish()
+    }
+}
+impl OPEN_FILENAME_FLAGS_EX {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for OPEN_FILENAME_FLAGS_EX {
@@ -1128,6 +1158,11 @@ unsafe impl ::windows::core::Abi for PAGESETUPDLG_FLAGS {
 impl ::core::fmt::Debug for PAGESETUPDLG_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PAGESETUPDLG_FLAGS").field(&self.0).finish()
+    }
+}
+impl PAGESETUPDLG_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PAGESETUPDLG_FLAGS {
@@ -1235,6 +1270,11 @@ unsafe impl ::windows::core::Abi for PRINTDLGEX_FLAGS {
 impl ::core::fmt::Debug for PRINTDLGEX_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PRINTDLGEX_FLAGS").field(&self.0).finish()
+    }
+}
+impl PRINTDLGEX_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PRINTDLGEX_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -7038,6 +7038,11 @@ impl ::core::fmt::Debug for CFE_EFFECTS {
         f.debug_tuple("CFE_EFFECTS").field(&self.0).finish()
     }
 }
+impl CFE_EFFECTS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CFE_EFFECTS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7173,6 +7178,11 @@ unsafe impl ::windows::core::Abi for CFM_MASK {
 impl ::core::fmt::Debug for CFM_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CFM_MASK").field(&self.0).finish()
+    }
+}
+impl CFM_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CFM_MASK {
@@ -7327,6 +7337,11 @@ unsafe impl ::windows::core::Abi for GETTEXTLENGTHEX_FLAGS {
 impl ::core::fmt::Debug for GETTEXTLENGTHEX_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GETTEXTLENGTHEX_FLAGS").field(&self.0).finish()
+    }
+}
+impl GETTEXTLENGTHEX_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GETTEXTLENGTHEX_FLAGS {
@@ -7625,6 +7640,11 @@ impl ::core::fmt::Debug for PARAFORMAT_BORDERS {
         f.debug_tuple("PARAFORMAT_BORDERS").field(&self.0).finish()
     }
 }
+impl PARAFORMAT_BORDERS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PARAFORMAT_BORDERS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7692,6 +7712,11 @@ impl ::core::fmt::Debug for PARAFORMAT_MASK {
         f.debug_tuple("PARAFORMAT_MASK").field(&self.0).finish()
     }
 }
+impl PARAFORMAT_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PARAFORMAT_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7753,6 +7778,11 @@ unsafe impl ::windows::core::Abi for PARAFORMAT_NUMBERING {
 impl ::core::fmt::Debug for PARAFORMAT_NUMBERING {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PARAFORMAT_NUMBERING").field(&self.0).finish()
+    }
+}
+impl PARAFORMAT_NUMBERING {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PARAFORMAT_NUMBERING {
@@ -7928,6 +7958,11 @@ impl ::core::fmt::Debug for REOBJECT_FLAGS {
         f.debug_tuple("REOBJECT_FLAGS").field(&self.0).finish()
     }
 }
+impl REOBJECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for REOBJECT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7991,6 +8026,11 @@ impl ::core::fmt::Debug for RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE {
         f.debug_tuple("RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE").field(&self.0).finish()
     }
 }
+impl RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RICH_EDIT_GET_CONTEXT_MENU_SEL_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8050,6 +8090,11 @@ unsafe impl ::windows::core::Abi for RICH_EDIT_GET_OBJECT_FLAGS {
 impl ::core::fmt::Debug for RICH_EDIT_GET_OBJECT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RICH_EDIT_GET_OBJECT_FLAGS").field(&self.0).finish()
+    }
+}
+impl RICH_EDIT_GET_OBJECT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for RICH_EDIT_GET_OBJECT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/mod.rs
@@ -6994,6 +6994,11 @@ impl ::core::fmt::Debug for BP_PAINTPARAMS_FLAGS {
         f.debug_tuple("BP_PAINTPARAMS_FLAGS").field(&self.0).finish()
     }
 }
+impl BP_PAINTPARAMS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for BP_PAINTPARAMS_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7533,6 +7538,11 @@ unsafe impl ::windows::core::Abi for COMBOBOX_EX_ITEM_FLAGS {
 impl ::core::fmt::Debug for COMBOBOX_EX_ITEM_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("COMBOBOX_EX_ITEM_FLAGS").field(&self.0).finish()
+    }
+}
+impl COMBOBOX_EX_ITEM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for COMBOBOX_EX_ITEM_FLAGS {
@@ -8098,6 +8108,11 @@ impl ::core::fmt::Debug for DLG_DIR_LIST_FILE_TYPE {
         f.debug_tuple("DLG_DIR_LIST_FILE_TYPE").field(&self.0).finish()
     }
 }
+impl DLG_DIR_LIST_FILE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DLG_DIR_LIST_FILE_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8353,6 +8368,11 @@ impl ::core::fmt::Debug for DRAW_THEME_PARENT_BACKGROUND_FLAGS {
         f.debug_tuple("DRAW_THEME_PARENT_BACKGROUND_FLAGS").field(&self.0).finish()
     }
 }
+impl DRAW_THEME_PARENT_BACKGROUND_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DRAW_THEME_PARENT_BACKGROUND_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8521,6 +8541,11 @@ unsafe impl ::windows::core::Abi for DTTOPTS_FLAGS {
 impl ::core::fmt::Debug for DTTOPTS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DTTOPTS_FLAGS").field(&self.0).finish()
+    }
+}
+impl DTTOPTS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DTTOPTS_FLAGS {
@@ -9775,6 +9800,11 @@ impl ::core::fmt::Debug for HDI_MASK {
         f.debug_tuple("HDI_MASK").field(&self.0).finish()
     }
 }
+impl HDI_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HDI_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10362,6 +10392,11 @@ impl ::core::fmt::Debug for HEADER_HITTEST_INFO_FLAGS {
         f.debug_tuple("HEADER_HITTEST_INFO_FLAGS").field(&self.0).finish()
     }
 }
+impl HEADER_HITTEST_INFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HEADER_HITTEST_INFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10809,6 +10844,11 @@ impl ::core::fmt::Debug for IMAGELIST_CREATION_FLAGS {
         f.debug_tuple("IMAGELIST_CREATION_FLAGS").field(&self.0).finish()
     }
 }
+impl IMAGELIST_CREATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IMAGELIST_CREATION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10946,6 +10986,11 @@ impl ::core::fmt::Debug for IMAGE_LIST_DRAW_STYLE {
         f.debug_tuple("IMAGE_LIST_DRAW_STYLE").field(&self.0).finish()
     }
 }
+impl IMAGE_LIST_DRAW_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IMAGE_LIST_DRAW_STYLE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11026,6 +11071,11 @@ unsafe impl ::windows::core::Abi for IMAGE_LIST_WRITE_STREAM_FLAGS {
 impl ::core::fmt::Debug for IMAGE_LIST_WRITE_STREAM_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IMAGE_LIST_WRITE_STREAM_FLAGS").field(&self.0).finish()
+    }
+}
+impl IMAGE_LIST_WRITE_STREAM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IMAGE_LIST_WRITE_STREAM_FLAGS {
@@ -11111,6 +11161,11 @@ unsafe impl ::windows::core::Abi for INITCOMMONCONTROLSEX_ICC {
 impl ::core::fmt::Debug for INITCOMMONCONTROLSEX_ICC {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("INITCOMMONCONTROLSEX_ICC").field(&self.0).finish()
+    }
+}
+impl INITCOMMONCONTROLSEX_ICC {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for INITCOMMONCONTROLSEX_ICC {
@@ -11424,6 +11479,11 @@ impl ::core::fmt::Debug for LIST_ITEM_FLAGS {
         f.debug_tuple("LIST_ITEM_FLAGS").field(&self.0).finish()
     }
 }
+impl LIST_ITEM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LIST_ITEM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11483,6 +11543,11 @@ unsafe impl ::windows::core::Abi for LIST_ITEM_STATE_FLAGS {
 impl ::core::fmt::Debug for LIST_ITEM_STATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LIST_ITEM_STATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl LIST_ITEM_STATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LIST_ITEM_STATE_FLAGS {
@@ -11556,6 +11621,11 @@ impl ::core::fmt::Debug for LIST_VIEW_BACKGROUND_IMAGE_FLAGS {
         f.debug_tuple("LIST_VIEW_BACKGROUND_IMAGE_FLAGS").field(&self.0).finish()
     }
 }
+impl LIST_VIEW_BACKGROUND_IMAGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LIST_VIEW_BACKGROUND_IMAGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11617,6 +11687,11 @@ unsafe impl ::windows::core::Abi for LIST_VIEW_GROUP_ALIGN_FLAGS {
 impl ::core::fmt::Debug for LIST_VIEW_GROUP_ALIGN_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LIST_VIEW_GROUP_ALIGN_FLAGS").field(&self.0).finish()
+    }
+}
+impl LIST_VIEW_GROUP_ALIGN_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LIST_VIEW_GROUP_ALIGN_FLAGS {
@@ -11688,6 +11763,11 @@ impl ::core::fmt::Debug for LIST_VIEW_GROUP_STATE_FLAGS {
         f.debug_tuple("LIST_VIEW_GROUP_STATE_FLAGS").field(&self.0).finish()
     }
 }
+impl LIST_VIEW_GROUP_STATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LIST_VIEW_GROUP_STATE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11739,6 +11819,11 @@ unsafe impl ::windows::core::Abi for LIST_VIEW_INSERT_MARK_FLAGS {
 impl ::core::fmt::Debug for LIST_VIEW_INSERT_MARK_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LIST_VIEW_INSERT_MARK_FLAGS").field(&self.0).finish()
+    }
+}
+impl LIST_VIEW_INSERT_MARK_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LIST_VIEW_INSERT_MARK_FLAGS {
@@ -11800,6 +11885,11 @@ unsafe impl ::windows::core::Abi for LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
 impl ::core::fmt::Debug for LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS").field(&self.0).finish()
+    }
+}
+impl LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LIST_VIEW_ITEM_COLUMN_FORMAT_FLAGS {
@@ -11871,6 +11961,11 @@ unsafe impl ::windows::core::Abi for LIST_VIEW_ITEM_FLAGS {
 impl ::core::fmt::Debug for LIST_VIEW_ITEM_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LIST_VIEW_ITEM_FLAGS").field(&self.0).finish()
+    }
+}
+impl LIST_VIEW_ITEM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LIST_VIEW_ITEM_FLAGS {
@@ -12014,6 +12109,11 @@ impl ::core::fmt::Debug for LVCOLUMNW_FORMAT {
         f.debug_tuple("LVCOLUMNW_FORMAT").field(&self.0).finish()
     }
 }
+impl LVCOLUMNW_FORMAT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LVCOLUMNW_FORMAT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12083,6 +12183,11 @@ impl ::core::fmt::Debug for LVCOLUMNW_MASK {
         f.debug_tuple("LVCOLUMNW_MASK").field(&self.0).finish()
     }
 }
+impl LVCOLUMNW_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LVCOLUMNW_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12144,6 +12249,11 @@ unsafe impl ::windows::core::Abi for LVFINDINFOW_FLAGS {
 impl ::core::fmt::Debug for LVFINDINFOW_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LVFINDINFOW_FLAGS").field(&self.0).finish()
+    }
+}
+impl LVFINDINFOW_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LVFINDINFOW_FLAGS {
@@ -12232,6 +12342,11 @@ impl ::core::fmt::Debug for LVGROUP_MASK {
         f.debug_tuple("LVGROUP_MASK").field(&self.0).finish()
     }
 }
+impl LVGROUP_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LVGROUP_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12315,6 +12430,11 @@ unsafe impl ::windows::core::Abi for LVHITTESTINFO_FLAGS {
 impl ::core::fmt::Debug for LVHITTESTINFO_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LVHITTESTINFO_FLAGS").field(&self.0).finish()
+    }
+}
+impl LVHITTESTINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LVHITTESTINFO_FLAGS {
@@ -12403,6 +12523,11 @@ impl ::core::fmt::Debug for LVTILEVIEWINFO_FLAGS {
         f.debug_tuple("LVTILEVIEWINFO_FLAGS").field(&self.0).finish()
     }
 }
+impl LVTILEVIEWINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for LVTILEVIEWINFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12458,6 +12583,11 @@ unsafe impl ::windows::core::Abi for LVTILEVIEWINFO_MASK {
 impl ::core::fmt::Debug for LVTILEVIEWINFO_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LVTILEVIEWINFO_MASK").field(&self.0).finish()
+    }
+}
+impl LVTILEVIEWINFO_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LVTILEVIEWINFO_MASK {
@@ -12604,6 +12734,11 @@ impl ::core::fmt::Debug for MCGRIDINFO_FLAGS {
         f.debug_tuple("MCGRIDINFO_FLAGS").field(&self.0).finish()
     }
 }
+impl MCGRIDINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MCGRIDINFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -12734,6 +12869,11 @@ unsafe impl ::windows::core::Abi for MCHITTESTINFO_HIT_FLAGS {
 impl ::core::fmt::Debug for MCHITTESTINFO_HIT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MCHITTESTINFO_HIT_FLAGS").field(&self.0).finish()
+    }
+}
+impl MCHITTESTINFO_HIT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MCHITTESTINFO_HIT_FLAGS {
@@ -13510,6 +13650,11 @@ impl ::core::fmt::Debug for NMCUSTOMDRAW_DRAW_STATE_FLAGS {
         f.debug_tuple("NMCUSTOMDRAW_DRAW_STATE_FLAGS").field(&self.0).finish()
     }
 }
+impl NMCUSTOMDRAW_DRAW_STATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NMCUSTOMDRAW_DRAW_STATE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13735,6 +13880,11 @@ impl ::core::fmt::Debug for NMPGSCROLL_KEYS {
         f.debug_tuple("NMPGSCROLL_KEYS").field(&self.0).finish()
     }
 }
+impl NMPGSCROLL_KEYS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NMPGSCROLL_KEYS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13792,6 +13942,11 @@ impl ::core::fmt::Debug for NMREBAR_MASK_FLAGS {
         f.debug_tuple("NMREBAR_MASK_FLAGS").field(&self.0).finish()
     }
 }
+impl NMREBAR_MASK_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NMREBAR_MASK_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13847,6 +14002,11 @@ unsafe impl ::windows::core::Abi for NMTBDISPINFOW_MASK {
 impl ::core::fmt::Debug for NMTBDISPINFOW_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NMTBDISPINFOW_MASK").field(&self.0).finish()
+    }
+}
+impl NMTBDISPINFOW_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NMTBDISPINFOW_MASK {
@@ -13920,6 +14080,11 @@ impl ::core::fmt::Debug for NMTBHOTITEM_FLAGS {
         f.debug_tuple("NMTBHOTITEM_FLAGS").field(&self.0).finish()
     }
 }
+impl NMTBHOTITEM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for NMTBHOTITEM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -13985,6 +14150,11 @@ unsafe impl ::windows::core::Abi for NM_TREEVIEW_ACTION {
 impl ::core::fmt::Debug for NM_TREEVIEW_ACTION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NM_TREEVIEW_ACTION").field(&self.0).finish()
+    }
+}
+impl NM_TREEVIEW_ACTION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NM_TREEVIEW_ACTION {
@@ -14283,6 +14453,11 @@ unsafe impl ::windows::core::Abi for OPEN_THEME_DATA_FLAGS {
 impl ::core::fmt::Debug for OPEN_THEME_DATA_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OPEN_THEME_DATA_FLAGS").field(&self.0).finish()
+    }
+}
+impl OPEN_THEME_DATA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for OPEN_THEME_DATA_FLAGS {
@@ -15002,6 +15177,11 @@ unsafe impl ::windows::core::Abi for SET_THEME_APP_PROPERTIES_FLAGS {
 impl ::core::fmt::Debug for SET_THEME_APP_PROPERTIES_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SET_THEME_APP_PROPERTIES_FLAGS").field(&self.0).finish()
+    }
+}
+impl SET_THEME_APP_PROPERTIES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SET_THEME_APP_PROPERTIES_FLAGS {
@@ -16452,6 +16632,11 @@ impl ::core::fmt::Debug for TA_PROPERTY_FLAG {
         f.debug_tuple("TA_PROPERTY_FLAG").field(&self.0).finish()
     }
 }
+impl TA_PROPERTY_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TA_PROPERTY_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -16608,6 +16793,11 @@ impl ::core::fmt::Debug for TBBUTTONINFOW_MASK {
         f.debug_tuple("TBBUTTONINFOW_MASK").field(&self.0).finish()
     }
 }
+impl TBBUTTONINFOW_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TBBUTTONINFOW_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -16727,6 +16917,11 @@ unsafe impl ::windows::core::Abi for TCITEMHEADERA_MASK {
 impl ::core::fmt::Debug for TCITEMHEADERA_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TCITEMHEADERA_MASK").field(&self.0).finish()
+    }
+}
+impl TCITEMHEADERA_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TCITEMHEADERA_MASK {
@@ -17847,6 +18042,11 @@ impl ::core::fmt::Debug for TOOLTIP_FLAGS {
         f.debug_tuple("TOOLTIP_FLAGS").field(&self.0).finish()
     }
 }
+impl TOOLTIP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TOOLTIP_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -18498,6 +18698,11 @@ impl ::core::fmt::Debug for TVHITTESTINFO_FLAGS {
         f.debug_tuple("TVHITTESTINFO_FLAGS").field(&self.0).finish()
     }
 }
+impl TVHITTESTINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TVHITTESTINFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -18625,6 +18830,11 @@ unsafe impl ::windows::core::Abi for TVITEM_MASK {
 impl ::core::fmt::Debug for TVITEM_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TVITEM_MASK").field(&self.0).finish()
+    }
+}
+impl TVITEM_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TVITEM_MASK {

--- a/crates/libs/windows/src/Windows/Win32/UI/HiDpi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/HiDpi/mod.rs
@@ -301,6 +301,11 @@ impl ::core::fmt::Debug for DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
         f.debug_tuple("DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS").field(&self.0).finish()
     }
 }
+impl DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DIALOG_CONTROL_DPI_CHANGE_BEHAVIORS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -358,6 +363,11 @@ unsafe impl ::windows::core::Abi for DIALOG_DPI_CHANGE_BEHAVIORS {
 impl ::core::fmt::Debug for DIALOG_DPI_CHANGE_BEHAVIORS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DIALOG_DPI_CHANGE_BEHAVIORS").field(&self.0).finish()
+    }
+}
+impl DIALOG_DPI_CHANGE_BEHAVIORS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DIALOG_DPI_CHANGE_BEHAVIORS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
@@ -5466,6 +5466,11 @@ impl ::core::fmt::Debug for IME_COMPOSITION_STRING {
         f.debug_tuple("IME_COMPOSITION_STRING").field(&self.0).finish()
     }
 }
+impl IME_COMPOSITION_STRING {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IME_COMPOSITION_STRING {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5553,6 +5558,11 @@ unsafe impl ::windows::core::Abi for IME_CONVERSION_MODE {
 impl ::core::fmt::Debug for IME_CONVERSION_MODE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IME_CONVERSION_MODE").field(&self.0).finish()
+    }
+}
+impl IME_CONVERSION_MODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IME_CONVERSION_MODE {
@@ -5783,6 +5793,11 @@ unsafe impl ::windows::core::Abi for IME_SENTENCE_MODE {
 impl ::core::fmt::Debug for IME_SENTENCE_MODE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IME_SENTENCE_MODE").field(&self.0).finish()
+    }
+}
+impl IME_SENTENCE_MODE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for IME_SENTENCE_MODE {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/KeyboardAndMouse/mod.rs
@@ -812,6 +812,11 @@ impl ::core::fmt::Debug for HOT_KEY_MODIFIERS {
         f.debug_tuple("HOT_KEY_MODIFIERS").field(&self.0).finish()
     }
 }
+impl HOT_KEY_MODIFIERS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HOT_KEY_MODIFIERS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -898,6 +903,11 @@ unsafe impl ::windows::core::Abi for KEYBD_EVENT_FLAGS {
 impl ::core::fmt::Debug for KEYBD_EVENT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KEYBD_EVENT_FLAGS").field(&self.0).finish()
+    }
+}
+impl KEYBD_EVENT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for KEYBD_EVENT_FLAGS {
@@ -1012,6 +1022,11 @@ impl ::core::fmt::Debug for MOUSE_EVENT_FLAGS {
         f.debug_tuple("MOUSE_EVENT_FLAGS").field(&self.0).finish()
     }
 }
+impl MOUSE_EVENT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MOUSE_EVENT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -1071,6 +1086,11 @@ unsafe impl ::windows::core::Abi for TRACKMOUSEEVENT_FLAGS {
 impl ::core::fmt::Debug for TRACKMOUSEEVENT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TRACKMOUSEEVENT_FLAGS").field(&self.0).finish()
+    }
+}
+impl TRACKMOUSEEVENT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TRACKMOUSEEVENT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Pointer/mod.rs
@@ -317,6 +317,11 @@ impl ::core::fmt::Debug for POINTER_FLAGS {
         f.debug_tuple("POINTER_FLAGS").field(&self.0).finish()
     }
 }
+impl POINTER_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for POINTER_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Touch/mod.rs
@@ -575,6 +575,11 @@ impl ::core::fmt::Debug for GESTURECONFIG_ID {
         f.debug_tuple("GESTURECONFIG_ID").field(&self.0).finish()
     }
 }
+impl GESTURECONFIG_ID {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GESTURECONFIG_ID {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -704,6 +709,11 @@ impl ::core::fmt::Debug for TOUCHEVENTF_FLAGS {
         f.debug_tuple("TOUCHEVENTF_FLAGS").field(&self.0).finish()
     }
 }
+impl TOUCHEVENTF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TOUCHEVENTF_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -759,6 +769,11 @@ unsafe impl ::windows::core::Abi for TOUCHINPUTMASKF_MASK {
 impl ::core::fmt::Debug for TOUCHINPUTMASKF_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TOUCHINPUTMASKF_MASK").field(&self.0).finish()
+    }
+}
+impl TOUCHINPUTMASKF_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TOUCHINPUTMASKF_MASK {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/XboxController/mod.rs
@@ -178,6 +178,11 @@ impl ::core::fmt::Debug for XINPUT_CAPABILITIES_FLAGS {
         f.debug_tuple("XINPUT_CAPABILITIES_FLAGS").field(&self.0).finish()
     }
 }
+impl XINPUT_CAPABILITIES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for XINPUT_CAPABILITIES_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -303,6 +308,11 @@ impl ::core::fmt::Debug for XINPUT_FLAG {
         f.debug_tuple("XINPUT_FLAG").field(&self.0).finish()
     }
 }
+impl XINPUT_FLAG {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for XINPUT_FLAG {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -388,6 +398,11 @@ impl ::core::fmt::Debug for XINPUT_GAMEPAD_BUTTON_FLAGS {
         f.debug_tuple("XINPUT_GAMEPAD_BUTTON_FLAGS").field(&self.0).finish()
     }
 }
+impl XINPUT_GAMEPAD_BUTTON_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for XINPUT_GAMEPAD_BUTTON_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -443,6 +458,11 @@ unsafe impl ::windows::core::Abi for XINPUT_KEYSTROKE_FLAGS {
 impl ::core::fmt::Debug for XINPUT_KEYSTROKE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XINPUT_KEYSTROKE_FLAGS").field(&self.0).finish()
+    }
+}
+impl XINPUT_KEYSTROKE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for XINPUT_KEYSTROKE_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/mod.rs
@@ -199,6 +199,11 @@ impl ::core::fmt::Debug for RAWINPUTDEVICE_FLAGS {
         f.debug_tuple("RAWINPUTDEVICE_FLAGS").field(&self.0).finish()
     }
 }
+impl RAWINPUTDEVICE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for RAWINPUTDEVICE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/InteractionContext/mod.rs
@@ -312,6 +312,11 @@ impl ::core::fmt::Debug for CROSS_SLIDE_FLAGS {
         f.debug_tuple("CROSS_SLIDE_FLAGS").field(&self.0).finish()
     }
 }
+impl CROSS_SLIDE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CROSS_SLIDE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -524,6 +529,11 @@ impl ::core::fmt::Debug for INTERACTION_CONFIGURATION_FLAGS {
         f.debug_tuple("INTERACTION_CONFIGURATION_FLAGS").field(&self.0).finish()
     }
 }
+impl INTERACTION_CONFIGURATION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for INTERACTION_CONFIGURATION_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -616,6 +626,11 @@ unsafe impl ::windows::core::Abi for INTERACTION_FLAGS {
 impl ::core::fmt::Debug for INTERACTION_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("INTERACTION_FLAGS").field(&self.0).finish()
+    }
+}
+impl INTERACTION_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for INTERACTION_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -3920,6 +3920,11 @@ impl ::core::fmt::Debug for DRAWPROGRESSFLAGS {
         f.debug_tuple("DRAWPROGRESSFLAGS").field(&self.0).finish()
     }
 }
+impl DRAWPROGRESSFLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for DRAWPROGRESSFLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -3999,6 +4004,11 @@ unsafe impl ::windows::core::Abi for GETPROPERTYSTOREFLAGS {
 impl ::core::fmt::Debug for GETPROPERTYSTOREFLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GETPROPERTYSTOREFLAGS").field(&self.0).finish()
+    }
+}
+impl GETPROPERTYSTOREFLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GETPROPERTYSTOREFLAGS {
@@ -4091,6 +4101,11 @@ impl ::core::fmt::Debug for PKA_FLAGS {
         f.debug_tuple("PKA_FLAGS").field(&self.0).finish()
     }
 }
+impl PKA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PKA_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4154,6 +4169,11 @@ unsafe impl ::windows::core::Abi for PLACEHOLDER_STATES {
 impl ::core::fmt::Debug for PLACEHOLDER_STATES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PLACEHOLDER_STATES").field(&self.0).finish()
+    }
+}
+impl PLACEHOLDER_STATES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PLACEHOLDER_STATES {
@@ -4416,6 +4436,11 @@ impl ::core::fmt::Debug for PROPDESC_FORMAT_FLAGS {
         f.debug_tuple("PROPDESC_FORMAT_FLAGS").field(&self.0).finish()
     }
 }
+impl PROPDESC_FORMAT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROPDESC_FORMAT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4561,6 +4586,11 @@ impl ::core::fmt::Debug for PROPDESC_SEARCHINFO_FLAGS {
         f.debug_tuple("PROPDESC_SEARCHINFO_FLAGS").field(&self.0).finish()
     }
 }
+impl PROPDESC_SEARCHINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROPDESC_SEARCHINFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4677,6 +4707,11 @@ impl ::core::fmt::Debug for PROPDESC_TYPE_FLAGS {
         f.debug_tuple("PROPDESC_TYPE_FLAGS").field(&self.0).finish()
     }
 }
+impl PROPDESC_TYPE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROPDESC_TYPE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4754,6 +4789,11 @@ unsafe impl ::windows::core::Abi for PROPDESC_VIEW_FLAGS {
 impl ::core::fmt::Debug for PROPDESC_VIEW_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROPDESC_VIEW_FLAGS").field(&self.0).finish()
+    }
+}
+impl PROPDESC_VIEW_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROPDESC_VIEW_FLAGS {
@@ -4844,6 +4884,11 @@ impl ::core::fmt::Debug for PROPERTYUI_FLAGS {
         f.debug_tuple("PROPERTYUI_FLAGS").field(&self.0).finish()
     }
 }
+impl PROPERTYUI_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROPERTYUI_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4905,6 +4950,11 @@ impl ::core::fmt::Debug for PROPERTYUI_FORMAT_FLAGS {
         f.debug_tuple("PROPERTYUI_FORMAT_FLAGS").field(&self.0).finish()
     }
 }
+impl PROPERTYUI_FORMAT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROPERTYUI_FORMAT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -4958,6 +5008,11 @@ unsafe impl ::windows::core::Abi for PROPERTYUI_NAME_FLAGS {
 impl ::core::fmt::Debug for PROPERTYUI_NAME_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROPERTYUI_NAME_FLAGS").field(&self.0).finish()
+    }
+}
+impl PROPERTYUI_NAME_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROPERTYUI_NAME_FLAGS {
@@ -5023,6 +5078,11 @@ impl ::core::fmt::Debug for PROPVAR_CHANGE_FLAGS {
         f.debug_tuple("PROPVAR_CHANGE_FLAGS").field(&self.0).finish()
     }
 }
+impl PROPVAR_CHANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PROPVAR_CHANGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5086,6 +5146,11 @@ unsafe impl ::windows::core::Abi for PROPVAR_COMPARE_FLAGS {
 impl ::core::fmt::Debug for PROPVAR_COMPARE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PROPVAR_COMPARE_FLAGS").field(&self.0).finish()
+    }
+}
+impl PROPVAR_COMPARE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PROPVAR_COMPARE_FLAGS {
@@ -5211,6 +5276,11 @@ impl ::core::fmt::Debug for PSTIME_FLAGS {
         f.debug_tuple("PSTIME_FLAGS").field(&self.0).finish()
     }
 }
+impl PSTIME_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PSTIME_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -5282,6 +5352,11 @@ unsafe impl ::windows::core::Abi for SYNC_ENGINE_STATE_FLAGS {
 impl ::core::fmt::Debug for SYNC_ENGINE_STATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SYNC_ENGINE_STATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl SYNC_ENGINE_STATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SYNC_ENGINE_STATE_FLAGS {
@@ -5357,6 +5432,11 @@ unsafe impl ::windows::core::Abi for SYNC_TRANSFER_STATUS {
 impl ::core::fmt::Debug for SYNC_TRANSFER_STATUS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SYNC_TRANSFER_STATUS").field(&self.0).finish()
+    }
+}
+impl SYNC_TRANSFER_STATUS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SYNC_TRANSFER_STATUS {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -47012,6 +47012,11 @@ impl ::core::fmt::Debug for ASSOCF {
         f.debug_tuple("ASSOCF").field(&self.0).finish()
     }
 }
+impl ASSOCF {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ASSOCF {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -48963,6 +48968,11 @@ impl ::core::fmt::Debug for FILEOPENDIALOGOPTIONS {
         f.debug_tuple("FILEOPENDIALOGOPTIONS").field(&self.0).finish()
     }
 }
+impl FILEOPENDIALOGOPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for FILEOPENDIALOGOPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -49498,6 +49508,11 @@ impl ::core::fmt::Debug for HLBWIF_FLAGS {
         f.debug_tuple("HLBWIF_FLAGS").field(&self.0).finish()
     }
 }
+impl HLBWIF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for HLBWIF_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -49557,6 +49572,11 @@ unsafe impl ::windows::core::Abi for HLFNAMEF {
 impl ::core::fmt::Debug for HLFNAMEF {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HLFNAMEF").field(&self.0).finish()
+    }
+}
+impl HLFNAMEF {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for HLFNAMEF {
@@ -49763,6 +49783,11 @@ unsafe impl ::windows::core::Abi for HLNF {
 impl ::core::fmt::Debug for HLNF {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HLNF").field(&self.0).finish()
+    }
+}
+impl HLNF {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for HLNF {
@@ -50514,6 +50539,11 @@ impl ::core::fmt::Debug for MM_FLAGS {
         f.debug_tuple("MM_FLAGS").field(&self.0).finish()
     }
 }
+impl MM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -50692,6 +50722,11 @@ unsafe impl ::windows::core::Abi for NOTIFY_ICON_DATA_FLAGS {
 impl ::core::fmt::Debug for NOTIFY_ICON_DATA_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NOTIFY_ICON_DATA_FLAGS").field(&self.0).finish()
+    }
+}
+impl NOTIFY_ICON_DATA_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for NOTIFY_ICON_DATA_FLAGS {
@@ -51041,6 +51076,11 @@ impl ::core::fmt::Debug for OPEN_AS_INFO_FLAGS {
         f.debug_tuple("OPEN_AS_INFO_FLAGS").field(&self.0).finish()
     }
 }
+impl OPEN_AS_INFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for OPEN_AS_INFO_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -51269,6 +51309,11 @@ impl ::core::fmt::Debug for PATHCCH_OPTIONS {
         f.debug_tuple("PATHCCH_OPTIONS").field(&self.0).finish()
     }
 }
+impl PATHCCH_OPTIONS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PATHCCH_OPTIONS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -51330,6 +51375,11 @@ impl ::core::fmt::Debug for PCS_RET {
         f.debug_tuple("PCS_RET").field(&self.0).finish()
     }
 }
+impl PCS_RET {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PCS_RET {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -51387,6 +51437,11 @@ unsafe impl ::windows::core::Abi for PIDISF_FLAGS {
 impl ::core::fmt::Debug for PIDISF_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PIDISF_FLAGS").field(&self.0).finish()
+    }
+}
+impl PIDISF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for PIDISF_FLAGS {
@@ -51620,6 +51675,11 @@ impl ::core::fmt::Debug for PRF_FLAGS {
         f.debug_tuple("PRF_FLAGS").field(&self.0).finish()
     }
 }
+impl PRF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PRF_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -51718,6 +51778,11 @@ unsafe impl ::windows::core::Abi for QITIPF_FLAGS {
 impl ::core::fmt::Debug for QITIPF_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("QITIPF_FLAGS").field(&self.0).finish()
+    }
+}
+impl QITIPF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for QITIPF_FLAGS {
@@ -52194,6 +52259,11 @@ impl ::core::fmt::Debug for SCALE_CHANGE_FLAGS {
         f.debug_tuple("SCALE_CHANGE_FLAGS").field(&self.0).finish()
     }
 }
+impl SCALE_CHANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SCALE_CHANGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -52590,6 +52660,11 @@ impl ::core::fmt::Debug for SHCNE_ID {
         f.debug_tuple("SHCNE_ID").field(&self.0).finish()
     }
 }
+impl SHCNE_ID {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SHCNE_ID {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -52665,6 +52740,11 @@ impl ::core::fmt::Debug for SHCNF_FLAGS {
         f.debug_tuple("SHCNF_FLAGS").field(&self.0).finish()
     }
 }
+impl SHCNF_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SHCNF_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -52722,6 +52802,11 @@ unsafe impl ::windows::core::Abi for SHCNRF_SOURCE {
 impl ::core::fmt::Debug for SHCNRF_SOURCE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SHCNRF_SOURCE").field(&self.0).finish()
+    }
+}
+impl SHCNRF_SOURCE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SHCNRF_SOURCE {
@@ -52897,6 +52982,11 @@ unsafe impl ::windows::core::Abi for SHELL_AUTOCOMPLETE_FLAGS {
 impl ::core::fmt::Debug for SHELL_AUTOCOMPLETE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SHELL_AUTOCOMPLETE_FLAGS").field(&self.0).finish()
+    }
+}
+impl SHELL_AUTOCOMPLETE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SHELL_AUTOCOMPLETE_FLAGS {
@@ -53093,6 +53183,11 @@ impl ::core::fmt::Debug for SHFMT_OPT {
         f.debug_tuple("SHFMT_OPT").field(&self.0).finish()
     }
 }
+impl SHFMT_OPT {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SHFMT_OPT {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -53269,6 +53364,11 @@ unsafe impl ::windows::core::Abi for SHGFI_FLAGS {
 impl ::core::fmt::Debug for SHGFI_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SHGFI_FLAGS").field(&self.0).finish()
+    }
+}
+impl SHGFI_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SHGFI_FLAGS {
@@ -53508,6 +53608,11 @@ impl ::core::fmt::Debug for SHGSI_FLAGS {
         f.debug_tuple("SHGSI_FLAGS").field(&self.0).finish()
     }
 }
+impl SHGSI_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SHGSI_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -53563,6 +53668,11 @@ unsafe impl ::windows::core::Abi for SHOP_TYPE {
 impl ::core::fmt::Debug for SHOP_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SHOP_TYPE").field(&self.0).finish()
+    }
+}
+impl SHOP_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SHOP_TYPE {
@@ -53983,6 +54093,11 @@ unsafe impl ::windows::core::Abi for SIIGBF {
 impl ::core::fmt::Debug for SIIGBF {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SIIGBF").field(&self.0).finish()
+    }
+}
+impl SIIGBF {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SIIGBF {
@@ -54409,6 +54524,11 @@ unsafe impl ::windows::core::Abi for SSF_MASK {
 impl ::core::fmt::Debug for SSF_MASK {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SSF_MASK").field(&self.0).finish()
+    }
+}
+impl SSF_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SSF_MASK {
@@ -56161,6 +56281,11 @@ unsafe impl ::windows::core::Abi for VALIDATEUNC_OPTION {
 impl ::core::fmt::Debug for VALIDATEUNC_OPTION {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VALIDATEUNC_OPTION").field(&self.0).finish()
+    }
+}
+impl VALIDATEUNC_OPTION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for VALIDATEUNC_OPTION {

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -11016,6 +11016,11 @@ impl ::core::fmt::Debug for ANCHOR_CHANGE_HISTORY_FLAGS {
         f.debug_tuple("ANCHOR_CHANGE_HISTORY_FLAGS").field(&self.0).finish()
     }
 }
+impl ANCHOR_CHANGE_HISTORY_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ANCHOR_CHANGE_HISTORY_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11069,6 +11074,11 @@ unsafe impl ::windows::core::Abi for GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
 impl ::core::fmt::Debug for GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GET_TEXT_AND_PROPERTY_UPDATES_FLAGS").field(&self.0).finish()
+    }
+}
+impl GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GET_TEXT_AND_PROPERTY_UPDATES_FLAGS {
@@ -11353,6 +11363,11 @@ impl ::core::fmt::Debug for TEXT_STORE_CHANGE_FLAGS {
         f.debug_tuple("TEXT_STORE_CHANGE_FLAGS").field(&self.0).finish()
     }
 }
+impl TEXT_STORE_CHANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TEXT_STORE_CHANGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11435,6 +11450,11 @@ impl ::core::fmt::Debug for TEXT_STORE_TEXT_CHANGE_FLAGS {
         f.debug_tuple("TEXT_STORE_TEXT_CHANGE_FLAGS").field(&self.0).finish()
     }
 }
+impl TEXT_STORE_TEXT_CHANGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TEXT_STORE_TEXT_CHANGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -11494,6 +11514,11 @@ unsafe impl ::windows::core::Abi for TF_CONTEXT_EDIT_CONTEXT_FLAGS {
 impl ::core::fmt::Debug for TF_CONTEXT_EDIT_CONTEXT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TF_CONTEXT_EDIT_CONTEXT_FLAGS").field(&self.0).finish()
+    }
+}
+impl TF_CONTEXT_EDIT_CONTEXT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for TF_CONTEXT_EDIT_CONTEXT_FLAGS {

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -6685,6 +6685,11 @@ impl ::core::fmt::Debug for ACCEL_VIRT_FLAGS {
         f.debug_tuple("ACCEL_VIRT_FLAGS").field(&self.0).finish()
     }
 }
+impl ACCEL_VIRT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ACCEL_VIRT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6754,6 +6759,11 @@ impl ::core::fmt::Debug for ANIMATE_WINDOW_FLAGS {
         f.debug_tuple("ANIMATE_WINDOW_FLAGS").field(&self.0).finish()
     }
 }
+impl ANIMATE_WINDOW_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for ANIMATE_WINDOW_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6807,6 +6817,11 @@ unsafe impl ::windows::core::Abi for CASCADE_WINDOWS_HOW {
 impl ::core::fmt::Debug for CASCADE_WINDOWS_HOW {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CASCADE_WINDOWS_HOW").field(&self.0).finish()
+    }
+}
+impl CASCADE_WINDOWS_HOW {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for CASCADE_WINDOWS_HOW {
@@ -6922,6 +6937,11 @@ impl ::core::fmt::Debug for CWP_FLAGS {
         f.debug_tuple("CWP_FLAGS").field(&self.0).finish()
     }
 }
+impl CWP_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for CWP_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -6983,6 +7003,11 @@ unsafe impl ::windows::core::Abi for DI_FLAGS {
 impl ::core::fmt::Debug for DI_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DI_FLAGS").field(&self.0).finish()
+    }
+}
+impl DI_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for DI_FLAGS {
@@ -7073,6 +7098,11 @@ unsafe impl ::windows::core::Abi for FLASHWINFO_FLAGS {
 impl ::core::fmt::Debug for FLASHWINFO_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FLASHWINFO_FLAGS").field(&self.0).finish()
+    }
+}
+impl FLASHWINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for FLASHWINFO_FLAGS {
@@ -7274,6 +7304,11 @@ impl ::core::fmt::Debug for GET_MENU_DEFAULT_ITEM_FLAGS {
         f.debug_tuple("GET_MENU_DEFAULT_ITEM_FLAGS").field(&self.0).finish()
     }
 }
+impl GET_MENU_DEFAULT_ITEM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for GET_MENU_DEFAULT_ITEM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7370,6 +7405,11 @@ unsafe impl ::windows::core::Abi for GUITHREADINFO_FLAGS {
 impl ::core::fmt::Debug for GUITHREADINFO_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GUITHREADINFO_FLAGS").field(&self.0).finish()
+    }
+}
+impl GUITHREADINFO_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for GUITHREADINFO_FLAGS {
@@ -7474,6 +7514,11 @@ impl ::core::fmt::Debug for IMAGE_FLAGS {
         f.debug_tuple("IMAGE_FLAGS").field(&self.0).finish()
     }
 }
+impl IMAGE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for IMAGE_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7535,6 +7580,11 @@ impl ::core::fmt::Debug for KBDLLHOOKSTRUCT_FLAGS {
         f.debug_tuple("KBDLLHOOKSTRUCT_FLAGS").field(&self.0).finish()
     }
 }
+impl KBDLLHOOKSTRUCT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for KBDLLHOOKSTRUCT_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7588,6 +7638,11 @@ unsafe impl ::windows::core::Abi for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
 impl ::core::fmt::Debug for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LAYERED_WINDOW_ATTRIBUTES_FLAGS").field(&self.0).finish()
+    }
+}
+impl LAYERED_WINDOW_ATTRIBUTES_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for LAYERED_WINDOW_ATTRIBUTES_FLAGS {
@@ -7680,6 +7735,11 @@ impl ::core::fmt::Debug for MENUINFO_MASK {
         f.debug_tuple("MENUINFO_MASK").field(&self.0).finish()
     }
 }
+impl MENUINFO_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MENUINFO_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7741,6 +7801,11 @@ unsafe impl ::windows::core::Abi for MENUINFO_STYLE {
 impl ::core::fmt::Debug for MENUINFO_STYLE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MENUINFO_STYLE").field(&self.0).finish()
+    }
+}
+impl MENUINFO_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MENUINFO_STYLE {
@@ -7850,6 +7915,11 @@ impl ::core::fmt::Debug for MENU_ITEM_FLAGS {
         f.debug_tuple("MENU_ITEM_FLAGS").field(&self.0).finish()
     }
 }
+impl MENU_ITEM_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MENU_ITEM_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7919,6 +7989,11 @@ impl ::core::fmt::Debug for MENU_ITEM_MASK {
         f.debug_tuple("MENU_ITEM_MASK").field(&self.0).finish()
     }
 }
+impl MENU_ITEM_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MENU_ITEM_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -7984,6 +8059,11 @@ unsafe impl ::windows::core::Abi for MENU_ITEM_STATE {
 impl ::core::fmt::Debug for MENU_ITEM_STATE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MENU_ITEM_STATE").field(&self.0).finish()
+    }
+}
+impl MENU_ITEM_STATE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MENU_ITEM_STATE {
@@ -8053,6 +8133,11 @@ unsafe impl ::windows::core::Abi for MENU_ITEM_TYPE {
 impl ::core::fmt::Debug for MENU_ITEM_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MENU_ITEM_TYPE").field(&self.0).finish()
+    }
+}
+impl MENU_ITEM_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MENU_ITEM_TYPE {
@@ -8229,6 +8314,11 @@ impl ::core::fmt::Debug for MESSAGEBOX_STYLE {
         f.debug_tuple("MESSAGEBOX_STYLE").field(&self.0).finish()
     }
 }
+impl MESSAGEBOX_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for MESSAGEBOX_STYLE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8348,6 +8438,11 @@ unsafe impl ::windows::core::Abi for MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
 impl ::core::fmt::Debug for MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS").field(&self.0).finish()
+    }
+}
+impl MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for MSG_WAIT_FOR_MULTIPLE_OBJECTS_EX_FLAGS {
@@ -8642,6 +8737,11 @@ impl ::core::fmt::Debug for PEEK_MESSAGE_REMOVE_TYPE {
         f.debug_tuple("PEEK_MESSAGE_REMOVE_TYPE").field(&self.0).finish()
     }
 }
+impl PEEK_MESSAGE_REMOVE_TYPE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for PEEK_MESSAGE_REMOVE_TYPE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8752,6 +8852,11 @@ unsafe impl ::windows::core::Abi for QUEUE_STATUS_FLAGS {
 impl ::core::fmt::Debug for QUEUE_STATUS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("QUEUE_STATUS_FLAGS").field(&self.0).finish()
+    }
+}
+impl QUEUE_STATUS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for QUEUE_STATUS_FLAGS {
@@ -8866,6 +8971,11 @@ impl ::core::fmt::Debug for SCROLLBAR_CONSTANTS {
         f.debug_tuple("SCROLLBAR_CONSTANTS").field(&self.0).finish()
     }
 }
+impl SCROLLBAR_CONSTANTS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SCROLLBAR_CONSTANTS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8929,6 +9039,11 @@ impl ::core::fmt::Debug for SCROLLINFO_MASK {
         f.debug_tuple("SCROLLINFO_MASK").field(&self.0).finish()
     }
 }
+impl SCROLLINFO_MASK {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SCROLLINFO_MASK {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -8988,6 +9103,11 @@ unsafe impl ::windows::core::Abi for SEND_MESSAGE_TIMEOUT_FLAGS {
 impl ::core::fmt::Debug for SEND_MESSAGE_TIMEOUT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SEND_MESSAGE_TIMEOUT_FLAGS").field(&self.0).finish()
+    }
+}
+impl SEND_MESSAGE_TIMEOUT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SEND_MESSAGE_TIMEOUT_FLAGS {
@@ -9069,6 +9189,11 @@ unsafe impl ::windows::core::Abi for SET_WINDOW_POS_FLAGS {
 impl ::core::fmt::Debug for SET_WINDOW_POS_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SET_WINDOW_POS_FLAGS").field(&self.0).finish()
+    }
+}
+impl SET_WINDOW_POS_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SET_WINDOW_POS_FLAGS {
@@ -9166,6 +9291,11 @@ unsafe impl ::windows::core::Abi for SHOW_WINDOW_CMD {
 impl ::core::fmt::Debug for SHOW_WINDOW_CMD {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SHOW_WINDOW_CMD").field(&self.0).finish()
+    }
+}
+impl SHOW_WINDOW_CMD {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SHOW_WINDOW_CMD {
@@ -9965,6 +10095,11 @@ impl ::core::fmt::Debug for SYSTEM_PARAMETERS_INFO_ACTION {
         f.debug_tuple("SYSTEM_PARAMETERS_INFO_ACTION").field(&self.0).finish()
     }
 }
+impl SYSTEM_PARAMETERS_INFO_ACTION {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for SYSTEM_PARAMETERS_INFO_ACTION {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10020,6 +10155,11 @@ unsafe impl ::windows::core::Abi for SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
 impl ::core::fmt::Debug for SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS").field(&self.0).finish()
+    }
+}
+impl SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for SYSTEM_PARAMETERS_INFO_UPDATE_FLAGS {
@@ -10140,6 +10280,11 @@ impl ::core::fmt::Debug for TRACK_POPUP_MENU_FLAGS {
         f.debug_tuple("TRACK_POPUP_MENU_FLAGS").field(&self.0).finish()
     }
 }
+impl TRACK_POPUP_MENU_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for TRACK_POPUP_MENU_FLAGS {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10226,6 +10371,11 @@ unsafe impl ::windows::core::Abi for WINDOWPLACEMENT_FLAGS {
 impl ::core::fmt::Debug for WINDOWPLACEMENT_FLAGS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WINDOWPLACEMENT_FLAGS").field(&self.0).finish()
+    }
+}
+impl WINDOWPLACEMENT_FLAGS {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WINDOWPLACEMENT_FLAGS {
@@ -10415,6 +10565,11 @@ impl ::core::fmt::Debug for WINDOW_EX_STYLE {
         f.debug_tuple("WINDOW_EX_STYLE").field(&self.0).finish()
     }
 }
+impl WINDOW_EX_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WINDOW_EX_STYLE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10598,6 +10753,11 @@ impl ::core::fmt::Debug for WINDOW_STYLE {
         f.debug_tuple("WINDOW_STYLE").field(&self.0).finish()
     }
 }
+impl WINDOW_STYLE {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for WINDOW_STYLE {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
@@ -10673,6 +10833,11 @@ unsafe impl ::windows::core::Abi for WNDCLASS_STYLES {
 impl ::core::fmt::Debug for WNDCLASS_STYLES {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WNDCLASS_STYLES").field(&self.0).finish()
+    }
+}
+impl WNDCLASS_STYLES {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
     }
 }
 impl ::core::ops::BitOr for WNDCLASS_STYLES {

--- a/crates/samples/windows/enum_windows/src/main.rs
+++ b/crates/samples/windows/enum_windows/src/main.rs
@@ -16,7 +16,7 @@ extern "system" fn enum_window(window: HWND, _: LPARAM) -> BOOL {
         };
         GetWindowInfo(window, &mut info).unwrap();
 
-        if !text.is_empty() && info.dwStyle & WS_VISIBLE != WINDOW_STYLE(0) {
+        if !text.is_empty() && info.dwStyle.contains(WS_VISIBLE) {
             println!("{} ({}, {})", text, info.rcWindow.left, info.rcWindow.top);
         }
 

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -121,6 +121,11 @@ impl ::core::fmt::Debug for Flags {
         f.debug_tuple("Flags").field(&self.0).finish()
     }
 }
+impl Flags {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for Flags {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/tests/component_client/src/bindings.rs
+++ b/crates/tests/component_client/src/bindings.rs
@@ -121,6 +121,11 @@ impl ::core::fmt::Debug for Flags {
         f.debug_tuple("Flags").field(&self.0).finish()
     }
 }
+impl Flags {
+    pub const fn contains(&self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+}
 impl ::core::ops::BitOr for Flags {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -10,10 +10,15 @@ fn nested() {
 
     let options = (InputStreamOptions::Partial | InputStreamOptions::ReadAhead) & InputStreamOptions::ReadAhead;
     assert!(options.0 == 2);
+    assert!(!options.contains(InputStreamOptions::Partial));
+    assert!(options.contains(InputStreamOptions::ReadAhead));
 
     let mut options = InputStreamOptions::Partial;
     options |= InputStreamOptions::ReadAhead;
     assert!(options.0 == 3);
+    assert!(options.contains(InputStreamOptions::Partial));
+    assert!(options.contains(InputStreamOptions::ReadAhead));
+
 
     options &= InputStreamOptions::ReadAhead;
     assert!(options.0 == 2);
@@ -45,4 +50,7 @@ fn win32_error() {
 fn messagebox_style() {
     let s: MESSAGEBOX_STYLE = MB_YESNOCANCEL | MB_HELP;
     assert!(s.0 == 0x4003);
+    assert!(s.contains(MB_YESNOCANCEL));
+    assert!(s.contains(MB_HELP));
+    assert!(!s.contains(MB_SYSTEMMODAL));
 }

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -19,7 +19,6 @@ fn nested() {
     assert!(options.contains(InputStreamOptions::Partial));
     assert!(options.contains(InputStreamOptions::ReadAhead));
 
-
     options &= InputStreamOptions::ReadAhead;
     assert!(options.0 == 2);
 }


### PR DESCRIPTION
The bitwise operators are generally sufficient, but I noticed some error-prone code that could be avoided with a `contains` method that does simplify this operation in particular. Related to #793. For example:

https://github.com/microsoft/windows-rs/blob/b3bf379c0699800c2dda50620b2cf274db1a7848/crates/samples/windows/enum_windows/src/main.rs#L19