### PR TITLE
Tweak web syndication sample to work with more web servers

### DIFF
--- a/crates/samples/windows/rss/src/main.rs
+++ b/crates/samples/windows/rss/src/main.rs
@@ -1,8 +1,14 @@
 use windows::{core::*, Foundation::Uri, Web::Syndication::SyndicationClient};
 
 fn main() -> Result<()> {
-    let uri = Uri::CreateUri(h!("https://blog.rust-lang.org/feed.xml"))?;
+    let uri = Uri::CreateUri(h!("https://blogs.windows.com/feed"))?;
     let client = SyndicationClient::new()?;
+
+    client.SetRequestHeader(
+        h!("User-Agent"),
+        h!("Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0)"),
+    )?;
+
     let feed = client.RetrieveFeedAsync(&uri)?.get()?;
 
     for item in feed.Items()? {


### PR DESCRIPTION
Turns out some web servers require a `user-agent` to be provided. 