### PR TITLE
Lock readme samples to last published version

### DIFF
--- a/crates/tests/readme/Cargo.toml
+++ b/crates/tests/readme/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies.windows]
-path = "../../libs/windows"
+version = "0.48"
 features = [
     "Data_Xml_Dom",
     "Win32_Foundation",
@@ -15,7 +15,7 @@ features = [
 ]
 
 [dependencies.windows-sys]
-path = "../../libs/sys"
+version = "0.48"
 features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -38,9 +38,9 @@ fn main() -> Result<()> {
 
     unsafe {
         let event = CreateEventW(None, true, false, None)?;
-        SetEvent(event)?;
-        WaitForSingleObject(event, 0)?;
-        CloseHandle(event)?;
+        SetEvent(event).ok()?;
+        WaitForSingleObject(event, 0).ok()?;
+        CloseHandle(event).ok()?;
 
         MessageBoxA(None, s!("Ansi"), s!("Caption"), MB_OK);
         MessageBoxW(None, w!("Wide"), w!("Caption"), MB_OK);


### PR DESCRIPTION
This just ensures that the readme samples are tested against the last published version rather than the latest version on github to avoid confusion (#2537).