### PR TITLE
Implement `type_name()` for `TypeRef`

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -60,6 +60,29 @@ impl<'a> Gen<'a> {
     }
 
     //
+    // TypeRef
+    //
+
+    pub fn type_ref_name(&self, ref_: TypeRef) -> TokenStream {
+        self.type_ref_name_imp(ref_, "")
+    }
+    pub fn type_ref_vtbl_name(&self, ref_: TypeRef) -> TokenStream {
+        self.type_ref_name_imp(ref_, "_Vtbl")
+    }
+    pub fn type_ref_name_imp(&self, ref_: TypeRef, suffix: &str) -> TokenStream {
+        let type_name = self.reader.type_ref_type_name(ref_);
+
+        assert!(!type_name.namespace.is_empty());
+
+        let mut namespace = self.namespace(type_name.namespace);
+        let mut name = to_ident(type_name.name);
+        name.push_str(suffix);
+
+        namespace.combine(&name);
+        namespace
+    }
+
+    //
     // Type
     //
 
@@ -156,13 +179,14 @@ impl<'a> Gen<'a> {
             Type::WinrtArray(ty) => self.type_name(ty),
             Type::WinrtArrayRef(ty) => self.type_name(ty),
             Type::ConstRef(ty) => self.type_name(ty),
-            _ => unimplemented!(),
+            Type::TypeRef(TypeDefOrRef::TypeRef(ref_)) => self.type_ref_name(*ref_),
+            x => unimplemented!("{:?}", x),
         }
     }
     pub fn type_vtbl_name(&self, ty: &Type) -> TokenStream {
         match ty {
             Type::TypeDef((def, generics)) => self.type_def_vtbl_name(*def, generics),
-            _ => unimplemented!(),
+            x => unimplemented!("{:?}", x),
         }
     }
     pub fn type_abi_name(&self, ty: &Type) -> TokenStream {
@@ -524,7 +548,7 @@ impl<'a> Gen<'a> {
                 tokens.push('\"');
                 tokens.into()
             }
-            _ => unimplemented!(),
+            x => unimplemented!("{:?}", x),
         }
     }
     pub fn typed_value(&self, value: &Value) -> TokenStream {
@@ -544,7 +568,7 @@ impl<'a> Gen<'a> {
             Value::String(_) => {
                 quote! { &str = #literal }
             }
-            _ => unimplemented!(),
+            x => unimplemented!("{:?}", x),
         }
     }
 
@@ -638,7 +662,7 @@ impl<'a> Gen<'a> {
                 AsyncKind::OperationWithProgress => {
                     quote! { AsyncOperationWithProgressCompletedHandler }
                 }
-                _ => unimplemented!(),
+                x => unimplemented!("{:?}", x),
             };
 
             let namespace = self.namespace("Windows.Foundation");

--- a/crates/libs/metadata/src/reader/mod.rs
+++ b/crates/libs/metadata/src/reader/mod.rs
@@ -96,7 +96,7 @@ impl SignatureParamKind {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AsyncKind {
     None,
     Action,


### PR DESCRIPTION
When running `tool_windows` on the latest `.winmd` generated with https://github.com/microsoft/win32metadata/pull/1591 to test the results of that metadata change, no implementation exists for `TypeRef`.  This implementation is rather trivial/straightforward based on `TypeDef`.

Going forward, also print the failed value when a `match` statement ends up in `_ => unimplemented!()` so that it is quicker to immediately debug what enum variant needs to be implemented.
