### PR TITLE
Stock collection support for `IMapView`

### DIFF
--- a/crates/libs/bindgen/src/extensions/impl/Foundation/Collections/MapView.rs
+++ b/crates/libs/bindgen/src/extensions/impl/Foundation/Collections/MapView.rs
@@ -1,0 +1,174 @@
+#[windows::core::implement(IMapView<K, V>, IIterable<IKeyValuePair<K, V>>)]
+struct StockMapView<K, V>
+where
+    K: windows::core::RuntimeType + 'static,
+    V: windows::core::RuntimeType + 'static,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    map: std::collections::BTreeMap<K::Default, V::Default>,
+}
+
+impl<K, V> IIterable_Impl<IKeyValuePair<K, V>> for StockMapView<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn First(&self) -> windows::core::Result<IIterator<IKeyValuePair<K, V>>> {
+        unsafe {
+            // TODO: ideally we can do an AddRef rather than a QI here (via cast)...
+            // and then we can get rid of the unsafe as well.
+            Ok(StockMapViewIterator::<K, V> {
+                _owner: self.cast()?,
+                current: std::sync::RwLock::new(self.map.iter()),
+            }
+            .into())
+        }
+    }
+}
+
+impl<K, V> IMapView_Impl<K, V> for StockMapView<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn Lookup(&self, key: &K::Default) -> windows::core::Result<V> {
+        let value = self
+            .map
+            .get(key)
+            .ok_or_else(|| windows::core::Error::from(windows::imp::E_BOUNDS))?;
+        V::from_default(value)
+    }
+    fn Size(&self) -> windows::core::Result<u32> {
+        Ok(self.map.len() as _)
+    }
+    fn HasKey(&self, key: &K::Default) -> windows::core::Result<bool> {
+        Ok(self.map.contains_key(key))
+    }
+    fn Split(
+        &self,
+        first: &mut std::option::Option<IMapView<K, V>>,
+        second: &mut std::option::Option<IMapView<K, V>>,
+    ) -> windows::core::Result<()> {
+        *first = None;
+        *second = None;
+        Ok(())
+    }
+}
+
+#[::windows::core::implement(IIterator<IKeyValuePair<K, V>>)]
+struct StockMapViewIterator<'a, K, V>
+where
+    K: windows::core::RuntimeType + 'static,
+    V: windows::core::RuntimeType + 'static,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    _owner: IIterable<IKeyValuePair<K, V>>,
+    current: ::std::sync::RwLock<std::collections::btree_map::Iter<'a, K::Default, V::Default>>,
+}
+
+impl<'a, K, V> IIterator_Impl<IKeyValuePair<K, V>> for StockMapViewIterator<'a, K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn Current(&self) -> ::windows::core::Result<IKeyValuePair<K, V>> {
+        let mut current = self.current.read().unwrap().clone().peekable();
+
+        if let Some((key, value)) = current.peek() {
+            Ok(StockKeyValuePair {
+                key: (*key).clone(),
+                value: (*value).clone(),
+            }
+            .into())
+        } else {
+            Err(windows::core::Error::from(windows::imp::E_BOUNDS))
+        }
+    }
+
+    fn HasCurrent(&self) -> ::windows::core::Result<bool> {
+        let mut current = self.current.read().unwrap().clone().peekable();
+
+        Ok(current.peek().is_some())
+    }
+
+    fn MoveNext(&self) -> ::windows::core::Result<bool> {
+        let mut current = self.current.write().unwrap();
+
+        current.next();
+        Ok(current.clone().peekable().peek().is_some())
+    }
+
+    fn GetMany(&self, pairs: &mut [Option<IKeyValuePair<K, V>>]) -> ::windows::core::Result<u32> {
+        let mut current = self.current.write().unwrap();
+        let mut actual = 0;
+
+        for pair in pairs {
+            if let Some((key, value)) = current.next() {
+                *pair = Some(
+                    StockKeyValuePair {
+                        key: (*key).clone(),
+                        value: (*value).clone(),
+                    }
+                    .into(),
+                );
+                actual += 1;
+            } else {
+                break;
+            }
+        }
+
+        Ok(actual as _)
+    }
+}
+
+#[windows::core::implement(IKeyValuePair<K, V>)]
+struct StockKeyValuePair<K, V>
+where
+    K: windows::core::RuntimeType + 'static,
+    V: windows::core::RuntimeType + 'static,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    key: K::Default,
+    value: V::Default,
+}
+
+impl<K, V> IKeyValuePair_Impl<K, V> for StockKeyValuePair<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn Key(&self) -> windows::core::Result<K> {
+        K::from_default(&self.key)
+    }
+    fn Value(&self) -> windows::core::Result<V> {
+        V::from_default(&self.value)
+    }
+}
+
+impl<K, V> ::core::convert::TryFrom<std::collections::BTreeMap<K::Default, V::Default>>
+    for IMapView<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    type Error = ::windows::core::Error;
+    fn try_from(
+        map: std::collections::BTreeMap<K::Default, V::Default>,
+    ) -> windows::core::Result<Self> {
+        // TODO: should provide a fallible try_into or more explicit allocator
+        Ok(StockMapView { map }.into())
+    }
+}

