### PR TITLE
Enable additional `raw-dylib` testing

### DIFF
--- a/.github/workflows/raw_dylib.yml
+++ b/.github/workflows/raw_dylib.yml
@@ -35,4 +35,9 @@ jobs:
         uses: ./.github/actions/fix-environment
           
       - name: Test
-        run: cargo test -p test_calling_convention
+        run: >
+          cargo test -p test_calling_convention &&
+          cargo test -p test_standalone &&
+          cargo test -p test_win32 &&
+          cargo test -p test_winrt &&
+          cargo test -p test_lib

--- a/crates/tests/lib/tests/sys.rs
+++ b/crates/tests/lib/tests/sys.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
+
 use windows_sys::{
     Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::ProcessStatus::*,
     Win32::System::Threading::*, Win32::Web::InternetExplorer::*,

--- a/crates/tests/standalone/src/lib.rs
+++ b/crates/tests/standalone/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg(test)]
+#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
 
 mod b_arch;
 mod b_bstr;


### PR DESCRIPTION
Just enables a bit more test coverage as we get [closer to stabilizing raw-dylib](https://github.com/rust-lang/rust/pull/109677). 