### PR TITLE
`AsImpl::as_impl` should be unsafe

### DIFF
--- a/crates/libs/core/src/as_impl.rs
+++ b/crates/libs/core/src/as_impl.rs
@@ -2,5 +2,9 @@
 ///
 /// This trait is automatically implemented when using the `implement` macro.
 pub trait AsImpl<T> {
-    fn as_impl(&self) -> &T;
+    /// # Safety
+    ///
+    /// The caller needs to ensure that `self` is actually implemented by the
+    /// implementation `T`.
+    unsafe fn as_impl(&self) -> &T;
 }

--- a/crates/libs/core/src/imp/weak_ref_count.rs
+++ b/crates/libs/core/src/imp/weak_ref_count.rs
@@ -1,3 +1,6 @@
+// TODO: looks like a bug in nightly clippy as the suggestion is invalid.
+#![allow(clippy::unnecessary_cast)]
+
 use super::*;
 use crate::ComInterface;
 use std::sync::atomic::{AtomicIsize, Ordering};

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -64,7 +64,7 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
                 }
             }
             impl #generics ::windows::core::AsImpl<#original_ident::#generics> for #interface_ident where #constraints {
-                fn as_impl(&self) -> &#original_ident::#generics {
+                unsafe fn as_impl(&self) -> &#original_ident::#generics {
                     let this = ::windows::core::Interface::as_raw(self);
                     // SAFETY: the offset is guranteed to be in bounds, and the implementation struct
                     // is guaranteed to live at least as long as `self`.

--- a/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
@@ -761,7 +761,7 @@ where
     <T as ::windows_core::Type<T>>::Default: ::std::clone::Clone,
 {
     fn Current(&self) -> ::windows_core::Result<T> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if owner.values.len() > current {
@@ -772,14 +772,14 @@ where
     }
 
     fn HasCurrent(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         Ok(owner.values.len() > current)
     }
 
     fn MoveNext(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if current < owner.values.len() {
@@ -790,7 +790,7 @@ where
     }
 
     fn GetMany(&self, values: &mut [T::Default]) -> ::windows_core::Result<u32> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         let actual = std::cmp::min(owner.values.len() - current, values.len());
@@ -1034,7 +1034,7 @@ where
     <T as ::windows_core::Type<T>>::Default: std::clone::Clone + std::cmp::PartialEq,
 {
     fn Current(&self) -> ::windows_core::Result<T> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if owner.values.len() > current {
@@ -1045,14 +1045,14 @@ where
     }
 
     fn HasCurrent(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         Ok(owner.values.len() > current)
     }
 
     fn MoveNext(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if current < owner.values.len() {
@@ -1063,7 +1063,7 @@ where
     }
 
     fn GetMany(&self, values: &mut [T::Default]) -> ::windows_core::Result<u32> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         let actual = std::cmp::min(owner.values.len() - current, values.len());

--- a/crates/tools/riddle/src/idl/mod.rs
+++ b/crates/tools/riddle/src/idl/mod.rs
@@ -234,10 +234,7 @@ impl Struct {
         let mut fields = vec![];
 
         let syn::Fields::Named(named) = item.fields else {
-            return Err(syn::Error::new(
-                item.span(),
-                "unnamed fields not supported",
-            ));
+            return Err(syn::Error::new(item.span(), "unnamed fields not supported"));
         };
 
         for field in named.named {

--- a/crates/tools/riddle/src/main.rs
+++ b/crates/tools/riddle/src/main.rs
@@ -277,7 +277,7 @@ fn canonicalize(path: &str) -> Result<String> {
 
     let path = path
         .to_string_lossy()
-        .trim_start_matches(r#"\\?\"#)
+        .trim_start_matches(r"\\?\")
         .to_string();
 
     match path.rsplit_once('.') {

--- a/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/Iterable.rs
+++ b/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/Iterable.rs
@@ -41,7 +41,7 @@ where
     <T as ::windows_core::Type<T>>::Default: ::std::clone::Clone,
 {
     fn Current(&self) -> ::windows_core::Result<T> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if owner.values.len() > current {
@@ -52,14 +52,14 @@ where
     }
 
     fn HasCurrent(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         Ok(owner.values.len() > current)
     }
 
     fn MoveNext(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if current < owner.values.len() {
@@ -71,7 +71,7 @@ where
     }
 
     fn GetMany(&self, values: &mut [T::Default]) -> ::windows_core::Result<u32> {
-        let owner: &StockIterable<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockIterable<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         let actual = std::cmp::min(owner.values.len() - current, values.len());

--- a/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/VectorView.rs
+++ b/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/VectorView.rs
@@ -77,7 +77,7 @@ where
     <T as ::windows_core::Type<T>>::Default: std::clone::Clone + std::cmp::PartialEq,
 {
     fn Current(&self) -> ::windows_core::Result<T> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if owner.values.len() > current {
@@ -88,14 +88,14 @@ where
     }
 
     fn HasCurrent(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         Ok(owner.values.len() > current)
     }
 
     fn MoveNext(&self) -> ::windows_core::Result<bool> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         if current < owner.values.len() {
@@ -107,7 +107,7 @@ where
     }
 
     fn GetMany(&self, values: &mut [T::Default]) -> ::windows_core::Result<u32> {
-        let owner: &StockVectorView<T> = ::windows_core::AsImpl::as_impl(&self.owner);
+        let owner: &StockVectorView<T> = unsafe { ::windows_core::AsImpl::as_impl(&self.owner) };
         let current = self.current.load(::std::sync::atomic::Ordering::Relaxed);
 
         let actual = std::cmp::min(owner.values.len() - current, values.len());

--- a/crates/tools/riddle/src/rust/try_format.rs
+++ b/crates/tools/riddle/src/rust/try_format.rs
@@ -16,7 +16,12 @@ pub fn try_format(writer: &super::Writer, tokens: &str) -> String {
 {allow}{tokens}"#
     );
 
-    let Ok(mut child) = std::process::Command::new("rustfmt").stdin(std::process::Stdio::piped()).stdout(std::process::Stdio::piped()).stderr(std::process::Stdio::null()).spawn() else {
+    let Ok(mut child) = std::process::Command::new("rustfmt")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .spawn()
+    else {
         return tokens;
     };
 


### PR DESCRIPTION
Fixes: #2498
