### PR TITLE
Specifically exclude `Windows.Win32.Web.MsHtml`

### DIFF
--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -30,7 +30,7 @@ const EXCLUDE_NAMESPACES: [&str; 28] = [
     "Windows.Win32.System.SideShow",
     "Windows.Win32.System.TransactionServer",
     "Windows.Win32.System.WinRT",
-    "Windows.Win32.Web",
+    "Windows.Win32.Web.MsHtml",
     "Windows.Win32.UI.Xaml",
 ];
 

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -2,7 +2,7 @@ use rayon::prelude::*;
 use std::io::prelude::*;
 
 /// Namespaces to exclude from code generation for the `windows` crate.
-const EXCLUDE_NAMESPACES: [&str; 14] = ["Windows.AI.MachineLearning.Preview", "Windows.ApplicationModel.SocialInfo", "Windows.Devices.AllJoyn", "Windows.Devices.Perception", "Windows.Security.Authentication.Identity.Provider", "Windows.Services.Cortana", "Windows.System.Power.Diagnostics", "Windows.System.Preview", "Windows.UI.Xaml", "Windows.Win32.Interop", "Windows.Win32.System.Diagnostics.Debug.WebApp", "Windows.Win32.System.WinRT.Xaml", "Windows.Win32.Web", "Windows.Win32.UI.Xaml"];
+const EXCLUDE_NAMESPACES: [&str; 14] = ["Windows.AI.MachineLearning.Preview", "Windows.ApplicationModel.SocialInfo", "Windows.Devices.AllJoyn", "Windows.Devices.Perception", "Windows.Security.Authentication.Identity.Provider", "Windows.Services.Cortana", "Windows.System.Power.Diagnostics", "Windows.System.Preview", "Windows.UI.Xaml", "Windows.Win32.Interop", "Windows.Win32.System.Diagnostics.Debug.WebApp", "Windows.Win32.System.WinRT.Xaml", "Windows.Win32.Web.MsHtml", "Windows.Win32.UI.Xaml"];
 
 fn main() {
     let mut rustfmt = true;


### PR DESCRIPTION
This doesn't make a difference today but if the metadata introduces some other `Windows.Win32.Web.*` namespace then we'll be ready.