--- a/crates/libs/bindgen/src/extensions/mod.rs
+++ b/crates/libs/bindgen/src/extensions/mod.rs
@@ -48,6 +48,7 @@ pub fn gen_impl(namespace: &str) -> TokenStream {
     match namespace {
         "Windows.Foundation.Collections" => concat!(
             include_str!("impl/Foundation/Collections/Iterable.rs"),
+            include_str!("impl/Foundation/Collections/MapView.rs"),
             include_str!("impl/Foundation/Collections/VectorView.rs"),
         ),
         _ => "",

--- a/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
@@ -829,6 +829,156 @@ where
         Ok(StockIterable { values }.into())
     }
 }
+#[windows::core::implement(IMapView<K, V>, IIterable<IKeyValuePair<K, V>>)]
+struct StockMapView<K, V>
+where
+    K: windows::core::RuntimeType + 'static,
+    V: windows::core::RuntimeType + 'static,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    map: std::collections::BTreeMap<K::Default, V::Default>,
+}
+
+impl<K, V> IIterable_Impl<IKeyValuePair<K, V>> for StockMapView<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn First(&self) -> windows::core::Result<IIterator<IKeyValuePair<K, V>>> {
+        unsafe {
+            // TODO: ideally we can do an AddRef rather than a QI here (via cast)...
+            // and then we can get rid of the unsafe as well.
+            Ok(StockMapViewIterator::<K, V> { _owner: self.cast()?, current: std::sync::RwLock::new(self.map.iter()) }.into())
+        }
+    }
+}
+
+impl<K, V> IMapView_Impl<K, V> for StockMapView<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn Lookup(&self, key: &K::Default) -> windows::core::Result<V> {
+        let value = self.map.get(key).ok_or_else(|| windows::core::Error::from(windows::imp::E_BOUNDS))?;
+        V::from_default(value)
+    }
+    fn Size(&self) -> windows::core::Result<u32> {
+        Ok(self.map.len() as _)
+    }
+    fn HasKey(&self, key: &K::Default) -> windows::core::Result<bool> {
+        Ok(self.map.contains_key(key))
+    }
+    fn Split(&self, first: &mut std::option::Option<IMapView<K, V>>, second: &mut std::option::Option<IMapView<K, V>>) -> windows::core::Result<()> {
+        *first = None;
+        *second = None;
+        Ok(())
+    }
+}
+
+#[::windows::core::implement(IIterator<IKeyValuePair<K, V>>)]
+struct StockMapViewIterator<'a, K, V>
+where
+    K: windows::core::RuntimeType + 'static,
+    V: windows::core::RuntimeType + 'static,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    _owner: IIterable<IKeyValuePair<K, V>>,
+    current: ::std::sync::RwLock<std::collections::btree_map::Iter<'a, K::Default, V::Default>>,
+}
+
+impl<'a, K, V> IIterator_Impl<IKeyValuePair<K, V>> for StockMapViewIterator<'a, K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn Current(&self) -> ::windows::core::Result<IKeyValuePair<K, V>> {
+        let mut current = self.current.read().unwrap().clone().peekable();
+
+        if let Some((key, value)) = current.peek() {
+            Ok(StockKeyValuePair { key: (*key).clone(), value: (*value).clone() }.into())
+        } else {
+            Err(windows::core::Error::from(windows::imp::E_BOUNDS))
+        }
+    }
+
+    fn HasCurrent(&self) -> ::windows::core::Result<bool> {
+        let mut current = self.current.read().unwrap().clone().peekable();
+
+        Ok(current.peek().is_some())
+    }
+
+    fn MoveNext(&self) -> ::windows::core::Result<bool> {
+        let mut current = self.current.write().unwrap();
+
+        current.next();
+        Ok(current.clone().peekable().peek().is_some())
+    }
+
+    fn GetMany(&self, pairs: &mut [Option<IKeyValuePair<K, V>>]) -> ::windows::core::Result<u32> {
+        let mut current = self.current.write().unwrap();
+        let mut actual = 0;
+
+        for pair in pairs {
+            if let Some((key, value)) = current.next() {
+                *pair = Some(StockKeyValuePair { key: (*key).clone(), value: (*value).clone() }.into());
+                actual += 1;
+            } else {
+                break;
+            }
+        }
+
+        Ok(actual as _)
+    }
+}
+
+#[windows::core::implement(IKeyValuePair<K, V>)]
+struct StockKeyValuePair<K, V>
+where
+    K: windows::core::RuntimeType + 'static,
+    V: windows::core::RuntimeType + 'static,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    key: K::Default,
+    value: V::Default,
+}
+
+impl<K, V> IKeyValuePair_Impl<K, V> for StockKeyValuePair<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    fn Key(&self) -> windows::core::Result<K> {
+        K::from_default(&self.key)
+    }
+    fn Value(&self) -> windows::core::Result<V> {
+        V::from_default(&self.value)
+    }
+}
+
+impl<K, V> ::core::convert::TryFrom<std::collections::BTreeMap<K::Default, V::Default>> for IMapView<K, V>
+where
+    K: windows::core::RuntimeType,
+    V: windows::core::RuntimeType,
+    <K as windows::core::Type<K>>::Default: std::clone::Clone + std::cmp::Ord,
+    <V as windows::core::Type<V>>::Default: std::clone::Clone,
+{
+    type Error = ::windows::core::Error;
+    fn try_from(map: std::collections::BTreeMap<K::Default, V::Default>) -> windows::core::Result<Self> {
+        // TODO: should provide a fallible try_into or more explicit allocator
+        Ok(StockMapView { map }.into())
+    }
+}
 #[windows::core::implement(IVectorView<T>, IIterable<T>)]
 struct StockVectorView<T>
 where

