### PR TITLE
Tweak riddle arguments

### DIFF
--- a/crates/tests/component/build.rs
+++ b/crates/tests/component/build.rs
@@ -31,14 +31,14 @@ fn main() {
         "--target-dir",
         "../../../target/test_component", // TODO: workaround for https://github.com/rust-lang/cargo/issues/6412
         "--",
-        "-in",
+        "--in",
         "component.winmd",
         &metadata_dir,
-        "-out",
+        "--out",
         "src/bindings.rs",
-        "-filter",
+        "--filter",
         "test_component",
-        "-config",
+        "--config",
         "IMPLEMENT",
     ]);
 

--- a/crates/tests/component_client/build.rs
+++ b/crates/tests/component_client/build.rs
@@ -8,12 +8,12 @@ fn main() {
         "--target-dir",
         "../../../target/test_component_client", // TODO: workaround for https://github.com/rust-lang/cargo/issues/6412
         "--",
-        "-in",
+        "--in",
         "../component/component.winmd",
         &format!("{}\\System32\\WinMetadata", env!("windir")),
-        "-out",
+        "--out",
         "src/bindings.rs",
-        "-filter",
+        "--filter",
         "test_component",
     ]);
 

--- a/crates/tests/riddle/src/lib.rs
+++ b/crates/tests/riddle/src/lib.rs
@@ -33,7 +33,7 @@ pub fn run_riddle(name: &str) -> Vec<windows_metadata::File> {
     let mut command = Command::new("cargo");
     command.args([
         "run", "-p", "riddle", "--", "--in", &idl, "--out", &rs, "--filter", "Test",
-    ]); // TODO: -config FLATTEN doesn't work for namespaces
+    ]); // TODO: --config FLATTEN doesn't work for namespaces
     assert!(command.status().unwrap().success());
 
     // Return winmd file for validation

--- a/crates/tests/riddle/src/lib.rs
+++ b/crates/tests/riddle/src/lib.rs
@@ -14,14 +14,14 @@ pub fn run_riddle(name: &str) -> Vec<windows_metadata::File> {
     // Convert .idl to .winmd
     let mut command = Command::new("cargo");
     command.args([
-        "run", "-p", "riddle", "--", "-in", &idl, "-out", &winmd, "-filter", "Test",
+        "run", "-p", "riddle", "--", "--in", &idl, "--out", &winmd, "--filter", "Test",
     ]);
     assert!(command.status().unwrap().success());
 
     // Convert .winmd back to .idl
     let mut command = Command::new("cargo");
     command.args([
-        "run", "-p", "riddle", "--", "-in", &winmd, "-out", &idl, "-filter", "Test",
+        "run", "-p", "riddle", "--", "--in", &winmd, "--out", &idl, "--filter", "Test",
     ]);
     assert!(command.status().unwrap().success());
 
@@ -32,7 +32,7 @@ pub fn run_riddle(name: &str) -> Vec<windows_metadata::File> {
     // Convert .idl to .rs
     let mut command = Command::new("cargo");
     command.args([
-        "run", "-p", "riddle", "--", "-in", &idl, "-out", &rs, "-filter", "Test",
+        "run", "-p", "riddle", "--", "--in", &idl, "--out", &rs, "--filter", "Test",
     ]); // TODO: -config FLATTEN doesn't work for namespaces
     assert!(command.status().unwrap().success());
 

--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -160,11 +160,11 @@ fn riddle(output: &str, filter: &[&str], config: &[&str]) {
         "--target-dir",
         "../../../target/test_standalone", // TODO: workaround for https://github.com/rust-lang/cargo/issues/6412
         "--",
-        "-in",
+        "--in",
         "../../libs/metadata/default",
-        "-out",
+        "--out",
         output,
-        "-filter",
+        "--filter",
     ]);
 
     command.args(filter);

--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -168,7 +168,7 @@ fn riddle(output: &str, filter: &[&str], config: &[&str]) {
     ]);
 
     command.args(filter);
