### PR TITLE
Test cross platform code generation

### DIFF
--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   generation:
     name: tool_${{ matrix.tool }}
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         tool: [windows, sys, yml, license, core, metadata]


### PR DESCRIPTION
This just switches the code gen validation workflow to run on Linux rather than Windows. If all goes well, this can continue to verify that code generation tooling is OS-agnostic. 