### PR TITLE
Preliminary support for variadic functions

### DIFF
--- a/crates/libs/bindgen/src/functions.rs
+++ b/crates/libs/bindgen/src/functions.rs
@@ -208,11 +208,12 @@ fn gen_link(gen: &Gen, signature: &Signature, cfg: &Cfg) -> TokenStream {
     let return_type = gen.return_sig(signature);
 
     // TODO: blocked on https://github.com/rust-lang/rust/issues/110505
-    let vararg = if signature.vararg && false {
-        "...".into()
-    } else {
-        quote! {}
-    };
+    // let vararg = if signature.vararg {
+    //     "...".into()
+    // } else {
+    //     quote! {}
+    // };
+    let vararg = quote! {};
 
     if gen.std || !gen.namespace.starts_with("Windows.") {
         let library = library.trim_end_matches(".dll");

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -146,6 +146,7 @@ pub struct Signature {
     pub def: MethodDef,
     pub params: Vec<SignatureParam>,
     pub return_type: Option<Type>,
+    pub vararg: bool,
 }
 
 pub struct SignatureParam {
@@ -603,9 +604,8 @@ impl<'a> Reader<'a> {
     }
     pub fn method_def_signature(&self, row: MethodDef, generics: &[Type]) -> Signature {
         let mut blob = self.row_blob(row.0, 4);
-        blob.read_usize();
-        blob.read_usize();
-
+        let vararg = blob.read_usize() == 0x05;
+        let _param_count = blob.read_usize();
         let mut return_type = self.type_from_blob(&mut blob, None, generics);
 
         let mut params: Vec<SignatureParam> = self
@@ -704,7 +704,7 @@ impl<'a> Reader<'a> {
             }
         }
 
-        Signature { def: row, params, return_type }
+        Signature { def: row, params, return_type, vararg }
     }
     pub fn method_def_extern_abi(&self, def: MethodDef) -> &'static str {
         let impl_map = self.method_def_impl_map(def).expect("ImplMap not found");

--- a/crates/libs/targets/src/lib.rs
+++ b/crates/libs/targets/src/lib.rs
@@ -8,12 +8,12 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #[macro_export]
 #[doc(hidden)]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? $(#[$($doc:tt)*])* fn $name:ident($($arg:ident: $argty:ty),*)$(->$ret:ty)?) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim", import_name_type = "undecorated")]
         extern $abi {
-            $(#[$($doc)*])*
+            $(#[$doc])?
             $(#[link_name=$link_name])?
-            pub fn $name($($arg: $argty),*) $(->$ret)?;
+            pub fn $($function)*;
         }
     )
 }
@@ -22,12 +22,12 @@ macro_rules! link {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? $(#[$($doc:tt)*])* fn $name:ident($($arg:ident: $argty:ty),*)$(->$ret:ty)?) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim")]
         extern "system" {
-            $(#[$($doc)*])*
+            $(#[$doc])?
             $(#[link_name=$link_name])?
-            pub fn $name($($arg: $argty),*) $(->$ret)?;
+            pub fn $($function)*;
         }
     )
 }
@@ -36,12 +36,12 @@ macro_rules! link {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? $(#[$($doc:tt)*])* fn $name:ident($($arg:ident: $argty:ty),*)$(->$ret:ty)?) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = "windows.0.48.0")]
         extern $abi {
-            $(#[$($doc)*])*
+            $(#[$doc])?
             $(#[link_name=$link_name])?
-            pub fn $name($($arg: $argty),*) $(->$ret)?;
+            pub fn $($function)*;
         }
     )
 }
@@ -50,10 +50,10 @@ macro_rules! link {
 #[macro_export]
 #[doc(hidden)]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? $(#[$($doc:tt)*])* fn $name:ident($($arg:ident: $argty:ty),*)$(->$ret:ty)?) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         extern $abi {
-            $(#[$($doc)*])*
-            pub fn $name($($arg: $argty),*) $(->$ret)?;
+            $(#[$doc])?
+            pub fn $($function)*;
         }
     )
 }


### PR DESCRIPTION
In the process of adding support for variadic Windows API functions, I ran into a Rust compiler bug:

https://github.com/rust-lang/rust/issues/110505

This update just adds the prep work to parse and detect variadic functions and simplifies the `link` macro to support declaring such variadic functions so that when this bug is fixed we can begin to support such functions.

