### PR TITLE
Advanced metadata filtering

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -41,7 +41,10 @@ pub fn namespace(gen: &Gen, tree: &Tree) -> String {
     let mut functions = BTreeMap::<&str, TokenStream>::new();
     let mut types = BTreeMap::<TypeKind, BTreeMap<&str, TokenStream>>::new();
 
-    for def in gen.reader.namespace_types(tree.namespace) {
+    for def in gen
+        .reader
+        .namespace_types(tree.namespace, &Default::default())
+    {
         let type_name = gen.reader.type_def_type_name(def);
         if REMAP_TYPES.iter().any(|(x, _)| x == &type_name) {
             continue;
@@ -145,7 +148,10 @@ pub fn namespace(gen: &Gen, tree: &Tree) -> String {
 pub fn namespace_impl(gen: &Gen, tree: &Tree) -> String {
     let mut types = BTreeMap::<&str, TokenStream>::new();
 
-    for def in gen.reader.namespace_types(tree.namespace) {
+    for def in gen
+        .reader
+        .namespace_types(tree.namespace, &Default::default())
+    {
         let type_name = gen.reader.type_def_type_name(def);
         if CORE_TYPES.iter().any(|(x, _)| x == &type_name) {
             continue;
@@ -172,7 +178,7 @@ pub fn namespace_impl(gen: &Gen, tree: &Tree) -> String {
 
 pub fn component(namespace: &str, files: &[File]) -> String {
     let reader = &Reader::new(files);
-    let tree = reader.tree(namespace, &[]).expect("Namespace not found");
+    let tree = reader.tree(namespace, &Default::default());
     let mut gen = Gen::new(reader);
     gen.namespace = tree.namespace;
     gen.component = true;

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -135,7 +135,7 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
                 let remaining = self.count.release();
                 if remaining == 0 {
                     unsafe {
-                        let _ = ::std::boxed::Box::from_raw(self as *const Self as *mut Self);
+                        _ = ::std::boxed::Box::from_raw(self as *const Self as *mut Self);
                     }
                 }
                 remaining

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -372,10 +372,10 @@ impl Parse for Interface {
         }
 
         let visibility = input.parse::<syn::Visibility>()?;
-        let _ = input.parse::<syn::Token![unsafe]>()?;
-        let _ = input.parse::<syn::Token![trait]>()?;
+        _ = input.parse::<syn::Token![unsafe]>()?;
+        _ = input.parse::<syn::Token![trait]>()?;
         let name = input.parse::<syn::Ident>()?;
-        let _ = input.parse::<syn::Token![:]>();
+        _ = input.parse::<syn::Token![:]>();
         let parent = input.parse::<syn::Path>().ok();
         let content;
         syn::braced!(content in input);

--- a/crates/libs/metadata/src/reader/filter.rs
+++ b/crates/libs/metadata/src/reader/filter.rs
@@ -1,0 +1,157 @@
+use super::*;
+
+#[derive(Default)]
+pub struct Filter<'a>(Vec<(&'a str, bool)>);
+
+impl<'a> Filter<'a> {
+    pub fn new(include: &[&'a str], exclude: &[&'a str]) -> Self {
+        let mut rules = vec![];
+
+        for include in include {
+            rules.push((*include, true));
+        }
+
+        for exclude in exclude {
+            rules.push((*exclude, false));
+        }
+
+        rules.sort_unstable_by(|left, right| {
+            let left = (left.0.len(), !left.1);
+            let right = (right.0.len(), !right.1);
+            left.cmp(&right).reverse()
+        });
+
+        Self(rules)
+    }
+
+    pub fn includes_namespace(&self, namespace: &str) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        for rule in &self.0 {
+            if rule.1 {
+                // include
+                if rule.0.starts_with(namespace) {
+                    return true;
+                }
+                if namespace.starts_with(rule.0) {
+                    return true;
+                }
+            } else {
+                // exclude
+                if namespace.starts_with(rule.0) {
+                    return false;
+                }
+            }
+        }
+
+        false
+    }
+
+    pub fn includes_type(&self, reader: &Reader, ty: TypeDef) -> bool {
+        self.includes_type_name(reader.type_def_type_name(ty))
+    }
+
+    fn includes_type_name(&self, type_name: TypeName) -> bool {
+        if self.is_empty() {
+            return true;
+        }
+
+        for rule in &self.0 {
+            if match_type_name(rule.0, type_name.namespace, type_name.name) {
+                return rule.1;
+            }
+        }
+
+        false
+    }
+
+    fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+}
+
+fn match_type_name(rule: &str, namespace: &str, name: &str) -> bool {
+    if rule.len() <= namespace.len() {
+        return namespace.starts_with(rule);
+    }
+
+    if !rule.starts_with(namespace) {
+        return false;
+    }
+
+    if rule.as_bytes()[namespace.len()] != b'.' {
+        return false;
+    }
+
+    name.starts_with(&rule[namespace.len() + 1..])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn includes_type_name(filter: &Filter, full_name: &str) -> bool {
+        filter.includes_type_name(TypeName::parse(full_name))
+    }
+
+    #[test]
+    fn test_namespace() {
+        let include = ["N1.N2"];
+        let exclude = ["N1.N2.N3"];
+        let f = Filter::new(&include, &exclude);
+
+        assert!(f.includes_namespace("N1"));
+        assert!(f.includes_namespace("N1.N2"));
+        assert!(f.includes_namespace("N1.N2.N4"));
+
+        assert!(!f.includes_namespace("N1.N2.N3"));
+        assert!(!f.includes_namespace("N1.N2.N3.N4"));
+    }
+
+    #[test]
+    fn test_simple() {
+        let include = ["N1", "N3", "N3.N4.N5"];
+        let exclude = ["N2", "N3.N4"];
+        let f = Filter::new(&include, &exclude);
+
+        assert!(!f.is_empty());
+
+        assert!(!includes_type_name(&f, "NN.T"));
+
+        assert!(includes_type_name(&f, "N1.T"));
+        assert!(includes_type_name(&f, "N3.T"));
+
+        assert!(!includes_type_name(&f, "N2.T"));
+        assert!(!includes_type_name(&f, "N3.N4.T"));
+
+        assert!(includes_type_name(&f, "N3.N4.N5.T"));
+    }
+
+    #[test]
+    fn filter_excludes_same_length() {
+        let include = ["N.N1", "N.N2"];
+        let exclude = ["N.N3", "N.N4"];
+        let f = Filter::new(&include, &exclude);
+
+        assert!(!f.is_empty());
+
+        assert!(includes_type_name(&f, "N.N1.T"));
+        assert!(includes_type_name(&f, "N.N2.T"));
+
+        assert!(!includes_type_name(&f, "N.N3.T"));
+        assert!(!includes_type_name(&f, "N.N4.T"));
+    }
+
+    #[test]
+    fn filter_exclude_include_precedence() {
+        let include = ["N.T"];
+        let exclude = ["N.T"];
+        let f = Filter::new(&include, &exclude);
+
+        assert!(!f.is_empty());
+
+        assert!(!includes_type_name(&f, "N.T"));
+    }
+}

--- a/crates/samples/windows/spellchecker/src/main.rs
+++ b/crates/samples/windows/spellchecker/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Result<()> {
                     // Get the next suggestion breaking if the call to `Next` failed
                     let mut suggestion = [PWSTR::null()];
                     unsafe {
-                        let _ = suggestions.Next(&mut suggestion, None);
+                        _ = suggestions.Next(&mut suggestion, None);
                     }
                     if suggestion[0].is_null() {
                         break;

--- a/crates/tests/implement/tests/data_object.rs
+++ b/crates/tests/implement/tests/data_object.rs
@@ -116,7 +116,7 @@ fn test() -> Result<()> {
         assert!(!(*i).EnumDAdvise);
 
         d.DUnadvise(0)?;
-        let _ = d.EnumDAdvise();
+        _ = d.EnumDAdvise();
 
         assert!((*i).DUnadvise);
         assert!((*i).EnumDAdvise);

--- a/crates/tests/interface/tests/non_com_existing.rs
+++ b/crates/tests/interface/tests/non_com_existing.rs
@@ -162,7 +162,7 @@ fn test() -> Result<()> {
 
         // Pass the callback to another API (ignore the result)...
         let mut source = None;
-        let _ = audio.CreateSourceVoice(&mut source, std::ptr::null(), 0, 0.0, &*callback, None, None);
+        _ = audio.CreateSourceVoice(&mut source, std::ptr::null(), 0, 0.0, &*callback, None, None);
 
         Ok(())
     }

--- a/crates/tests/matrix3x2/tests/matrix3x2.rs
+++ b/crates/tests/matrix3x2/tests/matrix3x2.rs
@@ -2,5 +2,5 @@ use windows::Foundation::Numerics::Matrix3x2;
 
 #[test]
 fn test() {
-    let _ = Matrix3x2::rotation(0.0, 1.0, 2.0);
+    _ = Matrix3x2::rotation(0.0, 1.0, 2.0);
 }

--- a/crates/tests/not_dll/tests/win.rs
+++ b/crates/tests/not_dll/tests/win.rs
@@ -5,6 +5,6 @@ use windows::Win32::Graphics::Printing::*;
 #[test]
 fn test() {
     unsafe {
-        let _ = GetSpoolFileHandle(None);
+        _ = GetSpoolFileHandle(None);
     }
 }

--- a/crates/tests/win32/tests/win32.rs
+++ b/crates/tests/win32/tests/win32.rs
@@ -51,7 +51,7 @@ fn rect() {
 
 #[test]
 fn dxgi_mode_desc() {
-    let _ = DXGI_MODE_DESC {
+    _ = DXGI_MODE_DESC {
         Width: 1,
         Height: 2,
         RefreshRate: DXGI_RATIONAL { Numerator: 3, Denominator: 5 },

--- a/crates/tools/gnu/src/main.rs
+++ b/crates/tools/gnu/src/main.rs
@@ -38,7 +38,7 @@ fn build_platform(platform: &str, dlltool: &str, ar: &str) {
 
     let libraries = lib::libraries();
     let output = std::path::PathBuf::from(format!("crates/targets/{platform}/lib"));
-    let _ = std::fs::remove_dir_all(&output);
+    _ = std::fs::remove_dir_all(&output);
     std::fs::create_dir_all(&output).unwrap();
 
     for (library, functions) in &libraries {

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -22,7 +22,7 @@ pub fn libraries() -> BTreeMap<String, BTreeMap<String, CallingConvention>> {
     let files = metadata::reader::File::with_default(&[]).unwrap();
     let reader = &metadata::reader::Reader::new(&files);
     let mut libraries = BTreeMap::<String, BTreeMap<String, CallingConvention>>::new();
-    let root = reader.tree("Windows", &[]).expect("`Windows` namespace not found");
+    let root = reader.tree("Windows", &Default::default());
 
     for tree in root.flatten() {
         if let Some(apis) = reader.get(metadata::reader::TypeName::new(tree.namespace, "Apis")).next() {

--- a/crates/tools/msvc/src/main.rs
+++ b/crates/tools/msvc/src/main.rs
@@ -21,7 +21,7 @@ fn main() {
 
     let libraries = lib::libraries();
     let output = std::path::PathBuf::from("crates/targets/baseline");
-    let _ = std::fs::remove_dir_all(&output);
+    _ = std::fs::remove_dir_all(&output);
     std::fs::create_dir_all(&output).unwrap();
 
     for (library, functions) in &libraries {

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -3,10 +3,7 @@ use std::io::prelude::*;
 
 /// Namespaces to include/exclude from code generation for the `windows-sys` crate.
 
-const INCLUDE_NAMESPACES: [&str; 2] = [
-    "Windows.Win32",
-    "Windows.Wdk",
-];
+const INCLUDE_NAMESPACES: [&str; 2] = ["Windows.Win32", "Windows.Wdk"];
 
 const EXCLUDE_NAMESPACES: [&str; 28] = [
     "Windows.Win32.AI.MachineLearning",

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -1,8 +1,13 @@
 use rayon::prelude::*;
-use std::collections::*;
 use std::io::prelude::*;
 
-/// Namespaces to exclude from code generation for the `windows-sys` crate.
+/// Namespaces to include/exclude from code generation for the `windows-sys` crate.
+
+const INCLUDE_NAMESPACES: [&str; 2] = [
+    "Windows.Win32",
+    "Windows.Wdk",
+];
+
 const EXCLUDE_NAMESPACES: [&str; 28] = [
     "Windows.Win32.AI.MachineLearning",
     "Windows.Win32.Graphics.CompositionSwapchain",
@@ -35,6 +40,7 @@ const EXCLUDE_NAMESPACES: [&str; 28] = [
 ];
 
 fn main() {
+    let time = std::time::Instant::now();
     let mut expect_namespace = false;
     let mut namespace = String::new();
     for arg in std::env::args() {
@@ -49,19 +55,17 @@ fn main() {
     }
     let mut output = std::path::PathBuf::from("crates/libs/sys/src/Windows");
     if namespace.is_empty() {
-        let _ = std::fs::remove_dir_all(&output);
+        _ = std::fs::remove_dir_all(&output);
     }
     output.pop();
     let files = metadata::reader::File::with_default(&[]).unwrap();
     let reader = &metadata::reader::Reader::new(&files);
     if !namespace.is_empty() {
-        let tree = reader.tree(&namespace, &[]).expect("Namespace not found");
+        let tree = reader.tree(&namespace, &Default::default());
         gen_tree(reader, &output, &tree);
         return;
     }
-    let win32 = reader.tree("Windows.Win32", &EXCLUDE_NAMESPACES).expect("`Windows.Win32` namespace not found");
-    let wdk = reader.tree("Windows.Wdk", &EXCLUDE_NAMESPACES).expect("`Windows.Win32` namespace not found");
-    let root = metadata::reader::Tree { namespace: "Windows", nested: BTreeMap::from([("Win32", win32), ("Wdk", wdk)]) };
+    let root = reader.tree("Windows", &metadata::reader::Filter::new(&INCLUDE_NAMESPACES, &EXCLUDE_NAMESPACES));
     let trees = root.flatten();
     trees.par_iter().for_each(|tree| gen_tree(reader, &output, tree));
     output.pop();
@@ -109,10 +113,11 @@ default = []
             file.write_all(format!("{feature} = []\n").as_bytes()).unwrap();
         }
     }
+
+    println!("  Finished in {:.2}s", time.elapsed().as_secs_f32());
 }
 
 fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &metadata::reader::Tree) {
-    println!("{}", tree.namespace);
     let mut path = std::path::PathBuf::from(output);
     path.push(tree.namespace.replace('.', "/"));
     std::fs::create_dir_all(&path).unwrap();

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -5,6 +5,7 @@ use std::io::prelude::*;
 const EXCLUDE_NAMESPACES: [&str; 14] = ["Windows.AI.MachineLearning.Preview", "Windows.ApplicationModel.SocialInfo", "Windows.Devices.AllJoyn", "Windows.Devices.Perception", "Windows.Security.Authentication.Identity.Provider", "Windows.Services.Cortana", "Windows.System.Power.Diagnostics", "Windows.System.Preview", "Windows.UI.Xaml", "Windows.Win32.Interop", "Windows.Win32.System.Diagnostics.Debug.WebApp", "Windows.Win32.System.WinRT.Xaml", "Windows.Win32.Web.MsHtml", "Windows.Win32.UI.Xaml"];
 
 fn main() {
+    let time = std::time::Instant::now();
     let mut expect_namespace = false;
     let mut namespace = String::new();
     for arg in std::env::args() {
@@ -19,17 +20,17 @@ fn main() {
     }
     let mut output = std::path::PathBuf::from("crates/libs/windows/src/Windows");
     if namespace.is_empty() {
-        let _ = std::fs::remove_dir_all(&output);
+        _ = std::fs::remove_dir_all(&output);
     }
     output.pop();
     let files = metadata::reader::File::with_default(&[]).unwrap();
     let reader = &metadata::reader::Reader::new(&files);
     if !namespace.is_empty() {
-        let tree = reader.tree(&namespace, &[]).expect("Namespace not found");
+        let tree = reader.tree(&namespace, &Default::default());
         gen_tree(reader, &output, &tree);
         return;
     }
-    let root = reader.tree("Windows", &EXCLUDE_NAMESPACES).expect("`Windows` namespace not found");
+    let root = reader.tree("Windows", &metadata::reader::Filter::new(&["Windows"], &EXCLUDE_NAMESPACES));
     let trees = root.flatten();
     trees.par_iter().for_each(|tree| gen_tree(reader, &output, tree));
     output.pop();
@@ -84,10 +85,11 @@ implement = ["windows-implement", "windows-interface"]
             file.write_all(format!("{feature} = []\n").as_bytes()).unwrap();
         }
     }
+
+    println!("  Finished in {:.2}s", time.elapsed().as_secs_f32());
 }
 
 fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &metadata::reader::Tree) {
-    println!("{}", tree.namespace);
     let mut path = std::path::PathBuf::from(output);
     path.push(tree.namespace.replace('.', "/"));
     std::fs::create_dir_all(&path).unwrap();


### PR DESCRIPTION
This adds support for more powerful metadata filtering needed for #1093 and the `riddle` tool.

This is a Rust port of the filtering support originally written by @Scottj1s for [cppwinrt](https://github.com/microsoft/cppwinrt).