### PR TITLE
Win32 metadata workarounds

### DIFF
--- a/crates/libs/bindgen/src/enums.rs
+++ b/crates/libs/bindgen/src/enums.rs
@@ -1,13 +1,7 @@
 use super::*;
 
 pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
-    let mut type_name = gen.reader.type_def_type_name(def);
-
-    // TODO: workaround for https://github.com/microsoft/win32metadata/issues/1497
-    if type_name.name == "MENU_POPUPSUBMENU_HCHOT" {
-        type_name.name = "POPUPSUBMENUHCHOTSTATES";
-    }
-
+    let type_name = gen.reader.type_def_type_name(def);
     let ident = to_ident(type_name.name);
     let underlying_type = gen.reader.type_def_underlying_type(def);
     let underlying_type = gen.type_name(&underlying_type);

--- a/crates/libs/bindgen/src/functions.rs
+++ b/crates/libs/bindgen/src/functions.rs
@@ -18,8 +18,7 @@ fn gen_sys_function(gen: &Gen, def: MethodDef) -> TokenStream {
     let abi = gen.reader.method_def_extern_abi(def);
     let link = gen.reader.method_def_module_name(def);
 
-    // TODO: skip inline functions for now.
-    if link == "forceinline" {
+    if link.is_empty() {
         return TokenStream::new();
     }
 
@@ -105,8 +104,7 @@ fn gen_win_function(gen: &Gen, def: MethodDef) -> TokenStream {
     } else {
         let link = gen.reader.method_def_module_name(def);
 
-        // TODO: skip inline functions for now.
-        if link == "forceinline" {
+        if link.is_empty() {
             return TokenStream::new();
         }
 

--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -72,7 +72,7 @@ pub fn namespace(gen: &Gen, tree: &Tree) -> String {
                         .entry(kind)
                         .or_default()
                         .insert(name, classes::gen(gen, def));
-                } else {
+                } else if gen.reader.type_def_name(def) == "Apis" {
                     for method in gen.reader.type_def_methods(def) {
                         let name = gen.reader.method_def_name(method);
                         functions

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -571,10 +571,12 @@ impl<'a> Reader<'a> {
     pub fn method_def_module_name(&self, row: MethodDef) -> String {
         if let Some(impl_map) = self.method_def_impl_map(row) {
             let scope = self.impl_map_scope(impl_map);
-            self.module_ref_name(scope).to_lowercase()
-        } else {
-            String::new()
+            let name = self.module_ref_name(scope);
+            if name.contains('.') {
+                return name.to_lowercase();
+            }
         }
+        String::new()
     }
     pub fn method_def_signature(&self, row: MethodDef, generics: &[Type]) -> Signature {
         let mut blob = self.row_blob(row.0, 4);
@@ -751,7 +753,7 @@ impl<'a> Reader<'a> {
     // ModuleRef table queries
     //
 
-    pub fn module_ref_name(&self, row: ModuleRef) -> &str {
+    fn module_ref_name(&self, row: ModuleRef) -> &str {
         self.row_str(row.0, 0)
     }
 

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -572,6 +572,9 @@ impl<'a> Reader<'a> {
         if let Some(impl_map) = self.method_def_impl_map(row) {
             let scope = self.impl_map_scope(impl_map);
             let name = self.module_ref_name(scope);
+            // If the module name lacks a `.` then its likely either an inline function, which windows-rs doesn't
+            // currently support, or it's an invalid import library since the extension must be known to generate
+            // an import table entry ambiguous.
             if name.contains('.') {
                 return name.to_lowercase();
             }

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -572,9 +572,9 @@ impl<'a> Reader<'a> {
         if let Some(impl_map) = self.method_def_impl_map(row) {
             let scope = self.impl_map_scope(impl_map);
             let name = self.module_ref_name(scope);
-            // If the module name lacks a `.` then its likely either an inline function, which windows-rs doesn't
-            // currently support, or it's an invalid import library since the extension must be known to generate
-            // an import table entry ambiguous.
+            // If the module name lacks a `.` then it's likely either an inline function, which windows-rs
+            // doesn't currently support, or an invalid import library since the extension must be known
+            // in order to generate an import table entry unambiguously.
             if name.contains('.') {
                 return name.to_lowercase();
             }

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -46,7 +46,7 @@ fn combine(files: &[metadata::reader::File], libraries: &mut BTreeMap<String, BT
         if let Some(apis) = reader.get(metadata::reader::TypeName::new(tree.namespace, "Apis")).next() {
             for method in reader.type_def_methods(apis) {
                 let library = reader.method_def_module_name(method);
-                if library == "forceinline" {
+                if library.is_empty() {
                     continue;
                 }
                 let impl_map = reader.method_def_impl_map(method).expect("ImplMap not found");


### PR DESCRIPTION
This update just removes an old workaround for https://github.com/microsoft/win32metadata/issues/1497 and adds a new workaround for https://github.com/microsoft/wdkmetadata/issues/30 to support updating to the latest metadata definitions. 