### PR TITLE
Workaround for `rustdoc` regression

### DIFF
--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -14,7 +14,6 @@ extern crate self as windows;
 pub use Windows::*;
 pub mod core;
 
-#[doc(hidden)]
 mod Windows;
 
 #[doc(hidden)]


### PR DESCRIPTION
Something changed in `rustdoc` since the last time I built the `windows` docs. This is just a workaround to get it to work as before.