-    command.arg("-config");
+    command.arg("--config");
     command.args(config);
 
     if !command.status().unwrap().success() {

--- a/crates/tools/core/bindings.txt
+++ b/crates/tools/core/bindings.txt
@@ -1,8 +1,8 @@
--in crates/libs/metadata/default
--out crates/libs/core/src/imp/bindings.rs
--config FLATTEN SYS MINIMAL
+--in crates/libs/metadata/default
+--out crates/libs/core/src/imp/bindings.rs
+--config FLATTEN SYS MINIMAL
 
--filter
+--filter
     Windows.Win32.Foundation.CloseHandle
     Windows.Win32.Foundation.ERROR_NO_UNICODE_TRANSLATION
     Windows.Win32.Foundation.GetLastError

--- a/crates/tools/core/com_bindings.txt
+++ b/crates/tools/core/com_bindings.txt
@@ -1,8 +1,8 @@
--in crates/libs/metadata/default
--out crates/libs/core/src/imp/com_bindings.rs
--config FLATTEN MINIMAL
+--in crates/libs/metadata/default
+--out crates/libs/core/src/imp/com_bindings.rs
+--config FLATTEN MINIMAL
 
--filter
+--filter
     Windows.Foundation.IReference
     Windows.Foundation.IStringable
     Windows.Foundation.PropertyValue

--- a/crates/tools/core/src/main.rs
+++ b/crates/tools/core/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-@",
+        "--etc",
         "crates/tools/core/bindings.txt",
     ]);
 
@@ -19,7 +19,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-@",
+        "--etc",
         "crates/tools/core/com_bindings.txt",
     ]);
 

--- a/crates/tools/core/src/main.rs
+++ b/crates/tools/core/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-etc",
+        "-@",
         "crates/tools/core/bindings.txt",
     ]);
 
@@ -19,7 +19,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-etc",
+        "-@",
         "crates/tools/core/com_bindings.txt",
     ]);
 

--- a/crates/tools/metadata/bindings.txt
+++ b/crates/tools/metadata/bindings.txt
@@ -1,8 +1,8 @@
--in crates/libs/metadata/default
--out crates/libs/metadata/src/imp/bindings.rs
--config FLATTEN SYS MINIMAL
+--in crates/libs/metadata/default
+--out crates/libs/metadata/src/imp/bindings.rs
+--config FLATTEN SYS MINIMAL
 
--filter
+--filter
     Windows.Win32.System.Diagnostics.Debug.IMAGE_COR20_HEADER
     Windows.Win32.System.Diagnostics.Debug.IMAGE_DIRECTORY_ENTRY_COM_DESCRIPTOR
     Windows.Win32.System.Diagnostics.Debug.IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE

--- a/crates/tools/metadata/src/main.rs
+++ b/crates/tools/metadata/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-@",
+        "--etc",
         "crates/tools/metadata/bindings.txt",
     ]);
 

--- a/crates/tools/metadata/src/main.rs
+++ b/crates/tools/metadata/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-etc",
+        "-@",
         "crates/tools/metadata/bindings.txt",
     ]);
 

--- a/crates/tools/riddle/src/args.rs
+++ b/crates/tools/riddle/src/args.rs
@@ -28,7 +28,7 @@ fn from_iter<T: Iterator<Item = String>>(result: &mut Vec<String>, args: T) -> R
             for args in crate::read_file_lines(&arg)? {
                 from_string(result, &args)?;
             }
