### PR TITLE
Strip `.dll` extension from raw-dylib link names

### DIFF
--- a/crates/libs/bindgen/src/functions.rs
+++ b/crates/libs/bindgen/src/functions.rs
@@ -58,6 +58,10 @@ fn gen_link<P: IntoIterator<Item = TokenStream>>(
     for param in params {
         tokens.push_str(&format!("{}, ", param.as_str()));
     }
+
+    // Strip the dll suffix, including it will cause runtime failures as the
+    // dynamic loader will look for eg. "kernel32.dll.dll"
+    let link = link.strip_suffix(".dll").unwrap_or(link);
     let tokens = tokens.trim_end_matches(", ");
     format!(
         "::windows_targets::link!(\"{link}\" \"{abi}\"{doc} fn {name}({tokens}) {return_type});"


### PR DESCRIPTION
As noted in the comment, currently `windows-bindgen` emits the full name of the dll including the extension, which will cause runtime failures since somewhere (linker? dynamic loader?) the extension is automatically added, causing the dll not to be found and abort.

I think the confusion may come from the [RFC](https://rust-lang.github.io/rfcs/2627-raw-dylib-kind.html) containing example code which _does_ include the extension.

```rust
#[cfg(windows)]
#[link(name = "kernel32.dll", kind = "raw-dylib")]
#[allow(non_snake_case)]
extern "system" {
    fn GetStdHandle(nStdHandle: u32) -> *mut u8;
}
```

Note this doesn't impact `bthprops.cpl` which is the 1? case I could find of a dynamic lib having an extension _other_ than .dll.

I was opening an issue and realized it was easier to just fix it.
