### PR TITLE
Simplified link generation

### DIFF
--- a/crates/libs/bindgen/src/functions.rs
+++ b/crates/libs/bindgen/src/functions.rs
@@ -205,7 +205,7 @@ fn gen_link(gen: &Gen, signature: &Signature, cfg: &Cfg) -> TokenStream {
         quote! { #name: #tokens }
     });
 
-    let return_type = gen.return_sig(&signature);
+    let return_type = gen.return_sig(signature);
 
     if gen.std || !gen.namespace.starts_with("Windows.") {
         let library = library.trim_end_matches(".dll");
@@ -233,7 +233,7 @@ fn gen_link(gen: &Gen, signature: &Signature, cfg: &Cfg) -> TokenStream {
         };
 
         let doc = if gen.sys {
-            gen.cfg_doc(&cfg).0
+            gen.cfg_doc(cfg).0
         } else {
             String::new()
         };

--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -168,6 +168,10 @@ impl<'a> Gen<'a> {
         }
     }
     pub fn type_abi_name(&self, ty: &Type) -> TokenStream {
+        if self.sys {
+            return self.type_default_name(ty);
+        }
+
         match ty {
             Type::IUnknown | Type::IInspectable => {
                 quote! { *mut ::core::ffi::c_void }
@@ -999,11 +1003,11 @@ impl<'a> Gen<'a> {
     pub fn return_sig(&self, signature: &Signature) -> TokenStream {
         if let Some(return_type) = &signature.return_type {
             let tokens = self.type_default_name(return_type);
-            format!("-> {}", tokens.as_str()).into()
+            format!(" -> {}", tokens.as_str()).into()
         } else if self.reader.method_def_does_not_return(signature.def) {
-            "-> !".into()
+            " -> !".into()
         } else {
-            "-> ()".into()
+            " -> ()".into()
         }
     }
     pub fn win32_args(&self, params: &[SignatureParam], kind: SignatureKind) -> TokenStream {

--- a/crates/libs/bindgen/src/standalone.rs
+++ b/crates/libs/bindgen/src/standalone.rs
@@ -4,9 +4,7 @@ use super::*;
 pub fn standalone(names: &[&str]) -> String {
     let files = &File::with_default(&[]).unwrap();
     let reader = &Reader::new(files);
-    let mut gen = &mut Gen::new(reader);
-    gen.standalone = true;
-    gen.sys = true;
+    let gen = &mut Gen::new(reader);
     standalone_imp(gen, names)
 }
 
@@ -14,14 +12,16 @@ pub fn standalone(names: &[&str]) -> String {
 pub fn standalone_std(names: &[&str]) -> String {
     let files = &File::with_default(&[]).unwrap();
     let reader = &Reader::new(files);
-    let mut gen = &mut Gen::new(reader);
-    gen.standalone = true;
-    gen.sys = true;
+    let gen = &mut Gen::new(reader);
     gen.std = true;
     standalone_imp(gen, names)
 }
 
-fn standalone_imp(gen: &Gen, names: &[&str]) -> String {
+fn standalone_imp(gen: &mut Gen, names: &[&str]) -> String {
+    gen.namespace = "Windows.";
+    gen.standalone = true;
+    gen.sys = true;
+
     let mut type_names = BTreeSet::new();
     let mut core_types = BTreeSet::new();
     let mut enums = BTreeSet::new();

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -27,11 +27,12 @@ fn combine(files: &[metadata::reader::File], libraries: &mut BTreeMap<String, BT
         let library = reader.method_def_module_name(method);
         let impl_map = reader.method_def_impl_map(method).expect("ImplMap not found");
         let flags = reader.impl_map_flags(impl_map);
+        let name = reader.impl_map_import_name(impl_map).to_string();
         if flags.contains(metadata::PInvokeAttributes::CONV_PLATFORM) {
             let params = reader.method_def_size(method);
-            libraries.entry(library).or_default().insert(reader.method_def_name(method).to_string(), CallingConvention::Stdcall(params));
+            libraries.entry(library).or_default().insert(name, CallingConvention::Stdcall(params));
         } else if flags.contains(metadata::PInvokeAttributes::CONV_CDECL) {
-            libraries.entry(library).or_default().insert(reader.method_def_name(method).to_string(), CallingConvention::Cdecl);
+            libraries.entry(library).or_default().insert(name, CallingConvention::Cdecl);
         } else {
             unimplemented!();
         }

--- a/crates/tools/msvc/src/main.rs
+++ b/crates/tools/msvc/src/main.rs
@@ -76,8 +76,6 @@ fn main() {
 }
 
 fn build_library(output: &std::path::Path, library: &str, functions: &BTreeMap<String, lib::CallingConvention>) {
-    println!("{library}");
-
     // Note that we don't use set_extension as it confuses PathBuf when the library name includes a period.
 
     let mut path = std::path::PathBuf::from(output);


### PR DESCRIPTION
The `windows-bindgen` crate now uses a centralized link generation function that consolidates a lot of the code related to generating the various link variants. It now also supports generating alternate symbol name imports (#2440). 