### PR TITLE
`windows-targets` 0.48.1

### DIFF
--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -16,7 +16,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies.windows-targets]
-version = "0.48.0"
+version = "0.48.1"
 path = "../targets"
 
 [features]

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -17,7 +17,7 @@ targets = []
 all-features = true
 
 [dependencies.windows-targets]
-version = "0.48.0"
+version = "0.48.1"
 path = "../targets"
 
 [features]

--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/targets/src/lib.rs
+++ b/crates/libs/targets/src/lib.rs
@@ -6,7 +6,6 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 
 #[cfg(all(windows_raw_dylib, target_arch = "x86"))]
 #[macro_export]
-#[doc(hidden)]
 macro_rules! link {
     ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim", import_name_type = "undecorated")]
@@ -20,7 +19,6 @@ macro_rules! link {
 
 #[cfg(all(windows_raw_dylib, not(target_arch = "x86")))]
 #[macro_export]
-#[doc(hidden)]
 macro_rules! link {
     ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim")]
@@ -34,7 +32,6 @@ macro_rules! link {
 
 #[cfg(all(windows, not(windows_raw_dylib)))]
 #[macro_export]
-#[doc(hidden)]
 macro_rules! link {
     ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = "windows.0.48.0")]
@@ -48,7 +45,6 @@ macro_rules! link {
 
 #[cfg(all(not(windows), not(windows_raw_dylib)))]
 #[macro_export]
-#[doc(hidden)]
 macro_rules! link {
     ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         extern $abi {

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -19,7 +19,7 @@ rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 windows-core = { path = "../core", version = "0.50.0" }
-windows-targets = { path = "../targets", version = "0.48.0" }
+windows-targets = { path = "../targets", version = "0.48.1" }
 windows-implement = { path = "../implement",  version = "0.48.0", optional = true }
 windows-interface = { path = "../interface",  version = "0.48.0", optional = true }
 


### PR DESCRIPTION
This is a semver-compatible update to the [windows-targets](https://crates.io/crates/windows-targets) crate to improve [gnullvm](https://doc.rust-lang.org/rustc/platform-support/pc-windows-gnullvm.html) compatibility by including #2515 as requested in #2557.

Other crates will not be updated at this time.
