### PR TITLE
Improve panic diagnostics

### DIFF
--- a/crates/libs/metadata/src/codes.rs
+++ b/crates/libs/metadata/src/codes.rs
@@ -13,7 +13,7 @@ impl Decode for AttributeType {
         let (kind, row) = (code & ((1 << 3) - 1), (code >> 3) - 1);
         match kind {
             3 => Self::MemberRef(MemberRef(Row::new(row, TABLE_MEMBERREF, file))),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 }
@@ -81,7 +81,7 @@ impl Decode for MemberRefParent {
         let (kind, row) = (code & ((1 << 3) - 1), (code >> 3) - 1);
         match kind {
             1 => Self::TypeRef(TypeRef(Row::new(row, TABLE_TYPEREF, file))),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 }
@@ -100,7 +100,7 @@ impl Decode for TypeDefOrRef {
             0 => Self::TypeDef(TypeDef(Row::new(row, TABLE_TYPEDEF, file))),
             1 => Self::TypeRef(TypeRef(Row::new(row, TABLE_TYPEREF, file))),
             2 => Self::TypeSpec(TypeSpec(Row::new(row, TABLE_TYPESPEC, file))),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 }
@@ -132,7 +132,7 @@ impl Decode for ResolutionScope {
             1 => Self::ModuleRef(ModuleRef(Row::new(row, TABLE_MODULEREF, file))),
             2 => Self::AssemblyRef(AssemblyRef(Row::new(row, TABLE_ASSEMBLYREF, file))),
             3 => Self::TypeRef(TypeRef(Row::new(row, TABLE_TYPEREF, file))),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 }

--- a/crates/libs/metadata/src/file.rs
+++ b/crates/libs/metadata/src/file.rs
@@ -102,7 +102,7 @@ impl File {
                 b"#~" => tables_data = (metadata_offset + stream_offset, stream_len),
                 b"#GUID" => {}
                 b"#US" => {}
-                _ => unimplemented!(),
+                rest => unimplemented!("{rest:?}"),
             }
             let mut padding = 4 - stream_name.len() % 4;
             if padding == 0 {
@@ -346,7 +346,7 @@ impl File {
             0..=3 => (initial_byte & 0x7f, 1),
             4..=5 => (initial_byte & 0x3f, 2),
             6 => (initial_byte & 0x1f, 4),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         };
         let mut blob_size = blob_size as usize;
         for byte in &self.bytes[offset + 1..offset + blob_size_bytes] {

--- a/crates/libs/metadata/src/guid.rs
+++ b/crates/libs/metadata/src/guid.rs
@@ -10,19 +10,19 @@ impl GUID {
         fn unwrap_u32(value: &Value) -> u32 {
             match value {
                 Value::U32(value) => *value,
-                _ => unimplemented!(),
+                rest => unimplemented!("{rest:?}"),
             }
         }
         fn unwrap_u16(value: &Value) -> u16 {
             match value {
                 Value::U16(value) => *value,
-                _ => unimplemented!(),
+                rest => unimplemented!("{rest:?}"),
             }
         }
         fn unwrap_u8(value: &Value) -> u8 {
             match value {
                 Value::U8(value) => *value,
-                _ => unimplemented!(),
+                rest => unimplemented!("{rest:?}"),
             }
         }
         Self(unwrap_u32(&args[0].1), unwrap_u16(&args[1].1), unwrap_u16(&args[2].1), unwrap_u8(&args[3].1), unwrap_u8(&args[4].1), unwrap_u8(&args[5].1), unwrap_u8(&args[6].1), unwrap_u8(&args[7].1), unwrap_u8(&args[8].1), unwrap_u8(&args[9].1), unwrap_u8(&args[10].1))

--- a/crates/libs/metadata/src/lib.rs
+++ b/crates/libs/metadata/src/lib.rs
@@ -102,7 +102,7 @@ impl SignatureParamKind {
     }
 }
 
-#[derive(PartialEq, Eq)]
+#[derive(PartialEq, Eq, Debug)]
 pub enum AsyncKind {
     None,
     Action,
@@ -330,7 +330,7 @@ impl<'a> Reader<'a> {
                 // It's impossible to know the type of a TypeRef so we just assume 32-bit integer which covers System.* attribute args
                 // reasonably well but the solution is to follow the WinRT metadata and define replacements for those attribute types.
                 Type::TypeRef(code) => Value::EnumRef(code, Box::new(values.read_integer(Type::I32))),
-                rest => todo!("{:?}", rest),
+                rest => unimplemented!("{rest:?}"),
             };
 
             args.push((String::new(), arg));
@@ -355,7 +355,7 @@ impl<'a> Reader<'a> {
                     name = values.read_str().into();
                     Value::EnumDef(def, Box::new(values.read_integer(self.type_def_underlying_type(def))))
                 }
-                _ => todo!("{:?}", arg_type),
+                rest => unimplemented!("{rest:?}"),
             };
             args.push((name, arg));
         }
@@ -396,7 +396,7 @@ impl<'a> Reader<'a> {
             Type::F32 => Value::F32(blob.read_f32()),
             Type::F64 => Value::F64(blob.read_f64()),
             Type::String => Value::String(blob.read_string()),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 
@@ -1327,7 +1327,7 @@ impl<'a> Reader<'a> {
                         result.insert(0, Type::IUnknown);
                         break;
                     }
-                    _ => unimplemented!(),
+                    rest => unimplemented!("{rest:?}"),
                 }
             }
         }
@@ -1638,7 +1638,7 @@ impl<'a> Reader<'a> {
         match code {
             TypeDefOrRef::TypeDef(row) => TypeName::new(self.type_def_namespace(row), self.type_def_name(row)),
             TypeDefOrRef::TypeRef(row) => TypeName::new(self.type_ref_namespace(row), self.type_ref_name(row)),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
     fn type_stdcall(&self, ty: &Type) -> usize {
@@ -1798,7 +1798,7 @@ impl<'a> Reader<'a> {
 
                 Type::TypeDef(def, args)
             }
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
     pub fn type_name(&self, ty: &Type) -> &str {
@@ -1828,7 +1828,7 @@ impl<'a> Reader<'a> {
             Type::GUID => "g16".to_string(),
             Type::HRESULT => "struct(Windows.Foundation.HResult;i4)".to_string(),
             Type::TypeDef(row, generics) => self.type_def_signature(*row, generics),
-            rest => todo!("{:?}", rest),
+            rest => unimplemented!("{rest:?}"),
         }
     }
     pub fn type_is_nullable(&self, ty: &Type) -> bool {

--- a/crates/tests/implement/tests/drop_target.rs
+++ b/crates/tests/implement/tests/drop_target.rs
@@ -8,22 +8,22 @@ struct DataObject();
 
 impl IDataObject_Impl for DataObject {
     fn GetData(&self, _: *const FORMATETC) -> Result<STGMEDIUM> {
-        todo!()
+        unimplemented!()
     }
     fn GetDataHere(&self, _: *const FORMATETC, _: *mut STGMEDIUM) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn QueryGetData(&self, _: *const FORMATETC) -> HRESULT {
-        todo!()
+        unimplemented!()
     }
     fn GetCanonicalFormatEtc(&self, _: *const FORMATETC, _: *mut FORMATETC) -> HRESULT {
-        todo!()
+        unimplemented!()
     }
     fn SetData(&self, _: *const FORMATETC, _: *const STGMEDIUM, _: BOOL) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn EnumFormatEtc(&self, _: u32) -> Result<IEnumFORMATETC> {
-        todo!()
+        unimplemented!()
     }
     fn DAdvise(
         &self,
@@ -37,10 +37,10 @@ impl IDataObject_Impl for DataObject {
         Ok(123)
     }
     fn DUnadvise(&self, _: u32) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn EnumDAdvise(&self) -> Result<IEnumSTATDATA> {
-        todo!()
+        unimplemented!()
     }
 }
 
@@ -68,7 +68,7 @@ impl IDropTarget_Impl for DropTarget {
         }
     }
     fn DragOver(&self, _: MODIFIERKEYS_FLAGS, _: &POINTL, _: *mut DROPEFFECT) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn DragLeave(&self) -> Result<()> {
         Ok(())
@@ -80,7 +80,7 @@ impl IDropTarget_Impl for DropTarget {
         _: &POINTL,
         _: *mut DROPEFFECT,
     ) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tests/implement/tests/from_raw_borrowed_winrt.rs
+++ b/crates/tests/implement/tests/from_raw_borrowed_winrt.rs
@@ -30,34 +30,34 @@ impl IBackgroundTask_Impl for Borrowed {
 
 impl IBackgroundTaskInstance_Impl for Borrowed {
     fn InstanceId(&self) -> Result<GUID> {
-        todo!()
+        unimplemented!()
     }
     fn Task(&self) -> Result<BackgroundTaskRegistration> {
-        todo!()
+        unimplemented!()
     }
     fn Progress(&self) -> Result<u32> {
-        todo!()
+        unimplemented!()
     }
     fn SetProgress(&self, _value: u32) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn TriggerDetails(&self) -> Result<IInspectable> {
-        todo!()
+        unimplemented!()
     }
     fn Canceled(
         &self,
         _cancelhandler: Option<&BackgroundTaskCanceledEventHandler>,
     ) -> Result<EventRegistrationToken> {
-        todo!()
+        unimplemented!()
     }
     fn RemoveCanceled(&self, _cookie: &EventRegistrationToken) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn SuspendedCount(&self) -> Result<u32> {
         Ok(*self.0.read().unwrap())
     }
     fn GetDeferral(&self) -> Result<BackgroundTaskDeferral> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tests/implement/tests/generic_default.rs
+++ b/crates/tests/implement/tests/generic_default.rs
@@ -50,7 +50,7 @@ where
     <T as Type<T>>::Default: PartialEq,
 {
     fn First(&self) -> Result<IIterator<T>> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tests/implement/tests/generic_generic.rs
+++ b/crates/tests/implement/tests/generic_generic.rs
@@ -39,7 +39,7 @@ where
     <T as Type<T>>::Default: PartialEq,
 {
     fn First(&self) -> Result<IIterator<T>> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tests/implement/tests/generic_stringable.rs
+++ b/crates/tests/implement/tests/generic_stringable.rs
@@ -28,7 +28,7 @@ impl IVectorView_Impl<IStringable> for Thing {
 
 impl IIterable_Impl<IStringable> for Thing {
     fn First(&self) -> Result<IIterator<IStringable>> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tests/implement/tests/properties.rs
+++ b/crates/tests/implement/tests/properties.rs
@@ -19,16 +19,16 @@ impl IPropertyStore_Impl for Object {
         Ok(123)
     }
     fn GetAt(&self, _: u32, _: *mut PROPERTYKEY) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn GetValue(&self, _: *const PROPERTYKEY) -> Result<PROPVARIANT> {
-        todo!()
+        unimplemented!()
     }
     fn SetValue(&self, _: *const PROPERTYKEY, _: *const PROPVARIANT) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
     fn Commit(&self) -> Result<()> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tests/implement/tests/vector.rs
+++ b/crates/tests/implement/tests/vector.rs
@@ -53,7 +53,7 @@ where
         }
     }
     fn GetMany(&self, _startindex: u32, _items: &mut [T::Default]) -> Result<u32> {
-        todo!();
+        unimplemented!();
     }
 }
 
@@ -162,7 +162,7 @@ where
     <T as Type<T>>::Default: PartialEq + Clone,
 {
     fn First(&self) -> Result<IIterator<T>> {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tests/interface/tests/non_com_existing.rs
+++ b/crates/tests/interface/tests/non_com_existing.rs
@@ -27,10 +27,10 @@ impl Default for Variable {
 
 impl ID3D10EffectBlendVariable_Impl for Variable {
     fn GetBlendState(&self, _: u32) -> Result<ID3D10BlendState> {
-        todo!();
+        unimplemented!();
     }
     fn GetBackingStore(&self, _: u32, _: *mut D3D10_BLEND_DESC) -> Result<()> {
-        todo!();
+        unimplemented!();
     }
 }
 
@@ -40,79 +40,79 @@ impl ID3D10EffectVariable_Impl for Variable {
         true.into()
     }
     fn GetType(&self) -> ::core::option::Option<ID3D10EffectType> {
-        todo!();
+        unimplemented!();
     }
     fn GetDesc(&self, _: *mut D3D10_EFFECT_VARIABLE_DESC) -> ::windows::core::Result<()> {
-        todo!();
+        unimplemented!();
     }
     fn GetAnnotationByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-        todo!();
+        unimplemented!();
     }
     fn GetAnnotationByName(
         &self,
         _: &::windows::core::PCSTR,
     ) -> ::core::option::Option<ID3D10EffectVariable> {
-        todo!();
+        unimplemented!();
     }
     fn GetMemberByIndex(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-        todo!();
+        unimplemented!();
     }
     fn GetMemberByName(
         &self,
         _: &::windows::core::PCSTR,
     ) -> ::core::option::Option<ID3D10EffectVariable> {
-        todo!();
+        unimplemented!();
     }
     fn GetMemberBySemantic(
         &self,
         _: &::windows::core::PCSTR,
     ) -> ::core::option::Option<ID3D10EffectVariable> {
-        todo!();
+        unimplemented!();
     }
     fn GetElement(&self, _: u32) -> ::core::option::Option<ID3D10EffectVariable> {
-        todo!();
+        unimplemented!();
     }
     fn GetParentConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
-        todo!();
+        unimplemented!();
     }
     fn AsScalar(&self) -> ::core::option::Option<ID3D10EffectScalarVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsVector(&self) -> ::core::option::Option<ID3D10EffectVectorVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsMatrix(&self) -> ::core::option::Option<ID3D10EffectMatrixVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsString(&self) -> ::core::option::Option<ID3D10EffectStringVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsShaderResource(&self) -> ::core::option::Option<ID3D10EffectShaderResourceVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsRenderTargetView(&self) -> ::core::option::Option<ID3D10EffectRenderTargetViewVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsDepthStencilView(&self) -> ::core::option::Option<ID3D10EffectDepthStencilViewVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsConstantBuffer(&self) -> ::core::option::Option<ID3D10EffectConstantBuffer> {
-        todo!();
+        unimplemented!();
     }
     fn AsShader(&self) -> ::core::option::Option<ID3D10EffectShaderVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsBlend(&self) -> ::core::option::Option<ID3D10EffectBlendVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsDepthStencil(&self) -> ::core::option::Option<ID3D10EffectDepthStencilVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsRasterizer(&self) -> ::core::option::Option<ID3D10EffectRasterizerVariable> {
-        todo!();
+        unimplemented!();
     }
     fn AsSampler(&self) -> ::core::option::Option<ID3D10EffectSamplerVariable> {
-        todo!();
+        unimplemented!();
     }
     fn SetRawValue(
         &self,
@@ -120,7 +120,7 @@ impl ID3D10EffectVariable_Impl for Variable {
         _: u32,
         _: u32,
     ) -> ::windows::core::Result<()> {
-        todo!();
+        unimplemented!();
     }
     fn GetRawValue(
         &self,
@@ -128,7 +128,7 @@ impl ID3D10EffectVariable_Impl for Variable {
         _: u32,
         _: u32,
     ) -> ::windows::core::Result<()> {
-        todo!();
+        unimplemented!();
     }
 }
 
@@ -136,23 +136,23 @@ struct Callback;
 
 impl IXAudio2VoiceCallback_Impl for Callback {
     fn OnVoiceProcessingPassStart(&self, _: u32) {
-        todo!()
+        unimplemented!()
     }
     fn OnVoiceProcessingPassEnd(&self) {
-        todo!()
+        unimplemented!()
     }
     fn OnStreamEnd(&self) {}
     fn OnBufferStart(&self, _: *mut std::ffi::c_void) {
-        todo!()
+        unimplemented!()
     }
     fn OnBufferEnd(&self, _: *mut std::ffi::c_void) {
-        todo!()
+        unimplemented!()
     }
     fn OnLoopEnd(&self, _: *mut std::ffi::c_void) {
-        todo!()
+        unimplemented!()
     }
     fn OnVoiceError(&self, _: *mut std::ffi::c_void, _: HRESULT) {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/crates/tools/riddle/src/idl/to_idl.rs
+++ b/crates/tools/riddle/src/idl/to_idl.rs
@@ -179,7 +179,7 @@ impl<'a> Writer<'a> {
                     quote! { #namespace#name<#(#generics,)*> }
                 }
             }
-            _ => todo!("{:?}", ty),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 

--- a/crates/tools/riddle/src/idl/to_winmd.rs
+++ b/crates/tools/riddle/src/idl/to_winmd.rs
@@ -157,11 +157,11 @@ fn write_class(_writer: &mut winmd::Writer, _namespace: &str, _name: &str, _memb
 
 //                     for input in &method.sig.inputs {
 //                         let syn::FnArg::Typed(pat_type) = input else {
-//                     todo!();
+//                     unimplemented!();
 //                 };
 
 //                         let syn::Pat::Ident(ref pat_ident) = *pat_type.pat else {
-//                     todo!();
+//                     unimplemented!();
 //                 };
 
 //                         let name = pat_ident.ident.to_string();
@@ -254,7 +254,7 @@ fn write_class(_writer: &mut winmd::Writer, _namespace: &str, _name: &str, _memb
 //     match expr {
 //         syn::Expr::Lit(lit) => self.read_expr_lit(lit, neg),
 //         syn::Expr::Unary(unary) => self.read_expr_unary(unary),
-//         _ => todo!("{:?}", expr),
+//         rest => unimplemented!("{rest:?}"),
 //     }
 // }
 
@@ -270,7 +270,7 @@ fn write_class(_writer: &mut winmd::Writer, _namespace: &str, _name: &str, _memb
 //     match lit {
 //         syn::Lit::Int(lit) => self.read_lit_int(lit, neg),
 //         syn::Lit::Str(lit) => self.read_lit_str(lit),
-//         _ => todo!("{:?}", lit),
+//         rest => unimplemented!("{rest:?}"),
 //     }
 // }
 
@@ -293,7 +293,7 @@ fn write_class(_writer: &mut winmd::Writer, _namespace: &str, _name: &str, _memb
 //         "u32" => Ok(Value::U32(parse(lit, neg)?)),
 //         "i64" => Ok(Value::I64(parse(lit, neg)?)),
 //         "u64" => Ok(Value::U64(parse(lit, neg)?)),
-//         suffix => todo!("suffix {:?}", suffix),
+//         suffix => unimplemented!("suffix {:?}", suffix),
 //     }
 // }
 
@@ -302,7 +302,7 @@ fn syn_type(namespace: &str, ty: &syn::Type) -> winmd::Type {
         syn::Type::Path(ty) => syn_type_path(namespace, ty),
         syn::Type::Ptr(ptr) => syn_type_ptr(namespace, ptr),
         syn::Type::Array(array) => syn_type_array(namespace, array),
-        _ => unimplemented!(),
+        rest => unimplemented!("{rest:?}"),
     }
 }
 

--- a/crates/tools/riddle/src/idl/writer.rs
+++ b/crates/tools/riddle/src/idl/writer.rs
@@ -107,7 +107,7 @@ impl Writer {
         match meta {
             syn::Meta::Path(path) => self.path(path),
             syn::Meta::List(list) => self.meta_list(list),
-            rest => todo!("{:?}", rest),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 
@@ -209,7 +209,7 @@ impl Writer {
     fn pat(&mut self, pat: &syn::Pat) {
         match pat {
             syn::Pat::Ident(pat_ident) => self.pat_ident(pat_ident),
-            rest => todo!("{:?}", rest),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 
@@ -222,7 +222,7 @@ impl Writer {
             syn::Type::Path(ty) => self.type_path(ty),
             syn::Type::Ptr(ptr) => self.type_ptr(ptr),
             syn::Type::Array(array) => self.type_array(array),
-            _ => todo!("{:?}", ty),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 
@@ -238,7 +238,7 @@ impl Writer {
         match expr {
             syn::Expr::Lit(lit) => self.expr_lit(lit),
             syn::Expr::Unary(unary) => self.expr_unary(unary),
-            _ => todo!("{:?}", expr),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 

--- a/crates/tools/riddle/src/rust/constants.rs
+++ b/crates/tools/riddle/src/rust/constants.rs
@@ -135,7 +135,7 @@ fn constant(gen: &Gen, def: Field) -> Option<String> {
             let args = gen.reader.attribute_args(attribute);
             match &args[0].1 {
                 Value::String(value) => value.clone(),
-                _ => unimplemented!(),
+                rest => unimplemented!("{rest:?}"),
             }
         })
 }

--- a/crates/tools/riddle/src/rust/gen.rs
+++ b/crates/tools/riddle/src/rust/gen.rs
@@ -170,13 +170,13 @@ impl<'a> Gen<'a> {
             Type::WinrtArray(ty) => self.type_name(ty),
             Type::WinrtArrayRef(ty) => self.type_name(ty),
             Type::ConstRef(ty) => self.type_name(ty),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
     pub fn type_vtbl_name(&self, ty: &Type) -> TokenStream {
         match ty {
             Type::TypeDef(def, generics) => self.type_def_vtbl_name(*def, generics),
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
     pub fn type_abi_name(&self, ty: &Type) -> TokenStream {
@@ -538,7 +538,7 @@ impl<'a> Gen<'a> {
                 tokens.push('\"');
                 tokens.into()
             }
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
     pub fn typed_value(&self, value: &Value) -> TokenStream {
@@ -558,7 +558,7 @@ impl<'a> Gen<'a> {
             Value::String(_) => {
                 quote! { &str = #literal }
             }
-            _ => unimplemented!(),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 
@@ -652,7 +652,7 @@ impl<'a> Gen<'a> {
                 AsyncKind::OperationWithProgress => {
                     quote! { AsyncOperationWithProgressCompletedHandler }
                 }
-                _ => unimplemented!(),
+                rest => unimplemented!("{rest:?}"),
             };
 
             let namespace = self.namespace("Windows.Foundation");

--- a/crates/tools/riddle/src/rust/interfaces.rs
+++ b/crates/tools/riddle/src/rust/interfaces.rs
@@ -117,7 +117,7 @@ fn gen_win_interface(gen: &Gen, def: TypeDef) -> TokenStream {
                             ));
                         }
                     }
-                    _ => unimplemented!(),
+                    rest => unimplemented!("{rest:?}"),
                 }
 
                 bases -= 1;

--- a/crates/tools/riddle/src/winmd/to_winmd.rs
+++ b/crates/tools/riddle/src/winmd/to_winmd.rs
@@ -74,6 +74,6 @@ fn writer_type(reader: &metadata::Reader, ty: &metadata::Type) -> winmd::Type {
             name: reader.type_def_name(*def).to_string(),
             generics: generics.iter().map(|ty| writer_type(reader, ty)).collect(),
         }),
-        rest => todo!("{:?}", rest),
+        rest => unimplemented!("{rest:?}"),
     }
 }

--- a/crates/tools/riddle/src/winmd/writer/mod.rs
+++ b/crates/tools/riddle/src/winmd/writer/mod.rs
@@ -133,7 +133,7 @@ impl Writer {
     //             blob.extend_from_slice(value.as_bytes());
     //             blob
     //         }
-    //         _ => todo!("{:?}", value),
+    //         rest => unimplemented!("{rest:?}"),
     //     };
 
     //     self.blobs.insert(&blob)
@@ -309,7 +309,7 @@ impl Writer {
                 }
                 self.type_blob(ty, blob);
             }
-            _ => todo!("{:?}", ty),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 }


### PR DESCRIPTION
This update attempts to provide some basic debug information for unimplemented code paths and standardizes on `unimplemented` rather than `todo` for consistency. 