### PR TITLE
Improve handling of packing vs alignment

### DIFF
--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -339,7 +339,7 @@ impl<'a> Reader<'a> {
     // ClassLayout table queries
     //
 
-    pub fn class_layout_packing_size(&self, row: ClassLayout) -> usize {
+    fn class_layout_packing_size(&self, row: ClassLayout) -> usize {
         self.row_usize(row.0, 0)
     }
 
@@ -831,6 +831,16 @@ impl<'a> Reader<'a> {
     }
     pub fn type_def_class_layout(&self, row: TypeDef) -> Option<ClassLayout> {
         self.row_equal_range(row.0, TABLE_CLASSLAYOUT, 2, (row.0.row + 1) as _).map(ClassLayout).next()
+    }
+    pub fn type_def_packing_size(&self, row: TypeDef) -> Option<usize> {
+        if let Some(layout) = self.type_def_class_layout(row) {
+            let packing_size = self.class_layout_packing_size(layout);
+            // TODO: workaround for https://github.com/microsoft/win32metadata/issues/380
+            if packing_size < 4 {
+                return Some(packing_size);
+            }
+        }
+        None
     }
     pub fn type_def_underlying_type(&self, row: TypeDef) -> Type {
         let field = self.type_def_fields(row).next().expect("Field not found");

--- a/crates/libs/metadata/src/reader/type_name.rs
+++ b/crates/libs/metadata/src/reader/type_name.rs
@@ -46,6 +46,7 @@ impl<'a> TypeName<'a> {
     pub const ULARGE_INTEGER: Self = Self::from_const("Windows.Win32.Foundation", "ULARGE_INTEGER");
     pub const IRestrictedErrorInfo: Self = Self::from_const("Windows.Win32.System.WinRT", "IRestrictedErrorInfo");
     pub const IDispatch: Self = Self::from_const("Windows.Win32.System.Com", "IDispatch");
+    pub const CONTEXT: Self = Self::from_const("Windows.Win32.System.Diagnostics.Debug", "CONTEXT");
 
     const fn from_const(namespace: &'static str, name: &'static str) -> Self {
         Self { namespace, name }

--- a/crates/libs/sys/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -6209,7 +6209,7 @@ impl ::core::clone::Clone for HIDD_ATTRIBUTES {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`*"]
 pub struct HIDD_CONFIGURATION {
     pub cookie: *mut ::core::ffi::c_void,
@@ -6379,7 +6379,7 @@ impl ::core::clone::Clone for HIDP_DATA_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`*"]
 pub struct HIDP_EXTENDED_ATTRIBUTES {
     pub NumGlobalUnknowns: u8,
@@ -6427,7 +6427,7 @@ impl ::core::clone::Clone for HIDP_KEYBOARD_MODIFIER_STATE_0_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`*"]
 pub struct HIDP_LINK_COLLECTION_NODE {
     pub LinkUsage: u16,

--- a/crates/libs/sys/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
@@ -695,7 +695,7 @@ impl ::core::clone::Clone for DMUS_DOWNLOADINFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`*"]
 pub struct DMUS_EVENTHEADER {
     pub cbEvent: u32,

--- a/crates/libs/sys/src/Windows/Win32/NetworkManagement/Rras/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/NetworkManagement/Rras/mod.rs
@@ -3300,7 +3300,7 @@ impl ::core::clone::Clone for PROJECTION_INFO2_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASADPARAMS {
@@ -3395,7 +3395,7 @@ impl ::core::clone::Clone for RASCOMMSETTINGS {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASCONNA {
@@ -3463,7 +3463,7 @@ impl ::core::clone::Clone for RASCONNSTATUSW {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASCONNW {
@@ -3535,7 +3535,7 @@ impl ::core::clone::Clone for RASCTRYINFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASCUSTOMSCRIPTEXTENSIONS {
@@ -3579,7 +3579,7 @@ impl ::core::clone::Clone for RASDEVINFOW {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`*"]
 pub struct RASDEVSPECIFICINFO {
     pub dwSize: u32,
@@ -3591,7 +3591,7 @@ impl ::core::clone::Clone for RASDEVSPECIFICINFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASDIALDLG {
@@ -3613,7 +3613,7 @@ impl ::core::clone::Clone for RASDIALDLG {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASDIALEXTENSIONS {
@@ -3634,7 +3634,7 @@ impl ::core::clone::Clone for RASDIALEXTENSIONS {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASDIALPARAMSA {
@@ -3658,7 +3658,7 @@ impl ::core::clone::Clone for RASDIALPARAMSA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`*"]
 pub struct RASDIALPARAMSW {
     pub dwSize: u32,
@@ -3679,7 +3679,7 @@ impl ::core::clone::Clone for RASDIALPARAMSW {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`*"]
 pub struct RASEAPINFO {
     pub dwSizeofEapInfo: u32,
@@ -3794,7 +3794,7 @@ impl ::core::clone::Clone for RASENTRYA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASENTRYDLGA {
@@ -3816,7 +3816,7 @@ impl ::core::clone::Clone for RASENTRYDLGA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASENTRYDLGW {
@@ -3943,7 +3943,7 @@ impl ::core::clone::Clone for RASENTRYW {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Networking_WinSock\"`*"]
 #[cfg(feature = "Win32_Networking_WinSock")]
 pub struct RASIKEV2_PROJECTION_INFO {
@@ -4033,7 +4033,7 @@ impl ::core::clone::Clone for RASNOUSERW {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASPBDLGA {
@@ -4056,7 +4056,7 @@ impl ::core::clone::Clone for RASPBDLGA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASPBDLGW {

--- a/crates/libs/sys/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
@@ -448,7 +448,7 @@ pub type SNMP_STATUS = u32;
 pub const SNMPAPI_ON: SNMP_STATUS = 1u32;
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`*"]
 pub const SNMPAPI_OFF: SNMP_STATUS = 0u32;
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct AsnAny {
@@ -463,7 +463,7 @@ impl ::core::clone::Clone for AsnAny {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub union AsnAny_0 {
@@ -488,7 +488,7 @@ impl ::core::clone::Clone for AsnAny_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`*"]
 pub struct AsnObjectIdentifier {
     pub idLength: u32,
@@ -500,7 +500,7 @@ impl ::core::clone::Clone for AsnObjectIdentifier {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct AsnOctetString {
@@ -516,7 +516,7 @@ impl ::core::clone::Clone for AsnOctetString {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct SnmpVarBind {
@@ -531,7 +531,7 @@ impl ::core::clone::Clone for SnmpVarBind {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct SnmpVarBindList {

--- a/crates/libs/sys/src/Windows/Win32/Networking/WinHttp/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/WinHttp/mod.rs
@@ -1372,7 +1372,7 @@ impl ::core::clone::Clone for WINHTTP_CONNECTION_INFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`, `\"Win32_Foundation\"`, `\"Win32_Networking_WinSock\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -1541,7 +1541,7 @@ impl ::core::clone::Clone for WINHTTP_MATCH_CONNECTION_GUID {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_MATCH_CONNECTION_GUID {
@@ -1688,7 +1688,7 @@ impl ::core::clone::Clone for WINHTTP_REQUEST_STATS {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_REQUEST_STATS {
@@ -1720,7 +1720,7 @@ impl ::core::clone::Clone for WINHTTP_REQUEST_TIMES {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_REQUEST_TIMES {
@@ -1754,7 +1754,7 @@ impl ::core::clone::Clone for WINHTTP_RESOLVER_CACHE_CONFIG {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_RESOLVER_CACHE_CONFIG {

--- a/crates/libs/sys/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -4134,7 +4134,7 @@ impl ::core::clone::Clone for ATM_CONNECTION_ID {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`*"]
 pub struct ATM_PVC_PARAMS {
     pub PvcConnectionId: ATM_CONNECTION_ID,

--- a/crates/libs/sys/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -9629,7 +9629,7 @@ impl ::core::clone::Clone for TRUSTED_POSIX_OFFSET_INFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Security_Authentication_Identity\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct USER_ALL_INFORMATION {

--- a/crates/libs/sys/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -6016,7 +6016,7 @@ impl ::core::clone::Clone for TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_ID {
     pub Anonymous: TXF_ID_0,
@@ -6027,7 +6027,7 @@ impl ::core::clone::Clone for TXF_ID {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_ID_0 {
     pub LowPart: i64,
@@ -6039,7 +6039,7 @@ impl ::core::clone::Clone for TXF_ID_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_AFFECTED_FILE {
     pub Version: u16,
@@ -6056,7 +6056,7 @@ impl ::core::clone::Clone for TXF_LOG_RECORD_AFFECTED_FILE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_BASE {
     pub Version: u16,
@@ -6069,7 +6069,7 @@ impl ::core::clone::Clone for TXF_LOG_RECORD_BASE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_TRUNCATE {
     pub Version: u16,
@@ -6088,7 +6088,7 @@ impl ::core::clone::Clone for TXF_LOG_RECORD_TRUNCATE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_WRITE {
     pub Version: u16,

--- a/crates/libs/sys/src/Windows/Win32/Storage/Jet/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Jet/mod.rs
@@ -2666,7 +2666,7 @@ impl ::core::clone::Clone for JET_COMMIT_ID {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -3644,7 +3644,7 @@ impl ::core::clone::Clone for JET_OBJECTINFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_OBJECTINFO {
@@ -3772,7 +3772,7 @@ impl ::core::clone::Clone for JET_RBSINFOMISC {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -3817,7 +3817,7 @@ impl ::core::clone::Clone for JET_RBSREVERTINFOMISC {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -3892,7 +3892,7 @@ impl ::core::clone::Clone for JET_RECSIZE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_RECSIZE {
@@ -3937,7 +3937,7 @@ impl ::core::clone::Clone for JET_RECSIZE2 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_RECSIZE2 {
@@ -4432,7 +4432,7 @@ impl ::core::clone::Clone for JET_THREADSTATS2 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_THREADSTATS2 {

--- a/crates/libs/sys/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -625,7 +625,7 @@ impl ::core::clone::Clone for PACKAGEDEPENDENCY_CONTEXT__ {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
 pub struct PACKAGE_ID {
     pub reserved: u32,
@@ -642,7 +642,7 @@ impl ::core::clone::Clone for PACKAGE_ID {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
 pub struct PACKAGE_INFO {
     pub reserved: u32,
@@ -669,7 +669,7 @@ impl ::core::clone::Clone for PACKAGE_VERSION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
 pub union PACKAGE_VERSION_0 {
     pub Version: u64,

--- a/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -7044,7 +7044,7 @@ impl ::core::clone::Clone for BUSDATA {
         *self
     }
 }
-#[repr(C)]
+#[repr(C, align(16))]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "aarch64")]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -7137,7 +7137,7 @@ impl ::core::clone::Clone for CONTEXT_0_0 {
         *self
     }
 }
-#[repr(C)]
+#[repr(C, align(16))]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "x86_64")]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -7251,7 +7251,7 @@ impl ::core::clone::Clone for CONTEXT_0_0 {
         *self
     }
 }
-#[repr(C)]
+#[repr(C, align(4))]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -7304,7 +7304,7 @@ impl ::core::clone::Clone for CPU_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct CPU_INFORMATION_0 {
     pub ProcessorFeatures: [u64; 2],
@@ -9635,7 +9635,7 @@ impl ::core::clone::Clone for IMAGE_FUNCTION_ENTRY {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct IMAGE_FUNCTION_ENTRY64 {
     pub StartingAddress: u64,
@@ -9648,7 +9648,7 @@ impl ::core::clone::Clone for IMAGE_FUNCTION_ENTRY64 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub union IMAGE_FUNCTION_ENTRY64_0 {
     pub EndOfPrologue: u64,
@@ -9732,7 +9732,7 @@ impl ::core::clone::Clone for IMAGE_LOAD_CONFIG_DIRECTORY32 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct IMAGE_LOAD_CONFIG_DIRECTORY64 {
     pub Size: u32,
@@ -9863,7 +9863,7 @@ impl ::core::clone::Clone for IMAGE_OPTIONAL_HEADER32 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct IMAGE_OPTIONAL_HEADER64 {
     pub Magic: IMAGE_OPTIONAL_HEADER_MAGIC,
@@ -10760,7 +10760,7 @@ impl ::core::clone::Clone for M128A {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"Win32_System_Kernel\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
 pub struct MINIDUMP_CALLBACK_INFORMATION {
@@ -10775,7 +10775,7 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
 pub struct MINIDUMP_CALLBACK_INPUT {
@@ -10817,7 +10817,7 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_INPUT_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 pub struct MINIDUMP_CALLBACK_OUTPUT {
@@ -10854,7 +10854,7 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_OUTPUT_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 pub struct MINIDUMP_CALLBACK_OUTPUT_0_0 {
@@ -10929,7 +10929,7 @@ impl ::core::clone::Clone for MINIDUMP_CALLBACK_OUTPUT_0_4 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_DIRECTORY {
     pub StreamType: u32,
@@ -10941,7 +10941,7 @@ impl ::core::clone::Clone for MINIDUMP_DIRECTORY {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_EXCEPTION {
     pub ExceptionCode: u32,
@@ -10958,7 +10958,7 @@ impl ::core::clone::Clone for MINIDUMP_EXCEPTION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub struct MINIDUMP_EXCEPTION_INFORMATION {
@@ -10974,7 +10974,7 @@ impl ::core::clone::Clone for MINIDUMP_EXCEPTION_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MINIDUMP_EXCEPTION_INFORMATION64 {
@@ -10991,7 +10991,7 @@ impl ::core::clone::Clone for MINIDUMP_EXCEPTION_INFORMATION64 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_EXCEPTION_STREAM {
     pub ThreadId: u32,
@@ -11005,7 +11005,7 @@ impl ::core::clone::Clone for MINIDUMP_EXCEPTION_STREAM {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
     pub MinimumAddress: u64,
@@ -11020,7 +11020,7 @@ impl ::core::clone::Clone for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_FUNCTION_TABLE_STREAM {
     pub SizeOfHeader: u32,
@@ -11036,7 +11036,7 @@ impl ::core::clone::Clone for MINIDUMP_FUNCTION_TABLE_STREAM {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_DATA_STREAM {
     pub SizeOfHeader: u32,
@@ -11050,7 +11050,7 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_DATA_STREAM {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_DESCRIPTOR {
     pub Handle: u64,
@@ -11067,7 +11067,7 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_DESCRIPTOR {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_DESCRIPTOR_2 {
     pub Handle: u64,
@@ -11086,7 +11086,7 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_DESCRIPTOR_2 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_OBJECT_INFORMATION {
     pub NextInfoRva: u32,
@@ -11099,7 +11099,7 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_OBJECT_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_OPERATION_LIST {
     pub SizeOfHeader: u32,
@@ -11113,7 +11113,7 @@ impl ::core::clone::Clone for MINIDUMP_HANDLE_OPERATION_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HEADER {
     pub Signature: u32,
@@ -11142,7 +11142,7 @@ impl ::core::clone::Clone for MINIDUMP_HEADER_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_INCLUDE_MODULE_CALLBACK {
     pub BaseOfImage: u64,
@@ -11153,7 +11153,7 @@ impl ::core::clone::Clone for MINIDUMP_INCLUDE_MODULE_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_INCLUDE_THREAD_CALLBACK {
     pub ThreadId: u32,
@@ -11164,7 +11164,7 @@ impl ::core::clone::Clone for MINIDUMP_INCLUDE_THREAD_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MINIDUMP_IO_CALLBACK {
@@ -11181,7 +11181,7 @@ impl ::core::clone::Clone for MINIDUMP_IO_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_LOCATION_DESCRIPTOR {
     pub DataSize: u32,
@@ -11193,7 +11193,7 @@ impl ::core::clone::Clone for MINIDUMP_LOCATION_DESCRIPTOR {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_LOCATION_DESCRIPTOR64 {
     pub DataSize: u64,
@@ -11205,7 +11205,7 @@ impl ::core::clone::Clone for MINIDUMP_LOCATION_DESCRIPTOR64 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY64_LIST {
     pub NumberOfMemoryRanges: u64,
@@ -11218,7 +11218,7 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY64_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_DESCRIPTOR {
     pub StartOfMemoryRange: u64,
@@ -11230,7 +11230,7 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_DESCRIPTOR {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_DESCRIPTOR64 {
     pub StartOfMemoryRange: u64,
@@ -11242,7 +11242,7 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_DESCRIPTOR64 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(feature = "Win32_System_Memory")]
 pub struct MINIDUMP_MEMORY_INFO {
@@ -11264,7 +11264,7 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_INFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_INFO_LIST {
     pub SizeOfHeader: u32,
@@ -11277,7 +11277,7 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_INFO_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_LIST {
     pub NumberOfMemoryRanges: u32,
@@ -11289,7 +11289,7 @@ impl ::core::clone::Clone for MINIDUMP_MEMORY_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MISC_INFO {
     pub SizeOfInfo: u32,
@@ -11305,7 +11305,7 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MISC_INFO_2 {
     pub SizeOfInfo: u32,
@@ -11326,7 +11326,7 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO_2 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Time\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 pub struct MINIDUMP_MISC_INFO_3 {
@@ -11355,7 +11355,7 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO_3 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Time\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 pub struct MINIDUMP_MISC_INFO_4 {
@@ -11386,7 +11386,7 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO_4 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Time\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 pub struct MINIDUMP_MISC_INFO_5 {
@@ -11419,7 +11419,7 @@ impl ::core::clone::Clone for MINIDUMP_MISC_INFO_5 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Storage_FileSystem\"`*"]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 pub struct MINIDUMP_MODULE {
@@ -11442,7 +11442,7 @@ impl ::core::clone::Clone for MINIDUMP_MODULE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Storage_FileSystem\"`*"]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 pub struct MINIDUMP_MODULE_CALLBACK {
@@ -11465,7 +11465,7 @@ impl ::core::clone::Clone for MINIDUMP_MODULE_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Storage_FileSystem\"`*"]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 pub struct MINIDUMP_MODULE_LIST {
@@ -11480,7 +11480,7 @@ impl ::core::clone::Clone for MINIDUMP_MODULE_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_PROCESS_VM_COUNTERS_1 {
     pub Revision: u16,
@@ -11501,7 +11501,7 @@ impl ::core::clone::Clone for MINIDUMP_PROCESS_VM_COUNTERS_1 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_PROCESS_VM_COUNTERS_2 {
     pub Revision: u16,
@@ -11532,7 +11532,7 @@ impl ::core::clone::Clone for MINIDUMP_PROCESS_VM_COUNTERS_2 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
     pub Offset: u64,
@@ -11545,7 +11545,7 @@ impl ::core::clone::Clone for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_STRING {
     pub Length: u32,
@@ -11557,7 +11557,7 @@ impl ::core::clone::Clone for MINIDUMP_STRING {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_BASIC_INFORMATION {
     pub TimerResolution: u32,
@@ -11577,7 +11577,7 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_BASIC_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
     pub AvailablePages: u64,
@@ -11591,7 +11591,7 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
     pub CurrentSize: u64,
@@ -11610,7 +11610,7 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_INFO {
     pub ProcessorArchitecture: PROCESSOR_ARCHITECTURE,
@@ -11679,7 +11679,7 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_INFO_1_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_MEMORY_INFO_1 {
     pub Revision: u16,
@@ -11695,7 +11695,7 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
     pub IdleProcessTime: u64,
@@ -11783,7 +11783,7 @@ impl ::core::clone::Clone for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD {
     pub ThreadId: u32,
@@ -11800,7 +11800,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "aarch64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -11823,7 +11823,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -11845,7 +11845,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_EX {
     pub ThreadId: u32,
@@ -11863,7 +11863,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_EX {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "aarch64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -11888,7 +11888,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_EX_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -11912,7 +11912,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_EX_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_EX_LIST {
     pub NumberOfThreads: u32,
@@ -11924,7 +11924,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_EX_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_INFO {
     pub ThreadId: u32,
@@ -11944,7 +11944,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_INFO {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_INFO_LIST {
     pub SizeOfHeader: u32,
@@ -11957,7 +11957,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_INFO_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_LIST {
     pub NumberOfThreads: u32,
@@ -11969,7 +11969,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_NAME {
     pub ThreadId: u32,
@@ -11981,7 +11981,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_NAME {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_NAME_LIST {
     pub NumberOfThreadNames: u32,
@@ -11993,7 +11993,7 @@ impl ::core::clone::Clone for MINIDUMP_THREAD_NAME_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_TOKEN_INFO_HEADER {
     pub TokenSize: u32,
@@ -12006,7 +12006,7 @@ impl ::core::clone::Clone for MINIDUMP_TOKEN_INFO_HEADER {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_TOKEN_INFO_LIST {
     pub TokenListSize: u32,
@@ -12020,7 +12020,7 @@ impl ::core::clone::Clone for MINIDUMP_TOKEN_INFO_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_UNLOADED_MODULE {
     pub BaseOfImage: u64,
@@ -12035,7 +12035,7 @@ impl ::core::clone::Clone for MINIDUMP_UNLOADED_MODULE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_UNLOADED_MODULE_LIST {
     pub SizeOfHeader: u32,
@@ -12048,7 +12048,7 @@ impl ::core::clone::Clone for MINIDUMP_UNLOADED_MODULE_LIST {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_USER_RECORD {
     pub Type: u32,
@@ -12060,7 +12060,7 @@ impl ::core::clone::Clone for MINIDUMP_USER_RECORD {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_USER_STREAM {
     pub Type: u32,
@@ -12073,7 +12073,7 @@ impl ::core::clone::Clone for MINIDUMP_USER_STREAM {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_USER_STREAM_INFORMATION {
     pub UserStreamCount: u32,
@@ -12085,7 +12085,7 @@ impl ::core::clone::Clone for MINIDUMP_USER_STREAM_INFORMATION {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_VM_POST_READ_CALLBACK {
     pub Offset: u64,
@@ -12100,7 +12100,7 @@ impl ::core::clone::Clone for MINIDUMP_VM_POST_READ_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_VM_PRE_READ_CALLBACK {
     pub Offset: u64,
@@ -12113,7 +12113,7 @@ impl ::core::clone::Clone for MINIDUMP_VM_PRE_READ_CALLBACK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_VM_QUERY_CALLBACK {
     pub Offset: u64,
@@ -14241,7 +14241,7 @@ impl ::core::clone::Clone for XSTATE_CONFIGURATION_0_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct XSTATE_CONFIG_FEATURE_MSC_INFO {
     pub SizeOfInfo: u32,

--- a/crates/libs/sys/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/SystemServices/mod.rs
@@ -7911,7 +7911,7 @@ impl ::core::clone::Clone for HIBERFILE_BUCKET {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
     pub BeginAddress: u64,
@@ -9006,7 +9006,7 @@ impl ::core::clone::Clone for IMAGE_TLS_DIRECTORY32_0_0 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct IMAGE_TLS_DIRECTORY64 {
     pub StartAddressOfRawData: u64,
@@ -9260,7 +9260,7 @@ impl ::core::clone::Clone for NETWORK_APP_INSTANCE_EA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct NON_PAGED_DEBUG_INFO {
     pub Signature: u16,

--- a/crates/libs/sys/src/Windows/Win32/System/VirtualDosMachines/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/VirtualDosMachines/mod.rs
@@ -188,7 +188,7 @@ pub const VDM_KGDT_R3_CODE: u32 = 24u32;
 pub const VDM_MAXIMUM_SUPPORTED_EXTENSION: u32 = 512u32;
 #[doc = "*Required features: `\"Win32_System_VirtualDosMachines\"`*"]
 pub const WOW_SYSTEM: u32 = 1u32;
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_VirtualDosMachines\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct GLOBALENTRY {
@@ -231,7 +231,7 @@ impl ::core::clone::Clone for IMAGE_NOTE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_VirtualDosMachines\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MODULEENTRY {

--- a/crates/libs/sys/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -2816,7 +2816,7 @@ impl ::core::clone::Clone for CHARRANGE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct CLIPBOARDFORMAT {
@@ -2847,7 +2847,7 @@ impl ::core::clone::Clone for COMPCOLOR {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct EDITSTREAM {
     pub dwCookie: usize,
@@ -2860,7 +2860,7 @@ impl ::core::clone::Clone for EDITSTREAM {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENCORRECTTEXT {
@@ -2876,7 +2876,7 @@ impl ::core::clone::Clone for ENCORRECTTEXT {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENDCOMPOSITIONNOTIFY {
@@ -2891,7 +2891,7 @@ impl ::core::clone::Clone for ENDCOMPOSITIONNOTIFY {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENDROPFILES {
@@ -2908,7 +2908,7 @@ impl ::core::clone::Clone for ENDROPFILES {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENLINK {
@@ -2926,7 +2926,7 @@ impl ::core::clone::Clone for ENLINK {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENLOWFIRTF {
@@ -2941,7 +2941,7 @@ impl ::core::clone::Clone for ENLOWFIRTF {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENOLEOPFAILED {
@@ -2958,7 +2958,7 @@ impl ::core::clone::Clone for ENOLEOPFAILED {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENPROTECTED {
@@ -2976,7 +2976,7 @@ impl ::core::clone::Clone for ENPROTECTED {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENSAVECLIPBOARD {
@@ -2992,7 +2992,7 @@ impl ::core::clone::Clone for ENSAVECLIPBOARD {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTA {
     pub chrg: CHARRANGE,
@@ -3004,7 +3004,7 @@ impl ::core::clone::Clone for FINDTEXTA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTEXA {
     pub chrg: CHARRANGE,
@@ -3017,7 +3017,7 @@ impl ::core::clone::Clone for FINDTEXTEXA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTEXW {
     pub chrg: CHARRANGE,
@@ -3030,7 +3030,7 @@ impl ::core::clone::Clone for FINDTEXTEXW {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTW {
     pub chrg: CHARRANGE,
@@ -3042,7 +3042,7 @@ impl ::core::clone::Clone for FINDTEXTW {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub struct FORMATRANGE {
@@ -3060,7 +3060,7 @@ impl ::core::clone::Clone for FORMATRANGE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct GETCONTEXTMENUEX {
@@ -3077,7 +3077,7 @@ impl ::core::clone::Clone for GETCONTEXTMENUEX {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct GETTEXTEX {
     pub cb: u32,
@@ -3104,7 +3104,7 @@ impl ::core::clone::Clone for GETTEXTLENGTHEX {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct GROUPTYPINGCHANGE {
@@ -3119,7 +3119,7 @@ impl ::core::clone::Clone for GROUPTYPINGCHANGE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct HYPHENATEINFO {
     pub cbSize: i16,
@@ -3157,7 +3157,7 @@ impl ::core::clone::Clone for IMECOMPTEXT {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MSGFILTER {
@@ -3174,7 +3174,7 @@ impl ::core::clone::Clone for MSGFILTER {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct OBJECTPOSITIONS {
@@ -3247,7 +3247,7 @@ impl ::core::clone::Clone for PARAFORMAT2 {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct PUNCTUATION {
     pub iSize: u32,
@@ -3282,7 +3282,7 @@ impl ::core::clone::Clone for REOBJECT {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_System_Com\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub struct REPASTESPECIAL {
@@ -3297,7 +3297,7 @@ impl ::core::clone::Clone for REPASTESPECIAL {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct REQRESIZE {
@@ -3312,7 +3312,7 @@ impl ::core::clone::Clone for REQRESIZE {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub struct RICHEDIT_IMAGE_PARAMETERS {
@@ -3331,7 +3331,7 @@ impl ::core::clone::Clone for RICHEDIT_IMAGE_PARAMETERS {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct SELCHANGE {
@@ -3406,7 +3406,7 @@ impl ::core::clone::Clone for TABLEROWPARMS {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct TEXTRANGEA {
     pub chrg: CHARRANGE,
@@ -3418,7 +3418,7 @@ impl ::core::clone::Clone for TEXTRANGEA {
         *self
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct TEXTRANGEW {
     pub chrg: CHARRANGE,

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -10521,7 +10521,7 @@ impl ::core::default::Default for HIDD_ATTRIBUTES {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`*"]
 pub struct HIDD_CONFIGURATION {
     pub cookie: *mut ::core::ffi::c_void,
@@ -10862,7 +10862,7 @@ impl ::core::default::Default for HIDP_DATA_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`*"]
 pub struct HIDP_EXTENDED_ATTRIBUTES {
     pub NumGlobalUnknowns: u8,
@@ -10953,7 +10953,7 @@ impl ::core::default::Default for HIDP_KEYBOARD_MODIFIER_STATE_0_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`*"]
 pub struct HIDP_LINK_COLLECTION_NODE {
     pub LinkUsage: u16,

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
@@ -6109,7 +6109,7 @@ impl ::core::default::Default for D3DADAPTER_IDENTIFIER9 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -6172,7 +6172,7 @@ impl ::core::default::Default for D3DAES_CTR_IV {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct D3DAES_CTR_IV {
@@ -7007,7 +7007,7 @@ impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_QUERYOUTPUTID_OUTPUT {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -8428,7 +8428,7 @@ impl ::core::default::Default for D3DMEMORYPRESSURE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct D3DMEMORYPRESSURE {
@@ -8482,7 +8482,7 @@ impl ::core::default::Default for D3DPRESENTSTATS {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D9\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct D3DPRESENTSTATS {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
@@ -2040,7 +2040,7 @@ impl ::core::default::Default for DMUS_DOWNLOADINFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Media_Audio_DirectMusic\"`*"]
 pub struct DMUS_EVENTHEADER {
     pub cbEvent: u32,

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -54493,7 +54493,7 @@ impl ::core::default::Default for D3DCONTENTPROTECTIONCAPS {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct D3DCONTENTPROTECTIONCAPS {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Rras/mod.rs
@@ -7384,7 +7384,7 @@ impl ::core::default::Default for PROJECTION_INFO2_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASADPARAMS {
@@ -7594,7 +7594,7 @@ impl ::core::default::Default for RASCOMMSETTINGS {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASCONNA {
@@ -7692,7 +7692,7 @@ impl ::core::default::Default for RASCONNSTATUSW {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASCONNW {
@@ -7836,7 +7836,7 @@ impl ::core::default::Default for RASCTRYINFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASCUSTOMSCRIPTEXTENSIONS {
@@ -7933,7 +7933,7 @@ impl ::core::default::Default for RASDEVINFOW {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`*"]
 pub struct RASDEVSPECIFICINFO {
     pub dwSize: u32,
@@ -7953,7 +7953,7 @@ impl ::core::default::Default for RASDEVSPECIFICINFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASDIALDLG {
@@ -7985,7 +7985,7 @@ impl ::core::default::Default for RASDIALDLG {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASDIALEXTENSIONS {
@@ -8016,7 +8016,7 @@ impl ::core::default::Default for RASDIALEXTENSIONS {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASDIALPARAMSA {
@@ -8050,7 +8050,7 @@ impl ::core::default::Default for RASDIALPARAMSA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`*"]
 pub struct RASDIALPARAMSW {
     pub dwSize: u32,
@@ -8079,7 +8079,7 @@ impl ::core::default::Default for RASDIALPARAMSW {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`*"]
 pub struct RASEAPINFO {
     pub dwSizeofEapInfo: u32,
@@ -8255,7 +8255,7 @@ impl ::core::default::Default for RASENTRYA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASENTRYDLGA {
@@ -8287,7 +8287,7 @@ impl ::core::default::Default for RASENTRYDLGA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASENTRYDLGW {
@@ -8477,7 +8477,7 @@ impl ::core::default::Default for RASENTRYW {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Networking_WinSock\"`*"]
 #[cfg(feature = "Win32_Networking_WinSock")]
 pub struct RASIKEV2_PROJECTION_INFO {
@@ -8658,7 +8658,7 @@ impl ::core::default::Default for RASNOUSERW {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASPBDLGA {
@@ -8691,7 +8691,7 @@ impl ::core::default::Default for RASPBDLGA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Rras\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct RASPBDLGW {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Snmp/mod.rs
@@ -1079,7 +1079,7 @@ impl ::core::fmt::Debug for SNMP_STATUS {
         f.debug_tuple("SNMP_STATUS").field(&self.0).finish()
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct AsnAny {
@@ -1104,7 +1104,7 @@ impl ::core::default::Default for AsnAny {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub union AsnAny_0 {
@@ -1139,7 +1139,7 @@ impl ::core::default::Default for AsnAny_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`*"]
 pub struct AsnObjectIdentifier {
     pub idLength: u32,
@@ -1159,7 +1159,7 @@ impl ::core::default::Default for AsnObjectIdentifier {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct AsnOctetString {
@@ -1185,7 +1185,7 @@ impl ::core::default::Default for AsnOctetString {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct SnmpVarBind {
@@ -1210,7 +1210,7 @@ impl ::core::default::Default for SnmpVarBind {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Snmp\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct SnmpVarBindList {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinHttp/mod.rs
@@ -2087,7 +2087,7 @@ impl ::core::default::Default for WINHTTP_CONNECTION_INFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`, `\"Win32_Foundation\"`, `\"Win32_Networking_WinSock\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Networking_WinSock"))]
@@ -2429,7 +2429,7 @@ impl ::core::default::Default for WINHTTP_MATCH_CONNECTION_GUID {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_MATCH_CONNECTION_GUID {
@@ -2781,7 +2781,7 @@ impl ::core::default::Default for WINHTTP_REQUEST_STATS {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_REQUEST_STATS {
@@ -2833,7 +2833,7 @@ impl ::core::default::Default for WINHTTP_REQUEST_TIMES {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_REQUEST_TIMES {
@@ -2887,7 +2887,7 @@ impl ::core::default::Default for WINHTTP_RESOLVER_CACHE_CONFIG {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinHttp\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct WINHTTP_RESOLVER_CACHE_CONFIG {

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -7419,7 +7419,7 @@ impl ::core::default::Default for ATM_CONNECTION_ID {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`*"]
 pub struct ATM_PVC_PARAMS {
     pub PvcConnectionId: ATM_CONNECTION_ID,

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -20219,7 +20219,7 @@ impl ::core::default::Default for TRUSTED_POSIX_OFFSET_INFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Security_Authentication_Identity\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct USER_ALL_INFORMATION {

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -17108,7 +17108,7 @@ impl ::core::default::Default for TRANSACTION_NOTIFICATION_TM_ONLINE_ARGUMENT {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_ID {
     pub Anonymous: TXF_ID_0,
@@ -17127,7 +17127,7 @@ impl ::core::default::Default for TXF_ID {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_ID_0 {
     pub LowPart: i64,
@@ -17147,7 +17147,7 @@ impl ::core::default::Default for TXF_ID_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_AFFECTED_FILE {
     pub Version: u16,
@@ -17172,7 +17172,7 @@ impl ::core::default::Default for TXF_LOG_RECORD_AFFECTED_FILE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_BASE {
     pub Version: u16,
@@ -17193,7 +17193,7 @@ impl ::core::default::Default for TXF_LOG_RECORD_BASE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_TRUNCATE {
     pub Version: u16,
@@ -17220,7 +17220,7 @@ impl ::core::default::Default for TXF_LOG_RECORD_TRUNCATE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_FileSystem\"`*"]
 pub struct TXF_LOG_RECORD_WRITE {
     pub Version: u16,

--- a/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
@@ -4796,7 +4796,7 @@ impl ::core::default::Default for JET_COMMIT_ID {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -6598,7 +6598,7 @@ impl ::core::default::Default for JET_OBJECTINFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_OBJECTINFO {
@@ -6883,7 +6883,7 @@ impl ::core::default::Default for JET_RBSINFOMISC {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -6952,7 +6952,7 @@ impl ::core::default::Default for JET_RBSREVERTINFOMISC {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Foundation\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_Foundation")]
@@ -7092,7 +7092,7 @@ impl ::core::default::Default for JET_RECSIZE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_RECSIZE {
@@ -7157,7 +7157,7 @@ impl ::core::default::Default for JET_RECSIZE2 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_RECSIZE2 {
@@ -8241,7 +8241,7 @@ impl ::core::default::Default for JET_THREADSTATS2 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`*"]
 #[cfg(target_arch = "x86")]
 pub struct JET_THREADSTATS2 {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -6445,7 +6445,7 @@ impl ::core::default::Default for PACKAGEDEPENDENCY_CONTEXT__ {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
 pub struct PACKAGE_ID {
     pub reserved: u32,
@@ -6470,7 +6470,7 @@ impl ::core::default::Default for PACKAGE_ID {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
 pub struct PACKAGE_INFO {
     pub reserved: u32,
@@ -6513,7 +6513,7 @@ impl ::core::default::Default for PACKAGE_VERSION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Packaging_Appx\"`*"]
 pub union PACKAGE_VERSION_0 {
     pub Version: u64,

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Debug/mod.rs
@@ -41431,7 +41431,7 @@ impl ::core::default::Default for BUSDATA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, align(16))]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "aarch64")]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -41609,7 +41609,7 @@ impl ::core::default::Default for CONTEXT_0_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, align(16))]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "x86_64")]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -41795,7 +41795,7 @@ impl ::core::default::Default for CONTEXT_0_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C)]
+#[repr(C, align(4))]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "x86")]
 #[cfg(feature = "Win32_System_Kernel")]
@@ -41868,7 +41868,7 @@ impl ::core::default::Default for CPU_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct CPU_INFORMATION_0 {
     pub ProcessorFeatures: [u64; 2],
@@ -47067,7 +47067,7 @@ impl ::core::default::Default for IMAGE_FUNCTION_ENTRY {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct IMAGE_FUNCTION_ENTRY64 {
     pub StartingAddress: u64,
@@ -47088,7 +47088,7 @@ impl ::core::default::Default for IMAGE_FUNCTION_ENTRY64 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub union IMAGE_FUNCTION_ENTRY64_0 {
     pub EndOfPrologue: u64,
@@ -47314,7 +47314,7 @@ impl ::core::default::Default for IMAGE_LOAD_CONFIG_DIRECTORY32 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct IMAGE_LOAD_CONFIG_DIRECTORY64 {
     pub Size: u32,
@@ -47568,7 +47568,7 @@ impl ::core::default::Default for IMAGE_OPTIONAL_HEADER32 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct IMAGE_OPTIONAL_HEADER64 {
     pub Magic: IMAGE_OPTIONAL_HEADER_MAGIC,
@@ -49688,7 +49688,7 @@ impl ::core::default::Default for M128A {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"Win32_System_Kernel\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel", feature = "Win32_System_Memory"))]
 pub struct MINIDUMP_CALLBACK_INFORMATION {
@@ -49713,7 +49713,7 @@ impl ::core::default::Default for MINIDUMP_CALLBACK_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_FileSystem\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_FileSystem", feature = "Win32_System_Kernel"))]
 pub struct MINIDUMP_CALLBACK_INPUT {
@@ -49775,7 +49775,7 @@ impl ::core::default::Default for MINIDUMP_CALLBACK_INPUT_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 pub struct MINIDUMP_CALLBACK_OUTPUT {
@@ -49832,7 +49832,7 @@ impl ::core::default::Default for MINIDUMP_CALLBACK_OUTPUT_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Memory"))]
 pub struct MINIDUMP_CALLBACK_OUTPUT_0_0 {
@@ -49985,7 +49985,7 @@ impl ::core::default::Default for MINIDUMP_CALLBACK_OUTPUT_0_4 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_DIRECTORY {
     pub StreamType: u32,
@@ -50005,7 +50005,7 @@ impl ::core::default::Default for MINIDUMP_DIRECTORY {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_EXCEPTION {
     pub ExceptionCode: u32,
@@ -50030,7 +50030,7 @@ impl ::core::default::Default for MINIDUMP_EXCEPTION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
 pub struct MINIDUMP_EXCEPTION_INFORMATION {
@@ -50056,7 +50056,7 @@ impl ::core::default::Default for MINIDUMP_EXCEPTION_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MINIDUMP_EXCEPTION_INFORMATION64 {
@@ -50083,7 +50083,7 @@ impl ::core::default::Default for MINIDUMP_EXCEPTION_INFORMATION64 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_EXCEPTION_STREAM {
     pub ThreadId: u32,
@@ -50105,7 +50105,7 @@ impl ::core::default::Default for MINIDUMP_EXCEPTION_STREAM {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
     pub MinimumAddress: u64,
@@ -50128,7 +50128,7 @@ impl ::core::default::Default for MINIDUMP_FUNCTION_TABLE_DESCRIPTOR {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_FUNCTION_TABLE_STREAM {
     pub SizeOfHeader: u32,
@@ -50152,7 +50152,7 @@ impl ::core::default::Default for MINIDUMP_FUNCTION_TABLE_STREAM {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_DATA_STREAM {
     pub SizeOfHeader: u32,
@@ -50174,7 +50174,7 @@ impl ::core::default::Default for MINIDUMP_HANDLE_DATA_STREAM {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_DESCRIPTOR {
     pub Handle: u64,
@@ -50199,7 +50199,7 @@ impl ::core::default::Default for MINIDUMP_HANDLE_DESCRIPTOR {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_DESCRIPTOR_2 {
     pub Handle: u64,
@@ -50226,7 +50226,7 @@ impl ::core::default::Default for MINIDUMP_HANDLE_DESCRIPTOR_2 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_OBJECT_INFORMATION {
     pub NextInfoRva: u32,
@@ -50247,7 +50247,7 @@ impl ::core::default::Default for MINIDUMP_HANDLE_OBJECT_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HANDLE_OPERATION_LIST {
     pub SizeOfHeader: u32,
@@ -50269,7 +50269,7 @@ impl ::core::default::Default for MINIDUMP_HANDLE_OPERATION_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_HEADER {
     pub Signature: u32,
@@ -50314,7 +50314,7 @@ impl ::core::default::Default for MINIDUMP_HEADER_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_INCLUDE_MODULE_CALLBACK {
     pub BaseOfImage: u64,
@@ -50333,7 +50333,7 @@ impl ::core::default::Default for MINIDUMP_INCLUDE_MODULE_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_INCLUDE_THREAD_CALLBACK {
     pub ThreadId: u32,
@@ -50352,7 +50352,7 @@ impl ::core::default::Default for MINIDUMP_INCLUDE_THREAD_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MINIDUMP_IO_CALLBACK {
@@ -50379,7 +50379,7 @@ impl ::core::default::Default for MINIDUMP_IO_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_LOCATION_DESCRIPTOR {
     pub DataSize: u32,
@@ -50399,7 +50399,7 @@ impl ::core::default::Default for MINIDUMP_LOCATION_DESCRIPTOR {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_LOCATION_DESCRIPTOR64 {
     pub DataSize: u64,
@@ -50419,7 +50419,7 @@ impl ::core::default::Default for MINIDUMP_LOCATION_DESCRIPTOR64 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY64_LIST {
     pub NumberOfMemoryRanges: u64,
@@ -50440,7 +50440,7 @@ impl ::core::default::Default for MINIDUMP_MEMORY64_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_DESCRIPTOR {
     pub StartOfMemoryRange: u64,
@@ -50460,7 +50460,7 @@ impl ::core::default::Default for MINIDUMP_MEMORY_DESCRIPTOR {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_DESCRIPTOR64 {
     pub StartOfMemoryRange: u64,
@@ -50480,7 +50480,7 @@ impl ::core::default::Default for MINIDUMP_MEMORY_DESCRIPTOR64 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_System_Memory\"`*"]
 #[cfg(feature = "Win32_System_Memory")]
 pub struct MINIDUMP_MEMORY_INFO {
@@ -50512,7 +50512,7 @@ impl ::core::default::Default for MINIDUMP_MEMORY_INFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_INFO_LIST {
     pub SizeOfHeader: u32,
@@ -50533,7 +50533,7 @@ impl ::core::default::Default for MINIDUMP_MEMORY_INFO_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MEMORY_LIST {
     pub NumberOfMemoryRanges: u32,
@@ -50553,7 +50553,7 @@ impl ::core::default::Default for MINIDUMP_MEMORY_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MISC_INFO {
     pub SizeOfInfo: u32,
@@ -50577,7 +50577,7 @@ impl ::core::default::Default for MINIDUMP_MISC_INFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_MISC_INFO_2 {
     pub SizeOfInfo: u32,
@@ -50606,7 +50606,7 @@ impl ::core::default::Default for MINIDUMP_MISC_INFO_2 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Time\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 pub struct MINIDUMP_MISC_INFO_3 {
@@ -50645,7 +50645,7 @@ impl ::core::default::Default for MINIDUMP_MISC_INFO_3 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Time\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 pub struct MINIDUMP_MISC_INFO_4 {
@@ -50686,7 +50686,7 @@ impl ::core::default::Default for MINIDUMP_MISC_INFO_4 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Time\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Time"))]
 pub struct MINIDUMP_MISC_INFO_5 {
@@ -50729,7 +50729,7 @@ impl ::core::default::Default for MINIDUMP_MISC_INFO_5 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Storage_FileSystem\"`*"]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 pub struct MINIDUMP_MODULE {
@@ -50762,7 +50762,7 @@ impl ::core::default::Default for MINIDUMP_MODULE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Storage_FileSystem\"`*"]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 pub struct MINIDUMP_MODULE_CALLBACK {
@@ -50795,7 +50795,7 @@ impl ::core::default::Default for MINIDUMP_MODULE_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Storage_FileSystem\"`*"]
 #[cfg(feature = "Win32_Storage_FileSystem")]
 pub struct MINIDUMP_MODULE_LIST {
@@ -50820,7 +50820,7 @@ impl ::core::default::Default for MINIDUMP_MODULE_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_PROCESS_VM_COUNTERS_1 {
     pub Revision: u16,
@@ -50849,7 +50849,7 @@ impl ::core::default::Default for MINIDUMP_PROCESS_VM_COUNTERS_1 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_PROCESS_VM_COUNTERS_2 {
     pub Revision: u16,
@@ -50888,7 +50888,7 @@ impl ::core::default::Default for MINIDUMP_PROCESS_VM_COUNTERS_2 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
     pub Offset: u64,
@@ -50909,7 +50909,7 @@ impl ::core::default::Default for MINIDUMP_READ_MEMORY_FAILURE_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_STRING {
     pub Length: u32,
@@ -50929,7 +50929,7 @@ impl ::core::default::Default for MINIDUMP_STRING {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_BASIC_INFORMATION {
     pub TimerResolution: u32,
@@ -50957,7 +50957,7 @@ impl ::core::default::Default for MINIDUMP_SYSTEM_BASIC_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION {
     pub AvailablePages: u64,
@@ -50979,7 +50979,7 @@ impl ::core::default::Default for MINIDUMP_SYSTEM_BASIC_PERFORMANCE_INFORMATION 
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
     pub CurrentSize: u64,
@@ -51006,7 +51006,7 @@ impl ::core::default::Default for MINIDUMP_SYSTEM_FILECACHE_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_INFO {
     pub ProcessorArchitecture: PROCESSOR_ARCHITECTURE,
@@ -51137,7 +51137,7 @@ impl ::core::default::Default for MINIDUMP_SYSTEM_INFO_1_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_MEMORY_INFO_1 {
     pub Revision: u16,
@@ -51161,7 +51161,7 @@ impl ::core::default::Default for MINIDUMP_SYSTEM_MEMORY_INFO_1 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
     pub IdleProcessTime: u64,
@@ -51257,7 +51257,7 @@ impl ::core::default::Default for MINIDUMP_SYSTEM_PERFORMANCE_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD {
     pub ThreadId: u32,
@@ -51282,7 +51282,7 @@ impl ::core::default::Default for MINIDUMP_THREAD {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "aarch64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -51317,7 +51317,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -51351,7 +51351,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_EX {
     pub ThreadId: u32,
@@ -51377,7 +51377,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_EX {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(target_arch = "aarch64")]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -51414,7 +51414,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_EX_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`, `\"Win32_Foundation\"`, `\"Win32_System_Kernel\"`*"]
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Kernel"))]
@@ -51450,7 +51450,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_EX_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_EX_LIST {
     pub NumberOfThreads: u32,
@@ -51470,7 +51470,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_EX_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_INFO {
     pub ThreadId: u32,
@@ -51498,7 +51498,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_INFO {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_INFO_LIST {
     pub SizeOfHeader: u32,
@@ -51519,7 +51519,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_INFO_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_LIST {
     pub NumberOfThreads: u32,
@@ -51539,7 +51539,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_NAME {
     pub ThreadId: u32,
@@ -51559,7 +51559,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_NAME {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_THREAD_NAME_LIST {
     pub NumberOfThreadNames: u32,
@@ -51579,7 +51579,7 @@ impl ::core::default::Default for MINIDUMP_THREAD_NAME_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_TOKEN_INFO_HEADER {
     pub TokenSize: u32,
@@ -51600,7 +51600,7 @@ impl ::core::default::Default for MINIDUMP_TOKEN_INFO_HEADER {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_TOKEN_INFO_LIST {
     pub TokenListSize: u32,
@@ -51622,7 +51622,7 @@ impl ::core::default::Default for MINIDUMP_TOKEN_INFO_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_UNLOADED_MODULE {
     pub BaseOfImage: u64,
@@ -51645,7 +51645,7 @@ impl ::core::default::Default for MINIDUMP_UNLOADED_MODULE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_UNLOADED_MODULE_LIST {
     pub SizeOfHeader: u32,
@@ -51666,7 +51666,7 @@ impl ::core::default::Default for MINIDUMP_UNLOADED_MODULE_LIST {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_USER_RECORD {
     pub Type: u32,
@@ -51686,7 +51686,7 @@ impl ::core::default::Default for MINIDUMP_USER_RECORD {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_USER_STREAM {
     pub Type: u32,
@@ -51707,7 +51707,7 @@ impl ::core::default::Default for MINIDUMP_USER_STREAM {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_USER_STREAM_INFORMATION {
     pub UserStreamCount: u32,
@@ -51727,7 +51727,7 @@ impl ::core::default::Default for MINIDUMP_USER_STREAM_INFORMATION {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_VM_POST_READ_CALLBACK {
     pub Offset: u64,
@@ -51750,7 +51750,7 @@ impl ::core::default::Default for MINIDUMP_VM_POST_READ_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_VM_PRE_READ_CALLBACK {
     pub Offset: u64,
@@ -51771,7 +51771,7 @@ impl ::core::default::Default for MINIDUMP_VM_PRE_READ_CALLBACK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct MINIDUMP_VM_QUERY_CALLBACK {
     pub Offset: u64,
@@ -55969,7 +55969,7 @@ impl ::core::default::Default for XSTATE_CONFIGURATION_0_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Diagnostics_Debug\"`*"]
 pub struct XSTATE_CONFIG_FEATURE_MSC_INFO {
     pub SizeOfInfo: u32,

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -9817,7 +9817,7 @@ impl ::core::default::Default for HIBERFILE_BUCKET {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct IMAGE_ALPHA64_RUNTIME_FUNCTION_ENTRY {
     pub BeginAddress: u64,
@@ -11907,7 +11907,7 @@ impl ::core::default::Default for IMAGE_TLS_DIRECTORY32_0_0 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct IMAGE_TLS_DIRECTORY64 {
     pub StartAddressOfRawData: u64,
@@ -12374,7 +12374,7 @@ impl ::core::default::Default for NETWORK_APP_INSTANCE_EA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct NON_PAGED_DEBUG_INFO {
     pub Signature: u16,

--- a/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/VirtualDosMachines/mod.rs
@@ -188,7 +188,7 @@ pub const VDM_KGDT_R3_CODE: u32 = 24u32;
 pub const VDM_MAXIMUM_SUPPORTED_EXTENSION: u32 = 512u32;
 #[doc = "*Required features: `\"Win32_System_VirtualDosMachines\"`*"]
 pub const WOW_SYSTEM: u32 = 1u32;
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_VirtualDosMachines\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct GLOBALENTRY {
@@ -265,7 +265,7 @@ impl ::core::default::Default for IMAGE_NOTE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_System_VirtualDosMachines\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MODULEENTRY {

--- a/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Controls/RichEdit/mod.rs
@@ -9841,7 +9841,7 @@ impl ::core::default::Default for CHARRANGE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct CLIPBOARDFORMAT {
@@ -9906,7 +9906,7 @@ impl ::core::default::Default for COMPCOLOR {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct EDITSTREAM {
     pub dwCookie: usize,
@@ -9927,7 +9927,7 @@ impl ::core::default::Default for EDITSTREAM {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENCORRECTTEXT {
@@ -9953,7 +9953,7 @@ impl ::core::default::Default for ENCORRECTTEXT {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENDCOMPOSITIONNOTIFY {
@@ -9978,7 +9978,7 @@ impl ::core::default::Default for ENDCOMPOSITIONNOTIFY {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENDROPFILES {
@@ -10005,7 +10005,7 @@ impl ::core::default::Default for ENDROPFILES {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENLINK {
@@ -10033,7 +10033,7 @@ impl ::core::default::Default for ENLINK {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENLOWFIRTF {
@@ -10058,7 +10058,7 @@ impl ::core::default::Default for ENLOWFIRTF {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENOLEOPFAILED {
@@ -10085,7 +10085,7 @@ impl ::core::default::Default for ENOLEOPFAILED {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENPROTECTED {
@@ -10113,7 +10113,7 @@ impl ::core::default::Default for ENPROTECTED {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct ENSAVECLIPBOARD {
@@ -10139,7 +10139,7 @@ impl ::core::default::Default for ENSAVECLIPBOARD {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTA {
     pub chrg: CHARRANGE,
@@ -10159,7 +10159,7 @@ impl ::core::default::Default for FINDTEXTA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTEXA {
     pub chrg: CHARRANGE,
@@ -10180,7 +10180,7 @@ impl ::core::default::Default for FINDTEXTEXA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTEXW {
     pub chrg: CHARRANGE,
@@ -10201,7 +10201,7 @@ impl ::core::default::Default for FINDTEXTEXW {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct FINDTEXTW {
     pub chrg: CHARRANGE,
@@ -10221,7 +10221,7 @@ impl ::core::default::Default for FINDTEXTW {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
 pub struct FORMATRANGE {
@@ -10249,7 +10249,7 @@ impl ::core::default::Default for FORMATRANGE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct GETCONTEXTMENUEX {
@@ -10276,7 +10276,7 @@ impl ::core::default::Default for GETCONTEXTMENUEX {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct GETTEXTEX {
     pub cb: u32,
@@ -10330,7 +10330,7 @@ impl ::core::default::Default for GETTEXTLENGTHEX {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct GROUPTYPINGCHANGE {
@@ -10355,7 +10355,7 @@ impl ::core::default::Default for GROUPTYPINGCHANGE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct HYPHENATEINFO {
     pub cbSize: i16,
@@ -10439,7 +10439,7 @@ impl ::core::default::Default for IMECOMPTEXT {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct MSGFILTER {
@@ -10466,7 +10466,7 @@ impl ::core::default::Default for MSGFILTER {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct OBJECTPOSITIONS {
@@ -10573,7 +10573,7 @@ impl ::core::default::Default for PARAFORMAT2 {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct PUNCTUATION {
     pub iSize: u32,
@@ -10638,7 +10638,7 @@ impl ::core::default::Default for REOBJECT {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_System_Com\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 pub struct REPASTESPECIAL {
@@ -10663,7 +10663,7 @@ impl ::core::default::Default for REPASTESPECIAL {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct REQRESIZE {
@@ -10688,7 +10688,7 @@ impl ::core::default::Default for REQRESIZE {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Graphics_Gdi\"`, `\"Win32_System_Com\"`*"]
 #[cfg(all(feature = "Win32_Graphics_Gdi", feature = "Win32_System_Com"))]
 pub struct RICHEDIT_IMAGE_PARAMETERS {
@@ -10709,7 +10709,7 @@ impl ::core::default::Default for RICHEDIT_IMAGE_PARAMETERS {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub struct SELCHANGE {
@@ -10870,7 +10870,7 @@ impl ::core::default::Default for TABLEROWPARMS {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct TEXTRANGEA {
     pub chrg: CHARRANGE,
@@ -10890,7 +10890,7 @@ impl ::core::default::Default for TEXTRANGEA {
         unsafe { ::core::mem::zeroed() }
     }
 }
-#[repr(C, packed(4))]
+#[repr(C)]
 #[doc = "*Required features: `\"Win32_UI_Controls_RichEdit\"`*"]
 pub struct TEXTRANGEW {
     pub chrg: CHARRANGE,

--- a/crates/tests/arch_feature/Cargo.toml
+++ b/crates/tests/arch_feature/Cargo.toml
@@ -7,17 +7,23 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_System_Diagnostics_Debug",
-    "Win32_System_SystemServices",
     "Win32_System_Environment",
     "Win32_System_Kernel",
+    "Win32_System_SystemServices",
+    "Win32_UI_Controls_Dialogs",
 ]
 
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [
+    "Win32_Foundation",
+    "Win32_Graphics_Gdi",
     "Win32_System_Diagnostics_Debug",
-    "Win32_System_SystemServices",
     "Win32_System_Environment",
     "Win32_System_Kernel",
+    "Win32_System_SystemServices",
+    "Win32_UI_Controls_Dialogs",
 ]

--- a/crates/tests/arch_feature/tests/sys.rs
+++ b/crates/tests/arch_feature/tests/sys.rs
@@ -1,9 +1,19 @@
-use windows_sys::{Win32::System::Diagnostics::Debug::CONTEXT, Win32::System::Environment::VBS_BASIC_ENCLAVE_BASIC_CALL_CREATE_THREAD};
+use windows_sys::{Win32::Graphics::Gdi::*, Win32::System::Diagnostics::Debug::*, Win32::System::Environment::*, Win32::UI::Controls::Dialogs::*};
 
 #[test]
 #[cfg(target_arch = "x86_64")]
 fn test() {
     assert_eq!(1232, core::mem::size_of::<CONTEXT>());
+    assert_eq!(16, core::mem::align_of::<CONTEXT>());
+
+    assert_eq!(1280, core::mem::size_of::<MINIDUMP_THREAD_CALLBACK>());
+    assert_eq!(16, core::mem::align_of::<MINIDUMP_THREAD_CALLBACK>());
+
+    assert_eq!(72, core::mem::size_of::<CHOOSECOLORA>());
+    assert_eq!(8, core::mem::align_of::<CHOOSECOLORA>());
+
+    assert_eq!(14, core::mem::size_of::<BITMAPFILEHEADER>());
+    assert_eq!(2, core::mem::align_of::<BITMAPFILEHEADER>());
 
     use windows_sys::Win32::System::Environment::VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64;
 
@@ -19,6 +29,16 @@ fn test() {
 #[cfg(target_arch = "x86")]
 fn test() {
     assert_eq!(716, core::mem::size_of::<CONTEXT>());
+    assert_eq!(4, core::mem::align_of::<CONTEXT>());
+
+    assert_eq!(744, core::mem::size_of::<MINIDUMP_THREAD_CALLBACK>());
+    assert_eq!(4, core::mem::align_of::<MINIDUMP_THREAD_CALLBACK>());
+
+    assert_eq!(36, core::mem::size_of::<CHOOSECOLORA>());
+    assert_eq!(1, core::mem::align_of::<CHOOSECOLORA>());
+
+    assert_eq!(14, core::mem::size_of::<BITMAPFILEHEADER>());
+    assert_eq!(2, core::mem::align_of::<BITMAPFILEHEADER>());
 
     use windows_sys::Win32::System::Environment::VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32;
 

--- a/crates/tests/arch_feature/tests/win.rs
+++ b/crates/tests/arch_feature/tests/win.rs
@@ -1,9 +1,19 @@
-use windows::{Win32::System::Diagnostics::Debug::CONTEXT, Win32::System::Environment::VBS_BASIC_ENCLAVE_BASIC_CALL_CREATE_THREAD};
+use windows::{Win32::Graphics::Gdi::*, Win32::System::Diagnostics::Debug::*, Win32::System::Environment::*, Win32::UI::Controls::Dialogs::*};
 
 #[test]
 #[cfg(target_arch = "x86_64")]
 fn test() {
     assert_eq!(1232, core::mem::size_of::<CONTEXT>());
+    assert_eq!(16, core::mem::align_of::<CONTEXT>());
+
+    assert_eq!(1280, core::mem::size_of::<MINIDUMP_THREAD_CALLBACK>());
+    assert_eq!(16, core::mem::align_of::<MINIDUMP_THREAD_CALLBACK>());
+
+    assert_eq!(72, core::mem::size_of::<CHOOSECOLORA>());
+    assert_eq!(8, core::mem::align_of::<CHOOSECOLORA>());
+
+    assert_eq!(14, core::mem::size_of::<BITMAPFILEHEADER>());
+    assert_eq!(2, core::mem::align_of::<BITMAPFILEHEADER>());
 
     use windows::Win32::System::Environment::VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR64;
 
@@ -19,6 +29,16 @@ fn test() {
 #[cfg(target_arch = "x86")]
 fn test() {
     assert_eq!(716, core::mem::size_of::<CONTEXT>());
+    assert_eq!(4, core::mem::align_of::<CONTEXT>());
+
+    assert_eq!(744, core::mem::size_of::<MINIDUMP_THREAD_CALLBACK>());
+    assert_eq!(4, core::mem::align_of::<MINIDUMP_THREAD_CALLBACK>());
+
+    assert_eq!(36, core::mem::size_of::<CHOOSECOLORA>());
+    assert_eq!(1, core::mem::align_of::<CHOOSECOLORA>());
+
+    assert_eq!(14, core::mem::size_of::<BITMAPFILEHEADER>());
+    assert_eq!(2, core::mem::align_of::<BITMAPFILEHEADER>());
 
     use windows::Win32::System::Environment::VBS_BASIC_ENCLAVE_THREAD_DESCRIPTOR32;
 


### PR DESCRIPTION
The `CONTEXT` issue (#2347) has come up numerous times and is still not addressed in the Win32 metadata where this definition originates (https://github.com/microsoft/win32metadata/issues/1044). Rather than waiting indefinitely for that to get fixed, I'm providing a workaround directly inside `windows-rs`. 

Addressing this issue requires a pair of workarounds:

* Add workaround for https://github.com/microsoft/win32metadata/issues/380 where unnecessary packing metadata is present. This is important because [Rust will not allow](https://doc.rust-lang.org/reference/type-layout.html) you to mix packing and alignment information on a struct. 

* Inject alignment information manually gathered from MSVC to properly set the alignment for the `CONTEXT` struct. 

The latter is obviously not scalable and hopefully the Win32 metadata will eventually be able to capture this information correctly as this no doubt affects other structs. 

Fixes: #2347