-        } else if arg == "-etc" {
+        } else if arg == "-@" {
             expand = true;
         } else {
             result.push(arg);

--- a/crates/tools/riddle/src/args.rs
+++ b/crates/tools/riddle/src/args.rs
@@ -28,7 +28,7 @@ fn from_iter<T: Iterator<Item = String>>(result: &mut Vec<String>, args: T) -> R
             for args in crate::read_file_lines(&arg)? {
                 from_string(result, &args)?;
             }
-        } else if arg == "-@" {
+        } else if arg == "--etc" {
             expand = true;
         } else {
             result.push(arg);

--- a/crates/tools/riddle/src/main.rs
+++ b/crates/tools/riddle/src/main.rs
@@ -33,12 +33,12 @@ fn run() -> Result<()> {
             r#"Usage: riddle.exe [options...]
 
 Options:
-  -in     <path>       Path to files and directories containing .winmd and .idl files
-  -out    <path>       Path to .winmd or .idl file to generate
-  -filter <namespace>  Namespaces to include or !exclude in output
-  -format              Format .idl files only
-  -config <key=value>  Override a configuration value
-  -etc    <path>       File containing command line options
+  -i,--in  <path>          Path to files and directories containing .winmd and .idl files
+  -o,--out <path>          Path to .winmd, .idl, or .rs file to generate
+  -f,--filter <namespace>  Namespaces to include or !exclude in output
+  -c,--config <key=value>  Override a configuration value
+  --format                 Format .idl files only
+  -@ <path>                File containing command line options
 "#
         );
         return Ok(());
@@ -59,11 +59,14 @@ Options:
 
         match kind {
             ArgKind::None => match arg.as_str() {
-                "-in" => kind = ArgKind::Input,
-                "-out" => kind = ArgKind::Output,
-                "-filter" => kind = ArgKind::Filter,
-                "-config" => kind = ArgKind::Config,
-                "-format" => format = true,
+                "--in" => kind = ArgKind::Input,
+                "-i" => kind = ArgKind::Input,
+                "--out" => kind = ArgKind::Output,
+                "-o" => kind = ArgKind::Output,
+                "--filter" => kind = ArgKind::Filter,
+                "-c" => kind = ArgKind::Config,
+                "--config" => kind = ArgKind::Config,
+                "--format" => format = true,
                 _ => return Err(Error::new(&format!("invalid option `{arg}`"))),
             },
             ArgKind::Output => {
@@ -94,7 +97,7 @@ Options:
     if format {
         if output.is_some() || !include.is_empty() || !exclude.is_empty() {
             return Err(Error::new(
-                "-format cannot be combined with -output, -include, or -exclude",
+                "--format cannot be combined with --out or --filter",
             ));
         }
 

--- a/crates/tools/riddle/src/main.rs
+++ b/crates/tools/riddle/src/main.rs
@@ -33,12 +33,12 @@ fn run() -> Result<()> {
             r#"Usage: riddle.exe [options...]
 
 Options:
-  -i,--in  <path>          Path to files and directories containing .winmd and .idl files
-  -o,--out <path>          Path to .winmd, .idl, or .rs file to generate
-  -f,--filter <namespace>  Namespaces to include or !exclude in output
-  -c,--config <key=value>  Override a configuration value
-  --format                 Format .idl files only
-  -@ <path>                File containing command line options
+  --in  <path>          Path to files and directories containing .winmd and .idl files
+  --out <path>          Path to .winmd, .idl, or .rs file to generate
+  --filter <namespace>  Namespaces to include or !exclude in output
+  --config <key=value>  Override a configuration value
+  --format              Format .idl files only
+  --etc <path>          File containing command line options
 "#
         );
         return Ok(());
@@ -60,11 +60,8 @@ Options:
         match kind {
             ArgKind::None => match arg.as_str() {
                 "--in" => kind = ArgKind::Input,
-                "-i" => kind = ArgKind::Input,
                 "--out" => kind = ArgKind::Output,
-                "-o" => kind = ArgKind::Output,
                 "--filter" => kind = ArgKind::Filter,
-                "-c" => kind = ArgKind::Config,
                 "--config" => kind = ArgKind::Config,
                 "--format" => format = true,
                 _ => return Err(Error::new(&format!("invalid option `{arg}`"))),

--- a/crates/tools/sys/bindings.txt
+++ b/crates/tools/sys/bindings.txt
@@ -1,8 +1,8 @@
--in crates/libs/metadata/default
--out crates/libs/sys/src/lib.rs
--config PACKAGE SYS
+--in crates/libs/metadata/default
+--out crates/libs/sys/src/lib.rs
+--config PACKAGE SYS
 
--filter
+--filter
     Windows.Win32
     Windows.Wdk
     !Windows.AI

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-@",
+        "--etc",
         "crates/tools/sys/bindings.txt",
     ]);
 

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-etc",
+        "-@",
         "crates/tools/sys/bindings.txt",
     ]);
 

--- a/crates/tools/windows/bindings.txt
+++ b/crates/tools/windows/bindings.txt
@@ -1,8 +1,8 @@
--in crates/libs/metadata/default
--out crates/libs/windows/src/lib.rs
--config PACKAGE
+--in crates/libs/metadata/default
+--out crates/libs/windows/src/lib.rs
+--config PACKAGE
 
--filter
+--filter
     Windows
     !Windows.AI.MachineLearning.Preview
     !Windows.ApplicationModel.SocialInfo

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-@",
+        "--etc",
         "crates/tools/windows/bindings.txt",
     ]);
 

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -6,7 +6,7 @@ fn main() {
         "-p",
         "riddle",
         "--",
-        "-etc",
+        "-@",
         "crates/tools/windows/bindings.txt",
     ]);
 


### PR DESCRIPTION
Aligns `riddle` long form arguments with experiences found in other command line tooling.

Some prior art on short/long arg syntax:
* https://www.gnu.org/software/libc/manual/html_node/Argument-Syntax.html
* https://docs.rs/clap/latest/clap/