### PR TITLE
Check diff of all targets, not just baseline

### DIFF
--- a/.github/workflows/lib.yml
+++ b/.github/workflows/lib.yml
@@ -50,11 +50,11 @@ jobs:
           name: libs
           path: crates/targets/*/lib/*
 
-      - name: Check baseline
+      - name: Check diff
         shell: bash
         run: |
           git add -N .
-          git diff --exit-code crates/targets/baseline || (echo '::error::Generated target libs are out-of-date.'; exit 1)
+          git diff --exit-code crates/targets || (echo '::error::Generated target libs are out-of-date.'; exit 1)
 
       - name: Check dumpbin
         shell: pwsh


### PR DESCRIPTION
Building on #2365, this should now ensure we have updated libs at all times, much like the gen workflow ensures code gen is always updated. 