### PR TITLE
Stabilize `raw_dylib` and `debugger_visualizer`

### DIFF
--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -4,7 +4,6 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![doc(html_no_source)]
 #![allow(non_snake_case)]
-#![cfg_attr(windows_debugger_visualizer, debugger_visualizer(natvis_file = "../windows.natvis"))]
 
 extern crate self as windows_core;
 

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -4,6 +4,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![doc(html_no_source)]
 #![allow(non_snake_case)]
+#![cfg_attr(windows_debugger_visualizer, debugger_visualizer(natvis_file = "../windows.natvis"))]
 
 extern crate self as windows_core;
 

--- a/crates/libs/core/src/lib.rs
+++ b/crates/libs/core/src/lib.rs
@@ -4,8 +4,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![doc(html_no_source)]
 #![allow(non_snake_case)]
-#![cfg_attr(windows_debugger_visualizer, feature(debugger_visualizer), debugger_visualizer(natvis_file = "../windows.natvis"))]
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
+#![cfg_attr(windows_debugger_visualizer, debugger_visualizer(natvis_file = "../windows.natvis"))]
 
 extern crate self as windows_core;
 

--- a/crates/libs/core/src/strings/hstring.rs
+++ b/crates/libs/core/src/strings/hstring.rs
@@ -66,7 +66,7 @@ impl HSTRING {
             return Ok(Self::new());
         }
 
-        let mut ptr = Header::alloc(len)?;
+        let ptr = Header::alloc(len)?;
 
         // Place each utf-16 character into the buffer and
         // increase len as we go along.

--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -5,7 +5,6 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #![no_std]
 #![doc(html_no_source)]
 #![allow(non_snake_case, clashing_extern_declarations)]
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
 
 extern crate self as windows_sys;
 mod Windows;

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -6,7 +6,6 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #![doc(html_no_source)]
 #![allow(non_snake_case, clashing_extern_declarations)]
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
 
 extern crate self as windows;
 pub use Windows::*;

--- a/crates/tests/core/tests/hstring.rs
+++ b/crates/tests/core/tests/hstring.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
-
 use std::convert::TryFrom;
 use windows::core::*;
 

--- a/crates/tests/lib/tests/sys.rs
+++ b/crates/tests/lib/tests/sys.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
-
 use windows_sys::{
     Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::ProcessStatus::*,
     Win32::System::Threading::*, Win32::Web::InternetExplorer::*,

--- a/crates/tests/standalone/src/lib.rs
+++ b/crates/tests/standalone/src/lib.rs
@@ -1,5 +1,4 @@
 #![cfg(test)]
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
 #![allow(clashing_extern_declarations)]
 
 mod b_arch;

--- a/crates/tests/targets/tests/link.rs
+++ b/crates/tests/targets/tests/link.rs
@@ -1,5 +1,4 @@
 #![cfg(test)]
-#![cfg_attr(windows_raw_dylib, feature(raw_dylib))]
 
 #[test]
 fn min() {


### PR DESCRIPTION
These features are entering their final stabilization period, so they no longer require an attribute to enable. 

They are still gated behind the `windows_raw_dylib` and `windows_debugger_visualizer` flags respectively, until MSRV can be bumped. 