### PR TITLE
Add reference for spurious warning about `cdylib` dependency 

### DIFF
--- a/crates/tests/component_client/Cargo.toml
+++ b/crates/tests/component_client/Cargo.toml
@@ -16,6 +16,6 @@ features = [
 ]
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
-# I'm not sure how to do that without this spurious warning.
+# Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
 [build-dependencies.test_component]
 path = "../component"


### PR DESCRIPTION
This is what I believe to be an incorrect warning on the part of Rust as this seems like a perfectly legitimate dependency. Anyway, just adding a note as @wesleywiser found an issue that matches the problem I'm hitting here. 

https://github.com/rust-lang/cargo/issues/7825