### PR TITLE
Improve metadata reader's `type_def_extends` to return `Option`

### DIFF
--- a/crates/libs/bindgen/src/classes.rs
+++ b/crates/libs/bindgen/src/classes.rs
@@ -16,7 +16,7 @@ pub fn gen(gen: &Gen, def: TypeDef) -> TokenStream {
 }
 
 fn gen_class(gen: &Gen, def: TypeDef) -> TokenStream {
-    if gen.reader.type_def_extends(def) == TypeName::Attribute {
+    if gen.reader.type_def_extends(def) == Some(TypeName::Attribute) {
         return TokenStream::new();
     }
 

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -1096,7 +1096,6 @@ impl<'a> Reader<'a> {
         None
     }
     pub fn type_def_bases(&self, mut row: TypeDef) -> Vec<TypeDef> {
-        // TODO: maybe return Vec<Type>
         let mut bases = Vec::new();
         loop {
             match self.type_def_extends(row) {

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -1151,7 +1151,8 @@ impl<'a> Reader<'a> {
     pub fn type_def_is_nullable(&self, row: TypeDef) -> bool {
         match self.type_def_kind(row) {
             TypeKind::Interface | TypeKind::Class => true,
-            // TODO: win32 callbacks should be nullable...
+            // Win32 callbacks are defined as `Option<T>` so we don't include them here to avoid them
+            // from being doubly wrapped in `Option`.
             TypeKind::Delegate => self.type_def_flags(row).contains(TypeAttributes::WINRT),
             _ => false,
         }
@@ -1404,7 +1405,8 @@ impl<'a> Reader<'a> {
         if self.type_size(&param.ty.deref()) > 16 {
             return false;
         }
-        // TODO: find a way to treat this like COM interface result values.
+        // Win32 callbacks are defined as `Option<T>` so we don't include them here to avoid
+        // producing the `Result<Option<T>>` anti-pattern.
         !self.type_is_callback(&param.ty.deref())
     }
     pub fn signature_kind(&self, signature: &Signature) -> SignatureKind {


### PR DESCRIPTION
According to ECMA-335, a `TypeDef` only "extends" another type if it is not an interface. This update just bakes this in to the `type_def_extends` method so that it is harder to accidentally misuse and easier to use correctly. 