### PR TITLE
Only exclude inline function constants

### DIFF
--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -262,10 +262,7 @@ impl<'a> Reader<'a> {
                 return false;
             }
 
-            // If the module name lacks a `.` then it's likely either an inline function, which windows-rs
-            // doesn't currently support, or an invalid import library since the extension must be known
-            // in order to generate an import table entry unambiguously.
-            return self.module_ref_name(self.impl_map_scope(impl_map)).contains('.');
+            self.module_ref_name(self.impl_map_scope(impl_map)) != "FORCEINLINE"
         })
     }
     pub fn namespace_constants(&self, namespace: &str) -> impl Iterator<Item = Field> + '_ {

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -262,6 +262,7 @@ impl<'a> Reader<'a> {
                 return false;
             }
 
+            // Skip "inline" function constants.
             self.module_ref_name(self.impl_map_scope(impl_map)) != "FORCEINLINE"
         })
     }


### PR DESCRIPTION
Previously, the Win32 metadata included some invalid function import information. This has been resolved and the broader exclusion was hurting some other scenarios like [webview-rs](https://github.com/wravery/webview2-rs).