### PR TITLE
Hardening for empty structs

### DIFF
--- a/crates/libs/bindgen/src/structs.rs
+++ b/crates/libs/bindgen/src/structs.rs
@@ -16,10 +16,24 @@ fn gen_struct_with_name(gen: &Gen, def: TypeDef, struct_name: &str, cfg: &Cfg) -
     let name = to_ident(struct_name);
 
     if gen.reader.type_def_fields(def).next().is_none() {
-        return quote! {
+        let mut tokens = quote! {
             #[repr(C)]
             pub struct #name(pub u8);
+            impl ::core::marker::Copy for #name {}
+            impl ::core::clone::Clone for #name {
+                fn clone(&self) -> Self {
+                    *self
+                }
+            }
         };
+        if !gen.sys {
+            tokens.combine(&quote! {
+                impl ::windows::core::TypeKind for #name {
+                    type TypeKind = ::windows::core::CopyType;
+                }
+            });
+        }
+        return tokens;
     }
 
     let flags = gen.reader.type_def_flags(def);

--- a/crates/libs/sys/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -844,10 +844,28 @@ impl ::core::clone::Clone for HH_WINTYPE {
 }
 #[repr(C)]
 pub struct IITGroup(pub u8);
+impl ::core::marker::Copy for IITGroup {}
+impl ::core::clone::Clone for IITGroup {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct IITQuery(pub u8);
+impl ::core::marker::Copy for IITQuery {}
+impl ::core::clone::Clone for IITQuery {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct IITStopWordList(pub u8);
+impl ::core::marker::Copy for IITStopWordList {}
+impl ::core::clone::Clone for IITStopWordList {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`*"]
 pub struct ROWSTATUS {

--- a/crates/libs/sys/src/Windows/Win32/Devices/AllJoyn/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/AllJoyn/mod.rs
@@ -1553,10 +1553,28 @@ pub const ALLJOYN_BYTE_ARRAY: alljoyn_typeid = 31073i32;
 pub const ALLJOYN_WILDCARD: alljoyn_typeid = 42i32;
 #[repr(C)]
 pub struct _alljoyn_abouticon_handle(pub u8);
+impl ::core::marker::Copy for _alljoyn_abouticon_handle {}
+impl ::core::clone::Clone for _alljoyn_abouticon_handle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _alljoyn_abouticonobj_handle(pub u8);
+impl ::core::marker::Copy for _alljoyn_abouticonobj_handle {}
+impl ::core::clone::Clone for _alljoyn_abouticonobj_handle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _alljoyn_abouticonproxy_handle(pub u8);
+impl ::core::marker::Copy for _alljoyn_abouticonproxy_handle {}
+impl ::core::clone::Clone for _alljoyn_abouticonproxy_handle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 pub type alljoyn_aboutdata = isize;
 pub type alljoyn_aboutdatalistener = isize;
 #[repr(C)]

--- a/crates/libs/sys/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -2151,10 +2151,28 @@ impl ::core::clone::Clone for WINBIO_VERSION {
 }
 #[repr(C)]
 pub struct _WINIBIO_ENGINE_CONTEXT(pub u8);
+impl ::core::marker::Copy for _WINIBIO_ENGINE_CONTEXT {}
+impl ::core::clone::Clone for _WINIBIO_ENGINE_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _WINIBIO_SENSOR_CONTEXT(pub u8);
+impl ::core::marker::Copy for _WINIBIO_SENSOR_CONTEXT {}
+impl ::core::clone::Clone for _WINIBIO_SENSOR_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _WINIBIO_STORAGE_CONTEXT(pub u8);
+impl ::core::marker::Copy for _WINIBIO_STORAGE_CONTEXT {}
+impl ::core::clone::Clone for _WINIBIO_STORAGE_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_Devices_BiometricFramework\"`, `\"Win32_Foundation\"`, `\"Win32_System_IO\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 pub type PIBIO_ENGINE_ACCEPT_PRIVATE_SENSOR_TYPE_INFO_FN = ::core::option::Option<unsafe extern "system" fn(pipeline: *mut WINBIO_PIPELINE, typeinfobufferaddress: *const u8, typeinfobuffersize: usize) -> ::windows_sys::core::HRESULT>;

--- a/crates/libs/sys/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -7020,6 +7020,12 @@ impl ::core::clone::Clone for USAGE_AND_PAGE {
 }
 #[repr(C)]
 pub struct _HIDP_PREPARSED_DATA(pub u8);
+impl ::core::marker::Copy for _HIDP_PREPARSED_DATA {}
+impl ::core::clone::Clone for _HIDP_PREPARSED_DATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type LPDICONFIGUREDEVICESCALLBACK = ::core::option::Option<unsafe extern "system" fn(param0: ::windows_sys::core::IUnknown, param1: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL>;

--- a/crates/libs/sys/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Globalization/mod.rs
@@ -8395,12 +8395,36 @@ impl ::core::clone::Clone for TEXTRANGE_PROPERTIES {
 }
 #[repr(C)]
 pub struct UBiDi(pub u8);
+impl ::core::marker::Copy for UBiDi {}
+impl ::core::clone::Clone for UBiDi {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UBiDiTransform(pub u8);
+impl ::core::marker::Copy for UBiDiTransform {}
+impl ::core::clone::Clone for UBiDiTransform {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UBreakIterator(pub u8);
+impl ::core::marker::Copy for UBreakIterator {}
+impl ::core::clone::Clone for UBreakIterator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UCPMap(pub u8);
+impl ::core::marker::Copy for UCPMap {}
+impl ::core::clone::Clone for UCPMap {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UCPTrie {
@@ -8440,6 +8464,12 @@ impl ::core::clone::Clone for UCPTrieData {
 }
 #[repr(C)]
 pub struct UCaseMap(pub u8);
+impl ::core::marker::Copy for UCaseMap {}
+impl ::core::clone::Clone for UCaseMap {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UCharIterator {
@@ -8468,16 +8498,52 @@ impl ::core::clone::Clone for UCharIterator {
 }
 #[repr(C)]
 pub struct UCharsetDetector(pub u8);
+impl ::core::marker::Copy for UCharsetDetector {}
+impl ::core::clone::Clone for UCharsetDetector {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UCharsetMatch(pub u8);
+impl ::core::marker::Copy for UCharsetMatch {}
+impl ::core::clone::Clone for UCharsetMatch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UCollationElements(pub u8);
+impl ::core::marker::Copy for UCollationElements {}
+impl ::core::clone::Clone for UCollationElements {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UCollator(pub u8);
+impl ::core::marker::Copy for UCollator {}
+impl ::core::clone::Clone for UCollator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UConstrainedFieldPosition(pub u8);
+impl ::core::marker::Copy for UConstrainedFieldPosition {}
+impl ::core::clone::Clone for UConstrainedFieldPosition {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UConverter(pub u8);
+impl ::core::marker::Copy for UConverter {}
+impl ::core::clone::Clone for UConverter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UConverterFromUnicodeArgs {
@@ -8498,6 +8564,12 @@ impl ::core::clone::Clone for UConverterFromUnicodeArgs {
 }
 #[repr(C)]
 pub struct UConverterSelector(pub u8);
+impl ::core::marker::Copy for UConverterSelector {}
+impl ::core::clone::Clone for UConverterSelector {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UConverterToUnicodeArgs {
@@ -8518,10 +8590,28 @@ impl ::core::clone::Clone for UConverterToUnicodeArgs {
 }
 #[repr(C)]
 pub struct UDateFormatSymbols(pub u8);
+impl ::core::marker::Copy for UDateFormatSymbols {}
+impl ::core::clone::Clone for UDateFormatSymbols {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UDateIntervalFormat(pub u8);
+impl ::core::marker::Copy for UDateIntervalFormat {}
+impl ::core::clone::Clone for UDateIntervalFormat {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UEnumeration(pub u8);
+impl ::core::marker::Copy for UEnumeration {}
+impl ::core::clone::Clone for UEnumeration {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UFieldPosition {
@@ -8537,24 +8627,84 @@ impl ::core::clone::Clone for UFieldPosition {
 }
 #[repr(C)]
 pub struct UFieldPositionIterator(pub u8);
+impl ::core::marker::Copy for UFieldPositionIterator {}
+impl ::core::clone::Clone for UFieldPositionIterator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UFormattedDateInterval(pub u8);
+impl ::core::marker::Copy for UFormattedDateInterval {}
+impl ::core::clone::Clone for UFormattedDateInterval {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UFormattedList(pub u8);
+impl ::core::marker::Copy for UFormattedList {}
+impl ::core::clone::Clone for UFormattedList {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UFormattedNumber(pub u8);
+impl ::core::marker::Copy for UFormattedNumber {}
+impl ::core::clone::Clone for UFormattedNumber {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UFormattedNumberRange(pub u8);
+impl ::core::marker::Copy for UFormattedNumberRange {}
+impl ::core::clone::Clone for UFormattedNumberRange {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UFormattedRelativeDateTime(pub u8);
+impl ::core::marker::Copy for UFormattedRelativeDateTime {}
+impl ::core::clone::Clone for UFormattedRelativeDateTime {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UFormattedValue(pub u8);
+impl ::core::marker::Copy for UFormattedValue {}
+impl ::core::clone::Clone for UFormattedValue {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UGenderInfo(pub u8);
+impl ::core::marker::Copy for UGenderInfo {}
+impl ::core::clone::Clone for UGenderInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UHashtable(pub u8);
+impl ::core::marker::Copy for UHashtable {}
+impl ::core::clone::Clone for UHashtable {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UIDNA(pub u8);
+impl ::core::marker::Copy for UIDNA {}
+impl ::core::clone::Clone for UIDNA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UIDNAInfo {
@@ -8573,12 +8723,36 @@ impl ::core::clone::Clone for UIDNAInfo {
 }
 #[repr(C)]
 pub struct UListFormatter(pub u8);
+impl ::core::marker::Copy for UListFormatter {}
+impl ::core::clone::Clone for UListFormatter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct ULocaleData(pub u8);
+impl ::core::marker::Copy for ULocaleData {}
+impl ::core::clone::Clone for ULocaleData {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct ULocaleDisplayNames(pub u8);
+impl ::core::marker::Copy for ULocaleDisplayNames {}
+impl ::core::clone::Clone for ULocaleDisplayNames {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UMutableCPTrie(pub u8);
+impl ::core::marker::Copy for UMutableCPTrie {}
+impl ::core::clone::Clone for UMutableCPTrie {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UNICODERANGE {
@@ -8593,10 +8767,28 @@ impl ::core::clone::Clone for UNICODERANGE {
 }
 #[repr(C)]
 pub struct UNormalizer2(pub u8);
+impl ::core::marker::Copy for UNormalizer2 {}
+impl ::core::clone::Clone for UNormalizer2 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UNumberFormatter(pub u8);
+impl ::core::marker::Copy for UNumberFormatter {}
+impl ::core::clone::Clone for UNumberFormatter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UNumberingSystem(pub u8);
+impl ::core::marker::Copy for UNumberingSystem {}
+impl ::core::clone::Clone for UNumberingSystem {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UParseError {
@@ -8613,12 +8805,36 @@ impl ::core::clone::Clone for UParseError {
 }
 #[repr(C)]
 pub struct UPluralRules(pub u8);
+impl ::core::marker::Copy for UPluralRules {}
+impl ::core::clone::Clone for UPluralRules {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct URegion(pub u8);
+impl ::core::marker::Copy for URegion {}
+impl ::core::clone::Clone for URegion {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct URegularExpression(pub u8);
+impl ::core::marker::Copy for URegularExpression {}
+impl ::core::clone::Clone for URegularExpression {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct URelativeDateTimeFormatter(pub u8);
+impl ::core::marker::Copy for URelativeDateTimeFormatter {}
+impl ::core::clone::Clone for URelativeDateTimeFormatter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UReplaceableCallbacks {
@@ -8637,8 +8853,20 @@ impl ::core::clone::Clone for UReplaceableCallbacks {
 }
 #[repr(C)]
 pub struct UResourceBundle(pub u8);
+impl ::core::marker::Copy for UResourceBundle {}
+impl ::core::clone::Clone for UResourceBundle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct USearch(pub u8);
+impl ::core::marker::Copy for USearch {}
+impl ::core::clone::Clone for USearch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct USerializedSet {
@@ -8655,14 +8883,44 @@ impl ::core::clone::Clone for USerializedSet {
 }
 #[repr(C)]
 pub struct USet(pub u8);
+impl ::core::marker::Copy for USet {}
+impl ::core::clone::Clone for USet {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct USpoofCheckResult(pub u8);
+impl ::core::marker::Copy for USpoofCheckResult {}
+impl ::core::clone::Clone for USpoofCheckResult {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct USpoofChecker(pub u8);
+impl ::core::marker::Copy for USpoofChecker {}
+impl ::core::clone::Clone for USpoofChecker {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UStringPrepProfile(pub u8);
+impl ::core::marker::Copy for UStringPrepProfile {}
+impl ::core::clone::Clone for UStringPrepProfile {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct UStringSearch(pub u8);
+impl ::core::marker::Copy for UStringSearch {}
+impl ::core::clone::Clone for UStringSearch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UText {

--- a/crates/libs/sys/src/Windows/Win32/Graphics/OpenGL/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Graphics/OpenGL/mod.rs
@@ -1910,10 +1910,28 @@ impl ::core::clone::Clone for EMRPIXELFORMAT {
 }
 #[repr(C)]
 pub struct GLUnurbs(pub u8);
+impl ::core::marker::Copy for GLUnurbs {}
+impl ::core::clone::Clone for GLUnurbs {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct GLUquadric(pub u8);
+impl ::core::marker::Copy for GLUquadric {}
+impl ::core::clone::Clone for GLUquadric {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct GLUtesselator(pub u8);
+impl ::core::marker::Copy for GLUtesselator {}
+impl ::core::clone::Clone for GLUtesselator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_OpenGL\"`*"]
 pub struct GLYPHMETRICSFLOAT {

--- a/crates/libs/sys/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -4492,10 +4492,28 @@ impl ::core::clone::Clone for DS3DVECTOR_2 {
 }
 #[repr(C)]
 pub struct IKsAllocator(pub u8);
+impl ::core::marker::Copy for IKsAllocator {}
+impl ::core::clone::Clone for IKsAllocator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct IKsAllocatorEx(pub u8);
+impl ::core::marker::Copy for IKsAllocatorEx {}
+impl ::core::clone::Clone for IKsAllocatorEx {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct IKsPin(pub u8);
+impl ::core::marker::Copy for IKsPin {}
+impl ::core::clone::Clone for IKsPin {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`*"]
 pub struct INTERLEAVED_AUDIO_FORMAT_INFORMATION {

--- a/crates/libs/sys/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
@@ -2127,6 +2127,12 @@ impl ::core::clone::Clone for DHCP_CLIENT_INFO_VQ {
 }
 #[repr(C)]
 pub struct DHCP_CLIENT_SEARCH_UNION(pub u8);
+impl ::core::marker::Copy for DHCP_CLIENT_SEARCH_UNION {}
+impl ::core::clone::Clone for DHCP_CLIENT_SEARCH_UNION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_FAILOVER_RELATIONSHIP {
@@ -2564,6 +2570,12 @@ impl ::core::clone::Clone for DHCP_OPTION_DATA_ELEMENT_0 {
 }
 #[repr(C)]
 pub struct DHCP_OPTION_ELEMENT_UNION(pub u8);
+impl ::core::marker::Copy for DHCP_OPTION_ELEMENT_UNION {}
+impl ::core::clone::Clone for DHCP_OPTION_ELEMENT_UNION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_OPTION_LIST {
@@ -2630,6 +2642,12 @@ impl ::core::clone::Clone for DHCP_OPTION_SCOPE_INFO6_0 {
 }
 #[repr(C)]
 pub struct DHCP_OPTION_SCOPE_UNION6(pub u8);
+impl ::core::marker::Copy for DHCP_OPTION_SCOPE_UNION6 {}
+impl ::core::clone::Clone for DHCP_OPTION_SCOPE_UNION6 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_OPTION_VALUE {
@@ -3264,10 +3282,28 @@ impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {
 }
 #[repr(C)]
 pub struct DHCP_SUBNET_ELEMENT_UNION(pub u8);
+impl ::core::marker::Copy for DHCP_SUBNET_ELEMENT_UNION {}
+impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_UNION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct DHCP_SUBNET_ELEMENT_UNION_V4(pub u8);
+impl ::core::marker::Copy for DHCP_SUBNET_ELEMENT_UNION_V4 {}
+impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_UNION_V4 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct DHCP_SUBNET_ELEMENT_UNION_V6(pub u8);
+impl ::core::marker::Copy for DHCP_SUBNET_ELEMENT_UNION_V6 {}
+impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_UNION_V6 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_SUBNET_INFO {

--- a/crates/libs/sys/src/Windows/Win32/Networking/Clustering/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/Clustering/mod.rs
@@ -6265,56 +6265,212 @@ impl ::core::clone::Clone for WitnessTagUpdateHelper {
 }
 #[repr(C)]
 pub struct _HCHANGE(pub u8);
+impl ::core::marker::Copy for _HCHANGE {}
+impl ::core::clone::Clone for _HCHANGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HCLUSCRYPTPROVIDER(pub u8);
+impl ::core::marker::Copy for _HCLUSCRYPTPROVIDER {}
+impl ::core::clone::Clone for _HCLUSCRYPTPROVIDER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HCLUSENUM(pub u8);
+impl ::core::marker::Copy for _HCLUSENUM {}
+impl ::core::clone::Clone for _HCLUSENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HCLUSENUMEX(pub u8);
+impl ::core::marker::Copy for _HCLUSENUMEX {}
+impl ::core::clone::Clone for _HCLUSENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HCLUSTER(pub u8);
+impl ::core::marker::Copy for _HCLUSTER {}
+impl ::core::clone::Clone for _HCLUSTER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HGROUP(pub u8);
+impl ::core::marker::Copy for _HGROUP {}
+impl ::core::clone::Clone for _HGROUP {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HGROUPENUM(pub u8);
+impl ::core::marker::Copy for _HGROUPENUM {}
+impl ::core::clone::Clone for _HGROUPENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HGROUPENUMEX(pub u8);
+impl ::core::marker::Copy for _HGROUPENUMEX {}
+impl ::core::clone::Clone for _HGROUPENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HGROUPSET(pub u8);
+impl ::core::marker::Copy for _HGROUPSET {}
+impl ::core::clone::Clone for _HGROUPSET {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HGROUPSETENUM(pub u8);
+impl ::core::marker::Copy for _HGROUPSETENUM {}
+impl ::core::clone::Clone for _HGROUPSETENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HNETINTERFACE(pub u8);
+impl ::core::marker::Copy for _HNETINTERFACE {}
+impl ::core::clone::Clone for _HNETINTERFACE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HNETINTERFACEENUM(pub u8);
+impl ::core::marker::Copy for _HNETINTERFACEENUM {}
+impl ::core::clone::Clone for _HNETINTERFACEENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HNETWORK(pub u8);
+impl ::core::marker::Copy for _HNETWORK {}
+impl ::core::clone::Clone for _HNETWORK {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HNETWORKENUM(pub u8);
+impl ::core::marker::Copy for _HNETWORKENUM {}
+impl ::core::clone::Clone for _HNETWORKENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HNODE(pub u8);
+impl ::core::marker::Copy for _HNODE {}
+impl ::core::clone::Clone for _HNODE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HNODEENUM(pub u8);
+impl ::core::marker::Copy for _HNODEENUM {}
+impl ::core::clone::Clone for _HNODEENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HNODEENUMEX(pub u8);
+impl ::core::marker::Copy for _HNODEENUMEX {}
+impl ::core::clone::Clone for _HNODEENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HREGBATCH(pub u8);
+impl ::core::marker::Copy for _HREGBATCH {}
+impl ::core::clone::Clone for _HREGBATCH {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HREGBATCHNOTIFICATION(pub u8);
+impl ::core::marker::Copy for _HREGBATCHNOTIFICATION {}
+impl ::core::clone::Clone for _HREGBATCHNOTIFICATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HREGBATCHPORT(pub u8);
+impl ::core::marker::Copy for _HREGBATCHPORT {}
+impl ::core::clone::Clone for _HREGBATCHPORT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HREGREADBATCH(pub u8);
+impl ::core::marker::Copy for _HREGREADBATCH {}
+impl ::core::clone::Clone for _HREGREADBATCH {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HREGREADBATCHREPLY(pub u8);
+impl ::core::marker::Copy for _HREGREADBATCHREPLY {}
+impl ::core::clone::Clone for _HREGREADBATCHREPLY {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HRESENUM(pub u8);
+impl ::core::marker::Copy for _HRESENUM {}
+impl ::core::clone::Clone for _HRESENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HRESENUMEX(pub u8);
+impl ::core::marker::Copy for _HRESENUMEX {}
+impl ::core::clone::Clone for _HRESENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HRESOURCE(pub u8);
+impl ::core::marker::Copy for _HRESOURCE {}
+impl ::core::clone::Clone for _HRESOURCE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _HRESTYPEENUM(pub u8);
+impl ::core::marker::Copy for _HRESTYPEENUM {}
+impl ::core::clone::Clone for _HRESTYPEENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
 pub type LPGROUP_CALLBACK_EX = ::core::option::Option<unsafe extern "system" fn(param0: *mut _HCLUSTER, param1: *mut _HGROUP, param2: *mut _HGROUP, param3: *mut ::core::ffi::c_void) -> u32>;
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]

--- a/crates/libs/sys/src/Windows/Win32/Networking/Ldap/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/Ldap/mod.rs
@@ -1354,6 +1354,12 @@ impl ::core::clone::Clone for LDAPModW_0 {
 }
 #[repr(C)]
 pub struct LDAPSearch(pub u8);
+impl ::core::marker::Copy for LDAPSearch {}
+impl ::core::clone::Clone for LDAPSearch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_Ldap\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/sys/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -6368,6 +6368,12 @@ impl ::core::clone::Clone for RIO_BUF {
 }
 #[repr(C)]
 pub struct RIO_BUFFERID_t(pub u8);
+impl ::core::marker::Copy for RIO_BUFFERID_t {}
+impl ::core::clone::Clone for RIO_BUFFERID_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`*"]
 pub struct RIO_CMSG_BUFFER {
@@ -6381,6 +6387,12 @@ impl ::core::clone::Clone for RIO_CMSG_BUFFER {
 }
 #[repr(C)]
 pub struct RIO_CQ_t(pub u8);
+impl ::core::marker::Copy for RIO_CQ_t {}
+impl ::core::clone::Clone for RIO_CQ_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -6471,6 +6483,12 @@ impl ::core::clone::Clone for RIO_NOTIFICATION_COMPLETION_0_1 {
 }
 #[repr(C)]
 pub struct RIO_RQ_t(pub u8);
+impl ::core::marker::Copy for RIO_RQ_t {}
+impl ::core::clone::Clone for RIO_RQ_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/sys/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
@@ -3051,6 +3051,12 @@ impl ::core::clone::Clone for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
 }
 #[repr(C)]
 pub struct WS_CHANNEL(pub u8);
+impl ::core::marker::Copy for WS_CHANNEL {}
+impl ::core::clone::Clone for WS_CHANNEL {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_CHANNEL_DECODER {
@@ -3509,6 +3515,12 @@ impl ::core::clone::Clone for WS_ENUM_VALUE {
 }
 #[repr(C)]
 pub struct WS_ERROR(pub u8);
+impl ::core::marker::Copy for WS_ERROR {}
+impl ::core::clone::Clone for WS_ERROR {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_ERROR_PROPERTY {
@@ -3644,6 +3656,12 @@ impl ::core::clone::Clone for WS_GUID_DESCRIPTION {
 }
 #[repr(C)]
 pub struct WS_HEAP(pub u8);
+impl ::core::marker::Copy for WS_HEAP {}
+impl ::core::clone::Clone for WS_HEAP {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_HEAP_PROPERTIES {
@@ -4171,6 +4189,12 @@ impl ::core::clone::Clone for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEMPLAT
 }
 #[repr(C)]
 pub struct WS_LISTENER(pub u8);
+impl ::core::marker::Copy for WS_LISTENER {}
+impl ::core::clone::Clone for WS_LISTENER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_LISTENER_PROPERTIES {
@@ -4198,6 +4222,12 @@ impl ::core::clone::Clone for WS_LISTENER_PROPERTY {
 }
 #[repr(C)]
 pub struct WS_MESSAGE(pub u8);
+impl ::core::marker::Copy for WS_MESSAGE {}
+impl ::core::clone::Clone for WS_MESSAGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -4240,6 +4270,12 @@ impl ::core::clone::Clone for WS_MESSAGE_PROPERTY {
 }
 #[repr(C)]
 pub struct WS_METADATA(pub u8);
+impl ::core::marker::Copy for WS_METADATA {}
+impl ::core::clone::Clone for WS_METADATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -4365,6 +4401,12 @@ impl ::core::clone::Clone for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
 }
 #[repr(C)]
 pub struct WS_OPERATION_CONTEXT(pub u8);
+impl ::core::marker::Copy for WS_OPERATION_CONTEXT {}
+impl ::core::clone::Clone for WS_OPERATION_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -4402,6 +4444,12 @@ impl ::core::clone::Clone for WS_PARAMETER_DESCRIPTION {
 }
 #[repr(C)]
 pub struct WS_POLICY(pub u8);
+impl ::core::marker::Copy for WS_POLICY {}
+impl ::core::clone::Clone for WS_POLICY {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_POLICY_CONSTRAINTS {
@@ -4695,6 +4743,12 @@ impl ::core::clone::Clone for WS_SECURITY_CONSTRAINTS {
 }
 #[repr(C)]
 pub struct WS_SECURITY_CONTEXT(pub u8);
+impl ::core::marker::Copy for WS_SECURITY_CONTEXT {}
+impl ::core::clone::Clone for WS_SECURITY_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING {
@@ -4858,6 +4912,12 @@ impl ::core::clone::Clone for WS_SECURITY_PROPERTY_CONSTRAINT_0 {
 }
 #[repr(C)]
 pub struct WS_SECURITY_TOKEN(pub u8);
+impl ::core::marker::Copy for WS_SECURITY_TOKEN {}
+impl ::core::clone::Clone for WS_SECURITY_TOKEN {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -4927,6 +4987,12 @@ impl ::core::clone::Clone for WS_SERVICE_ENDPOINT_PROPERTY {
 }
 #[repr(C)]
 pub struct WS_SERVICE_HOST(pub u8);
+impl ::core::marker::Copy for WS_SERVICE_HOST {}
+impl ::core::clone::Clone for WS_SERVICE_HOST {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -4996,6 +5062,12 @@ impl ::core::clone::Clone for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
 }
 #[repr(C)]
 pub struct WS_SERVICE_PROXY(pub u8);
+impl ::core::marker::Copy for WS_SERVICE_PROXY {}
+impl ::core::clone::Clone for WS_SERVICE_PROXY {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_SERVICE_SECURITY_IDENTITIES {
@@ -5737,6 +5809,12 @@ impl ::core::clone::Clone for WS_XML_BOOL_TEXT {
 }
 #[repr(C)]
 pub struct WS_XML_BUFFER(pub u8);
+impl ::core::marker::Copy for WS_XML_BUFFER {}
+impl ::core::clone::Clone for WS_XML_BUFFER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_XML_BUFFER_PROPERTY {
@@ -6001,6 +6079,12 @@ impl ::core::clone::Clone for WS_XML_QNAME_TEXT {
 }
 #[repr(C)]
 pub struct WS_XML_READER(pub u8);
+impl ::core::marker::Copy for WS_XML_READER {}
+impl ::core::clone::Clone for WS_XML_READER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -6276,6 +6360,12 @@ impl ::core::clone::Clone for WS_XML_UTF8_TEXT {
 }
 #[repr(C)]
 pub struct WS_XML_WRITER(pub u8);
+impl ::core::marker::Copy for WS_XML_WRITER {}
+impl ::core::clone::Clone for WS_XML_WRITER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/sys/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -9892,6 +9892,12 @@ impl ::core::clone::Clone for X509Certificate {
 }
 #[repr(C)]
 pub struct _HMAPPER(pub u8);
+impl ::core::marker::Copy for _HMAPPER {}
+impl ::core::clone::Clone for _HMAPPER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_Security_Authentication_Identity\"`, `\"Win32_Security_Credentials\"`*"]
 #[cfg(feature = "Win32_Security_Credentials")]
 pub type ACCEPT_SECURITY_CONTEXT_FN = ::core::option::Option<unsafe extern "system" fn(param0: *mut super::super::Credentials::SecHandle, param1: *mut super::super::Credentials::SecHandle, param2: *mut SecBufferDesc, param3: u32, param4: u32, param5: *mut super::super::Credentials::SecHandle, param6: *mut SecBufferDesc, param7: *mut u32, param8: *mut i64) -> ::windows_sys::core::HRESULT>;

--- a/crates/libs/sys/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -1427,6 +1427,12 @@ impl ::core::clone::Clone for SPropAttrArray {
 }
 #[repr(C)]
 pub struct _MSGSESS(pub u8);
+impl ::core::marker::Copy for _MSGSESS {}
+impl ::core::clone::Clone for _MSGSESS {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Imapi\"`*"]
 pub struct tagIMMPID_GUIDLIST_ITEM {

--- a/crates/libs/sys/src/Windows/Win32/Storage/IscsiDisc/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/IscsiDisc/mod.rs
@@ -2134,5 +2134,11 @@ impl ::core::clone::Clone for STORAGE_FIRMWARE_SLOT_INFO_V2 {
 }
 #[repr(C)]
 pub struct _ADAPTER_OBJECT(pub u8);
+impl ::core::marker::Copy for _ADAPTER_OBJECT {}
+impl ::core::clone::Clone for _ADAPTER_OBJECT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_Storage_IscsiDisc\"`*"]
 pub type PDUMP_DEVICE_POWERON_ROUTINE = ::core::option::Option<unsafe extern "system" fn(context: *const ::core::ffi::c_void) -> i32>;

--- a/crates/libs/sys/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Storage/Vss/mod.rs
@@ -705,6 +705,12 @@ pub const VSS_WS_FAILED_AT_BACKUPSHUTDOWN: VSS_WRITER_STATE = 15i32;
 pub const VSS_WS_COUNT: VSS_WRITER_STATE = 16i32;
 #[repr(C)]
 pub struct IVssExamineWriterMetadata(pub u8);
+impl ::core::marker::Copy for IVssExamineWriterMetadata {}
+impl ::core::clone::Clone for IVssExamineWriterMetadata {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Vss\"`*"]
 pub struct VSS_DIFF_AREA_PROP {

--- a/crates/libs/sys/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/AddressBook/mod.rs
@@ -1647,6 +1647,12 @@ impl ::core::clone::Clone for WAB_PARAM {
 }
 #[repr(C)]
 pub struct _WABACTIONITEM(pub u8);
+impl ::core::marker::Copy for _WABACTIONITEM {}
+impl ::core::clone::Clone for _WABACTIONITEM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]

--- a/crates/libs/sys/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -579,6 +579,12 @@ impl ::core::clone::Clone for OLESTREAMVTBL {
 }
 #[repr(C)]
 pub struct PMemoryAllocator(pub u8);
+impl ::core::marker::Copy for PMemoryAllocator {}
+impl ::core::clone::Clone for PMemoryAllocator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
 pub struct PROPBAG2 {

--- a/crates/libs/sys/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Com/mod.rs
@@ -1919,6 +1919,12 @@ impl ::core::clone::Clone for HYPER_SIZEDARR {
 }
 #[repr(C)]
 pub struct IContext(pub u8);
+impl ::core::marker::Copy for IContext {}
+impl ::core::clone::Clone for IContext {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
 pub struct IDLDESC {
@@ -1933,6 +1939,12 @@ impl ::core::clone::Clone for IDLDESC {
 }
 #[repr(C)]
 pub struct IEnumContextProps(pub u8);
+impl ::core::marker::Copy for IEnumContextProps {}
+impl ::core::clone::Clone for IEnumContextProps {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
 pub struct INTERFACEINFO {

--- a/crates/libs/sys/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Iis/mod.rs
@@ -2690,6 +2690,12 @@ impl ::core::clone::Clone for PRE_PROCESS_PARAMETERS {
 }
 #[repr(C)]
 pub struct _IIS_CRYPTO_BLOB(pub u8);
+impl ::core::marker::Copy for _IIS_CRYPTO_BLOB {}
+impl ::core::clone::Clone for _IIS_CRYPTO_BLOB {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type PFN_GETEXTENSIONVERSION = ::core::option::Option<unsafe extern "system" fn(pver: *mut HSE_VERSION_INFO) -> super::super::Foundation::BOOL>;

--- a/crates/libs/sys/src/Windows/Win32/System/RemoteManagement/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/RemoteManagement/mod.rs
@@ -1352,6 +1352,12 @@ pub const WSMAN_FLAG_SERVER_BUFFERING_MODE_BLOCK: WSManShellFlag = 8i32;
 pub const WSMAN_FLAG_RECEIVE_DELAY_OUTPUT_STREAM: WSManShellFlag = 16i32;
 #[repr(C)]
 pub struct WSMAN_API(pub u8);
+impl ::core::marker::Copy for WSMAN_API {}
+impl ::core::clone::Clone for WSMAN_API {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`*"]
 pub struct WSMAN_AUTHENTICATION_CREDENTIALS {
@@ -1406,6 +1412,12 @@ impl ::core::clone::Clone for WSMAN_CERTIFICATE_DETAILS {
 }
 #[repr(C)]
 pub struct WSMAN_COMMAND(pub u8);
+impl ::core::marker::Copy for WSMAN_COMMAND {}
+impl ::core::clone::Clone for WSMAN_COMMAND {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`*"]
 pub struct WSMAN_COMMAND_ARG_SET {
@@ -1566,6 +1578,12 @@ impl ::core::clone::Clone for WSMAN_KEY {
 }
 #[repr(C)]
 pub struct WSMAN_OPERATION(pub u8);
+impl ::core::marker::Copy for WSMAN_OPERATION {}
+impl ::core::clone::Clone for WSMAN_OPERATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -1745,8 +1763,20 @@ impl ::core::clone::Clone for WSMAN_SENDER_DETAILS {
 }
 #[repr(C)]
 pub struct WSMAN_SESSION(pub u8);
+impl ::core::marker::Copy for WSMAN_SESSION {}
+impl ::core::clone::Clone for WSMAN_SESSION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct WSMAN_SHELL(pub u8);
+impl ::core::marker::Copy for WSMAN_SHELL {}
+impl ::core::clone::Clone for WSMAN_SHELL {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`*"]
 pub struct WSMAN_SHELL_ASYNC {

--- a/crates/libs/sys/src/Windows/Win32/System/Rpc/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Rpc/mod.rs
@@ -2947,6 +2947,12 @@ impl ::core::clone::Clone for NDR64_VAR_ARRAY_HEADER_FORMAT {
 }
 #[repr(C)]
 pub struct NDR_ALLOC_ALL_NODES_CONTEXT(pub u8);
+impl ::core::marker::Copy for NDR_ALLOC_ALL_NODES_CONTEXT {}
+impl ::core::clone::Clone for NDR_ALLOC_ALL_NODES_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]
 pub struct NDR_CS_ROUTINES {
@@ -2987,6 +2993,12 @@ impl ::core::clone::Clone for NDR_EXPR_DESC {
 }
 #[repr(C)]
 pub struct NDR_POINTER_QUEUE_STATE(pub u8);
+impl ::core::marker::Copy for NDR_POINTER_QUEUE_STATE {}
+impl ::core::clone::Clone for NDR_POINTER_QUEUE_STATE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]
 pub struct NDR_SCONTEXT {
@@ -4376,10 +4388,28 @@ impl ::core::clone::Clone for XMIT_ROUTINE_QUINTUPLE {
 }
 #[repr(C)]
 pub struct _NDR_ASYNC_MESSAGE(pub u8);
+impl ::core::marker::Copy for _NDR_ASYNC_MESSAGE {}
+impl ::core::clone::Clone for _NDR_ASYNC_MESSAGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _NDR_CORRELATION_INFO(pub u8);
+impl ::core::marker::Copy for _NDR_CORRELATION_INFO {}
+impl ::core::clone::Clone for _NDR_CORRELATION_INFO {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _NDR_PROC_CONTEXT(pub u8);
+impl ::core::marker::Copy for _NDR_PROC_CONTEXT {}
+impl ::core::clone::Clone for _NDR_PROC_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]
 pub type CS_TAG_GETTING_ROUTINE = ::core::option::Option<unsafe extern "system" fn(hbinding: *mut ::core::ffi::c_void, fserverside: i32, pulsendingtag: *mut u32, puldesiredreceivingtag: *mut u32, pulreceivingtag: *mut u32, pstatus: *mut u32) -> ()>;
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]

--- a/crates/libs/sys/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Search/mod.rs
@@ -10789,6 +10789,12 @@ impl ::core::clone::Clone for INCREMENTAL_ACCESS_INFO {
 }
 #[repr(C)]
 pub struct IRowsetExactScroll(pub u8);
+impl ::core::marker::Copy for IRowsetExactScroll {}
+impl ::core::clone::Clone for IRowsetExactScroll {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/sys/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Services/mod.rs
@@ -1095,6 +1095,12 @@ impl ::core::clone::Clone for SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {
 }
 #[repr(C)]
 pub struct _SC_NOTIFICATION_REGISTRATION(pub u8);
+impl ::core::marker::Copy for _SC_NOTIFICATION_REGISTRATION {}
+impl ::core::clone::Clone for _SC_NOTIFICATION_REGISTRATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_System_Services\"`*"]
 pub type HANDLER_FUNCTION = ::core::option::Option<unsafe extern "system" fn(dwcontrol: u32) -> ()>;
 #[doc = "*Required features: `\"Win32_System_Services\"`*"]

--- a/crates/libs/sys/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/SystemServices/mod.rs
@@ -6655,6 +6655,12 @@ impl ::core::clone::Clone for APPLICATIONLAUNCH_SETTING_VALUE {
 }
 #[repr(C)]
 pub struct AtlThunkData_t(pub u8);
+impl ::core::marker::Copy for AtlThunkData_t {}
+impl ::core::clone::Clone for AtlThunkData_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct COMPONENT_FILTER {
@@ -9585,6 +9591,12 @@ impl ::core::clone::Clone for TAPE_WMI_OPERATIONS {
 }
 #[repr(C)]
 pub struct TEB(pub u8);
+impl ::core::marker::Copy for TEB {}
+impl ::core::clone::Clone for TEB {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -9616,8 +9628,20 @@ impl ::core::clone::Clone for TOKEN_SID_INFORMATION {
 }
 #[repr(C)]
 pub struct TP_CLEANUP_GROUP(pub u8);
+impl ::core::marker::Copy for TP_CLEANUP_GROUP {}
+impl ::core::clone::Clone for TP_CLEANUP_GROUP {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct TP_POOL(pub u8);
+impl ::core::marker::Copy for TP_POOL {}
+impl ::core::clone::Clone for TP_POOL {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct TRANSACTIONMANAGER_BASIC_INFORMATION {

--- a/crates/libs/sys/src/Windows/Win32/System/Threading/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Threading/mod.rs
@@ -1975,6 +1975,12 @@ impl ::core::clone::Clone for TP_CALLBACK_ENVIRON_V3 {
 }
 #[repr(C)]
 pub struct TP_CALLBACK_ENVIRON_V3_0(pub u8);
+impl ::core::marker::Copy for TP_CALLBACK_ENVIRON_V3_0 {}
+impl ::core::clone::Clone for TP_CALLBACK_ENVIRON_V3_0 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Threading\"`*"]
 pub union TP_CALLBACK_ENVIRON_V3_1 {

--- a/crates/libs/sys/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -3159,8 +3159,20 @@ impl ::core::clone::Clone for WLDP_HOST_INFORMATION {
 }
 #[repr(C)]
 pub struct _D3DHAL_CALLBACKS(pub u8);
+impl ::core::marker::Copy for _D3DHAL_CALLBACKS {}
+impl ::core::clone::Clone for _D3DHAL_CALLBACKS {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _D3DHAL_GLOBALDRIVERDATA(pub u8);
+impl ::core::marker::Copy for _D3DHAL_GLOBALDRIVERDATA {}
+impl ::core::clone::Clone for _D3DHAL_GLOBALDRIVERDATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`*"]
 pub type APPLICATION_RECOVERY_CALLBACK = ::core::option::Option<unsafe extern "system" fn(pvparameter: *mut ::core::ffi::c_void) -> u32>;
 #[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`*"]

--- a/crates/libs/sys/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/System/Wmi/mod.rs
@@ -3300,6 +3300,12 @@ impl ::core::clone::Clone for MI_Module {
 }
 #[repr(C)]
 pub struct MI_Module_Self(pub u8);
+impl ::core::marker::Copy for MI_Module_Self {}
+impl ::core::clone::Clone for MI_Module_Self {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
 pub struct MI_ObjectDecl {

--- a/crates/libs/sys/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -976,3 +976,9 @@ impl ::core::clone::Clone for PROPPRG {
 }
 #[repr(C)]
 pub struct SERIALIZEDPROPSTORAGE(pub u8);
+impl ::core::marker::Copy for SERIALIZEDPROPSTORAGE {}
+impl ::core::clone::Clone for SERIALIZEDPROPSTORAGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}

--- a/crates/libs/sys/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/UI/Shell/mod.rs
@@ -10902,6 +10902,12 @@ impl ::core::clone::Clone for NC_ADDRESS {
 }
 #[repr(C)]
 pub struct NC_ADDRESS_0(pub u8);
+impl ::core::marker::Copy for NC_ADDRESS_0 {}
+impl ::core::clone::Clone for NC_ADDRESS_0 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C, packed(1))]
 #[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_WindowsAndMessaging\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -12741,8 +12747,20 @@ impl ::core::clone::Clone for WTS_THUMBNAILID {
 }
 #[repr(C)]
 pub struct _APPCONSTRAIN_REGISTRATION(pub u8);
+impl ::core::marker::Copy for _APPCONSTRAIN_REGISTRATION {}
+impl ::core::clone::Clone for _APPCONSTRAIN_REGISTRATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 pub struct _APPSTATE_REGISTRATION(pub u8);
+impl ::core::marker::Copy for _APPSTATE_REGISTRATION {}
+impl ::core::clone::Clone for _APPSTATE_REGISTRATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type APPLET_PROC = ::core::option::Option<unsafe extern "system" fn(hwndcpl: super::super::Foundation::HWND, msg: u32, lparam1: super::super::Foundation::LPARAM, lparam2: super::super::Foundation::LPARAM) -> i32>;

--- a/crates/libs/sys/src/Windows/Win32/Web/InternetExplorer/mod.rs
+++ b/crates/libs/sys/src/Windows/Win32/Web/InternetExplorer/mod.rs
@@ -1239,6 +1239,12 @@ pub const SCMP_RIGHT: SCROLLABLECONTEXTMENU_PLACEMENT = 3i32;
 pub const SCMP_FULL: SCROLLABLECONTEXTMENU_PLACEMENT = 4i32;
 #[repr(C)]
 pub struct HTMLPersistEvents(pub u8);
+impl ::core::marker::Copy for HTMLPersistEvents {}
+impl ::core::clone::Clone for HTMLPersistEvents {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Web_InternetExplorer\"`*"]
 pub struct IELAUNCHURLINFO {
@@ -1254,6 +1260,12 @@ impl ::core::clone::Clone for IELAUNCHURLINFO {
 }
 #[repr(C)]
 pub struct LayoutRectEvents(pub u8);
+impl ::core::marker::Copy for LayoutRectEvents {}
+impl ::core::clone::Clone for LayoutRectEvents {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Web_InternetExplorer\"`*"]
 pub struct NAVIGATEDATA {

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -2042,10 +2042,37 @@ impl ::core::default::Default for HH_WINTYPE {
 }
 #[repr(C)]
 pub struct IITGroup(pub u8);
+impl ::core::marker::Copy for IITGroup {}
+impl ::core::clone::Clone for IITGroup {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IITGroup {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct IITQuery(pub u8);
+impl ::core::marker::Copy for IITQuery {}
+impl ::core::clone::Clone for IITQuery {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IITQuery {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct IITStopWordList(pub u8);
+impl ::core::marker::Copy for IITStopWordList {}
+impl ::core::clone::Clone for IITStopWordList {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IITStopWordList {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Data_HtmlHelp\"`*"]
 pub struct ROWSTATUS {

--- a/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/AllJoyn/mod.rs
@@ -6258,10 +6258,37 @@ impl ::core::fmt::Debug for alljoyn_typeid {
 }
 #[repr(C)]
 pub struct _alljoyn_abouticon_handle(pub u8);
+impl ::core::marker::Copy for _alljoyn_abouticon_handle {}
+impl ::core::clone::Clone for _alljoyn_abouticon_handle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _alljoyn_abouticon_handle {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _alljoyn_abouticonobj_handle(pub u8);
+impl ::core::marker::Copy for _alljoyn_abouticonobj_handle {}
+impl ::core::clone::Clone for _alljoyn_abouticonobj_handle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _alljoyn_abouticonobj_handle {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _alljoyn_abouticonproxy_handle(pub u8);
+impl ::core::marker::Copy for _alljoyn_abouticonproxy_handle {}
+impl ::core::clone::Clone for _alljoyn_abouticonproxy_handle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _alljoyn_abouticonproxy_handle {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]
 pub struct alljoyn_aboutdata(pub isize);

--- a/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -4660,10 +4660,37 @@ impl ::core::default::Default for WINBIO_VERSION {
 }
 #[repr(C)]
 pub struct _WINIBIO_ENGINE_CONTEXT(pub u8);
+impl ::core::marker::Copy for _WINIBIO_ENGINE_CONTEXT {}
+impl ::core::clone::Clone for _WINIBIO_ENGINE_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _WINIBIO_ENGINE_CONTEXT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _WINIBIO_SENSOR_CONTEXT(pub u8);
+impl ::core::marker::Copy for _WINIBIO_SENSOR_CONTEXT {}
+impl ::core::clone::Clone for _WINIBIO_SENSOR_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _WINIBIO_SENSOR_CONTEXT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _WINIBIO_STORAGE_CONTEXT(pub u8);
+impl ::core::marker::Copy for _WINIBIO_STORAGE_CONTEXT {}
+impl ::core::clone::Clone for _WINIBIO_STORAGE_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _WINIBIO_STORAGE_CONTEXT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_Devices_BiometricFramework\"`, `\"Win32_Foundation\"`, `\"Win32_System_IO\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_IO"))]
 pub type PIBIO_ENGINE_ACCEPT_PRIVATE_SENSOR_TYPE_INFO_FN = ::core::option::Option<unsafe extern "system" fn(pipeline: *mut WINBIO_PIPELINE, typeinfobufferaddress: *const u8, typeinfobuffersize: usize) -> ::windows::core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -12052,6 +12052,15 @@ impl ::core::default::Default for USAGE_AND_PAGE {
 }
 #[repr(C)]
 pub struct _HIDP_PREPARSED_DATA(pub u8);
+impl ::core::marker::Copy for _HIDP_PREPARSED_DATA {}
+impl ::core::clone::Clone for _HIDP_PREPARSED_DATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HIDP_PREPARSED_DATA {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type LPDICONFIGUREDEVICESCALLBACK = ::core::option::Option<unsafe extern "system" fn(param0: ::core::option::Option<::windows::core::IUnknown>, param1: *mut ::core::ffi::c_void) -> super::super::Foundation::BOOL>;

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -22134,12 +22134,48 @@ impl ::core::default::Default for TEXTRANGE_PROPERTIES {
 }
 #[repr(C)]
 pub struct UBiDi(pub u8);
+impl ::core::marker::Copy for UBiDi {}
+impl ::core::clone::Clone for UBiDi {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UBiDi {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UBiDiTransform(pub u8);
+impl ::core::marker::Copy for UBiDiTransform {}
+impl ::core::clone::Clone for UBiDiTransform {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UBiDiTransform {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UBreakIterator(pub u8);
+impl ::core::marker::Copy for UBreakIterator {}
+impl ::core::clone::Clone for UBreakIterator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UBreakIterator {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UCPMap(pub u8);
+impl ::core::marker::Copy for UCPMap {}
+impl ::core::clone::Clone for UCPMap {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UCPMap {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UCPTrie {
@@ -22195,6 +22231,15 @@ impl ::core::default::Default for UCPTrieData {
 }
 #[repr(C)]
 pub struct UCaseMap(pub u8);
+impl ::core::marker::Copy for UCaseMap {}
+impl ::core::clone::Clone for UCaseMap {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UCaseMap {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UCharIterator {
@@ -22236,16 +22281,70 @@ impl ::core::default::Default for UCharIterator {
 }
 #[repr(C)]
 pub struct UCharsetDetector(pub u8);
+impl ::core::marker::Copy for UCharsetDetector {}
+impl ::core::clone::Clone for UCharsetDetector {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UCharsetDetector {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UCharsetMatch(pub u8);
+impl ::core::marker::Copy for UCharsetMatch {}
+impl ::core::clone::Clone for UCharsetMatch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UCharsetMatch {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UCollationElements(pub u8);
+impl ::core::marker::Copy for UCollationElements {}
+impl ::core::clone::Clone for UCollationElements {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UCollationElements {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UCollator(pub u8);
+impl ::core::marker::Copy for UCollator {}
+impl ::core::clone::Clone for UCollator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UCollator {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UConstrainedFieldPosition(pub u8);
+impl ::core::marker::Copy for UConstrainedFieldPosition {}
+impl ::core::clone::Clone for UConstrainedFieldPosition {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UConstrainedFieldPosition {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UConverter(pub u8);
+impl ::core::marker::Copy for UConverter {}
+impl ::core::clone::Clone for UConverter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UConverter {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UConverterFromUnicodeArgs {
@@ -22285,6 +22384,15 @@ impl ::core::default::Default for UConverterFromUnicodeArgs {
 }
 #[repr(C)]
 pub struct UConverterSelector(pub u8);
+impl ::core::marker::Copy for UConverterSelector {}
+impl ::core::clone::Clone for UConverterSelector {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UConverterSelector {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UConverterToUnicodeArgs {
@@ -22324,10 +22432,37 @@ impl ::core::default::Default for UConverterToUnicodeArgs {
 }
 #[repr(C)]
 pub struct UDateFormatSymbols(pub u8);
+impl ::core::marker::Copy for UDateFormatSymbols {}
+impl ::core::clone::Clone for UDateFormatSymbols {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UDateFormatSymbols {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UDateIntervalFormat(pub u8);
+impl ::core::marker::Copy for UDateIntervalFormat {}
+impl ::core::clone::Clone for UDateIntervalFormat {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UDateIntervalFormat {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UEnumeration(pub u8);
+impl ::core::marker::Copy for UEnumeration {}
+impl ::core::clone::Clone for UEnumeration {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UEnumeration {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UFieldPosition {
@@ -22362,24 +22497,114 @@ impl ::core::default::Default for UFieldPosition {
 }
 #[repr(C)]
 pub struct UFieldPositionIterator(pub u8);
+impl ::core::marker::Copy for UFieldPositionIterator {}
+impl ::core::clone::Clone for UFieldPositionIterator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UFieldPositionIterator {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UFormattedDateInterval(pub u8);
+impl ::core::marker::Copy for UFormattedDateInterval {}
+impl ::core::clone::Clone for UFormattedDateInterval {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UFormattedDateInterval {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UFormattedList(pub u8);
+impl ::core::marker::Copy for UFormattedList {}
+impl ::core::clone::Clone for UFormattedList {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UFormattedList {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UFormattedNumber(pub u8);
+impl ::core::marker::Copy for UFormattedNumber {}
+impl ::core::clone::Clone for UFormattedNumber {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UFormattedNumber {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UFormattedNumberRange(pub u8);
+impl ::core::marker::Copy for UFormattedNumberRange {}
+impl ::core::clone::Clone for UFormattedNumberRange {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UFormattedNumberRange {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UFormattedRelativeDateTime(pub u8);
+impl ::core::marker::Copy for UFormattedRelativeDateTime {}
+impl ::core::clone::Clone for UFormattedRelativeDateTime {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UFormattedRelativeDateTime {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UFormattedValue(pub u8);
+impl ::core::marker::Copy for UFormattedValue {}
+impl ::core::clone::Clone for UFormattedValue {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UFormattedValue {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UGenderInfo(pub u8);
+impl ::core::marker::Copy for UGenderInfo {}
+impl ::core::clone::Clone for UGenderInfo {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UGenderInfo {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UHashtable(pub u8);
+impl ::core::marker::Copy for UHashtable {}
+impl ::core::clone::Clone for UHashtable {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UHashtable {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UIDNA(pub u8);
+impl ::core::marker::Copy for UIDNA {}
+impl ::core::clone::Clone for UIDNA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UIDNA {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UIDNAInfo {
@@ -22417,12 +22642,48 @@ impl ::core::default::Default for UIDNAInfo {
 }
 #[repr(C)]
 pub struct UListFormatter(pub u8);
+impl ::core::marker::Copy for UListFormatter {}
+impl ::core::clone::Clone for UListFormatter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UListFormatter {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct ULocaleData(pub u8);
+impl ::core::marker::Copy for ULocaleData {}
+impl ::core::clone::Clone for ULocaleData {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for ULocaleData {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct ULocaleDisplayNames(pub u8);
+impl ::core::marker::Copy for ULocaleDisplayNames {}
+impl ::core::clone::Clone for ULocaleDisplayNames {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for ULocaleDisplayNames {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UMutableCPTrie(pub u8);
+impl ::core::marker::Copy for UMutableCPTrie {}
+impl ::core::clone::Clone for UMutableCPTrie {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UMutableCPTrie {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UNICODERANGE {
@@ -22456,10 +22717,37 @@ impl ::core::default::Default for UNICODERANGE {
 }
 #[repr(C)]
 pub struct UNormalizer2(pub u8);
+impl ::core::marker::Copy for UNormalizer2 {}
+impl ::core::clone::Clone for UNormalizer2 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UNormalizer2 {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UNumberFormatter(pub u8);
+impl ::core::marker::Copy for UNumberFormatter {}
+impl ::core::clone::Clone for UNumberFormatter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UNumberFormatter {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UNumberingSystem(pub u8);
+impl ::core::marker::Copy for UNumberingSystem {}
+impl ::core::clone::Clone for UNumberingSystem {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UNumberingSystem {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UParseError {
@@ -22495,12 +22783,48 @@ impl ::core::default::Default for UParseError {
 }
 #[repr(C)]
 pub struct UPluralRules(pub u8);
+impl ::core::marker::Copy for UPluralRules {}
+impl ::core::clone::Clone for UPluralRules {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UPluralRules {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct URegion(pub u8);
+impl ::core::marker::Copy for URegion {}
+impl ::core::clone::Clone for URegion {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for URegion {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct URegularExpression(pub u8);
+impl ::core::marker::Copy for URegularExpression {}
+impl ::core::clone::Clone for URegularExpression {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for URegularExpression {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct URelativeDateTimeFormatter(pub u8);
+impl ::core::marker::Copy for URelativeDateTimeFormatter {}
+impl ::core::clone::Clone for URelativeDateTimeFormatter {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for URelativeDateTimeFormatter {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UReplaceableCallbacks {
@@ -22538,8 +22862,26 @@ impl ::core::default::Default for UReplaceableCallbacks {
 }
 #[repr(C)]
 pub struct UResourceBundle(pub u8);
+impl ::core::marker::Copy for UResourceBundle {}
+impl ::core::clone::Clone for UResourceBundle {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UResourceBundle {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct USearch(pub u8);
+impl ::core::marker::Copy for USearch {}
+impl ::core::clone::Clone for USearch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for USearch {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct USerializedSet {
@@ -22575,14 +22917,59 @@ impl ::core::default::Default for USerializedSet {
 }
 #[repr(C)]
 pub struct USet(pub u8);
+impl ::core::marker::Copy for USet {}
+impl ::core::clone::Clone for USet {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for USet {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct USpoofCheckResult(pub u8);
+impl ::core::marker::Copy for USpoofCheckResult {}
+impl ::core::clone::Clone for USpoofCheckResult {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for USpoofCheckResult {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct USpoofChecker(pub u8);
+impl ::core::marker::Copy for USpoofChecker {}
+impl ::core::clone::Clone for USpoofChecker {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for USpoofChecker {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UStringPrepProfile(pub u8);
+impl ::core::marker::Copy for UStringPrepProfile {}
+impl ::core::clone::Clone for UStringPrepProfile {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UStringPrepProfile {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct UStringSearch(pub u8);
+impl ::core::marker::Copy for UStringSearch {}
+impl ::core::clone::Clone for UStringSearch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for UStringSearch {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 pub struct UText {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -21444,6 +21444,15 @@ impl ::core::fmt::Debug for D3DX11_SCAN_OPCODE {
 }
 #[repr(C)]
 pub struct CD3D11_VIDEO_DEFAULT(pub u8);
+impl ::core::marker::Copy for CD3D11_VIDEO_DEFAULT {}
+impl ::core::clone::Clone for CD3D11_VIDEO_DEFAULT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for CD3D11_VIDEO_DEFAULT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_Direct3D11\"`*"]
 pub struct D3D11_AES_CTR_IV {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
@@ -15718,6 +15718,15 @@ impl ::core::default::Default for MDL {
 }
 #[repr(C)]
 pub struct MDL_0(pub u8);
+impl ::core::marker::Copy for MDL_0 {}
+impl ::core::clone::Clone for MDL_0 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for MDL_0 {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`*"]
 pub struct PROCESS_LIST {
@@ -16216,12 +16225,48 @@ impl ::core::default::Default for VMEMR {
 }
 #[repr(C)]
 pub struct _DDFXROP(pub u8);
+impl ::core::marker::Copy for _DDFXROP {}
+impl ::core::clone::Clone for _DDFXROP {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _DDFXROP {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _DD_DESTROYDRIVERDATA(pub u8);
+impl ::core::marker::Copy for _DD_DESTROYDRIVERDATA {}
+impl ::core::clone::Clone for _DD_DESTROYDRIVERDATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _DD_DESTROYDRIVERDATA {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _DD_GETVPORTAUTOFLIPSURFACEDATA(pub u8);
+impl ::core::marker::Copy for _DD_GETVPORTAUTOFLIPSURFACEDATA {}
+impl ::core::clone::Clone for _DD_GETVPORTAUTOFLIPSURFACEDATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _DD_GETVPORTAUTOFLIPSURFACEDATA {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _DD_SETMODEDATA(pub u8);
+impl ::core::marker::Copy for _DD_SETMODEDATA {}
+impl ::core::clone::Clone for _DD_SETMODEDATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _DD_SETMODEDATA {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_Graphics_DirectDraw\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type LPCLIPPERCALLBACK = ::core::option::Option<unsafe extern "system" fn(lpddclipper: ::core::option::Option<IDirectDrawClipper>, hwnd: super::super::Foundation::HWND, code: u32, lpcontext: *mut ::core::ffi::c_void) -> u32>;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/OpenGL/mod.rs
@@ -4162,10 +4162,37 @@ impl ::core::default::Default for EMRPIXELFORMAT {
 }
 #[repr(C)]
 pub struct GLUnurbs(pub u8);
+impl ::core::marker::Copy for GLUnurbs {}
+impl ::core::clone::Clone for GLUnurbs {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for GLUnurbs {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct GLUquadric(pub u8);
+impl ::core::marker::Copy for GLUquadric {}
+impl ::core::clone::Clone for GLUquadric {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for GLUquadric {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct GLUtesselator(pub u8);
+impl ::core::marker::Copy for GLUtesselator {}
+impl ::core::clone::Clone for GLUtesselator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for GLUtesselator {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Graphics_OpenGL\"`*"]
 pub struct GLYPHMETRICSFLOAT {

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -8499,10 +8499,37 @@ impl ::core::default::Default for DS3DVECTOR_2 {
 }
 #[repr(C)]
 pub struct IKsAllocator(pub u8);
+impl ::core::marker::Copy for IKsAllocator {}
+impl ::core::clone::Clone for IKsAllocator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IKsAllocator {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct IKsAllocatorEx(pub u8);
+impl ::core::marker::Copy for IKsAllocatorEx {}
+impl ::core::clone::Clone for IKsAllocatorEx {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IKsAllocatorEx {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct IKsPin(pub u8);
+impl ::core::marker::Copy for IKsPin {}
+impl ::core::clone::Clone for IKsPin {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IKsPin {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Media_KernelStreaming\"`*"]
 pub struct INTERLEAVED_AUDIO_FORMAT_INFORMATION {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dhcp/mod.rs
@@ -5634,6 +5634,15 @@ impl ::core::default::Default for DHCP_CLIENT_INFO_VQ {
 }
 #[repr(C)]
 pub struct DHCP_CLIENT_SEARCH_UNION(pub u8);
+impl ::core::marker::Copy for DHCP_CLIENT_SEARCH_UNION {}
+impl ::core::clone::Clone for DHCP_CLIENT_SEARCH_UNION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for DHCP_CLIENT_SEARCH_UNION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_FAILOVER_RELATIONSHIP {
@@ -6668,6 +6677,15 @@ impl ::core::default::Default for DHCP_OPTION_DATA_ELEMENT_0 {
 }
 #[repr(C)]
 pub struct DHCP_OPTION_ELEMENT_UNION(pub u8);
+impl ::core::marker::Copy for DHCP_OPTION_ELEMENT_UNION {}
+impl ::core::clone::Clone for DHCP_OPTION_ELEMENT_UNION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for DHCP_OPTION_ELEMENT_UNION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_OPTION_LIST {
@@ -6785,6 +6803,15 @@ impl ::core::default::Default for DHCP_OPTION_SCOPE_INFO6_0 {
 }
 #[repr(C)]
 pub struct DHCP_OPTION_SCOPE_UNION6(pub u8);
+impl ::core::marker::Copy for DHCP_OPTION_SCOPE_UNION6 {}
+impl ::core::clone::Clone for DHCP_OPTION_SCOPE_UNION6 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for DHCP_OPTION_SCOPE_UNION6 {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_OPTION_VALUE {
@@ -8203,10 +8230,37 @@ impl ::core::default::Default for DHCP_SUBNET_ELEMENT_INFO_ARRAY_V6 {
 }
 #[repr(C)]
 pub struct DHCP_SUBNET_ELEMENT_UNION(pub u8);
+impl ::core::marker::Copy for DHCP_SUBNET_ELEMENT_UNION {}
+impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_UNION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for DHCP_SUBNET_ELEMENT_UNION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct DHCP_SUBNET_ELEMENT_UNION_V4(pub u8);
+impl ::core::marker::Copy for DHCP_SUBNET_ELEMENT_UNION_V4 {}
+impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_UNION_V4 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for DHCP_SUBNET_ELEMENT_UNION_V4 {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct DHCP_SUBNET_ELEMENT_UNION_V6(pub u8);
+impl ::core::marker::Copy for DHCP_SUBNET_ELEMENT_UNION_V6 {}
+impl ::core::clone::Clone for DHCP_SUBNET_ELEMENT_UNION_V6 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for DHCP_SUBNET_ELEMENT_UNION_V6 {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dhcp\"`*"]
 pub struct DHCP_SUBNET_INFO {

--- a/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Clustering/mod.rs
@@ -17638,56 +17638,290 @@ impl ::core::default::Default for WitnessTagUpdateHelper {
 }
 #[repr(C)]
 pub struct _HCHANGE(pub u8);
+impl ::core::marker::Copy for _HCHANGE {}
+impl ::core::clone::Clone for _HCHANGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HCHANGE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HCLUSCRYPTPROVIDER(pub u8);
+impl ::core::marker::Copy for _HCLUSCRYPTPROVIDER {}
+impl ::core::clone::Clone for _HCLUSCRYPTPROVIDER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HCLUSCRYPTPROVIDER {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HCLUSENUM(pub u8);
+impl ::core::marker::Copy for _HCLUSENUM {}
+impl ::core::clone::Clone for _HCLUSENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HCLUSENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HCLUSENUMEX(pub u8);
+impl ::core::marker::Copy for _HCLUSENUMEX {}
+impl ::core::clone::Clone for _HCLUSENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HCLUSENUMEX {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HCLUSTER(pub u8);
+impl ::core::marker::Copy for _HCLUSTER {}
+impl ::core::clone::Clone for _HCLUSTER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HCLUSTER {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HGROUP(pub u8);
+impl ::core::marker::Copy for _HGROUP {}
+impl ::core::clone::Clone for _HGROUP {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HGROUP {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HGROUPENUM(pub u8);
+impl ::core::marker::Copy for _HGROUPENUM {}
+impl ::core::clone::Clone for _HGROUPENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HGROUPENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HGROUPENUMEX(pub u8);
+impl ::core::marker::Copy for _HGROUPENUMEX {}
+impl ::core::clone::Clone for _HGROUPENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HGROUPENUMEX {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HGROUPSET(pub u8);
+impl ::core::marker::Copy for _HGROUPSET {}
+impl ::core::clone::Clone for _HGROUPSET {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HGROUPSET {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HGROUPSETENUM(pub u8);
+impl ::core::marker::Copy for _HGROUPSETENUM {}
+impl ::core::clone::Clone for _HGROUPSETENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HGROUPSETENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HNETINTERFACE(pub u8);
+impl ::core::marker::Copy for _HNETINTERFACE {}
+impl ::core::clone::Clone for _HNETINTERFACE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HNETINTERFACE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HNETINTERFACEENUM(pub u8);
+impl ::core::marker::Copy for _HNETINTERFACEENUM {}
+impl ::core::clone::Clone for _HNETINTERFACEENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HNETINTERFACEENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HNETWORK(pub u8);
+impl ::core::marker::Copy for _HNETWORK {}
+impl ::core::clone::Clone for _HNETWORK {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HNETWORK {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HNETWORKENUM(pub u8);
+impl ::core::marker::Copy for _HNETWORKENUM {}
+impl ::core::clone::Clone for _HNETWORKENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HNETWORKENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HNODE(pub u8);
+impl ::core::marker::Copy for _HNODE {}
+impl ::core::clone::Clone for _HNODE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HNODE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HNODEENUM(pub u8);
+impl ::core::marker::Copy for _HNODEENUM {}
+impl ::core::clone::Clone for _HNODEENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HNODEENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HNODEENUMEX(pub u8);
+impl ::core::marker::Copy for _HNODEENUMEX {}
+impl ::core::clone::Clone for _HNODEENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HNODEENUMEX {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HREGBATCH(pub u8);
+impl ::core::marker::Copy for _HREGBATCH {}
+impl ::core::clone::Clone for _HREGBATCH {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HREGBATCH {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HREGBATCHNOTIFICATION(pub u8);
+impl ::core::marker::Copy for _HREGBATCHNOTIFICATION {}
+impl ::core::clone::Clone for _HREGBATCHNOTIFICATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HREGBATCHNOTIFICATION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HREGBATCHPORT(pub u8);
+impl ::core::marker::Copy for _HREGBATCHPORT {}
+impl ::core::clone::Clone for _HREGBATCHPORT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HREGBATCHPORT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HREGREADBATCH(pub u8);
+impl ::core::marker::Copy for _HREGREADBATCH {}
+impl ::core::clone::Clone for _HREGREADBATCH {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HREGREADBATCH {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HREGREADBATCHREPLY(pub u8);
+impl ::core::marker::Copy for _HREGREADBATCHREPLY {}
+impl ::core::clone::Clone for _HREGREADBATCHREPLY {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HREGREADBATCHREPLY {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HRESENUM(pub u8);
+impl ::core::marker::Copy for _HRESENUM {}
+impl ::core::clone::Clone for _HRESENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HRESENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HRESENUMEX(pub u8);
+impl ::core::marker::Copy for _HRESENUMEX {}
+impl ::core::clone::Clone for _HRESENUMEX {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HRESENUMEX {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HRESOURCE(pub u8);
+impl ::core::marker::Copy for _HRESOURCE {}
+impl ::core::clone::Clone for _HRESOURCE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HRESOURCE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _HRESTYPEENUM(pub u8);
+impl ::core::marker::Copy for _HRESTYPEENUM {}
+impl ::core::clone::Clone for _HRESTYPEENUM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HRESTYPEENUM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]
 pub type LPGROUP_CALLBACK_EX = ::core::option::Option<unsafe extern "system" fn(param0: *mut _HCLUSTER, param1: *mut _HGROUP, param2: *mut _HGROUP, param3: *mut ::core::ffi::c_void) -> u32>;
 #[doc = "*Required features: `\"Win32_Networking_Clustering\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/Ldap/mod.rs
@@ -3387,6 +3387,15 @@ impl ::core::default::Default for LDAPModW_0 {
 }
 #[repr(C)]
 pub struct LDAPSearch(pub u8);
+impl ::core::marker::Copy for LDAPSearch {}
+impl ::core::clone::Clone for LDAPSearch {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for LDAPSearch {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_Ldap\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -12151,6 +12151,15 @@ impl ::core::default::Default for RIO_BUF {
 }
 #[repr(C)]
 pub struct RIO_BUFFERID_t(pub u8);
+impl ::core::marker::Copy for RIO_BUFFERID_t {}
+impl ::core::clone::Clone for RIO_BUFFERID_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for RIO_BUFFERID_t {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`*"]
 pub struct RIO_CMSG_BUFFER {
@@ -12183,6 +12192,15 @@ impl ::core::default::Default for RIO_CMSG_BUFFER {
 }
 #[repr(C)]
 pub struct RIO_CQ_t(pub u8);
+impl ::core::marker::Copy for RIO_CQ_t {}
+impl ::core::clone::Clone for RIO_CQ_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for RIO_CQ_t {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -12357,6 +12375,15 @@ impl ::core::default::Default for RIO_NOTIFICATION_COMPLETION_0_1 {
 }
 #[repr(C)]
 pub struct RIO_RQ_t(pub u8);
+impl ::core::marker::Copy for RIO_RQ_t {}
+impl ::core::clone::Clone for RIO_RQ_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for RIO_RQ_t {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WinSock\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WindowsWebServices/mod.rs
@@ -7214,6 +7214,15 @@ impl ::core::default::Default for WS_CERT_SIGNED_SAML_AUTHENTICATOR {
 }
 #[repr(C)]
 pub struct WS_CHANNEL(pub u8);
+impl ::core::marker::Copy for WS_CHANNEL {}
+impl ::core::clone::Clone for WS_CHANNEL {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_CHANNEL {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_CHANNEL_DECODER {
@@ -8254,6 +8263,15 @@ impl ::core::default::Default for WS_ENUM_VALUE {
 }
 #[repr(C)]
 pub struct WS_ERROR(pub u8);
+impl ::core::marker::Copy for WS_ERROR {}
+impl ::core::clone::Clone for WS_ERROR {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_ERROR {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_ERROR_PROPERTY {
@@ -8580,6 +8598,15 @@ impl ::core::default::Default for WS_GUID_DESCRIPTION {
 }
 #[repr(C)]
 pub struct WS_HEAP(pub u8);
+impl ::core::marker::Copy for WS_HEAP {}
+impl ::core::clone::Clone for WS_HEAP {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_HEAP {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_HEAP_PROPERTIES {
@@ -9858,6 +9885,15 @@ impl ::core::default::Default for WS_KERBEROS_APREQ_MESSAGE_SECURITY_BINDING_TEM
 }
 #[repr(C)]
 pub struct WS_LISTENER(pub u8);
+impl ::core::marker::Copy for WS_LISTENER {}
+impl ::core::clone::Clone for WS_LISTENER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_LISTENER {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_LISTENER_PROPERTIES {
@@ -9923,6 +9959,15 @@ impl ::core::default::Default for WS_LISTENER_PROPERTY {
 }
 #[repr(C)]
 pub struct WS_MESSAGE(pub u8);
+impl ::core::marker::Copy for WS_MESSAGE {}
+impl ::core::clone::Clone for WS_MESSAGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_MESSAGE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -10027,6 +10072,15 @@ impl ::core::default::Default for WS_MESSAGE_PROPERTY {
 }
 #[repr(C)]
 pub struct WS_METADATA(pub u8);
+impl ::core::marker::Copy for WS_METADATA {}
+impl ::core::clone::Clone for WS_METADATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_METADATA {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -10319,6 +10373,15 @@ impl ::core::default::Default for WS_OPAQUE_WINDOWS_INTEGRATED_AUTH_CREDENTIAL {
 }
 #[repr(C)]
 pub struct WS_OPERATION_CONTEXT(pub u8);
+impl ::core::marker::Copy for WS_OPERATION_CONTEXT {}
+impl ::core::clone::Clone for WS_OPERATION_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_OPERATION_CONTEXT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -10391,6 +10454,15 @@ impl ::core::default::Default for WS_PARAMETER_DESCRIPTION {
 }
 #[repr(C)]
 pub struct WS_POLICY(pub u8);
+impl ::core::marker::Copy for WS_POLICY {}
+impl ::core::clone::Clone for WS_POLICY {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_POLICY {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_POLICY_CONSTRAINTS {
@@ -11124,6 +11196,15 @@ impl ::core::default::Default for WS_SECURITY_CONSTRAINTS {
 }
 #[repr(C)]
 pub struct WS_SECURITY_CONTEXT(pub u8);
+impl ::core::marker::Copy for WS_SECURITY_CONTEXT {}
+impl ::core::clone::Clone for WS_SECURITY_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_SECURITY_CONTEXT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_SECURITY_CONTEXT_MESSAGE_SECURITY_BINDING {
@@ -11534,6 +11615,15 @@ impl ::core::default::Default for WS_SECURITY_PROPERTY_CONSTRAINT_0 {
 }
 #[repr(C)]
 pub struct WS_SECURITY_TOKEN(pub u8);
+impl ::core::marker::Copy for WS_SECURITY_TOKEN {}
+impl ::core::clone::Clone for WS_SECURITY_TOKEN {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_SECURITY_TOKEN {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -11678,6 +11768,15 @@ impl ::core::default::Default for WS_SERVICE_ENDPOINT_PROPERTY {
 }
 #[repr(C)]
 pub struct WS_SERVICE_HOST(pub u8);
+impl ::core::marker::Copy for WS_SERVICE_HOST {}
+impl ::core::clone::Clone for WS_SERVICE_HOST {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_SERVICE_HOST {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -11840,6 +11939,15 @@ impl ::core::default::Default for WS_SERVICE_PROPERTY_CLOSE_CALLBACK {
 }
 #[repr(C)]
 pub struct WS_SERVICE_PROXY(pub u8);
+impl ::core::marker::Copy for WS_SERVICE_PROXY {}
+impl ::core::clone::Clone for WS_SERVICE_PROXY {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_SERVICE_PROXY {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_SERVICE_SECURITY_IDENTITIES {
@@ -13656,6 +13764,15 @@ impl ::core::default::Default for WS_XML_BOOL_TEXT {
 }
 #[repr(C)]
 pub struct WS_XML_BUFFER(pub u8);
+impl ::core::marker::Copy for WS_XML_BUFFER {}
+impl ::core::clone::Clone for WS_XML_BUFFER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_XML_BUFFER {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`*"]
 pub struct WS_XML_BUFFER_PROPERTY {
@@ -14302,6 +14419,15 @@ impl ::core::default::Default for WS_XML_QNAME_TEXT {
 }
 #[repr(C)]
 pub struct WS_XML_READER(pub u8);
+impl ::core::marker::Copy for WS_XML_READER {}
+impl ::core::clone::Clone for WS_XML_READER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_XML_READER {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -14990,6 +15116,15 @@ impl ::core::default::Default for WS_XML_UTF8_TEXT {
 }
 #[repr(C)]
 pub struct WS_XML_WRITER(pub u8);
+impl ::core::marker::Copy for WS_XML_WRITER {}
+impl ::core::clone::Clone for WS_XML_WRITER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WS_XML_WRITER {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Networking_WindowsWebServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -20696,6 +20696,15 @@ impl ::core::default::Default for X509Certificate {
 }
 #[repr(C)]
 pub struct _HMAPPER(pub u8);
+impl ::core::marker::Copy for _HMAPPER {}
+impl ::core::clone::Clone for _HMAPPER {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _HMAPPER {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_Security_Authentication_Identity\"`, `\"Win32_Security_Credentials\"`*"]
 #[cfg(feature = "Win32_Security_Credentials")]
 pub type ACCEPT_SECURITY_CONTEXT_FN = ::core::option::Option<unsafe extern "system" fn(param0: *mut super::super::Credentials::SecHandle, param1: *mut super::super::Credentials::SecHandle, param2: *mut SecBufferDesc, param3: u32, param4: u32, param5: *mut super::super::Credentials::SecHandle, param6: *mut SecBufferDesc, param7: *mut u32, param8: *mut i64) -> ::windows::core::HRESULT>;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -8835,6 +8835,15 @@ impl ::core::default::Default for SPropAttrArray {
 }
 #[repr(C)]
 pub struct _MSGSESS(pub u8);
+impl ::core::marker::Copy for _MSGSESS {}
+impl ::core::clone::Clone for _MSGSESS {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _MSGSESS {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Imapi\"`*"]
 pub struct tagIMMPID_GUIDLIST_ITEM {

--- a/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
@@ -4905,6 +4905,15 @@ impl ::core::default::Default for STORAGE_FIRMWARE_SLOT_INFO_V2 {
 }
 #[repr(C)]
 pub struct _ADAPTER_OBJECT(pub u8);
+impl ::core::marker::Copy for _ADAPTER_OBJECT {}
+impl ::core::clone::Clone for _ADAPTER_OBJECT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _ADAPTER_OBJECT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_Storage_IscsiDisc\"`*"]
 pub type PDUMP_DEVICE_POWERON_ROUTINE = ::core::option::Option<unsafe extern "system" fn(context: *const ::core::ffi::c_void) -> i32>;
 #[cfg(feature = "implement")]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -3646,6 +3646,15 @@ impl ::core::fmt::Debug for VSS_WRITER_STATE {
 }
 #[repr(C)]
 pub struct IVssExamineWriterMetadata(pub u8);
+impl ::core::marker::Copy for IVssExamineWriterMetadata {}
+impl ::core::clone::Clone for IVssExamineWriterMetadata {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IVssExamineWriterMetadata {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Storage_Vss\"`*"]
 pub struct VSS_DIFF_AREA_PROP {

--- a/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AddressBook/mod.rs
@@ -5498,6 +5498,15 @@ impl ::core::default::Default for WAB_PARAM {
 }
 #[repr(C)]
 pub struct _WABACTIONITEM(pub u8);
+impl ::core::marker::Copy for _WABACTIONITEM {}
+impl ::core::clone::Clone for _WABACTIONITEM {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _WABACTIONITEM {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_AddressBook\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -2458,6 +2458,15 @@ impl ::core::default::Default for OLESTREAMVTBL {
 }
 #[repr(C)]
 pub struct PMemoryAllocator(pub u8);
+impl ::core::marker::Copy for PMemoryAllocator {}
+impl ::core::clone::Clone for PMemoryAllocator {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for PMemoryAllocator {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
 pub struct PROPBAG2 {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -11668,6 +11668,15 @@ impl ::core::default::Default for HYPER_SIZEDARR {
 }
 #[repr(C)]
 pub struct IContext(pub u8);
+impl ::core::marker::Copy for IContext {}
+impl ::core::clone::Clone for IContext {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IContext {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
 pub struct IDLDESC {
@@ -11701,6 +11710,15 @@ impl ::core::default::Default for IDLDESC {
 }
 #[repr(C)]
 pub struct IEnumContextProps(pub u8);
+impl ::core::marker::Copy for IEnumContextProps {}
+impl ::core::clone::Clone for IEnumContextProps {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IEnumContextProps {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Com\"`*"]
 pub struct INTERFACEINFO {

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
@@ -5441,6 +5441,15 @@ impl ::core::default::Default for PRE_PROCESS_PARAMETERS {
 }
 #[repr(C)]
 pub struct _IIS_CRYPTO_BLOB(pub u8);
+impl ::core::marker::Copy for _IIS_CRYPTO_BLOB {}
+impl ::core::clone::Clone for _IIS_CRYPTO_BLOB {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _IIS_CRYPTO_BLOB {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_System_Iis\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type PFN_GETEXTENSIONVERSION = ::core::option::Option<unsafe extern "system" fn(pver: *mut HSE_VERSION_INFO) -> super::super::Foundation::BOOL>;

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteManagement/mod.rs
@@ -3050,6 +3050,15 @@ impl ::core::fmt::Debug for WSManShellFlag {
 }
 #[repr(C)]
 pub struct WSMAN_API(pub u8);
+impl ::core::marker::Copy for WSMAN_API {}
+impl ::core::clone::Clone for WSMAN_API {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WSMAN_API {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`*"]
 pub struct WSMAN_AUTHENTICATION_CREDENTIALS {
@@ -3158,6 +3167,15 @@ impl ::core::default::Default for WSMAN_CERTIFICATE_DETAILS {
 }
 #[repr(C)]
 pub struct WSMAN_COMMAND(pub u8);
+impl ::core::marker::Copy for WSMAN_COMMAND {}
+impl ::core::clone::Clone for WSMAN_COMMAND {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WSMAN_COMMAND {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`*"]
 pub struct WSMAN_COMMAND_ARG_SET {
@@ -3521,6 +3539,15 @@ impl ::core::default::Default for WSMAN_KEY {
 }
 #[repr(C)]
 pub struct WSMAN_OPERATION(pub u8);
+impl ::core::marker::Copy for WSMAN_OPERATION {}
+impl ::core::clone::Clone for WSMAN_OPERATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WSMAN_OPERATION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -3911,8 +3938,26 @@ impl ::core::default::Default for WSMAN_SENDER_DETAILS {
 }
 #[repr(C)]
 pub struct WSMAN_SESSION(pub u8);
+impl ::core::marker::Copy for WSMAN_SESSION {}
+impl ::core::clone::Clone for WSMAN_SESSION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WSMAN_SESSION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct WSMAN_SHELL(pub u8);
+impl ::core::marker::Copy for WSMAN_SHELL {}
+impl ::core::clone::Clone for WSMAN_SHELL {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for WSMAN_SHELL {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_RemoteManagement\"`*"]
 pub struct WSMAN_SHELL_ASYNC {

--- a/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Rpc/mod.rs
@@ -8242,6 +8242,15 @@ impl ::core::default::Default for NDR64_VAR_ARRAY_HEADER_FORMAT {
 }
 #[repr(C)]
 pub struct NDR_ALLOC_ALL_NODES_CONTEXT(pub u8);
+impl ::core::marker::Copy for NDR_ALLOC_ALL_NODES_CONTEXT {}
+impl ::core::clone::Clone for NDR_ALLOC_ALL_NODES_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for NDR_ALLOC_ALL_NODES_CONTEXT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]
 pub struct NDR_CS_ROUTINES {
@@ -8333,6 +8342,15 @@ impl ::core::default::Default for NDR_EXPR_DESC {
 }
 #[repr(C)]
 pub struct NDR_POINTER_QUEUE_STATE(pub u8);
+impl ::core::marker::Copy for NDR_POINTER_QUEUE_STATE {}
+impl ::core::clone::Clone for NDR_POINTER_QUEUE_STATE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for NDR_POINTER_QUEUE_STATE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]
 pub struct NDR_SCONTEXT {
@@ -11284,10 +11302,37 @@ impl ::core::default::Default for XMIT_ROUTINE_QUINTUPLE {
 }
 #[repr(C)]
 pub struct _NDR_ASYNC_MESSAGE(pub u8);
+impl ::core::marker::Copy for _NDR_ASYNC_MESSAGE {}
+impl ::core::clone::Clone for _NDR_ASYNC_MESSAGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _NDR_ASYNC_MESSAGE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _NDR_CORRELATION_INFO(pub u8);
+impl ::core::marker::Copy for _NDR_CORRELATION_INFO {}
+impl ::core::clone::Clone for _NDR_CORRELATION_INFO {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _NDR_CORRELATION_INFO {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _NDR_PROC_CONTEXT(pub u8);
+impl ::core::marker::Copy for _NDR_PROC_CONTEXT {}
+impl ::core::clone::Clone for _NDR_PROC_CONTEXT {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _NDR_PROC_CONTEXT {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]
 pub type CS_TAG_GETTING_ROUTINE = ::core::option::Option<unsafe extern "system" fn(hbinding: *mut ::core::ffi::c_void, fserverside: i32, pulsendingtag: *mut u32, puldesiredreceivingtag: *mut u32, pulreceivingtag: *mut u32, pstatus: *mut u32) -> ()>;
 #[doc = "*Required features: `\"Win32_System_Rpc\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -26970,6 +26970,15 @@ impl ::core::default::Default for INCREMENTAL_ACCESS_INFO {
 }
 #[repr(C)]
 pub struct IRowsetExactScroll(pub u8);
+impl ::core::marker::Copy for IRowsetExactScroll {}
+impl ::core::clone::Clone for IRowsetExactScroll {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for IRowsetExactScroll {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
@@ -2779,6 +2779,15 @@ impl ::core::default::Default for SERVICE_TRIGGER_SPECIFIC_DATA_ITEM {
 }
 #[repr(C)]
 pub struct _SC_NOTIFICATION_REGISTRATION(pub u8);
+impl ::core::marker::Copy for _SC_NOTIFICATION_REGISTRATION {}
+impl ::core::clone::Clone for _SC_NOTIFICATION_REGISTRATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _SC_NOTIFICATION_REGISTRATION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_System_Services\"`*"]
 pub type HANDLER_FUNCTION = ::core::option::Option<unsafe extern "system" fn(dwcontrol: u32) -> ()>;
 #[doc = "*Required features: `\"Win32_System_Services\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -7774,6 +7774,15 @@ impl ::core::default::Default for APPLICATIONLAUNCH_SETTING_VALUE {
 }
 #[repr(C)]
 pub struct AtlThunkData_t(pub u8);
+impl ::core::marker::Copy for AtlThunkData_t {}
+impl ::core::clone::Clone for AtlThunkData_t {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for AtlThunkData_t {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct COMPONENT_FILTER {
@@ -13650,6 +13659,15 @@ impl ::core::default::Default for TAPE_WMI_OPERATIONS {
 }
 #[repr(C)]
 pub struct TEB(pub u8);
+impl ::core::marker::Copy for TEB {}
+impl ::core::clone::Clone for TEB {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for TEB {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -13729,8 +13747,26 @@ impl ::core::default::Default for TOKEN_SID_INFORMATION {
 }
 #[repr(C)]
 pub struct TP_CLEANUP_GROUP(pub u8);
+impl ::core::marker::Copy for TP_CLEANUP_GROUP {}
+impl ::core::clone::Clone for TP_CLEANUP_GROUP {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for TP_CLEANUP_GROUP {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct TP_POOL(pub u8);
+impl ::core::marker::Copy for TP_POOL {}
+impl ::core::clone::Clone for TP_POOL {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for TP_POOL {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_SystemServices\"`*"]
 pub struct TRANSACTIONMANAGER_BASIC_INFORMATION {

--- a/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Threading/mod.rs
@@ -5974,6 +5974,15 @@ impl ::core::default::Default for TP_CALLBACK_ENVIRON_V3 {
 }
 #[repr(C)]
 pub struct TP_CALLBACK_ENVIRON_V3_0(pub u8);
+impl ::core::marker::Copy for TP_CALLBACK_ENVIRON_V3_0 {}
+impl ::core::clone::Clone for TP_CALLBACK_ENVIRON_V3_0 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for TP_CALLBACK_ENVIRON_V3_0 {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Threading\"`*"]
 pub union TP_CALLBACK_ENVIRON_V3_1 {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -2838,6 +2838,15 @@ impl ::core::default::Default for ServerInformation {
 }
 #[repr(C)]
 pub struct _RO_REGISTRATION_COOKIE(pub u8);
+impl ::core::marker::Copy for _RO_REGISTRATION_COOKIE {}
+impl ::core::clone::Clone for _RO_REGISTRATION_COOKIE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _RO_REGISTRATION_COOKIE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
 pub type PFNGETACTIVATIONFACTORY = ::core::option::Option<unsafe extern "system" fn(param0: ::windows::core::HSTRING, param1: *mut ::core::option::Option<IActivationFactory>) -> ::windows::core::HRESULT>;
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -7565,8 +7565,26 @@ impl ::core::default::Default for WLDP_HOST_INFORMATION {
 }
 #[repr(C)]
 pub struct _D3DHAL_CALLBACKS(pub u8);
+impl ::core::marker::Copy for _D3DHAL_CALLBACKS {}
+impl ::core::clone::Clone for _D3DHAL_CALLBACKS {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _D3DHAL_CALLBACKS {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _D3DHAL_GLOBALDRIVERDATA(pub u8);
+impl ::core::marker::Copy for _D3DHAL_GLOBALDRIVERDATA {}
+impl ::core::clone::Clone for _D3DHAL_GLOBALDRIVERDATA {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _D3DHAL_GLOBALDRIVERDATA {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`*"]
 pub type APPLICATION_RECOVERY_CALLBACK = ::core::option::Option<unsafe extern "system" fn(pvparameter: *mut ::core::ffi::c_void) -> u32>;
 #[doc = "*Required features: `\"Win32_System_WindowsProgramming\"`*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -13139,6 +13139,15 @@ impl ::core::default::Default for MI_Module {
 }
 #[repr(C)]
 pub struct MI_Module_Self(pub u8);
+impl ::core::marker::Copy for MI_Module_Self {}
+impl ::core::clone::Clone for MI_Module_Self {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for MI_Module_Self {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
 pub struct MI_ObjectDecl {

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -5560,5 +5560,14 @@ impl ::core::default::Default for PROPPRG {
 }
 #[repr(C)]
 pub struct SERIALIZEDPROPSTORAGE(pub u8);
+impl ::core::marker::Copy for SERIALIZEDPROPSTORAGE {}
+impl ::core::clone::Clone for SERIALIZEDPROPSTORAGE {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for SERIALIZEDPROPSTORAGE {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[cfg(feature = "implement")]
 ::core::include!("impl.rs");

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -62631,6 +62631,15 @@ impl ::core::default::Default for NC_ADDRESS {
 }
 #[repr(C)]
 pub struct NC_ADDRESS_0(pub u8);
+impl ::core::marker::Copy for NC_ADDRESS_0 {}
+impl ::core::clone::Clone for NC_ADDRESS_0 {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for NC_ADDRESS_0 {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C, packed(1))]
 #[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_UI_WindowsAndMessaging\"`*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]
@@ -66005,8 +66014,26 @@ impl ::core::default::Default for WTS_THUMBNAILID {
 }
 #[repr(C)]
 pub struct _APPCONSTRAIN_REGISTRATION(pub u8);
+impl ::core::marker::Copy for _APPCONSTRAIN_REGISTRATION {}
+impl ::core::clone::Clone for _APPCONSTRAIN_REGISTRATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _APPCONSTRAIN_REGISTRATION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 pub struct _APPSTATE_REGISTRATION(pub u8);
+impl ::core::marker::Copy for _APPSTATE_REGISTRATION {}
+impl ::core::clone::Clone for _APPSTATE_REGISTRATION {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for _APPSTATE_REGISTRATION {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[doc = "*Required features: `\"Win32_UI_Shell\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type APPLET_PROC = ::core::option::Option<unsafe extern "system" fn(hwndcpl: super::super::Foundation::HWND, msg: u32, lparam1: super::super::Foundation::LPARAM, lparam2: super::super::Foundation::LPARAM) -> i32>;

--- a/crates/libs/windows/src/Windows/Win32/Web/InternetExplorer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Web/InternetExplorer/mod.rs
@@ -6739,6 +6739,15 @@ impl ::core::fmt::Debug for SCROLLABLECONTEXTMENU_PLACEMENT {
 }
 #[repr(C)]
 pub struct HTMLPersistEvents(pub u8);
+impl ::core::marker::Copy for HTMLPersistEvents {}
+impl ::core::clone::Clone for HTMLPersistEvents {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for HTMLPersistEvents {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Web_InternetExplorer\"`*"]
 pub struct IELAUNCHURLINFO {
@@ -6773,6 +6782,15 @@ impl ::core::default::Default for IELAUNCHURLINFO {
 }
 #[repr(C)]
 pub struct LayoutRectEvents(pub u8);
+impl ::core::marker::Copy for LayoutRectEvents {}
+impl ::core::clone::Clone for LayoutRectEvents {
+    fn clone(&self) -> Self {
+        *self
+    }
+}
+impl ::windows::core::TypeKind for LayoutRectEvents {
+    type TypeKind = ::windows::core::CopyType;
+}
 #[repr(C)]
 #[doc = "*Required features: `\"Win32_Web_InternetExplorer\"`*"]
 pub struct NAVIGATEDATA {


### PR DESCRIPTION
MSVC defines an empty struct as having the layout of a struct with a single byte field. For this reason, `windows-rs` has always generated it accordingly in Rust. However, this has actually been masking a lot of invalid structs in the Win32 and WDK metadata. https://github.com/microsoft/wdkmetadata/issues/31

Hopefully we can get those cleaned up in metadata. In the meantime, this just further hardens `windows-bindgen` to support such types in a first-class way. This should also help unblock #2446.