--- a/crates/libs/windows/src/core/strings/hstring.rs
+++ b/crates/libs/windows/src/core/strings/hstring.rs
@@ -196,6 +196,20 @@ impl std::convert::From<&std::ffi::OsString> for HSTRING {
     }
 }
 
+impl Eq for HSTRING {}
+
+impl Ord for HSTRING {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.as_wide().cmp(&other.as_wide())
+    }
+}
+
+impl PartialOrd for HSTRING {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
 impl PartialEq for HSTRING {
     fn eq(&self, other: &Self) -> bool {
         *self.as_wide() == *other.as_wide()

--- a/crates/libs/windows/src/core/strings/hstring.rs
+++ b/crates/libs/windows/src/core/strings/hstring.rs
@@ -200,7 +200,7 @@ impl Eq for HSTRING {}
 
 impl Ord for HSTRING {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        self.as_wide().cmp(&other.as_wide())
+        self.as_wide().cmp(other.as_wide())
     }
 }
 

--- a/crates/tests/collections/tests/stock_map_view.rs
+++ b/crates/tests/collections/tests/stock_map_view.rs
@@ -1,0 +1,111 @@
+#![allow(non_snake_case)]
+
+use std::collections::BTreeMap;
+use std::convert::TryFrom;
+use windows::{core::*, Foundation::Collections::*, Win32::Foundation::E_BOUNDS};
+
+#[test]
+fn primitive() -> Result<()> {
+    let m = IMapView::<i32, u64>::try_from(BTreeMap::from([]))?;
+    assert_eq!(m.Lookup(0).unwrap_err().code(), E_BOUNDS);
+    assert_eq!(m.Size()?, 0);
+    assert_eq!(m.HasKey(0)?, false);
+    let mut left = None;
+    let mut right = None;
+    m.Split(&mut left, &mut right)?;
+
+    let m = IMapView::<i32, u64>::try_from(BTreeMap::from([(1, 10), (2, 20)]))?;
+    assert_eq!(m.Lookup(1i32)?, 10u64);
+    assert_eq!(m.Lookup(2)?, 20);
+    assert_eq!(m.Size()?, 2);
+    assert_eq!(m.HasKey(2)?, true);
+
+    let able: IIterable<IKeyValuePair<i32, u64>> = m.cast()?;
+    let m2: IMapView<i32, u64> = able.cast()?;
+    assert_eq!(m, m2);
+
+    Ok(())
+}
+
+#[test]
+fn primitive_iterator() -> Result<()> {
+    let able = IMapView::<i32, u64>::try_from(BTreeMap::from([]))?;
+    let iter = able.First()?;
+
+    assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
+    assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
+
+    assert!(!iter.HasCurrent()?);
+    assert!(!iter.HasCurrent()?);
+
+    assert!(!iter.MoveNext()?);
+    assert!(!iter.MoveNext()?);
+
+    let mut values = vec![];
+    values.resize_with(5, Default::default);
+    assert_eq!(iter.GetMany(&mut values)?, 0);
+
+    let able = IMapView::<i32, u64>::try_from(BTreeMap::from([(1, 10), (2, 20), (3, 30)]))?;
+    let iter = able.First()?;
+
+    assert_eq!(iter.Current()?.Key()?, 1i32);
+    assert_eq!(iter.Current()?.Value()?, 10u64);
+
+    assert!(iter.HasCurrent()?);
+    assert!(iter.HasCurrent()?);
+
+    assert!(iter.MoveNext()?);
+    assert_eq!(iter.Current()?.Key()?, 2);
+    assert_eq!(iter.Current()?.Value()?, 20);
+    assert!(iter.HasCurrent()?);
+    assert!(iter.HasCurrent()?);
+
+    assert!(iter.MoveNext()?);
+    assert_eq!(iter.Current()?.Key()?, 3);
+    assert_eq!(iter.Current()?.Value()?, 30);
+    assert!(iter.HasCurrent()?);
+    assert!(iter.HasCurrent()?);
+
+    assert!(!iter.MoveNext()?);
+    assert!(!iter.MoveNext()?);
+    assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
+    assert_eq!(iter.Current().unwrap_err().code(), E_BOUNDS);
+    assert!(!iter.HasCurrent()?);
+    assert!(!iter.HasCurrent()?);
+
+    let iter = able.First()?;
+    let mut values = vec![];
+    values.resize_with(5, Default::default);
+    assert_eq!(iter.GetMany(&mut values)?, 3);
+    assert!(compare_with(&values[0], &1, &10)?);
+    assert!(compare_with(&values[1], &2, &20)?);
+    assert!(compare_with(&values[2], &3, &30)?);
+    assert!(values[3].is_none());
+    assert!(values[4].is_none());
+    assert_eq!(iter.GetMany(&mut values)?, 0);
+
+    let iter = able.First()?;
+    let mut values = vec![];
+    values.resize_with(1, Default::default);
+    assert_eq!(iter.GetMany(&mut values)?, 1);
+    assert!(compare_with(&values[0], &1, &10)?);
+    let mut values = vec![];
+    values.resize_with(2, Default::default);
+    assert_eq!(iter.GetMany(&mut values)?, 2);
+    assert!(compare_with(&values[0], &2, &20)?);
+    assert!(compare_with(&values[1], &3, &30)?);
+    assert_eq!(iter.GetMany(&mut values)?, 0);
+
+    Ok(())
+}
+
+fn compare_with<K, V>(pair: &Option<IKeyValuePair<K, V>>, key: &K, value: &V) -> Result<bool>
+where
+    K: RuntimeType + std::cmp::PartialEq,
+    V: RuntimeType + std::cmp::PartialEq,
+{
+    match pair {
+        None => Ok(false),
+        Some(pair) => Ok(&pair.Key()? == key && &pair.Value()? == value),
+    }
+}


### PR DESCRIPTION
Building on #2350 and as part of #91, this update adds a stock implementation of `IMapView<T>`. You can now write the following:

```rust
let map = BTreeMap::from([(1, 10), (2, 20), (3, 30)]);
let map: IMapView<i32, u64> = map.try_into()?;
```

Fixes: #91