### PR TITLE
Add CredEnumerate sample

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -41,6 +41,7 @@ jobs:
           cargo clippy -p sample_counter_sys &&
           cargo clippy -p sample_create_window &&
           cargo clippy -p sample_create_window_sys &&
+          cargo clippy -p sample_credentials &&
           cargo clippy -p sample_data_protection &&
           cargo clippy -p sample_dcomp &&
           cargo clippy -p sample_device_watcher &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,7 @@ jobs:
           cargo test -p sample_counter_sys &&
           cargo test -p sample_create_window &&
           cargo test -p sample_create_window_sys &&
+          cargo test -p sample_credentials &&
           cargo test -p sample_data_protection &&
           cargo test -p sample_dcomp &&
           cargo test -p sample_device_watcher &&
@@ -95,8 +96,8 @@ jobs:
           cargo test -p test_does_not_return &&
           cargo test -p test_enums &&
           cargo test -p test_error &&
-          cargo test -p test_event &&
           cargo clean &&
+          cargo test -p test_event &&
           cargo test -p test_extensions &&
           cargo test -p test_handles &&
           cargo test -p test_helpers &&

--- a/crates/samples/windows/credentials/Cargo.toml
+++ b/crates/samples/windows/credentials/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sample_credentials"
+version = "0.0.0"
+edition = "2018"
+publish = false
+
+[dependencies.windows]
+path = "../../../libs/windows"
+features = [
+    "Win32_Foundation",
+    "Win32_Security_Credentials"
+]

--- a/crates/samples/windows/credentials/src/main.rs
+++ b/crates/samples/windows/credentials/src/main.rs
@@ -1,0 +1,40 @@
+use windows::{
+    core::PCWSTR,
+    Win32::Security::Credentials::{
+        CredEnumerateW, CredFree, CREDENTIALW, CRED_ENUMERATE_ALL_CREDENTIALS,
+    },
+};
+
+fn main() -> windows::core::Result<()> {
+    let mut count = 0;
+    let mut credentials_ptr = std::ptr::null_mut();
+    unsafe {
+        CredEnumerateW(
+            PCWSTR::null(),
+            CRED_ENUMERATE_ALL_CREDENTIALS,
+            &mut count,
+            &mut credentials_ptr,
+        )?;
+
+        let credentials =
+            std::slice::from_raw_parts::<&CREDENTIALW>(credentials_ptr as _, count as usize);
+
+        for credential in credentials {
+            println!("/* CREDENTIALW */");
+            println!("Type: {:?}", credential.Type);
+            if !credential.TargetName.is_null() {
+                println!("Target: {}", credential.TargetName.display());
+            }
+            if !credential.UserName.is_null() {
+                println!("User name: {}", credential.UserName.display());
+            }
+            println!();
+        }
+    }
+
+    unsafe {
+        CredFree(std::mem::transmute(credentials_ptr));
+    }
+
+    Ok(())
+}

--- a/crates/samples/windows/credentials/src/main.rs
+++ b/crates/samples/windows/credentials/src/main.rs
@@ -1,5 +1,4 @@
 use windows::{
-    core::PCWSTR,
     Win32::Security::Credentials::{
         CredEnumerateW, CredFree, CREDENTIALW, CRED_ENUMERATE_ALL_CREDENTIALS,
     },
@@ -10,7 +9,7 @@ fn main() -> windows::core::Result<()> {
     let mut credentials_ptr = std::ptr::null_mut();
     unsafe {
         CredEnumerateW(
-            PCWSTR::null(),
+            None,
             CRED_ENUMERATE_ALL_CREDENTIALS,
             &mut count,
             &mut credentials_ptr,
@@ -30,9 +29,7 @@ fn main() -> windows::core::Result<()> {
             }
             println!();
         }
-    }
 
-    unsafe {
         CredFree(std::mem::transmute(credentials_ptr));
     }
 

--- a/crates/samples/windows/credentials/src/main.rs
+++ b/crates/samples/windows/credentials/src/main.rs
@@ -1,7 +1,5 @@
-use windows::{
-    Win32::Security::Credentials::{
-        CredEnumerateW, CredFree, CREDENTIALW, CRED_ENUMERATE_ALL_CREDENTIALS,
-    },
+use windows::Win32::Security::Credentials::{
+    CredEnumerateW, CredFree, CREDENTIALW, CRED_ENUMERATE_ALL_CREDENTIALS,
 };
 
 fn main() -> windows::core::Result<()> {


### PR DESCRIPTION
Demonstrates handling of the confusing pointer indirection needed to call `CredEnumerate` successfully.

See also: https://github.com/microsoft/windows-rs/issues/2555