### PR TITLE
Version 0.50.0

### DIFF
--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-core"
-version = "0.48.0"
+version = "0.50.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -18,7 +18,7 @@ targets = []
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-windows-core = { path = "../core", version = "0.48.0" }
+windows-core = { path = "../core", version = "0.50.0" }
 windows-targets = { path = "../targets", version = "0.48.0" }
 windows-implement = { path = "../implement",  version = "0.48.0", optional = true }
 windows-interface = { path = "../interface",  version = "0.48.0", optional = true }

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -58,7 +58,7 @@ targets = []
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-windows-core = { path = "../core", version = "0.48.0" }
+windows-core = { path = "../core", version = "0.50.0" }
 windows-targets = { path = "../targets", version = "0.48.0" }
 windows-implement = { path = "../implement",  version = "0.48.0", optional = true }
 windows-interface = { path = "../interface",  version = "0.48.0", optional = true }


### PR DESCRIPTION
This update includes the first published version of the `windows-core` crate (#2475) as requested in #2527. 

Other crates will not be updated at this time.
