### PR TITLE
Improved attribute parsing and generation

### DIFF
--- a/crates/libs/metadata/src/reader/codes.rs
+++ b/crates/libs/metadata/src/reader/codes.rs
@@ -86,7 +86,7 @@ impl Decode for MemberRefParent {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub enum TypeDefOrRef {
     None,
     TypeDef(TypeDef),

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -329,6 +329,8 @@ impl<'a> Reader<'a> {
                 Type::String => Value::String(values.read_str().to_string()),
                 Type::TypeName => Value::TypeDef(self.get(TypeName::parse(values.read_str())).next().expect("Type not found")),
                 Type::TypeDef((def, _)) => Value::EnumDef(def, values.read_integer(self.type_def_underlying_type(def))),
+                // It's impossible to know the type of a TypeRef so we just assume 32-bit integer which covers System.* attribute args
+                // reasonably well but the solution is to follow the WinRT metadata and define replacements for those attribute types.
                 Type::TypeRef(code) => Value::EnumRef(code, values.read_integer(Type::I32)),
                 rest => todo!("{:?}", rest),
             };

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -1350,7 +1350,7 @@ impl<'a> Reader<'a> {
         self.row_str(row.0, 2)
     }
     pub fn type_ref_type_name(&self, row: TypeRef) -> TypeName {
-        TypeName::new(self.type_ref_name(row), self.type_ref_namespace(row))
+        TypeName::new(self.type_ref_namespace(row), self.type_ref_name(row))
     }
 
     //

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -127,7 +127,9 @@ pub enum Value {
     F64(f64),
     String(String),
     TypeDef(TypeDef),
-    Enum(TypeDef, Integer),
+    TypeRef(TypeDefOrRef),
+    EnumDef(TypeDef, Integer),
+    EnumRef(TypeDefOrRef, Integer),
 }
 
 pub struct Signature {
@@ -326,8 +328,9 @@ impl<'a> Reader<'a> {
                 Type::U64 => Value::U64(values.read_u64()),
                 Type::String => Value::String(values.read_str().to_string()),
                 Type::TypeName => Value::TypeDef(self.get(TypeName::parse(values.read_str())).next().expect("Type not found")),
-                Type::TypeDef((def, _)) => Value::Enum(def, values.read_integer(self.type_def_underlying_type(def))),
-                _ => unimplemented!(),
+                Type::TypeDef((def, _)) => Value::EnumDef(def, values.read_integer(self.type_def_underlying_type(def))),
+                Type::TypeRef(code) => Value::EnumRef(code, values.read_integer(Type::I32)),
+                rest => todo!("{:?}", rest),
             };
 
             args.push((String::new(), arg));
@@ -350,12 +353,15 @@ impl<'a> Reader<'a> {
                 0x55 => {
                     let def = self.get(TypeName::parse(&name)).next().expect("Type not found");
                     name = values.read_str().into();
-                    Value::Enum(def, values.read_integer(self.type_def_underlying_type(def)))
+                    Value::EnumDef(def, values.read_integer(self.type_def_underlying_type(def)))
                 }
-                _ => unimplemented!(),
+                _ => todo!("{:?}", arg_type),
             };
             args.push((name, arg));
         }
+
+        assert_eq!(sig.slice.len(), 0);
+        assert_eq!(values.slice.len(), 0);
 
         args
     }
@@ -1116,7 +1122,7 @@ impl<'a> Reader<'a> {
             match self.attribute_name(attribute) {
                 "AgileAttribute" => return true,
                 "MarshalingBehaviorAttribute" => {
-                    if let Some((_, Value::Enum(_, Integer::I32(2)))) = self.attribute_args(attribute).get(0) {
+                    if let Some((_, Value::EnumDef(_, Integer::I32(2)))) = self.attribute_args(attribute).get(0) {
                         return true;
                     }
                 }
@@ -1462,7 +1468,7 @@ impl<'a> Reader<'a> {
         for attribute in attributes {
             match self.attribute_name(attribute) {
                 "SupportedArchitectureAttribute" => {
-                    if let Some((_, Value::Enum(_, Integer::I32(value)))) = self.attribute_args(attribute).get(0) {
+                    if let Some((_, Value::EnumDef(_, Integer::I32(value)))) = self.attribute_args(attribute).get(0) {
                         if value & 1 == 1 {
                             cfg.arches.insert("x86");
                         }
@@ -1628,7 +1634,7 @@ impl<'a> Reader<'a> {
         result.sort_by(|a, b| self.type_name(&a.ty).cmp(self.type_name(&b.ty)));
         result
     }
-    fn type_def_or_ref(&self, code: TypeDefOrRef) -> TypeName {
+    pub fn type_def_or_ref(&self, code: TypeDefOrRef) -> TypeName {
         match code {
             TypeDefOrRef::TypeDef(row) => TypeName::new(self.type_def_namespace(row), self.type_def_name(row)),
             TypeDefOrRef::TypeRef(row) => TypeName::new(self.type_ref_namespace(row), self.type_ref_name(row)),
@@ -1724,7 +1730,7 @@ impl<'a> Reader<'a> {
         if let Some(ty) = self.get(full_name).next() {
             Type::TypeDef((ty, Vec::new()))
         } else {
-            panic!("Type not found: {}", full_name);
+            Type::TypeRef(code)
         }
     }
     fn type_from_blob(&self, blob: &mut Blob, enclosing: Option<TypeDef>, generics: &[Type]) -> Type {

--- a/crates/libs/metadata/src/reader/type.rs
+++ b/crates/libs/metadata/src/reader/type.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Clone, PartialEq, PartialOrd, Eq, Ord, Debug)]
 pub enum Type {
     Void,
     Bool,
@@ -28,6 +28,7 @@ pub enum Type {
     PCWSTR,
     BSTR,
     TypeName,
+    TypeRef(TypeDefOrRef),
     GenericParam(GenericParam),
     TypeDef((TypeDef, Vec<Self>)),
     MutPtr((Box<Self>, usize)),

--- a/crates/libs/metadata/src/writer/idl/format.rs
+++ b/crates/libs/metadata/src/writer/idl/format.rs
@@ -74,6 +74,7 @@ impl Printer {
     }
 
     fn idl_interface(&mut self, member: &IdlInterface) {
+        self.attrs(&member.attributes);
         self.word("interface ");
         self.ident(&member.ident);
         self.word(" {");
@@ -91,7 +92,22 @@ impl Printer {
         self.word("}");
     }
 
+    fn attrs(&mut self, attrs: &[syn::Attribute]) {
+        for attr in attrs {
+            self.attr(attr);
+        }
+    }
+
+    fn attr(&mut self, attr: &syn::Attribute) {
+        self.word("#[");
+        self.path(&attr.path);
+        self.word("]");
+        self.newline();
+    }
+
     fn idl_struct(&mut self, member: &IdlStruct) {
+        self.attrs(&member.item.attrs);
+
         self.word("struct ");
         self.ident(&member.item.ident);
         self.word(" {");
@@ -112,6 +128,8 @@ impl Printer {
     }
 
     fn idl_enum(&mut self, member: &IdlEnum) {
+        self.attrs(&member.item.attrs);
+
         self.word("enum ");
         self.ident(&member.item.ident);
         self.word(" {");

--- a/crates/libs/metadata/src/writer/idl/write.rs
+++ b/crates/libs/metadata/src/writer/idl/write.rs
@@ -24,7 +24,9 @@ fn module_to_idl(name: &str, module: &Module) -> TokenStream {
 }
 
 fn type_def_to_idl(module: &Module, name: &str, ty: &TypeDef) -> TokenStream {
-    if let Some(extends) = &ty.extends {
+    let attributes = attributes_to_idl(&ty.attributes);
+
+    let ty = if let Some(extends) = &ty.extends {
         if extends.namespace == "System" {
             if extends.name == "Enum" {
                 enum_to_idl(module, name, ty)
@@ -40,6 +42,11 @@ fn type_def_to_idl(module: &Module, name: &str, ty: &TypeDef) -> TokenStream {
         }
     } else {
         interface_to_idl(module, name, ty)
+    };
+
+    quote! {
+        #attributes
+        #ty
     }
 }
 
@@ -81,6 +88,19 @@ fn struct_to_idl(module: &Module, name: &str, ty: &TypeDef) -> TokenStream {
         struct #name {
             #(#fields),*
         }
+    }
+}
+
+fn attributes_to_idl(attributes: &[Attribute]) -> TokenStream {
+    let attributes = attributes.iter().map(|attribute| {
+        let name = to_ident(&attribute.ty.name);
+        quote! {
+            #[#name]
+        }
+    });
+
+    quote! {
+        #(#attributes)*
     }
 }
 

--- a/crates/libs/metadata/src/writer/idl/write.rs
+++ b/crates/libs/metadata/src/writer/idl/write.rs
@@ -74,27 +74,27 @@ fn enum_to_idl(module: &Module, name: &str, ty: &TypeDef) -> TokenStream {
 }
 
 fn value_to_idl(module: &Module, value: &Value) -> TokenStream {
-        match value {
-            Value::Bool(value) => value.to_string().into(),
-            Value::U8(value) => format!("{value}u8").into(),
-            Value::I8(value) => format!("{value}i8").into(),
-            Value::U16(value) => format!("{value}u16").into(),
-            Value::I16(value) => format!("{value}i16").into(),
-            Value::U32(value) => format!("{value}u32").into(),
-            Value::I32(value) => format!("{value}i32").into(),
-            Value::U64(value) => format!("{value}u64").into(),
-            Value::I64(value) => format!("{value}i64").into(),
-            Value::F32(value) => format!("{value}f32").into(),
-            Value::F64(value) => format!("{value}f64").into(),
-            Value::String(value) => value.into(),
-            Value::TypeName(type_name) => {
-                let type_name = reader::TypeName::parse(type_name);
-                let namespace = namespace_to_idl(&module.namespace, &type_name.namespace);
-                let name = to_ident(&type_name.name);
-                quote! { #namespace#name }
-            }
-            rest => todo!("{:?}", rest),
+    match value {
+        Value::Bool(value) => value.to_string().into(),
+        Value::U8(value) => format!("{value}u8").into(),
+        Value::I8(value) => format!("{value}i8").into(),
+        Value::U16(value) => format!("{value}u16").into(),
+        Value::I16(value) => format!("{value}i16").into(),
+        Value::U32(value) => format!("{value}u32").into(),
+        Value::I32(value) => format!("{value}i32").into(),
+        Value::U64(value) => format!("{value}u64").into(),
+        Value::I64(value) => format!("{value}i64").into(),
+        Value::F32(value) => format!("{value}f32").into(),
+        Value::F64(value) => format!("{value}f64").into(),
+        Value::String(value) => value.into(),
+        Value::TypeName(type_name) => {
+            let type_name = reader::TypeName::parse(type_name);
+            let namespace = namespace_to_idl(&module.namespace, type_name.namespace);
+            let name = to_ident(type_name.name);
+            quote! { #namespace#name }
         }
+        rest => todo!("{:?}", rest),
+    }
 }
 
 fn struct_to_idl(module: &Module, name: &str, ty: &TypeDef) -> TokenStream {
@@ -129,7 +129,7 @@ fn attributes_to_idl(module: &Module, attributes: &[Attribute]) -> TokenStream {
                 if name.is_empty() {
                     value_to_idl(module, value)
                 } else {
-                    let name = to_ident(&name);
+                    let name = to_ident(name);
                     let value = value_to_idl(module, value);
                     quote! {
                         #name: #value

--- a/crates/libs/metadata/src/writer/mod.rs
+++ b/crates/libs/metadata/src/writer/mod.rs
@@ -241,23 +241,7 @@ impl Value {
             _ => todo!(),
         }
     }
-    fn to_expr(&self) -> String {
-        match self {
-            Self::Bool(value) => value.to_string(),
-            Self::U8(value) => format!("{value}u8"),
-            Self::I8(value) => format!("{value}i8"),
-            Self::U16(value) => format!("{value}u16"),
-            Self::I16(value) => format!("{value}i16"),
-            Self::U32(value) => format!("{value}u32"),
-            Self::I32(value) => format!("{value}i32"),
-            Self::U64(value) => format!("{value}u64"),
-            Self::I64(value) => format!("{value}i64"),
-            Self::F32(value) => format!("{value}f32"),
-            Self::F64(value) => format!("{value}f64"),
-            Self::String(value) => value.clone(),
-            _ => todo!(),
-        }
-    }
+
     fn neg(&self) -> Self {
         use std::ops::Neg;
         match self {

--- a/crates/tests/metadata/tests/attribute_enum.rs
+++ b/crates/tests/metadata/tests/attribute_enum.rs
@@ -52,7 +52,7 @@ fn check_attr_arg_enum(
         .find(|(name, _)| name == arg_name)
         .unwrap();
 
-    if let Value::Enum(ty, Integer::I32(value)) = value {
+    if let Value::EnumDef(ty, Integer::I32(value)) = value {
         assert_eq!(expected_type, reader.type_def_type_name(ty).to_string());
         assert_eq!(expected_value, value);
     } else {

--- a/crates/tools/riddle/src/main.rs
+++ b/crates/tools/riddle/src/main.rs
@@ -27,7 +27,6 @@ Options:
   -out    <path>       Path to .winmd or .idl file to generate
   -filter <namespace>  Namespaces to include or !exclude in output
   -format              Format .idl files only
-  -verbose             Show detailed information
 "#
         );
         return Ok(());
@@ -39,7 +38,6 @@ Options:
     let mut include = Vec::<&str>::new();
     let mut exclude = Vec::<&str>::new();
     let mut format = false;
-    let mut verbose = false;
 
     for arg in &args {
         if arg.starts_with('-') {
@@ -52,7 +50,6 @@ Options:
                 "-out" => kind = ArgKind::Output,
                 "-filter" => kind = ArgKind::Filter,
                 "-format" => format = true,
-                "-verbose" => verbose = true,
                 _ => return Err(Error::new(&format!("invalid option: `{arg}`"))),
             },
             ArgKind::Output => {
@@ -108,10 +105,7 @@ Options:
     module.validate()?;
     module.write(output)?;
 
-    if verbose {
-        println!("  Finished writing `{}` in {:.2}s", canonicalize(output)?, time.elapsed().as_secs_f32());
-    }
-
+    println!("  Finished writing `{}` in {:.2}s", canonicalize(output)?, time.elapsed().as_secs_f32());
     Ok(())
 }
 


### PR DESCRIPTION
This update more accurately captures metadata attribute arguments, accounting for .NET types that aren't available in the parser. Long term this won't be a problem as windows-rs metadata becomes self-hosting, but this at least allows for parsing Win32 metadata in the short term. 

I ran into a blocking issue with the `syn` crate for which I need to step away from riddle for a bit and upgrade to `syn` version 2 so I'm going to tackle that next. 