### PR TITLE
Token privilege samples

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -54,6 +54,8 @@ jobs:
           cargo clippy -p sample_message_box_sys &&
           cargo clippy -p sample_ocr &&
           cargo clippy -p sample_overlapped &&
+          cargo clippy -p sample_privileges &&
+          cargo clippy -p sample_privileges_sys &&
           cargo clippy -p sample_rss &&
           cargo clippy -p sample_simple &&
           cargo clippy -p sample_spellchecker &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,6 +61,8 @@ jobs:
           cargo test --target ${{ matrix.target }} -p sample_message_box_sys &&
           cargo test --target ${{ matrix.target }} -p sample_ocr &&
           cargo test --target ${{ matrix.target }} -p sample_overlapped &&
+          cargo test --target ${{ matrix.target }} -p sample_privileges &&
+          cargo test --target ${{ matrix.target }} -p sample_privileges_sys &&
           cargo test --target ${{ matrix.target }} -p sample_rss &&
           cargo test --target ${{ matrix.target }} -p sample_simple &&
           cargo test --target ${{ matrix.target }} -p sample_spellchecker &&
@@ -91,8 +93,8 @@ jobs:
           cargo test --target ${{ matrix.target }} -p test_dispatch &&
           cargo test --target ${{ matrix.target }} -p test_does_not_return &&
           cargo test --target ${{ matrix.target }} -p test_enums &&
-          cargo test --target ${{ matrix.target }} -p test_error &&
           cargo clean &&
+          cargo test --target ${{ matrix.target }} -p test_error &&
           cargo test --target ${{ matrix.target }} -p test_event &&
           cargo test --target ${{ matrix.target }} -p test_extensions &&
           cargo test --target ${{ matrix.target }} -p test_handles &&

--- a/crates/samples/windows-sys/privileges/Cargo.toml
+++ b/crates/samples/windows-sys/privileges/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sample_privileges_sys"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies.windows-sys]
+path = "../../../libs/sys"
+features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_System_Memory",
+]

--- a/crates/samples/windows-sys/privileges/src/main.rs
+++ b/crates/samples/windows-sys/privileges/src/main.rs
@@ -1,0 +1,56 @@
+use windows_sys::{Win32::Security::*, Win32::System::Memory::*, Win32::System::Threading::*};
+
+fn main() {
+    unsafe {
+        let mut token = 0;
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token);
+        let mut bytes_required = 0;
+
+        GetTokenInformation(
+            token,
+            TokenPrivileges,
+            std::ptr::null_mut(),
+            0,
+            &mut bytes_required,
+        );
+
+        let buffer = LocalAlloc(LPTR, bytes_required as _);
+
+        GetTokenInformation(
+            token,
+            TokenPrivileges,
+            buffer as *mut _,
+            bytes_required,
+            &mut bytes_required,
+        );
+
+        let header = &*(buffer as *const TOKEN_PRIVILEGES);
+
+        let privileges =
+            std::slice::from_raw_parts(header.Privileges.as_ptr(), header.PrivilegeCount as _);
+
+        for privilege in privileges {
+            let mut name_len = 0;
+
+            LookupPrivilegeNameW(
+                std::ptr::null(),
+                &privilege.Luid,
+                std::ptr::null_mut(),
+                &mut name_len,
+            );
+
+            let mut name = vec![0u16; (name_len + 1) as usize];
+
+            LookupPrivilegeNameW(
+                std::ptr::null(),
+                &privilege.Luid,
+                name.as_mut_ptr(),
+                &mut name_len,
+            );
+
+            println!("{}", String::from_utf16_lossy(&name));
+        }
+
+        LocalFree(buffer);
+    }
+}

--- a/crates/samples/windows/privileges/Cargo.toml
+++ b/crates/samples/windows/privileges/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "sample_privileges"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies.windows]
+path = "../../../libs/windows"
+features = [
+    "Win32_Foundation",
+    "Win32_Security",
+    "Win32_System_Threading",
+    "Win32_System_Memory",
+]

--- a/crates/samples/windows/privileges/src/main.rs
+++ b/crates/samples/windows/privileges/src/main.rs
@@ -1,0 +1,44 @@
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Security::*, Win32::System::Memory::*,
+    Win32::System::Threading::*,
+};
+
+fn main() -> Result<()> {
+    unsafe {
+        let mut token = HANDLE::default();
+        OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).ok()?;
+
+        let mut bytes_required = 0;
+        GetTokenInformation(token, TokenPrivileges, None, 0, &mut bytes_required);
+
+        let buffer = LocalAlloc(LPTR, bytes_required as _)?;
+
+        GetTokenInformation(
+            token,
+            TokenPrivileges,
+            Some(buffer.0 as *mut _),
+            bytes_required,
+            &mut bytes_required,
+        )
+        .ok()?;
+
+        let header = &*(buffer.0 as *const TOKEN_PRIVILEGES);
+
+        let privileges =
+            std::slice::from_raw_parts(header.Privileges.as_ptr(), header.PrivilegeCount as _);
+
+        for privilege in privileges {
+            let mut name_len = 0;
+            LookupPrivilegeNameW(None, &privilege.Luid, PWSTR::null(), &mut name_len);
+
+            let mut name = vec![0u16; (name_len + 1) as usize];
+            let name = PWSTR(name.as_mut_ptr());
+            LookupPrivilegeNameW(None, &privilege.Luid, name, &mut name_len).ok()?;
+
+            println!("{}", name.display())
+        }
+
+        _ = LocalFree(buffer);
+        Ok(())
+    }
+}


### PR DESCRIPTION
A pair of samples that illustrate how to query token privileges with both the `windows` and `windows-sys` crates.

Related to #2375.