### PR TITLE
Implement `std::error::Error` for new metadata `Error` type

### DIFF
--- a/crates/libs/metadata/src/error.rs
+++ b/crates/libs/metadata/src/error.rs
@@ -7,6 +7,8 @@ pub struct Error {
     span: Option<(usize, usize)>,
 }
 
+impl std::error::Error for Error {}
+
 impl From<Error> for std::io::Error {
     fn from(error: Error) -> Self {
         std::io::Error::new(std::io::ErrorKind::Other, error.message.as_str())


### PR DESCRIPTION
Since the introduction of [a new `Error` type in the metadata] it is impossible to bubble up results from `File::new()` into `anyhow` using the `?` operator because this type doesn't implement `Error`, while it can be trivially implemented with all functions left at their default implementation.

[a new `Error` type in the metadata]: https://github.com/microsoft/windows-rs/pull/2510/files#r1203845316

Fixes: https://github.com/microsoft/windows-rs/pull/2510/files#r1203845316
