### PR TITLE
Metadata reader: Preserve type when reading enum values in attributes

### DIFF
--- a/crates/libs/metadata/src/reader/blob.rs
+++ b/crates/libs/metadata/src/reader/blob.rs
@@ -128,6 +128,19 @@ impl<'a> Blob<'a> {
         self.offset(8);
         value
     }
+    pub fn read_integer(&mut self, ty: Type) -> Integer {
+        match ty {
+            Type::I8 => Integer::I8(self.read_i8()),
+            Type::U8 => Integer::U8(self.read_u8()),
+            Type::I16 => Integer::I16(self.read_i16()),
+            Type::U16 => Integer::U16(self.read_u16()),
+            Type::I32 => Integer::I32(self.read_i32()),
+            Type::U32 => Integer::U32(self.read_u32()),
+            Type::I64 => Integer::I64(self.read_i64()),
+            Type::U64 => Integer::U64(self.read_u64()),
+            _ => panic!("Type is not an integer"),
+        }
+    }
     fn offset(&mut self, offset: usize) {
         self.slice = &self.slice[offset..];
     }

--- a/crates/tests/metadata/tests/attribute_enum.rs
+++ b/crates/tests/metadata/tests/attribute_enum.rs
@@ -1,0 +1,29 @@
+use metadata::reader::{Attribute, File, Integer, Reader, TypeName, Value};
+
+#[test]
+fn attribute_enum() {
+    let files = File::with_default(&[]).unwrap();
+    let reader = &Reader::new(&files);
+
+    let def = reader.get(TypeName::new("Windows.Win32.UI.WindowsAndMessaging", "Apis")).next().unwrap();
+    let method = reader.type_def_methods(def).find(|&m| reader.method_def_name(m) == "SetWindowLongPtrA").unwrap();
+    let attrs = reader.method_def_attributes(method);
+    check_attr_arg_enum(reader, attrs, "SupportedArchitectureAttribute", "", "Windows.Win32.Interop.Architecture", 4 | 2);
+
+    // The only attribute currently with a named enum argument is "GCPressure".
+    let def = reader.get(TypeName::new("Windows.Graphics.Imaging", "BitmapBuffer")).next().unwrap();
+    let attrs = reader.type_def_attributes(def);
+    check_attr_arg_enum(reader, attrs, "GCPressureAttribute", "amount", "Windows.Foundation.Metadata.GCPressureAmount", 2);
+}
+
+fn check_attr_arg_enum(reader: &Reader, mut attrs: impl Iterator<Item = Attribute>, attr_name: &str, arg_name: &str, expected_type: &str, expected_value: i32) {
+    let attr = attrs.find(|&attr| reader.attribute_name(attr) == attr_name).unwrap();
+    let (_, value) = reader.attribute_args(attr).drain(..).find(|(name, _)| name == arg_name).unwrap();
+
+    if let Value::Enum(ty, Integer::I32(value)) = value {
+        assert_eq!(expected_type, reader.type_def_type_name(ty).to_string());
+        assert_eq!(expected_value, value);
+    } else {
+        panic!("Value not found");
+    }
+}


### PR DESCRIPTION
Also implement parsing enums in named arguments.

I've gone back on forth on whether to use an `i32`, `u64` or an `Integer` type to store the value. I eventually landed on the latter but please stop me if I'm over-engineering this.

Closes: #2330
