### PR TITLE
Consolidate formatting code

### DIFF
--- a/crates/libs/bindgen/src/lib.rs
+++ b/crates/libs/bindgen/src/lib.rs
@@ -15,15 +15,18 @@ mod implements;
 mod interfaces;
 mod iterators;
 mod method_names;
+mod standalone;
 mod structs;
+mod try_format;
 mod winrt_methods;
+
 use metadata::reader::*;
 use method_names::*;
+pub use standalone::*;
 use std::collections::*;
 use std::fmt::Write;
 use tokens::*;
-mod standalone;
-pub use standalone::*;
+use try_format::*;
 
 #[doc(hidden)]
 pub use gen::*;
@@ -149,7 +152,7 @@ pub fn namespace(gen: &Gen, tree: &Tree) -> String {
     }
 
     tokens.combine(&extensions::gen_mod(gen, tree.namespace));
-    tokens.into_string()
+    try_format(tokens.into_string())
 }
 
 #[doc(hidden)]
@@ -181,7 +184,7 @@ pub fn namespace_impl(gen: &Gen, tree: &Tree) -> String {
     };
 
     tokens.combine(&extensions::gen_impl(tree.namespace));
-    tokens.into_string()
+    try_format(tokens.into_string())
 }
 
 /// Generates bindings for a specific component namespace.
@@ -193,7 +196,7 @@ pub fn component(namespace: &str, files: &[File]) -> String {
     gen.component = true;
     let mut bindings = crate::namespace(&gen, &tree);
     bindings.push_str(&namespace_impl(&gen, &tree));
-    bindings
+    try_format(bindings)
 }
 
 fn allow() -> TokenStream {

--- a/crates/libs/bindgen/src/standalone.rs
+++ b/crates/libs/bindgen/src/standalone.rs
@@ -268,38 +268,6 @@ fn standalone_imp(gen: &Gen, names: &[&str]) -> String {
     try_format(tokens.into_string())
 }
 
-fn try_format(tokens: String) -> String {
-    use std::io::Write;
-
-    let Ok(mut child) = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn() else {
-        return tokens;
-    };
-
-    let Some(mut stdin) = child.stdin.take() else {
-        return tokens;
-    };
-
-    if stdin.write_all(tokens.as_bytes()).is_err() {
-        return tokens;
-    }
-
-    drop(stdin);
-
-    let Ok(output) = child.wait_with_output() else {
-        return tokens;
-    };
-
-    if !output.status.success() {
-        return tokens;
-    }
-
-    if let Ok(result) = String::from_utf8(output.stdout) {
-        result
-    } else {
-        tokens
-    }
-}
-
 #[derive(Default)]
 struct SortedTokens(BTreeMap<String, TokenStream>);
 

--- a/crates/libs/bindgen/src/try_format.rs
+++ b/crates/libs/bindgen/src/try_format.rs
@@ -1,0 +1,31 @@
+pub fn try_format(tokens: String) -> String {
+    use std::io::Write;
+
+    let Ok(mut child) = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn() else {
+        return tokens;
+    };
+
+    let Some(mut stdin) = child.stdin.take() else {
+        return tokens;
+    };
+
+    if stdin.write_all(tokens.as_bytes()).is_err() {
+        return tokens;
+    }
+
+    drop(stdin);
+
+    let Ok(output) = child.wait_with_output() else {
+        return tokens;
+    };
+
+    if !output.status.success() {
+        return tokens;
+    }
+
+    if let Ok(result) = String::from_utf8(output.stdout) {
+        result
+    } else {
+        tokens
+    }
+}

--- a/crates/tests/component/build.rs
+++ b/crates/tests/component/build.rs
@@ -29,7 +29,6 @@ fn main() -> std::io::Result<()> {
         "src/bindings.rs",
         bindgen::component("test_component", &files),
     )?;
-    Command::new("rustfmt").arg("src/bindings.rs").status()?;
 
     Ok(())
 }

--- a/crates/tests/component_client/build.rs
+++ b/crates/tests/component_client/build.rs
@@ -1,5 +1,4 @@
 use std::fs::*;
-use std::process::*;
 
 fn main() -> std::io::Result<()> {
     create_dir_all(".windows/winmd")?;
@@ -13,6 +12,5 @@ fn main() -> std::io::Result<()> {
         "src/bindings.rs",
         bindgen::component("test_component", &files),
     )?;
-    Command::new("rustfmt").arg("src/bindings.rs").status()?;
     Ok(())
 }

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -1,21 +1,4 @@
 use std::collections::*;
-use std::io::*;
-
-/// Formats the token string
-pub fn format(namespace: &str, tokens: &mut String) {
-    let mut child = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn().expect("Failed to spawn `rustfmt`");
-    let mut stdin = child.stdin.take().expect("Failed to open stdin");
-    stdin.write_all(tokens.as_bytes()).unwrap();
-    drop(stdin);
-    let output = child.wait_with_output().unwrap();
-
-    if output.status.success() {
-        *tokens = String::from_utf8(output.stdout).expect("Failed to parse UTF-8");
-    } else {
-        // TODO: This doesn't print anything useful
-        println!("rustfmt failed for `{namespace}` with status {}\nError:\n{}", output.status, String::from_utf8_lossy(&output.stderr));
-    }
-}
 
 /// Returns the libraries and their function and stack sizes used by the gnu and msvc tools to build the umbrella libs.
 pub fn libraries() -> BTreeMap<String, BTreeMap<String, CallingConvention>> {

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -124,7 +124,6 @@ fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &
     gen.namespace = tree.namespace;
     gen.sys = true;
     gen.doc = true;
-    let mut tokens = bindgen::namespace(&gen, tree);
-    lib::format(tree.namespace, &mut tokens);
+    let tokens = bindgen::namespace(&gen, tree);
     std::fs::write(path.join("mod.rs"), tokens).unwrap();
 }

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -99,7 +99,13 @@ fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &
     gen.namespace = tree.namespace;
     gen.doc = true;
     let mut tokens = bindgen::namespace(&gen, tree);
-    tokens.push_str(r#"#[cfg(feature = "implement")] ::core::include!("impl.rs");"#);
+
+    tokens.push_str(
+        r#"#[cfg(feature = "implement")]
+::core::include!("impl.rs");
+"#,
+    );
+
     std::fs::write(path.join("mod.rs"), tokens).unwrap();
     let tokens = bindgen::namespace_impl(&gen, tree);
     std::fs::write(path.join("impl.rs"), tokens).unwrap();

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -100,9 +100,7 @@ fn gen_tree(reader: &metadata::reader::Reader, output: &std::path::Path, tree: &
     gen.doc = true;
     let mut tokens = bindgen::namespace(&gen, tree);
     tokens.push_str(r#"#[cfg(feature = "implement")] ::core::include!("impl.rs");"#);
-    lib::format(tree.namespace, &mut tokens);
     std::fs::write(path.join("mod.rs"), tokens).unwrap();
-    let mut tokens = bindgen::namespace_impl(&gen, tree);
-    lib::format(tree.namespace, &mut tokens);
+    let tokens = bindgen::namespace_impl(&gen, tree);
     std::fs::write(path.join("impl.rs"), tokens).unwrap();
 }


### PR DESCRIPTION
The `try_format` function is the simplest and this lets us manage a single implementation that all libraries can use. 

Code generated by `windows-bindgen` is now formatted directly, avoiding the need to post-format generated code. 