### PR TITLE
metadata `Reader::attribute_args` enhancements

### DIFF
--- a/crates/libs/metadata/src/reader/blob.rs
+++ b/crates/libs/metadata/src/reader/blob.rs
@@ -70,6 +70,14 @@ impl<'a> Blob<'a> {
             String::from_utf16_lossy(slice)
         }
     }
+    pub fn read_bool(&mut self) -> bool {
+        // A bool is specified as "a single byte with value 0 (false) or 1 (true)".
+        match self.read_u8() {
+            0 => false,
+            1 => true,
+            _ => panic!("Illegal bool value"),
+        }
+    }
     pub fn read_i8(&mut self) -> i8 {
         let value = i8::from_le_bytes(self[..1].try_into().unwrap());
         self.offset(1);

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -1591,7 +1591,11 @@ impl<'a> Reader<'a> {
             }
         }
 
-        Type::TypeDef((self.get(full_name).next().expect("Type not found"), Vec::new()))
+        if let Some(ty) = self.get(full_name).next() {
+            Type::TypeDef((ty, Vec::new()))
+        } else {
+            panic!("Type not found: {}", full_name);
+        }
     }
     fn type_from_blob(&self, blob: &mut Blob, enclosing: Option<TypeDef>, generics: &[Type]) -> Option<Type> {
         let is_winrt_const_ref = blob.read_modifiers().iter().any(|def| self.type_def_or_ref(*def) == TypeName::IsConst);

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -278,6 +278,7 @@ impl<'a> Reader<'a> {
 
         for _ in 0..fixed_arg_count {
             let arg = match self.type_from_blob(&mut sig, None, &[]).expect("Type not found") {
+                Type::Bool => Value::Bool(values.read_bool()),
                 Type::I8 => Value::I8(values.read_i8()),
                 Type::U8 => Value::U8(values.read_u8()),
                 Type::I16 => Value::I16(values.read_i16()),
@@ -313,7 +314,7 @@ impl<'a> Reader<'a> {
             let arg_type = values.read_u8();
             let name = values.read_str().to_string();
             let arg = match arg_type {
-                0x02 => Value::Bool(values.read_u8() != 0),
+                0x02 => Value::Bool(values.read_bool()),
                 0x06 => Value::I16(values.read_i16()),
                 0x08 => Value::I32(values.read_i32()),
                 0x09 => Value::U32(values.read_u32()),


### PR DESCRIPTION
I've been playing with reading attribute metadata and wanted to help fix a couple of issues I encountered:

* `ComVisibleAttribute` has a bool argument, so it's useful to be able to read it. I also added a panic if the blob bool value is not either 0 or 1 (as per the spec). Admittedly this may be overkill but I figured it'd help detect if something has gone wrong somewhere.
* `UnmanagedFunctionPointerAttribute` requires `System.Runtime.InteropServices.CallingConvention` and `AttributeUsageAttribute` requires `System.AttributeTargets`. Neither of which are part of the default metadata files. I've added the type name to the panic message to make this easier to diagnose but I guess this is a win32metadata issue?