### PR TITLE
Standalone code generation now includes dependencies automatically

### DIFF
--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -1,11 +1,6 @@
 fn main() {
     let apis = [
-        "Windows.Win32.Foundation.BOOL",
         "Windows.Win32.Foundation.CloseHandle",
-        "Windows.Win32.Foundation.HANDLE",
-        "Windows.Win32.Foundation.WIN32_ERROR",
-        "Windows.Win32.Security.SECURITY_ATTRIBUTES",
-        "Windows.Win32.System.Com.CLSCTX",
         "Windows.Win32.System.Com.CoCreateInstance",
         "Windows.Win32.System.Com.STGTY_REPEAT",
         "Windows.Win32.System.Threading.CreateEventW",

--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -1,13 +1,5 @@
 fn main() {
-    let apis = [
-        "Windows.Win32.Foundation.CloseHandle",
-        "Windows.Win32.System.Com.CoCreateInstance",
-        "Windows.Win32.System.Com.STGTY_REPEAT",
-        "Windows.Win32.System.Threading.CreateEventW",
-        "Windows.Win32.System.Threading.SetEvent",
-        "Windows.Win32.System.Threading.WaitForSingleObject",
-        "Windows.Win32.UI.Animation.UIAnimationManager",
-    ];
+    let apis = ["Windows.Win32.Foundation.CloseHandle", "Windows.Win32.System.Com.CoCreateInstance", "Windows.Win32.System.Com.STGTY_REPEAT", "Windows.Win32.System.Threading.CreateEventW", "Windows.Win32.System.Threading.SetEvent", "Windows.Win32.System.Threading.WaitForSingleObject", "Windows.Win32.UI.Animation.UIAnimationManager"];
 
     let bindings = windows_bindgen::standalone(&apis);
     std::fs::write("src/bindings.rs", bindings).unwrap();


### PR DESCRIPTION
This just makes it more convenient to use the new `standalone` function introduced in #2396.

Fixes: #2407
