### PR TITLE
Remove `prettyplease` dependency

### DIFF
--- a/crates/tools/lib/Cargo.toml
+++ b/crates/tools/lib/Cargo.toml
@@ -6,5 +6,4 @@ publish = false
 
 [dependencies]
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }
-prettyplease = "0.1"
 syn = "1.0"

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -2,17 +2,7 @@ use std::collections::*;
 use std::io::*;
 
 /// Formats the token string
-pub fn format(namespace: &str, tokens: &mut String, use_rustfmt: bool) {
-    if use_rustfmt {
-        rustfmt(namespace, tokens);
-    } else {
-        let file = syn::parse_file(tokens).unwrap();
-        *tokens = prettyplease::unparse(&file);
-    }
-}
-
-/// Formats the token string with `rustfmt`
-pub fn rustfmt(name: &str, tokens: &mut String) {
+pub fn format(namespace: &str, tokens: &mut String) {
     let mut child = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn().expect("Failed to spawn `rustfmt`");
     let mut stdin = child.stdin.take().expect("Failed to open stdin");
     stdin.write_all(tokens.as_bytes()).unwrap();
@@ -22,7 +12,7 @@ pub fn rustfmt(name: &str, tokens: &mut String) {
     if output.status.success() {
         *tokens = String::from_utf8(output.stdout).expect("Failed to parse UTF-8");
     } else {
-        println!("rustfmt failed for `{name}` with status {}\nError:\n{}", output.status, String::from_utf8_lossy(&output.stderr));
+        println!("rustfmt failed for `{namespace}` with status {}\nError:\n{}", output.status, String::from_utf8_lossy(&output.stderr));
     }
 }
 


### PR DESCRIPTION
I considered using this more extensively but due to https://github.com/dtolnay/prettyplease/issues/35 I decided to stick with `rustfmt` until I can build something a little more streamlined. 