### PR TITLE
Prefer explicit casts 

### DIFF
--- a/crates/libs/core/src/event.rs
+++ b/crates/libs/core/src/event.rs
@@ -248,8 +248,8 @@ impl<T: ComInterface> Delegate<T> {
     fn to_token(&self) -> i64 {
         unsafe {
             match self {
-                Self::Direct(delegate) => crate::imp::EncodePointer(std::mem::transmute_copy(delegate)) as _,
-                Self::Indirect(delegate) => crate::imp::EncodePointer(std::mem::transmute_copy(delegate)) as _,
+                Self::Direct(delegate) => crate::imp::EncodePointer(std::mem::transmute_copy(delegate)) as i64,
+                Self::Indirect(delegate) => crate::imp::EncodePointer(std::mem::transmute_copy(delegate)) as i64,
             }
         }
     }

--- a/crates/libs/core/src/hresult.rs
+++ b/crates/libs/core/src/hresult.rs
@@ -85,7 +85,7 @@ impl HRESULT {
         let mut message = HeapString(std::ptr::null_mut());
 
         unsafe {
-            let size = crate::imp::FormatMessageW(crate::imp::FORMAT_MESSAGE_ALLOCATE_BUFFER | crate::imp::FORMAT_MESSAGE_FROM_SYSTEM | crate::imp::FORMAT_MESSAGE_IGNORE_INSERTS, std::ptr::null(), self.0 as _, 0, &mut message.0 as *mut _ as *mut _, 0, std::ptr::null());
+            let size = crate::imp::FormatMessageW(crate::imp::FORMAT_MESSAGE_ALLOCATE_BUFFER | crate::imp::FORMAT_MESSAGE_FROM_SYSTEM | crate::imp::FORMAT_MESSAGE_IGNORE_INSERTS, std::ptr::null(), self.0 as u32, 0, &mut message.0 as *mut _ as *mut _, 0, std::ptr::null());
 
             HSTRING::from_wide(crate::imp::wide_trim_end(std::slice::from_raw_parts(message.0 as *const u16, size as usize))).unwrap_or_default()
         }
@@ -93,7 +93,7 @@ impl HRESULT {
 
     /// Maps a Win32 error code to an HRESULT value.
     pub(crate) fn from_win32(error: u32) -> Self {
-        Self(if error == 0 { 0 } else { (error & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
+        Self(if error == 0 { 0 } else { (error & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as i32)
     }
 }
 

--- a/crates/libs/core/src/imp/ref_count.rs
+++ b/crates/libs/core/src/imp/ref_count.rs
@@ -8,7 +8,7 @@ pub struct RefCount(pub(crate) AtomicI32);
 impl RefCount {
     /// Creates a new `RefCount` with an initial value of `1`.
     pub fn new(count: u32) -> Self {
-        Self(AtomicI32::new(count as _))
+        Self(AtomicI32::new(count as i32))
     }
 
     /// Increments the reference count, returning the new value.

--- a/crates/libs/core/src/strings/bstr.rs
+++ b/crates/libs/core/src/strings/bstr.rs
@@ -42,7 +42,7 @@ impl BSTR {
             return Ok(Self::new());
         }
 
-        let result = unsafe { Self(crate::imp::SysAllocStringLen(value.as_ptr(), value.len() as _)) };
+        let result = unsafe { Self(crate::imp::SysAllocStringLen(value.as_ptr(), value.len() as u32)) };
 
         if result.is_empty() {
             Err(crate::imp::E_OUTOFMEMORY.into())

--- a/crates/libs/metadata/src/blob.rs
+++ b/crates/libs/metadata/src/blob.rs
@@ -48,7 +48,7 @@ impl<'a> Blob<'a> {
         let mut mods = vec![];
         loop {
             let (value, offset) = self.peek_usize();
-            if value != ELEMENT_TYPE_CMOD_OPT as _ && value != ELEMENT_TYPE_CMOD_REQD as _ {
+            if value != ELEMENT_TYPE_CMOD_OPT as usize && value != ELEMENT_TYPE_CMOD_REQD as usize {
                 break;
             } else {
                 self.offset(offset);

--- a/crates/libs/metadata/src/codes.rs
+++ b/crates/libs/metadata/src/codes.rs
@@ -32,7 +32,7 @@ pub enum HasAttribute {
 
 impl HasAttribute {
     pub fn encode(&self) -> usize {
-        (match self {
+        match self {
             Self::MethodDef(row) => (row.0.row + 1) << 5,
             Self::Field(row) => ((row.0.row + 1) << 5) | 1,
             Self::TypeRef(row) => ((row.0.row + 1) << 5) | 2,
@@ -42,7 +42,7 @@ impl HasAttribute {
             Self::MemberRef(row) => ((row.0.row + 1) << 5) | 6,
             Self::TypeSpec(row) => ((row.0.row + 1) << 5) | 13,
             Self::GenericParam(row) => ((row.0.row + 1) << 5) | 19,
-        }) as _
+        }
     }
 }
 
@@ -53,9 +53,9 @@ pub enum HasConstant {
 
 impl HasConstant {
     pub fn encode(&self) -> usize {
-        (match self {
+        match self {
             Self::Field(row) => (row.0.row + 1) << 2,
-        }) as _
+        }
     }
 }
 
@@ -66,9 +66,9 @@ pub enum MemberForwarded {
 
 impl MemberForwarded {
     pub fn encode(&self) -> usize {
-        (match self {
+        match self {
             Self::MethodDef(value) => ((value.0.row + 1) << 1) | 1,
-        }) as _
+        }
     }
 }
 
@@ -111,9 +111,9 @@ pub enum TypeOrMethodDef {
 
 impl TypeOrMethodDef {
     pub fn encode(&self) -> usize {
-        (match self {
+        match self {
             Self::TypeDef(value) => (value.0.row + 1) << 1,
-        }) as _
+        }
     }
 }
 

--- a/crates/libs/metadata/src/file/mod.rs
+++ b/crates/libs/metadata/src/file/mod.rs
@@ -26,7 +26,7 @@ impl File {
 
         let dos = result.bytes.view_as::<IMAGE_DOS_HEADER>(0)?;
 
-        if dos.e_magic != IMAGE_DOS_SIGNATURE as _ || result.bytes.copy_as::<u32>(dos.e_lfanew as _)? != IMAGE_NT_SIGNATURE {
+        if dos.e_magic != IMAGE_DOS_SIGNATURE || result.bytes.copy_as::<u32>(dos.e_lfanew as usize)? != IMAGE_NT_SIGNATURE {
             return Err(());
         }
 
@@ -47,14 +47,14 @@ impl File {
             _ => return Err(()),
         };
 
-        let clr = result.bytes.view_as::<IMAGE_COR20_HEADER>(offset_from_rva(section_from_rva(sections, com_virtual_address)?, com_virtual_address) as _)?;
+        let clr = result.bytes.view_as::<IMAGE_COR20_HEADER>(offset_from_rva(section_from_rva(sections, com_virtual_address)?, com_virtual_address))?;
 
-        if clr.cb != std::mem::size_of::<IMAGE_COR20_HEADER>() as _ {
+        if clr.cb != std::mem::size_of::<IMAGE_COR20_HEADER>() as u32 {
             return Err(());
         }
 
         let metadata_offset = offset_from_rva(section_from_rva(sections, clr.MetaData.VirtualAddress)?, clr.MetaData.VirtualAddress);
-        let metadata = result.bytes.view_as::<METADATA_HEADER>(metadata_offset as _)?;
+        let metadata = result.bytes.view_as::<METADATA_HEADER>(metadata_offset)?;
 
         if metadata.signature != METADATA_SIGNATURE {
             return Err(());
@@ -119,7 +119,7 @@ impl File {
                 continue;
             }
 
-            let len = result.bytes.copy_as::<u32>(view)? as _;
+            let len = result.bytes.copy_as::<u32>(view)? as usize;
             view += 4;
 
             match i {

--- a/crates/libs/metadata/src/file/reader.rs
+++ b/crates/libs/metadata/src/file/reader.rs
@@ -6,7 +6,7 @@ pub trait RowReader<'a> {
     fn row_usize<R: AsRow>(&self, row: R, column: usize) -> usize {
         let file = self.row_file(row);
         let row = row.to_row();
-        file.usize(row.row as _, R::TABLE as _, column)
+        file.usize(row.row, R::TABLE, column)
     }
 
     fn row_str<R: AsRow>(&self, row: R, column: usize) -> &'a str {
@@ -148,7 +148,7 @@ pub trait RowReader<'a> {
     //
 
     fn field_flags(&self, row: Field) -> FieldAttributes {
-        FieldAttributes(self.row_usize(row, 0) as _)
+        FieldAttributes(self.row_usize(row, 0) as u16)
     }
 
     fn field_name(&self, row: Field) -> &'a str {
@@ -216,7 +216,7 @@ pub trait RowReader<'a> {
     }
 
     fn method_def_flags(&self, row: MethodDef) -> MethodAttributes {
-        MethodAttributes(self.row_usize(row, 2) as _)
+        MethodAttributes(self.row_usize(row, 2) as u16)
     }
 
     fn method_def_name(&self, row: MethodDef) -> &'a str {
@@ -269,7 +269,7 @@ pub trait RowReader<'a> {
     //
 
     fn param_flags(&self, row: Param) -> ParamAttributes {
-        ParamAttributes(self.row_usize(row, 0) as _)
+        ParamAttributes(self.row_usize(row, 0) as u16)
     }
 
     fn param_sequence(&self, row: Param) -> usize {
@@ -289,7 +289,7 @@ pub trait RowReader<'a> {
     //
 
     fn type_def_flags(&self, row: TypeDef) -> TypeAttributes {
-        TypeAttributes(self.row_usize(row, 0) as _)
+        TypeAttributes(self.row_usize(row, 0) as u32)
     }
 
     fn type_def_name(&self, row: TypeDef) -> &'a str {
@@ -324,15 +324,15 @@ pub trait RowReader<'a> {
     }
 
     fn type_def_interface_impls(&self, row: TypeDef) -> RowIterator<InterfaceImpl> {
-        self.row_equal_range(row, 0, (row.0.row + 1) as _)
+        self.row_equal_range(row, 0, row.0.row + 1)
     }
 
     fn type_def_enclosing_type(&self, row: TypeDef) -> Option<TypeDef> {
-        self.row_equal_range::<TypeDef, NestedClass>(row, 0, (row.0.row + 1) as _).next().map(|row| TypeDef(Row::new(self.row_usize(row, 1) - 1, row.file())))
+        self.row_equal_range::<TypeDef, NestedClass>(row, 0, row.0.row + 1).next().map(|row| TypeDef(Row::new(self.row_usize(row, 1) - 1, row.file())))
     }
 
     fn type_def_class_layout(&self, row: TypeDef) -> Option<ClassLayout> {
-        self.row_equal_range(row, 2, (row.0.row + 1) as _).next()
+        self.row_equal_range(row, 2, row.0.row + 1).next()
     }
 
     fn type_def_is_scoped(&self, row: TypeDef) -> bool {

--- a/crates/libs/metadata/src/row.rs
+++ b/crates/libs/metadata/src/row.rs
@@ -6,7 +6,7 @@ pub struct Row {
 
 impl Row {
     pub fn new(row: usize, file: usize) -> Self {
-        Self { row: row as _, file: file as _ }
+        Self { row, file }
     }
 
     fn next(&self) -> Self {
@@ -48,7 +48,7 @@ impl<R: AsRow> Iterator for RowIterator<R> {
     type Item = R;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.rows.next().map(|row| R::from_row(Row::new(row, self.file as _)))
+        self.rows.next().map(|row| R::from_row(Row::new(row, self.file)))
     }
 }
 

--- a/crates/libs/metadata/src/type.rs
+++ b/crates/libs/metadata/src/type.rs
@@ -44,7 +44,7 @@ impl Type {
     /// Creates a `Type` object from an `ELEMENT_TYPE` (see ECMA-335) type constant, typically
     /// used to indicate the type of a constant or primitive type signature.
     pub fn from_code(code: usize) -> Option<Self> {
-        match code as _ {
+        match code as u8 {
             ELEMENT_TYPE_VOID => Some(Self::Void),
             ELEMENT_TYPE_BOOLEAN => Some(Self::Bool),
             ELEMENT_TYPE_CHAR => Some(Self::Char),

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/impl.rs
@@ -63,12 +63,12 @@ impl II2cDeviceProvider_Vtbl {
         unsafe extern "system" fn Write<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: II2cDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer_array_size: u32, buffer: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Write(::core::slice::from_raw_parts(::core::mem::transmute_copy(&buffer), buffer_array_size as _)).into()
+            this.Write(::core::slice::from_raw_parts(::core::mem::transmute_copy(&buffer), buffer_array_size as usize)).into()
         }
         unsafe extern "system" fn WritePartial<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: II2cDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer_array_size: u32, buffer: *const u8, result__: *mut ProviderI2cTransferResult) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.WritePartial(::core::slice::from_raw_parts(::core::mem::transmute_copy(&buffer), buffer_array_size as _)) {
+            match this.WritePartial(::core::slice::from_raw_parts(::core::mem::transmute_copy(&buffer), buffer_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::windows_core::HRESULT(0)
@@ -79,12 +79,12 @@ impl II2cDeviceProvider_Vtbl {
         unsafe extern "system" fn Read<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: II2cDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer_array_size: u32, buffer: *mut u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Read(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&buffer), buffer_array_size as _)).into()
+            this.Read(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&buffer), buffer_array_size as usize)).into()
         }
         unsafe extern "system" fn ReadPartial<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: II2cDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer_array_size: u32, buffer: *mut u8, result__: *mut ProviderI2cTransferResult) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.ReadPartial(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&buffer), buffer_array_size as _)) {
+            match this.ReadPartial(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&buffer), buffer_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::windows_core::HRESULT(0)
@@ -95,12 +95,12 @@ impl II2cDeviceProvider_Vtbl {
         unsafe extern "system" fn WriteRead<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: II2cDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, writeBuffer_array_size: u32, writebuffer: *const u8, readBuffer_array_size: u32, readbuffer: *mut u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.WriteRead(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as _), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as _)).into()
+            this.WriteRead(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as usize), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as usize)).into()
         }
         unsafe extern "system" fn WriteReadPartial<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: II2cDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, writeBuffer_array_size: u32, writebuffer: *const u8, readBuffer_array_size: u32, readbuffer: *mut u8, result__: *mut ProviderI2cTransferResult) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.WriteReadPartial(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as _), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as _)) {
+            match this.WriteReadPartial(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as usize), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::windows_core::HRESULT(0)

--- a/crates/libs/windows/src/Windows/Devices/Sms/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/impl.rs
@@ -47,7 +47,7 @@ impl ISmsBinaryMessage_Vtbl {
         unsafe extern "system" fn SetData<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISmsBinaryMessage_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.SetData(::core::slice::from_raw_parts(::core::mem::transmute_copy(&value), value_array_size as _)).into()
+            this.SetData(::core::slice::from_raw_parts(::core::mem::transmute_copy(&value), value_array_size as usize)).into()
         }
         Self {
             base__: ::windows_core::IInspectable_Vtbl::new::<Identity, ISmsBinaryMessage, OFFSET>(),

--- a/crates/libs/windows/src/Windows/Devices/Spi/Provider/impl.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/Provider/impl.rs
@@ -74,22 +74,22 @@ impl ISpiDeviceProvider_Vtbl {
         unsafe extern "system" fn Write<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISpiDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer_array_size: u32, buffer: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Write(::core::slice::from_raw_parts(::core::mem::transmute_copy(&buffer), buffer_array_size as _)).into()
+            this.Write(::core::slice::from_raw_parts(::core::mem::transmute_copy(&buffer), buffer_array_size as usize)).into()
         }
         unsafe extern "system" fn Read<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISpiDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer_array_size: u32, buffer: *mut u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Read(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&buffer), buffer_array_size as _)).into()
+            this.Read(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&buffer), buffer_array_size as usize)).into()
         }
         unsafe extern "system" fn TransferSequential<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISpiDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, writeBuffer_array_size: u32, writebuffer: *const u8, readBuffer_array_size: u32, readbuffer: *mut u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.TransferSequential(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as _), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as _)).into()
+            this.TransferSequential(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as usize), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as usize)).into()
         }
         unsafe extern "system" fn TransferFullDuplex<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISpiDeviceProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, writeBuffer_array_size: u32, writebuffer: *const u8, readBuffer_array_size: u32, readbuffer: *mut u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.TransferFullDuplex(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as _), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as _)).into()
+            this.TransferFullDuplex(::core::slice::from_raw_parts(::core::mem::transmute_copy(&writebuffer), writeBuffer_array_size as usize), ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&readbuffer), readBuffer_array_size as usize)).into()
         }
         Self {
             base__: ::windows_core::IInspectable_Vtbl::new::<Identity, ISpiDeviceProvider, OFFSET>(),

--- a/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/impl.rs
@@ -86,7 +86,7 @@ impl<T: ::windows_core::RuntimeType + 'static> IIterator_Vtbl<T> {
         unsafe extern "system" fn GetMany<T: ::windows_core::RuntimeType + 'static, Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IIterator_Impl<T>, const OFFSET: isize>(this: *mut ::core::ffi::c_void, items_array_size: u32, items: *mut ::windows_core::AbiType<T>, result__: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.GetMany(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as _)) {
+            match this.GetMany(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::windows_core::HRESULT(0)
@@ -573,7 +573,7 @@ impl<T: ::windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
         unsafe extern "system" fn GetMany<T: ::windows_core::RuntimeType + 'static, Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IVector_Impl<T>, const OFFSET: isize>(this: *mut ::core::ffi::c_void, startindex: u32, items_array_size: u32, items: *mut ::windows_core::AbiType<T>, result__: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.GetMany(startindex, ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as _)) {
+            match this.GetMany(startindex, ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::windows_core::HRESULT(0)
@@ -584,7 +584,7 @@ impl<T: ::windows_core::RuntimeType + 'static> IVector_Vtbl<T> {
         unsafe extern "system" fn ReplaceAll<T: ::windows_core::RuntimeType + 'static, Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IVector_Impl<T>, const OFFSET: isize>(this: *mut ::core::ffi::c_void, items_array_size: u32, items: *const ::windows_core::AbiType<T>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.ReplaceAll(::core::slice::from_raw_parts(::core::mem::transmute_copy(&items), items_array_size as _)).into()
+            this.ReplaceAll(::core::slice::from_raw_parts(::core::mem::transmute_copy(&items), items_array_size as usize)).into()
         }
         Self {
             base__: ::windows_core::IInspectable_Vtbl::new::<Identity, IVector<T>, OFFSET>(),
@@ -701,7 +701,7 @@ impl<T: ::windows_core::RuntimeType + 'static> IVectorView_Vtbl<T> {
         unsafe extern "system" fn GetMany<T: ::windows_core::RuntimeType + 'static, Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IVectorView_Impl<T>, const OFFSET: isize>(this: *mut ::core::ffi::c_void, startindex: u32, items_array_size: u32, items: *mut ::windows_core::AbiType<T>, result__: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.GetMany(startindex, ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as _)) {
+            match this.GetMany(startindex, ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&items), items_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::windows_core::HRESULT(0)
@@ -797,7 +797,7 @@ where
         let (values, _) = values.split_at_mut(actual);
         values.clone_from_slice(&owner.values[current..current + actual]);
         self.current.fetch_add(actual, ::std::sync::atomic::Ordering::Relaxed);
-        Ok(actual as _)
+        Ok(actual as u32)
     }
 }
 
@@ -851,7 +851,7 @@ where
         V::from_default(value)
     }
     fn Size(&self) -> ::windows_core::Result<u32> {
-        Ok(self.map.len() as _)
+        Ok(self.map.len() as u32)
     }
     fn HasKey(&self, key: &K::Default) -> ::windows_core::Result<bool> {
         Ok(self.map.contains_key(key))
@@ -918,7 +918,7 @@ where
             }
         }
 
-        Ok(actual as _)
+        Ok(actual)
     }
 }
 
@@ -995,12 +995,12 @@ where
         T::from_default(item)
     }
     fn Size(&self) -> ::windows_core::Result<u32> {
-        Ok(self.values.len() as _)
+        Ok(self.values.len() as u32)
     }
     fn IndexOf(&self, value: &T::Default, result: &mut u32) -> ::windows_core::Result<bool> {
         match self.values.iter().position(|element| element == value) {
             Some(index) => {
-                *result = index as _;
+                *result = index as u32;
                 Ok(true)
             }
             None => Ok(false),
@@ -1014,7 +1014,7 @@ where
         let actual = std::cmp::min(self.values.len() - current, values.len());
         let (values, _) = values.split_at_mut(actual);
         values.clone_from_slice(&self.values[current..current + actual]);
-        Ok(actual as _)
+        Ok(actual as u32)
     }
 }
 
@@ -1070,7 +1070,7 @@ where
         let (values, _) = values.split_at_mut(actual);
         values.clone_from_slice(&owner.values[current..current + actual]);
         self.current.fetch_add(actual, ::std::sync::atomic::Ordering::Relaxed);
-        Ok(actual as _)
+        Ok(actual as u32)
     }
 }
 

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/impl.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/impl.rs
@@ -173,7 +173,7 @@ impl IGipGameControllerInputSink_Vtbl {
         unsafe extern "system" fn OnMessageReceived<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGipGameControllerInputSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, timestamp: u64, messageclass: GipMessageClass, messageid: u8, sequenceid: u8, messageBuffer_array_size: u32, messagebuffer: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.OnMessageReceived(timestamp, messageclass, messageid, sequenceid, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&messagebuffer), messageBuffer_array_size as _)).into()
+            this.OnMessageReceived(timestamp, messageclass, messageid, sequenceid, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&messagebuffer), messageBuffer_array_size as usize)).into()
         }
         Self {
             base__: ::windows_core::IInspectable_Vtbl::new::<Identity, IGipGameControllerInputSink, OFFSET>(),
@@ -197,7 +197,7 @@ impl IHidGameControllerInputSink_Vtbl {
         unsafe extern "system" fn OnInputReportReceived<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IHidGameControllerInputSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, timestamp: u64, reportid: u8, reportBuffer_array_size: u32, reportbuffer: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.OnInputReportReceived(timestamp, reportid, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&reportbuffer), reportBuffer_array_size as _)).into()
+            this.OnInputReportReceived(timestamp, reportid, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&reportbuffer), reportBuffer_array_size as usize)).into()
         }
         Self {
             base__: ::windows_core::IInspectable_Vtbl::new::<Identity, IHidGameControllerInputSink, OFFSET>(),
@@ -220,7 +220,7 @@ impl IXusbGameControllerInputSink_Vtbl {
         unsafe extern "system" fn OnInputReceived<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IXusbGameControllerInputSink_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, timestamp: u64, reportid: u8, inputBuffer_array_size: u32, inputbuffer: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.OnInputReceived(timestamp, reportid, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&inputbuffer), inputBuffer_array_size as _)).into()
+            this.OnInputReceived(timestamp, reportid, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&inputbuffer), inputBuffer_array_size as usize)).into()
         }
         Self {
             base__: ::windows_core::IInspectable_Vtbl::new::<Identity, IXusbGameControllerInputSink, OFFSET>(),

--- a/crates/libs/windows/src/Windows/Media/Protection/PlayReady/impl.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/PlayReady/impl.rs
@@ -132,7 +132,7 @@ impl INDDownloadEngine_Vtbl {
         unsafe extern "system" fn Open<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDDownloadEngine_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uri: *mut ::core::ffi::c_void, sessionIDBytes_array_size: u32, sessionidbytes: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Open(::windows_core::from_raw_borrowed(&uri), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _)).into()
+            this.Open(::windows_core::from_raw_borrowed(&uri), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as usize)).into()
         }
         unsafe extern "system" fn Pause<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDDownloadEngine_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -241,7 +241,7 @@ impl INDDownloadEngineNotifier_Vtbl {
         unsafe extern "system" fn OnPlayReadyObjectReceived<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDDownloadEngineNotifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dataBytes_array_size: u32, databytes: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.OnPlayReadyObjectReceived(::core::slice::from_raw_parts(::core::mem::transmute_copy(&databytes), dataBytes_array_size as _)).into()
+            this.OnPlayReadyObjectReceived(::core::slice::from_raw_parts(::core::mem::transmute_copy(&databytes), dataBytes_array_size as usize)).into()
         }
         unsafe extern "system" fn OnContentIDReceived<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDDownloadEngineNotifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, licensefetchdescriptor: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -251,7 +251,7 @@ impl INDDownloadEngineNotifier_Vtbl {
         unsafe extern "system" fn OnDataReceived<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDDownloadEngineNotifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dataBytes_array_size: u32, databytes: *const u8, bytesreceived: u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.OnDataReceived(::core::slice::from_raw_parts(::core::mem::transmute_copy(&databytes), dataBytes_array_size as _), bytesreceived).into()
+            this.OnDataReceived(::core::slice::from_raw_parts(::core::mem::transmute_copy(&databytes), dataBytes_array_size as usize), bytesreceived).into()
         }
         unsafe extern "system" fn OnEndOfStream<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDDownloadEngineNotifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -429,7 +429,7 @@ impl INDMessenger_Vtbl {
         unsafe extern "system" fn SendRegistrationRequestAsync<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDMessenger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sessionIDBytes_array_size: u32, sessionidbytes: *const u8, challengeDataBytes_array_size: u32, challengedatabytes: *const u8, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.SendRegistrationRequestAsync(::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as _)) {
+            match this.SendRegistrationRequestAsync(::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as usize), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
@@ -441,7 +441,7 @@ impl INDMessenger_Vtbl {
         unsafe extern "system" fn SendProximityDetectionStartAsync<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDMessenger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdtype: NDProximityDetectionType, transmitterChannelBytes_array_size: u32, transmitterchannelbytes: *const u8, sessionIDBytes_array_size: u32, sessionidbytes: *const u8, challengeDataBytes_array_size: u32, challengedatabytes: *const u8, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.SendProximityDetectionStartAsync(pdtype, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&transmitterchannelbytes), transmitterChannelBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as _)) {
+            match this.SendProximityDetectionStartAsync(pdtype, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&transmitterchannelbytes), transmitterChannelBytes_array_size as usize), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as usize), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
@@ -453,7 +453,7 @@ impl INDMessenger_Vtbl {
         unsafe extern "system" fn SendProximityDetectionResponseAsync<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDMessenger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdtype: NDProximityDetectionType, transmitterChannelBytes_array_size: u32, transmitterchannelbytes: *const u8, sessionIDBytes_array_size: u32, sessionidbytes: *const u8, responseDataBytes_array_size: u32, responsedatabytes: *const u8, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.SendProximityDetectionResponseAsync(pdtype, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&transmitterchannelbytes), transmitterChannelBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&responsedatabytes), responseDataBytes_array_size as _)) {
+            match this.SendProximityDetectionResponseAsync(pdtype, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&transmitterchannelbytes), transmitterChannelBytes_array_size as usize), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as usize), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&responsedatabytes), responseDataBytes_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
@@ -465,7 +465,7 @@ impl INDMessenger_Vtbl {
         unsafe extern "system" fn SendLicenseFetchRequestAsync<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDMessenger_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, sessionIDBytes_array_size: u32, sessionidbytes: *const u8, challengeDataBytes_array_size: u32, challengedatabytes: *const u8, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.SendLicenseFetchRequestAsync(::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as _), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as _)) {
+            match this.SendLicenseFetchRequestAsync(::core::slice::from_raw_parts(::core::mem::transmute_copy(&sessionidbytes), sessionIDBytes_array_size as usize), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&challengedatabytes), challengeDataBytes_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);
@@ -698,7 +698,7 @@ impl INDStreamParser_Vtbl {
         unsafe extern "system" fn ParseData<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDStreamParser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dataBytes_array_size: u32, databytes: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.ParseData(::core::slice::from_raw_parts(::core::mem::transmute_copy(&databytes), dataBytes_array_size as _)).into()
+            this.ParseData(::core::slice::from_raw_parts(::core::mem::transmute_copy(&databytes), dataBytes_array_size as usize)).into()
         }
         unsafe extern "system" fn GetStreamInformation<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDStreamParser_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, descriptor: *mut ::core::ffi::c_void, streamtype: *mut NDMediaStreamType, result__: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -774,12 +774,12 @@ impl INDStreamParserNotifier_Vtbl {
         unsafe extern "system" fn OnSampleParsed<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDStreamParserNotifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, streamid: u32, streamtype: NDMediaStreamType, streamsample: *mut ::core::ffi::c_void, pts: i64, ccformat: NDClosedCaptionFormat, ccDataBytes_array_size: u32, ccdatabytes: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.OnSampleParsed(streamid, streamtype, ::windows_core::from_raw_borrowed(&streamsample), pts, ccformat, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&ccdatabytes), ccDataBytes_array_size as _)).into()
+            this.OnSampleParsed(streamid, streamtype, ::windows_core::from_raw_borrowed(&streamsample), pts, ccformat, ::core::slice::from_raw_parts(::core::mem::transmute_copy(&ccdatabytes), ccDataBytes_array_size as usize)).into()
         }
         unsafe extern "system" fn OnBeginSetupDecryptor<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDStreamParserNotifier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, descriptor: *mut ::core::ffi::c_void, keyid: ::windows_core::GUID, proBytes_array_size: u32, probytes: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.OnBeginSetupDecryptor(::windows_core::from_raw_borrowed(&descriptor), ::core::mem::transmute(&keyid), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&probytes), proBytes_array_size as _)).into()
+            this.OnBeginSetupDecryptor(::windows_core::from_raw_borrowed(&descriptor), ::core::mem::transmute(&keyid), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&probytes), proBytes_array_size as usize)).into()
         }
         Self {
             base__: ::windows_core::IInspectable_Vtbl::new::<Identity, INDStreamParserNotifier, OFFSET>(),
@@ -1482,7 +1482,7 @@ impl IPlayReadyServiceRequest_Vtbl {
         unsafe extern "system" fn ProcessManualEnablingResponse<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IPlayReadyServiceRequest_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, responseBytes_array_size: u32, responsebytes: *const u8, result__: *mut ::windows_core::HRESULT) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.ProcessManualEnablingResponse(::core::slice::from_raw_parts(::core::mem::transmute_copy(&responsebytes), responseBytes_array_size as _)) {
+            match this.ProcessManualEnablingResponse(::core::slice::from_raw_parts(::core::mem::transmute_copy(&responsebytes), responseBytes_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::windows_core::HRESULT(0)

--- a/crates/libs/windows/src/Windows/Networking/Vpn/impl.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/impl.rs
@@ -297,7 +297,7 @@ impl IVpnInterfaceIdFactory_Vtbl {
         unsafe extern "system" fn CreateVpnInterfaceId<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IVpnInterfaceIdFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, address_array_size: u32, address: *const u8, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            match this.CreateVpnInterfaceId(::core::slice::from_raw_parts(::core::mem::transmute_copy(&address), address_array_size as _)) {
+            match this.CreateVpnInterfaceId(::core::slice::from_raw_parts(::core::mem::transmute_copy(&address), address_array_size as usize)) {
                 ::core::result::Result::Ok(ok__) => {
                     ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                     ::core::mem::forget(ok__);

--- a/crates/libs/windows/src/Windows/Storage/Streams/impl.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/impl.rs
@@ -186,7 +186,7 @@ impl IDataReader_Vtbl {
         unsafe extern "system" fn ReadBytes<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IDataReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *mut u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.ReadBytes(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&value), value_array_size as _)).into()
+            this.ReadBytes(::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&value), value_array_size as usize)).into()
         }
         unsafe extern "system" fn ReadBuffer<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IDataReader_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, length: u32, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -503,7 +503,7 @@ impl IDataWriter_Vtbl {
         unsafe extern "system" fn WriteBytes<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IDataWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.WriteBytes(::core::slice::from_raw_parts(::core::mem::transmute_copy(&value), value_array_size as _)).into()
+            this.WriteBytes(::core::slice::from_raw_parts(::core::mem::transmute_copy(&value), value_array_size as usize)).into()
         }
         unsafe extern "system" fn WriteBuffer<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IDataWriter_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffer: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -176,7 +176,7 @@ impl<F: FnMut(&[u8]) -> ::windows_core::Result<bool> + ::core::marker::Send + 's
     }
     unsafe extern "system" fn Invoke(this: *mut ::core::ffi::c_void, pduData_array_size: u32, pdudata: *const u8, result__: *mut bool) -> ::windows_core::HRESULT {
         let this = this as *mut *mut ::core::ffi::c_void as *mut Self;
-        match ((*this).invoke)(::core::slice::from_raw_parts(::core::mem::transmute_copy(&pdudata), pduData_array_size as _)) {
+        match ((*this).invoke)(::core::slice::from_raw_parts(::core::mem::transmute_copy(&pdudata), pduData_array_size as usize)) {
             ::core::result::Result::Ok(ok__) => {
                 ::core::ptr::write(result__, ::core::mem::transmute_copy(&ok__));
                 ::windows_core::HRESULT(0)

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/impl.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/impl.rs
@@ -42,7 +42,7 @@ impl ICoreAutomationRemoteOperationExtensionProvider_Vtbl {
         unsafe extern "system" fn CallExtension<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ICoreAutomationRemoteOperationExtensionProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, extensionid: ::windows_core::GUID, context: *mut ::core::ffi::c_void, operandIds_array_size: u32, operandids: *const AutomationRemoteOperationOperandId) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.CallExtension(::core::mem::transmute(&extensionid), ::windows_core::from_raw_borrowed(&context), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&operandids), operandIds_array_size as _)).into()
+            this.CallExtension(::core::mem::transmute(&extensionid), ::windows_core::from_raw_borrowed(&context), ::core::slice::from_raw_parts(::core::mem::transmute_copy(&operandids), operandIds_array_size as usize)).into()
         }
         unsafe extern "system" fn IsExtensionSupported<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ICoreAutomationRemoteOperationExtensionProvider_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, extensionid: ::windows_core::GUID, result__: *mut bool) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -21790,7 +21790,7 @@ impl WIN32_ERROR {
     }
     #[inline]
     pub const fn to_hresult(self) -> ::windows_core::HRESULT {
-        ::windows_core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
+        ::windows_core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as i32)
     }
     #[inline]
     pub fn from_error(error: &::windows_core::Error) -> ::core::option::Option<Self> {

--- a/crates/samples/windows-sys/privileges/src/main.rs
+++ b/crates/samples/windows-sys/privileges/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
             &mut bytes_required,
         );
 
-        let buffer = LocalAlloc(LPTR, bytes_required as _);
+        let buffer = LocalAlloc(LPTR, bytes_required as usize);
 
         GetTokenInformation(
             token,
@@ -29,7 +29,7 @@ fn main() {
         let header = &*(buffer as *const TOKEN_PRIVILEGES);
 
         let privileges =
-            std::slice::from_raw_parts(header.Privileges.as_ptr(), header.PrivilegeCount as _);
+            std::slice::from_raw_parts(header.Privileges.as_ptr(), header.PrivilegeCount as usize);
 
         for privilege in privileges {
             let mut name_len = 0;

--- a/crates/samples/windows/data_protection/src/main.rs
+++ b/crates/samples/windows/data_protection/src/main.rs
@@ -25,5 +25,8 @@ fn main() -> std::io::Result<()> {
 unsafe fn as_mut_bytes(buffer: &IBuffer) -> Result<&mut [u8]> {
     let interop = buffer.cast::<IBufferByteAccess>()?;
     let data = interop.Buffer()?;
-    Ok(std::slice::from_raw_parts_mut(data, buffer.Length()? as _))
+    Ok(std::slice::from_raw_parts_mut(
+        data,
+        buffer.Length()? as usize,
+    ))
 }

--- a/crates/samples/windows/dcomp/src/main.rs
+++ b/crates/samples/windows/dcomp/src/main.rs
@@ -91,7 +91,7 @@ impl Window {
                     for column in 0..CARD_COLUMNS {
                         print!(
                             " {}",
-                            char::from_u32(cards[row * CARD_COLUMNS + column].value as _)
+                            char::from_u32(cards[row * CARD_COLUMNS + column].value as u32)
                                 .expect("char")
                         );
                     }
@@ -211,13 +211,13 @@ impl Window {
             let mut rect = RECT {
                 left: 0,
                 top: 0,
-                right: logical_to_physical(WINDOW_WIDTH, self.dpi.0) as _,
-                bottom: logical_to_physical(WINDOW_HEIGHT, self.dpi.1) as _,
+                right: logical_to_physical(WINDOW_WIDTH, self.dpi.0) as i32,
+                bottom: logical_to_physical(WINDOW_HEIGHT, self.dpi.1) as i32,
             };
 
             AdjustWindowRect(
                 &mut rect,
-                WINDOW_STYLE(GetWindowLongW(self.handle, GWL_STYLE) as _),
+                WINDOW_STYLE(GetWindowLongW(self.handle, GWL_STYLE) as u32),
                 false,
             )?;
 
@@ -367,7 +367,7 @@ impl Window {
             let monitor = MonitorFromWindow(self.handle, MONITOR_DEFAULTTONEAREST);
             let mut dpi = (0, 0);
             GetDpiForMonitor(monitor, MDT_EFFECTIVE_DPI, &mut dpi.0, &mut dpi.1)?;
-            self.dpi = (dpi.0 as _, dpi.1 as _);
+            self.dpi = (dpi.0 as f32, dpi.1 as f32);
 
             if cfg!(debug_assertions) {
                 println!("initial dpi: {:?}", self.dpi);
@@ -580,8 +580,8 @@ fn create_surface(
 ) -> Result<IDCompositionSurface> {
     unsafe {
         device.CreateSurface(
-            width as _,
-            height as _,
+            width as u32,
+            height as u32,
             DXGI_FORMAT_B8G8R8A8_UNORM,
             DXGI_ALPHA_MODE_PREMULTIPLIED,
         )
@@ -680,8 +680,8 @@ fn draw_card_front(
         dc.SetDpi(dpi.0, dpi.1);
 
         dc.SetTransform(&Matrix3x2::translation(
-            physical_to_logical(offset.x as _, dpi.0),
-            physical_to_logical(offset.y as _, dpi.1),
+            physical_to_logical(offset.x as f32, dpi.0),
+            physical_to_logical(offset.y as f32, dpi.1),
         ));
 
         dc.Clear(Some(&D2D1_COLOR_F {
@@ -721,12 +721,12 @@ fn draw_card_back(
         dc.SetDpi(dpi.0, dpi.1);
 
         dc.SetTransform(&Matrix3x2::translation(
-            physical_to_logical(dc_offset.x as _, dpi.0),
-            physical_to_logical(dc_offset.y as _, dpi.1),
+            physical_to_logical(dc_offset.x as f32, dpi.0),
+            physical_to_logical(dc_offset.y as f32, dpi.1),
         ));
 
-        let left = physical_to_logical(offset.0 as _, dpi.0);
-        let top = physical_to_logical(offset.1 as _, dpi.1);
+        let left = physical_to_logical(offset.0, dpi.0);
+        let top = physical_to_logical(offset.1, dpi.1);
 
         dc.DrawBitmap(
             bitmap,

--- a/crates/samples/windows/memory_buffer/src/main.rs
+++ b/crates/samples/windows/memory_buffer/src/main.rs
@@ -11,7 +11,7 @@ unsafe fn as_mut_slice(buffer: &IMemoryBufferReference) -> Result<&mut [u8]> {
     let mut len = 0;
 
     interop.GetBuffer(&mut data, &mut len)?;
-    Ok(std::slice::from_raw_parts_mut(data, len as _))
+    Ok(std::slice::from_raw_parts_mut(data, len as usize))
 }
 
 fn main() -> Result<()> {

--- a/crates/samples/windows/privileges/src/main.rs
+++ b/crates/samples/windows/privileges/src/main.rs
@@ -11,7 +11,7 @@ fn main() -> Result<()> {
         let mut bytes_required = 0;
         _ = GetTokenInformation(token, TokenPrivileges, None, 0, &mut bytes_required);
 
-        let buffer = LocalAlloc(LPTR, bytes_required as _)?;
+        let buffer = LocalAlloc(LPTR, bytes_required as usize)?;
 
         GetTokenInformation(
             token,
@@ -24,7 +24,7 @@ fn main() -> Result<()> {
         let header = &*(buffer.0 as *const TOKEN_PRIVILEGES);
 
         let privileges =
-            std::slice::from_raw_parts(header.Privileges.as_ptr(), header.PrivilegeCount as _);
+            std::slice::from_raw_parts(header.Privileges.as_ptr(), header.PrivilegeCount as usize);
 
         for privilege in privileges {
             let mut name_len = 0;

--- a/crates/tests/bcrypt/tests/sys.rs
+++ b/crates/tests/bcrypt/tests/sys.rs
@@ -23,17 +23,22 @@ fn test() {
                 des,
                 BCRYPT_OBJECT_LENGTH,
                 object_len.as_mut_ptr(),
-                object_len.len() as _,
+                object_len.len() as u32,
                 &mut bytes_copied,
                 0
             )
         );
         let object_len = u32::from_le_bytes(object_len);
 
-        let mut shared_secret = vec![0; object_len as _];
+        let mut shared_secret = vec![0; object_len as usize];
         assert_eq!(
             STATUS_SUCCESS,
-            BCryptGenRandom(rng, shared_secret.as_mut_ptr(), shared_secret.len() as _, 0)
+            BCryptGenRandom(
+                rng,
+                shared_secret.as_mut_ptr(),
+                shared_secret.len() as u32,
+                0
+            )
         );
 
         let mut encrypt_key = std::ptr::null_mut();
@@ -45,7 +50,7 @@ fn test() {
                 std::ptr::null_mut(),
                 0,
                 shared_secret.as_ptr(),
-                shared_secret.len() as _,
+                shared_secret.len() as u32,
                 0
             )
         );
@@ -57,7 +62,7 @@ fn test() {
                 des,
                 BCRYPT_BLOCK_LENGTH,
                 block_len.as_mut_ptr(),
-                block_len.len() as _,
+                block_len.len() as u32,
                 &mut bytes_copied,
                 0
             )
@@ -75,7 +80,7 @@ fn test() {
             BCryptEncrypt(
                 encrypt_key,
                 send_buffer.as_ptr(),
-                send_buffer.len() as _,
+                send_buffer.len() as u32,
                 std::ptr::null(),
                 std::ptr::null_mut(),
                 0,
@@ -86,18 +91,18 @@ fn test() {
             )
         );
 
-        let mut encrypted = vec![0; encrypted_len as _];
+        let mut encrypted = vec![0; encrypted_len as usize];
         assert_eq!(
             STATUS_SUCCESS,
             BCryptEncrypt(
                 encrypt_key,
                 send_buffer.as_ptr(),
-                send_buffer.len() as _,
+                send_buffer.len() as u32,
                 std::ptr::null(),
                 std::ptr::null_mut(),
                 0,
                 encrypted.as_mut_ptr(),
-                encrypted.len() as _,
+                encrypted.len() as u32,
                 &mut encrypted_len,
                 0
             )
@@ -112,7 +117,7 @@ fn test() {
                 std::ptr::null_mut(),
                 0,
                 shared_secret.as_ptr(),
-                shared_secret.len() as _,
+                shared_secret.len() as u32,
                 0
             )
         );
@@ -123,7 +128,7 @@ fn test() {
             BCryptDecrypt(
                 decrypt_key,
                 encrypted.as_ptr(),
-                encrypted.len() as _,
+                encrypted.len() as u32,
                 std::ptr::null(),
                 std::ptr::null_mut(),
                 0,
@@ -134,18 +139,18 @@ fn test() {
             )
         );
 
-        let mut decrypted = vec![0; decrypted_len as _];
+        let mut decrypted = vec![0; decrypted_len as usize];
         assert_eq!(
             STATUS_SUCCESS,
             BCryptDecrypt(
                 decrypt_key,
                 encrypted.as_ptr(),
-                encrypted.len() as _,
+                encrypted.len() as u32,
                 std::ptr::null(),
                 std::ptr::null_mut(),
                 0,
                 decrypted.as_mut_ptr(),
-                decrypted.len() as _,
+                decrypted.len() as u32,
                 &mut decrypted_len,
                 0
             )

--- a/crates/tests/bcrypt/tests/win.rs
+++ b/crates/tests/bcrypt/tests/win.rs
@@ -20,7 +20,7 @@ fn test() -> Result<()> {
         )?;
         let object_len = u32::from_le_bytes(object_len);
 
-        let mut shared_secret = vec![0; object_len as _];
+        let mut shared_secret = vec![0; object_len as usize];
         BCryptGenRandom(rng, &mut shared_secret, Default::default())?;
 
         let mut encrypt_key = Default::default();
@@ -52,7 +52,7 @@ fn test() -> Result<()> {
             Default::default(),
         )?;
 
-        let mut encrypted = vec![0; encrypted_len as _];
+        let mut encrypted = vec![0; encrypted_len as usize];
         BCryptEncrypt(
             encrypt_key,
             Some(&send_buffer),
@@ -77,7 +77,7 @@ fn test() -> Result<()> {
             Default::default(),
         )?;
 
-        let mut decrypted = vec![0; decrypted_len as _];
+        let mut decrypted = vec![0; decrypted_len as usize];
         BCryptDecrypt(
             decrypt_key,
             Some(&encrypted),

--- a/crates/tests/calling_convention/tests/sys.rs
+++ b/crates/tests/calling_convention/tests/sys.rs
@@ -7,7 +7,7 @@ use windows_sys::{
 fn calling_convention() {
     unsafe {
         // This function requires cdecl on x86.
-        assert_eq!(ERROR_BUSY, LdapMapErrorToWin32(LDAP_BUSY as _));
+        assert_eq!(ERROR_BUSY, LdapMapErrorToWin32(LDAP_BUSY as u32));
 
         // This function requires stdcall on x86.
         GetTickCount();
@@ -19,8 +19,10 @@ fn variadic() {
     unsafe {
         let mut buffer = vec![0u8; 1024];
         let len = wsprintfA(buffer.as_mut_ptr(), s!("test-%d-%d!"), 123u32, 456u32);
-        let result =
-            std::str::from_utf8_unchecked(&std::slice::from_raw_parts(buffer.as_ptr(), len as _));
+        let result = std::str::from_utf8_unchecked(&std::slice::from_raw_parts(
+            buffer.as_ptr(),
+            len as usize,
+        ));
         assert_eq!(result, "test-123-456!");
     }
 }

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -597,10 +597,13 @@ impl IClass_Vtbl {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
             match this.Int32Array(
-                ::core::slice::from_raw_parts(::core::mem::transmute_copy(&a), a_array_size as _),
+                ::core::slice::from_raw_parts(
+                    ::core::mem::transmute_copy(&a),
+                    a_array_size as usize,
+                ),
                 ::core::slice::from_raw_parts_mut(
                     ::core::mem::transmute_copy(&b),
-                    b_array_size as _,
+                    b_array_size as usize,
                 ),
                 ::windows_core::ArrayProxy::from_raw_parts(
                     ::core::mem::transmute_copy(&c),
@@ -635,10 +638,13 @@ impl IClass_Vtbl {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
             match this.StringArray(
-                ::core::slice::from_raw_parts(::core::mem::transmute_copy(&a), a_array_size as _),
+                ::core::slice::from_raw_parts(
+                    ::core::mem::transmute_copy(&a),
+                    a_array_size as usize,
+                ),
                 ::core::slice::from_raw_parts_mut(
                     ::core::mem::transmute_copy(&b),
-                    b_array_size as _,
+                    b_array_size as usize,
                 ),
                 ::windows_core::ArrayProxy::from_raw_parts(
                     ::core::mem::transmute_copy(&c),

--- a/crates/tests/error/tests/std.rs
+++ b/crates/tests/error/tests/std.rs
@@ -22,8 +22,11 @@ fn conversions() {
     );
 
     // std::io::Error from WIN32_ERROR
-    let std_error = std::io::Error::from_raw_os_error(ERROR_INVALID_DATA.0 as _);
-    assert_eq!(std_error.raw_os_error().unwrap(), ERROR_INVALID_DATA.0 as _);
+    let std_error = std::io::Error::from_raw_os_error(ERROR_INVALID_DATA.0 as i32);
+    assert_eq!(
+        std_error.raw_os_error().unwrap(),
+        ERROR_INVALID_DATA.0 as i32
+    );
     assert_eq!(format!("{std_error}"), "The data is invalid. (os error 13)");
 
     // Starting with WIN32_ERROR...

--- a/crates/tests/implement/tests/generic_default.rs
+++ b/crates/tests/implement/tests/generic_default.rs
@@ -26,13 +26,13 @@ where
     }
 
     fn Size(&self) -> Result<u32> {
-        Ok(self.0.len() as _)
+        Ok(self.0.len() as u32)
     }
 
     fn IndexOf(&self, value: &T::Default, result: &mut u32) -> Result<bool> {
         match self.0.iter().position(|element| element == value) {
             Some(index) => {
-                *result = index as _;
+                *result = index as u32;
                 Ok(true)
             }
             None => Ok(false),

--- a/crates/tests/implement/tests/generic_primitive.rs
+++ b/crates/tests/implement/tests/generic_primitive.rs
@@ -12,7 +12,7 @@ struct Thing();
 #[allow(non_snake_case)]
 impl IVectorView_Impl<i32> for Thing {
     fn GetAt(&self, index: u32) -> Result<i32> {
-        Ok(index as _)
+        Ok(index as i32)
     }
 
     fn Size(&self) -> Result<u32> {
@@ -20,7 +20,7 @@ impl IVectorView_Impl<i32> for Thing {
     }
 
     fn IndexOf(&self, value: &i32, index: &mut u32) -> Result<bool> {
-        *index = *value as _;
+        *index = *value as u32;
         Ok(true)
     }
 

--- a/crates/tests/implement/tests/vector.rs
+++ b/crates/tests/implement/tests/vector.rs
@@ -40,13 +40,13 @@ where
     }
     fn Size(&self) -> Result<u32> {
         let reader = self.0.read().unwrap();
-        Ok(reader.len() as _)
+        Ok(reader.len() as u32)
     }
     fn IndexOf(&self, value: &T::Default, result: &mut u32) -> Result<bool> {
         let reader = self.0.read().unwrap();
         match reader.iter().position(|element| element == value) {
             Some(index) => {
-                *result = index as _;
+                *result = index as u32;
                 Ok(true)
             }
             None => Ok(false),
@@ -88,7 +88,7 @@ where
         } else {
             let len = writer.len();
             writer.try_reserve(len + 1).map_err(|_| err_memory())?;
-            writer.insert(index as _, value.clone());
+            writer.insert(index as usize, value.clone());
             Ok(())
         }
     }

--- a/crates/tests/interface/tests/com.rs
+++ b/crates/tests/interface/tests/com.rs
@@ -78,8 +78,8 @@ impl ICustomPersistMemory_Impl for Persist {
 
     unsafe fn Load(&self, input: *const core::ffi::c_void, size: u32) -> HRESULT {
         let mut writer = self.0.write().unwrap();
-        if size <= writer.memory.len() as _ {
-            std::ptr::copy(input, writer.memory.as_mut_ptr() as _, size as _);
+        if size <= writer.memory.len() as u32 {
+            std::ptr::copy(input, writer.memory.as_mut_ptr() as _, size as usize);
             writer.dirty = true;
             S_OK
         } else {
@@ -89,8 +89,8 @@ impl ICustomPersistMemory_Impl for Persist {
 
     unsafe fn Save(&self, output: *mut core::ffi::c_void, clear_dirty: BOOL, size: u32) -> HRESULT {
         let mut writer = self.0.write().unwrap();
-        if size <= writer.memory.len() as _ {
-            std::ptr::copy(writer.memory.as_mut_ptr() as _, output, size as _);
+        if size <= writer.memory.len() as u32 {
+            std::ptr::copy(writer.memory.as_mut_ptr() as _, output, size as usize);
             if clear_dirty.as_bool() {
                 writer.dirty = false;
             }
@@ -102,7 +102,7 @@ impl ICustomPersistMemory_Impl for Persist {
 
     unsafe fn GetSizeMax(&self, len: *mut u32) -> HRESULT {
         let reader = self.0.read().unwrap();
-        *len = reader.memory.len() as _;
+        *len = reader.memory.len() as u32;
         S_OK
     }
 

--- a/crates/tests/riddle/src/lib.rs
+++ b/crates/tests/riddle/src/lib.rs
@@ -34,8 +34,9 @@ pub fn run_riddle(name: &str) -> Vec<windows_metadata::File> {
     // Convert .rd to .rs
     let mut command = Command::new("cargo");
     command.args([
-        "run", "-p", "riddle", "--", "--in", &rd, "--out", &rs, "--filter", "Test",
-    ]); // TODO: --config FLATTEN doesn't work for namespaces
+        "run", "-p", "riddle", "--", "--in", &rd, "--out", &rs, "--filter", "Test", "--config",
+        "FLATTEN",
+    ]);
     assert!(command.status().unwrap().success());
 
     // Return winmd file for validation

--- a/crates/tests/riddle/src/nested_module.rs
+++ b/crates/tests/riddle/src/nested_module.rs
@@ -7,43 +7,39 @@
     dead_code,
     clippy::all
 )]
-pub mod NestedModule {
-    #[repr(C)]
-    pub struct NestedType {
-        pub field: f32,
+#[repr(C)]
+pub struct NestedType {
+    pub field: f32,
+}
+impl ::core::marker::Copy for NestedType {}
+impl ::core::clone::Clone for NestedType {
+    fn clone(&self) -> Self {
+        *self
     }
-    impl ::core::marker::Copy for NestedType {}
-    impl ::core::clone::Clone for NestedType {
-        fn clone(&self) -> Self {
-            *self
-        }
+}
+impl ::core::fmt::Debug for NestedType {
+    fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
+        f.debug_struct("NestedType")
+            .field("field", &self.field)
+            .finish()
     }
-    impl ::core::fmt::Debug for NestedType {
-        fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-            f.debug_struct("NestedType")
-                .field("field", &self.field)
-                .finish()
-        }
+}
+impl ::windows_core::TypeKind for NestedType {
+    type TypeKind = ::windows_core::CopyType;
+}
+impl ::windows_core::RuntimeType for NestedType {
+    const SIGNATURE: ::windows_core::imp::ConstBuffer =
+        ::windows_core::imp::ConstBuffer::from_slice(b"struct(Test.NestedModule.NestedType;f4)");
+}
+impl ::core::cmp::PartialEq for NestedType {
+    fn eq(&self, other: &Self) -> bool {
+        self.field == other.field
     }
-    impl ::windows_core::TypeKind for NestedType {
-        type TypeKind = ::windows_core::CopyType;
-    }
-    impl ::windows_core::RuntimeType for NestedType {
-        const SIGNATURE: ::windows_core::imp::ConstBuffer =
-            ::windows_core::imp::ConstBuffer::from_slice(
-                b"struct(Test.NestedModule.NestedType;f4)",
-            );
-    }
-    impl ::core::cmp::PartialEq for NestedType {
-        fn eq(&self, other: &Self) -> bool {
-            self.field == other.field
-        }
-    }
-    impl ::core::cmp::Eq for NestedType {}
-    impl ::core::default::Default for NestedType {
-        fn default() -> Self {
-            unsafe { ::core::mem::zeroed() }
-        }
+}
+impl ::core::cmp::Eq for NestedType {}
+impl ::core::default::Default for NestedType {
+    fn default() -> Self {
+        unsafe { ::core::mem::zeroed() }
     }
 }
 #[repr(C)]

--- a/crates/tests/targets/tests/symbol.rs
+++ b/crates/tests/targets/tests/symbol.rs
@@ -5,14 +5,17 @@ fn symbol() {
     unsafe {
         use windows_sys::Win32::Security::Authentication::Identity::RtlGenRandom;
         let mut buffer = [0u8; 8];
-        assert_eq!(RtlGenRandom(buffer.as_mut_ptr() as _, buffer.len() as _), 1);
+        assert_eq!(
+            RtlGenRandom(buffer.as_mut_ptr() as _, buffer.len() as u32),
+            1
+        );
         assert_ne!(&buffer, &[0u8; 8]);
     }
     unsafe {
         use windows::Win32::Security::Authentication::Identity::RtlGenRandom;
         let mut buffer = [0u8; 8];
         assert_eq!(
-            RtlGenRandom(buffer.as_mut_ptr() as _, buffer.len() as _),
+            RtlGenRandom(buffer.as_mut_ptr() as _, buffer.len() as u32),
             true
         );
         assert_ne!(&buffer, &[0u8; 8]);

--- a/crates/tests/win32/tests/win32.rs
+++ b/crates/tests/win32/tests/win32.rs
@@ -149,7 +149,7 @@ fn com() -> windows::core::Result<()> {
 
         let mut copied = 0;
         stream
-            .Write(values.as_ptr() as _, values.len() as _, Some(&mut copied))
+            .Write(values.as_ptr() as _, values.len() as u32, Some(&mut copied))
             .ok()?;
         assert!(copied == 4);
 
@@ -162,7 +162,7 @@ fn com() -> windows::core::Result<()> {
         stream
             .Read(
                 values.as_mut_ptr() as _,
-                values.len() as _,
+                values.len() as u32,
                 Some(&mut copied),
             )
             .ok()?;

--- a/crates/tests/win32/tests/winsock.rs
+++ b/crates/tests/win32/tests/winsock.rs
@@ -15,7 +15,7 @@ fn in_addr() {
     fn in_addr_to_string(in_addr: &IN_ADDR) -> String {
         unsafe {
             let mut chars = [0; 24];
-            inet_ntop(AF_INET.0 as _, in_addr as *const IN_ADDR as _, &mut chars);
+            inet_ntop(AF_INET.0 as i32, in_addr as *const IN_ADDR as _, &mut chars);
             std::ffi::CStr::from_ptr(chars.as_ptr() as *const _)
                 .to_str()
                 .unwrap()

--- a/crates/tests/win32_arrays/tests/xmllite.rs
+++ b/crates/tests/win32_arrays/tests/xmllite.rs
@@ -48,7 +48,7 @@ fn test() -> Result<()> {
         assert_eq!(node_type, XmlNodeType_Element);
         reader.GetLocalName(&mut name, Some(&mut name_len))?;
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as usize)),
             "html"
         );
 
@@ -57,7 +57,7 @@ fn test() -> Result<()> {
         assert_eq!(node_type, XmlNodeType_Element);
         reader.GetLocalName(&mut name, Some(&mut name_len))?;
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as usize)),
             "head"
         );
 
@@ -71,7 +71,7 @@ fn test() -> Result<()> {
         let mut read_count = 0;
 
         while reader.ReadValueChunk(&mut chunk, &mut chars_read).is_ok() && chars_read > 0 {
-            message.extend_from_slice(&chunk[0..chars_read as _]);
+            message.extend_from_slice(&chunk[0..chars_read as usize]);
             read_count += 1;
         }
 
@@ -96,7 +96,10 @@ fn test() -> Result<()> {
         reader.ReadValueChunk(&mut chunk, &mut chars_read).ok()?;
         assert_eq!(chars_read, 4);
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(chunk.as_ptr(), chars_read as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(
+                chunk.as_ptr(),
+                chars_read as usize
+            )),
             "Rust"
         );
 
@@ -140,7 +143,7 @@ fn lite() -> Result<()> {
         assert_eq!(node_type, XmlNodeType_Element);
         reader.GetLocalName(&mut name, Some(&mut name_len))?;
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as usize)),
             "html"
         );
 
@@ -149,13 +152,13 @@ fn lite() -> Result<()> {
 
         reader.GetLocalName(&mut name, Some(&mut name_len))?;
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as usize)),
             "no-value"
         );
 
         reader.GetValue(&mut name, Some(&mut name_len))?;
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as usize)),
             ""
         );
 
@@ -163,13 +166,13 @@ fn lite() -> Result<()> {
 
         reader.GetLocalName(&mut name, Some(&mut name_len))?;
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as usize)),
             "with-value"
         );
 
         reader.GetValue(&mut name, Some(&mut name_len))?;
         assert_eq!(
-            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as _)),
+            String::from_utf16_lossy(std::slice::from_raw_parts(name.0, name_len as usize)),
             "value"
         );
 

--- a/crates/tools/riddle/src/rd/to_winmd.rs
+++ b/crates/tools/riddle/src/rd/to_winmd.rs
@@ -97,7 +97,7 @@ fn write_interface(
         Extends: 0,
         FieldList: 0,
         Flags: flags.0,
-        MethodList: writer.tables.MethodDef.len() as _,
+        MethodList: writer.tables.MethodDef.len() as u32,
         TypeName: writer.strings.insert(name),
         TypeNamespace: writer.strings.insert(namespace),
     });
@@ -112,13 +112,13 @@ fn write_interface(
             Flags: 0,
             Name: writer.strings.insert(&method.sig.ident.to_string()),
             Signature: signature,
-            ParamList: writer.tables.Param.len() as _,
+            ParamList: writer.tables.Param.len() as u32,
         });
 
         for (sequence, param) in sig.params.iter().enumerate() {
             writer.tables.Param.push(winmd::Param {
                 Flags: 0,
-                Sequence: (sequence + 1) as _,
+                Sequence: (sequence + 1) as u16,
                 Name: writer.strings.insert(&param.name),
             });
         }
@@ -136,7 +136,7 @@ fn write_struct(writer: &mut winmd::Writer, namespace: &str, name: &str, member:
 
     writer.tables.TypeDef.push(winmd::TypeDef {
         Extends: extends,
-        FieldList: writer.tables.Field.len() as _,
+        FieldList: writer.tables.Field.len() as u32,
         Flags: flags.0,
         MethodList: 0,
         TypeName: writer.strings.insert(name),

--- a/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/Iterable.rs
+++ b/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/Iterable.rs
@@ -79,7 +79,7 @@ where
         values.clone_from_slice(&owner.values[current..current + actual]);
         self.current
             .fetch_add(actual, ::std::sync::atomic::Ordering::Relaxed);
-        Ok(actual as _)
+        Ok(actual as u32)
     }
 }
 

--- a/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/MapView.rs
+++ b/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/MapView.rs
@@ -44,7 +44,7 @@ where
         V::from_default(value)
     }
     fn Size(&self) -> ::windows_core::Result<u32> {
-        Ok(self.map.len() as _)
+        Ok(self.map.len() as u32)
     }
     fn HasKey(&self, key: &K::Default) -> ::windows_core::Result<bool> {
         Ok(self.map.contains_key(key))
@@ -125,7 +125,7 @@ where
             }
         }
 
-        Ok(actual as _)
+        Ok(actual)
     }
 }
 

--- a/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/VectorView.rs
+++ b/crates/tools/riddle/src/rust/extensions/impl/Foundation/Collections/VectorView.rs
@@ -38,12 +38,12 @@ where
         T::from_default(item)
     }
     fn Size(&self) -> ::windows_core::Result<u32> {
-        Ok(self.values.len() as _)
+        Ok(self.values.len() as u32)
     }
     fn IndexOf(&self, value: &T::Default, result: &mut u32) -> ::windows_core::Result<bool> {
         match self.values.iter().position(|element| element == value) {
             Some(index) => {
-                *result = index as _;
+                *result = index as u32;
                 Ok(true)
             }
             None => Ok(false),
@@ -57,7 +57,7 @@ where
         let actual = std::cmp::min(self.values.len() - current, values.len());
         let (values, _) = values.split_at_mut(actual);
         values.clone_from_slice(&self.values[current..current + actual]);
-        Ok(actual as _)
+        Ok(actual as u32)
     }
 }
 
@@ -115,7 +115,7 @@ where
         values.clone_from_slice(&owner.values[current..current + actual]);
         self.current
             .fetch_add(actual, ::std::sync::atomic::Ordering::Relaxed);
-        Ok(actual as _)
+        Ok(actual as u32)
     }
 }
 

--- a/crates/tools/riddle/src/rust/extensions/mod/Win32/Foundation/WIN32_ERROR.rs
+++ b/crates/tools/riddle/src/rust/extensions/mod/Win32/Foundation/WIN32_ERROR.rs
@@ -9,7 +9,7 @@ impl WIN32_ERROR {
     }
     #[inline]
     pub const fn to_hresult(self) -> ::windows_core::HRESULT {
-        ::windows_core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
+        ::windows_core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as i32)
     }
     #[inline]
     pub fn from_error(error: &::windows_core::Error) -> ::core::option::Option<Self> {

--- a/crates/tools/riddle/src/rust/winrt_methods.rs
+++ b/crates/tools/riddle/src/rust/winrt_methods.rs
@@ -252,7 +252,7 @@ fn gen_winrt_invoke_arg(writer: &Writer, param: &SignatureParam) -> TokenStream 
         .contains(ParamAttributes::In)
     {
         if param.ty.is_winrt_array() {
-            quote! { ::core::slice::from_raw_parts(::core::mem::transmute_copy(&#name), #abi_size_name as _) }
+            quote! { ::core::slice::from_raw_parts(::core::mem::transmute_copy(&#name), #abi_size_name as usize) }
         } else if writer.reader.type_is_primitive(&param.ty) {
             quote! { #name }
         } else if param.ty.is_const_ref() {
@@ -263,7 +263,7 @@ fn gen_winrt_invoke_arg(writer: &Writer, param: &SignatureParam) -> TokenStream 
             quote! { ::core::mem::transmute(&#name) }
         }
     } else if param.ty.is_winrt_array() {
-        quote! { ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&#name), #abi_size_name as _) }
+        quote! { ::core::slice::from_raw_parts_mut(::core::mem::transmute_copy(&#name), #abi_size_name as usize) }
     } else if param.ty.is_winrt_array_ref() {
         quote! { ::windows_core::ArrayProxy::from_raw_parts(::core::mem::transmute_copy(&#name), #abi_size_name).as_array() }
     } else {

--- a/crates/tools/riddle/src/rust/writer.rs
+++ b/crates/tools/riddle/src/rust/writer.rs
@@ -1135,7 +1135,7 @@ impl<'a> Writer<'a> {
                 SignatureParamKind::ArrayFixed(fixed) => {
                     let ty = param.ty.deref();
                     let ty = self.type_default_name(&ty);
-                    let len = Literal::u32_unsuffixed(fixed as _);
+                    let len = Literal::u32_unsuffixed(fixed as u32);
                     let ty = if self
                         .reader
                         .param_flags(param.def)

--- a/crates/tools/riddle/src/winmd/to_winmd.rs
+++ b/crates/tools/riddle/src/winmd/to_winmd.rs
@@ -35,9 +35,9 @@ pub fn from_reader(
 
         writer.tables.TypeDef.push(writer::TypeDef {
             Extends: extends,
-            FieldList: writer.tables.Field.len() as _,
+            FieldList: writer.tables.Field.len() as u32,
             Flags: reader.type_def_flags(def).0,
-            MethodList: writer.tables.MethodDef.len() as _,
+            MethodList: writer.tables.MethodDef.len() as u32,
             TypeName: writer.strings.insert(reader.type_def_name(def)),
             TypeNamespace: writer.strings.insert(reader.type_def_namespace(def)),
         });
@@ -67,13 +67,13 @@ pub fn from_reader(
                 Flags: 0,
                 Name: writer.strings.insert(name),
                 Signature: signature,
-                ParamList: writer.tables.Param.len() as _,
+                ParamList: writer.tables.Param.len() as u32,
             });
 
             for (sequence, param) in sig.params.iter().enumerate() {
                 writer.tables.Param.push(writer::Param {
                     Flags: 0,
-                    Sequence: (sequence + 1) as _,
+                    Sequence: (sequence + 1) as u16,
                     Name: writer.strings.insert(&param.name),
                 });
             }

--- a/crates/tools/riddle/src/winmd/writer/blobs.rs
+++ b/crates/tools/riddle/src/winmd/writer/blobs.rs
@@ -23,19 +23,19 @@ impl Blobs {
 
         match self.map.entry(value.to_vec()) {
             Entry::Vacant(entry) => {
-                let offset = *entry.insert(self.stream.len() as _);
+                let offset = *entry.insert(self.stream.len() as u32);
                 let len = value.len();
                 match len {
-                    0..=0x7F => self.stream.push(len as _),
+                    0..=0x7F => self.stream.push(len as u8),
                     0x80..=0x3FFF => {
-                        self.stream.push((0x80 | len >> 8) as _);
-                        self.stream.push((0xFF & len) as _);
+                        self.stream.push((0x80 | len >> 8) as u8);
+                        self.stream.push((0xFF & len) as u8);
                     }
                     _ => {
-                        self.stream.push((0xC0 | len >> 24) as _);
-                        self.stream.push((0xFF & len >> 16) as _);
-                        self.stream.push((0xFF & len >> 8) as _);
-                        self.stream.push((0xFF & len) as _);
+                        self.stream.push((0xC0 | len >> 24) as u8);
+                        self.stream.push((0xFF & len >> 16) as u8);
+                        self.stream.push((0xFF & len >> 8) as u8);
+                        self.stream.push((0xFF & len) as u8);
                     }
                 }
                 self.stream.extend_from_slice(value);

--- a/crates/tools/riddle/src/winmd/writer/mod.rs
+++ b/crates/tools/riddle/src/winmd/writer/mod.rs
@@ -91,8 +91,8 @@ impl Writer {
     //             TypeName: self.strings.insert(name),
     //             TypeNamespace: self.strings.insert(namespace),
     //             Extends: extends,
-    //             FieldList: self.tables.Field.len() as _,
-    //             MethodList: self.tables.MethodDef.len() as _,
+    //             FieldList: self.tables.Field.len() as u32,
+    //             MethodList: self.tables.MethodDef.len() as u32,
     //         });
     //         for field in &def.fields {
     //             let blob = self.insert_field_sig(&field.ty);
@@ -104,9 +104,9 @@ impl Writer {
     //         }
     //         for method in &def.methods {
     //             let blob = self.insert_method_sig(method);
-    //             self.tables.MethodDef.push(MethodDef { RVA: 0, ImplFlags: 0, Flags: method.flags.0, Name: self.strings.insert(&method.name), Signature: blob, ParamList: self.tables.Param.len() as _ });
+    //             self.tables.MethodDef.push(MethodDef { RVA: 0, ImplFlags: 0, Flags: method.flags.0, Name: self.strings.insert(&method.name), Signature: blob, ParamList: self.tables.Param.len() as u32 });
     //             for (sequence, param) in method.params.iter().enumerate() {
-    //                 self.tables.Param.push(Param { Flags: param.flags.0, Sequence: (sequence + 1) as _, Name: self.strings.insert(&param.name) });
+    //                 self.tables.Param.push(Param { Flags: param.flags.0, Sequence: (sequence + 1) as u32, Name: self.strings.insert(&param.name) });
     //             }
     //         }
     //     }
@@ -233,91 +233,91 @@ impl Writer {
 
     fn type_blob(&mut self, ty: &Type, blob: &mut Vec<u8>) {
         match ty {
-            Type::Void => blob.push(ELEMENT_TYPE_VOID as _),
-            Type::Bool => blob.push(ELEMENT_TYPE_BOOLEAN as _),
-            Type::Char => blob.push(ELEMENT_TYPE_CHAR as _),
-            Type::I8 => blob.push(ELEMENT_TYPE_I1 as _),
-            Type::U8 => blob.push(ELEMENT_TYPE_U1 as _),
-            Type::I16 => blob.push(ELEMENT_TYPE_I2 as _),
-            Type::U16 => blob.push(ELEMENT_TYPE_U2 as _),
-            Type::I32 => blob.push(ELEMENT_TYPE_I4 as _),
-            Type::U32 => blob.push(ELEMENT_TYPE_U4 as _),
-            Type::I64 => blob.push(ELEMENT_TYPE_I8 as _),
-            Type::U64 => blob.push(ELEMENT_TYPE_U8 as _),
-            Type::F32 => blob.push(ELEMENT_TYPE_R4 as _),
-            Type::F64 => blob.push(ELEMENT_TYPE_R8 as _),
-            Type::ISize => blob.push(ELEMENT_TYPE_I as _),
-            Type::USize => blob.push(ELEMENT_TYPE_U as _),
-            Type::String => blob.push(ELEMENT_TYPE_STRING as _),
-            Type::IInspectable => blob.push(ELEMENT_TYPE_OBJECT as _),
+            Type::Void => blob.push(ELEMENT_TYPE_VOID),
+            Type::Bool => blob.push(ELEMENT_TYPE_BOOLEAN),
+            Type::Char => blob.push(ELEMENT_TYPE_CHAR),
+            Type::I8 => blob.push(ELEMENT_TYPE_I1),
+            Type::U8 => blob.push(ELEMENT_TYPE_U1),
+            Type::I16 => blob.push(ELEMENT_TYPE_I2),
+            Type::U16 => blob.push(ELEMENT_TYPE_U2),
+            Type::I32 => blob.push(ELEMENT_TYPE_I4),
+            Type::U32 => blob.push(ELEMENT_TYPE_U4),
+            Type::I64 => blob.push(ELEMENT_TYPE_I8),
+            Type::U64 => blob.push(ELEMENT_TYPE_U8),
+            Type::F32 => blob.push(ELEMENT_TYPE_R4),
+            Type::F64 => blob.push(ELEMENT_TYPE_R8),
+            Type::ISize => blob.push(ELEMENT_TYPE_I),
+            Type::USize => blob.push(ELEMENT_TYPE_U),
+            Type::String => blob.push(ELEMENT_TYPE_STRING),
+            Type::IInspectable => blob.push(ELEMENT_TYPE_OBJECT),
             Type::GUID => {
                 let code = self.insert_type_ref("System", "Guid");
-                blob.push(ELEMENT_TYPE_VALUETYPE as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_VALUETYPE);
+                usize_blob(code as usize, blob);
             }
             Type::HRESULT => {
                 let code = self.insert_type_ref("Windows.Foundation", "HResult");
-                blob.push(ELEMENT_TYPE_VALUETYPE as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_VALUETYPE);
+                usize_blob(code as usize, blob);
             }
             Type::TypeRef(ty) => {
                 let code = self.insert_type_ref(&ty.namespace, &ty.name);
-                blob.push(ELEMENT_TYPE_VALUETYPE as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_VALUETYPE);
+                usize_blob(code as usize, blob);
             }
             Type::BSTR => {
                 let code = self.insert_type_ref("Windows.Win32.Foundation", "BSTR");
-                blob.push(ELEMENT_TYPE_VALUETYPE as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_VALUETYPE);
+                usize_blob(code as usize, blob);
             }
             Type::IUnknown => {
                 let code = self.insert_type_ref("Windows.Win32.Foundation", "IUnknown");
-                blob.push(ELEMENT_TYPE_VALUETYPE as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_VALUETYPE);
+                usize_blob(code as usize, blob);
             }
             Type::PCWSTR | Type::PWSTR => {
                 let code = self.insert_type_ref("Windows.Win32.Foundation", "PWSTR");
-                blob.push(ELEMENT_TYPE_VALUETYPE as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_VALUETYPE);
+                usize_blob(code as usize, blob);
             }
             Type::PCSTR | Type::PSTR => {
                 let code = self.insert_type_ref("Windows.Win32.Foundation", "PSTR");
-                blob.push(ELEMENT_TYPE_VALUETYPE as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_VALUETYPE);
+                usize_blob(code as usize, blob);
             }
             Type::ConstRef(ty) => {
-                usize_blob(ELEMENT_TYPE_CMOD_OPT as _, blob);
+                usize_blob(ELEMENT_TYPE_CMOD_OPT as usize, blob);
                 usize_blob(
-                    self.insert_type_ref("System.Runtime.CompilerServices", "IsConst") as _,
+                    self.insert_type_ref("System.Runtime.CompilerServices", "IsConst") as usize,
                     blob,
                 );
-                usize_blob(ELEMENT_TYPE_BYREF as _, blob);
+                usize_blob(ELEMENT_TYPE_BYREF as usize, blob);
                 self.type_blob(ty, blob);
             }
             Type::WinrtArrayRef(ty) => {
-                usize_blob(ELEMENT_TYPE_BYREF as _, blob);
-                usize_blob(ELEMENT_TYPE_SZARRAY as _, blob);
+                usize_blob(ELEMENT_TYPE_BYREF as usize, blob);
+                usize_blob(ELEMENT_TYPE_SZARRAY as usize, blob);
                 self.type_blob(ty, blob);
             }
             Type::WinrtArray(ty) => {
-                usize_blob(ELEMENT_TYPE_SZARRAY as _, blob);
+                usize_blob(ELEMENT_TYPE_SZARRAY as usize, blob);
                 self.type_blob(ty, blob);
             }
             Type::Win32Array(ty, bounds) => {
-                usize_blob(ELEMENT_TYPE_ARRAY as _, blob);
+                usize_blob(ELEMENT_TYPE_ARRAY as usize, blob);
                 self.type_blob(ty, blob);
                 usize_blob(1, blob); // rank
                 usize_blob(1, blob); // count
-                usize_blob(*bounds as _, blob);
+                usize_blob(*bounds, blob);
             }
             Type::TypeName => {
                 let code = self.insert_type_ref("System", "Type");
-                blob.push(ELEMENT_TYPE_CLASS as _);
-                usize_blob(code as _, blob);
+                blob.push(ELEMENT_TYPE_CLASS);
+                usize_blob(code as usize, blob);
             }
             Type::MutPtr(ty, pointers) | Type::ConstPtr(ty, pointers) => {
                 for _ in 0..*pointers {
-                    usize_blob(ELEMENT_TYPE_PTR as _, blob);
+                    usize_blob(ELEMENT_TYPE_PTR as usize, blob);
                 }
                 self.type_blob(ty, blob);
             }
@@ -336,15 +336,15 @@ fn usize_blob(value: usize, blob: &mut Vec<u8>) {
     assert!(value < 0x20000000);
 
     if value < 0x80 {
-        blob.push(value as _);
+        blob.push(value as u8);
     } else if value < 0x4000 {
-        blob.push((0x80 | (value & 0x3F00) >> 8) as _);
-        blob.push((value & 0xFF) as _);
+        blob.push((0x80 | (value & 0x3F00) >> 8) as u8);
+        blob.push((value & 0xFF) as u8);
     } else {
-        blob.push((0xC0 | (value & 0x1F000000) >> 24) as _);
-        blob.push(((value & 0xFF0000) >> 16) as _);
-        blob.push(((value & 0xFF00) >> 8) as _);
-        blob.push((value & 0xFF) as _);
+        blob.push((0xC0 | (value & 0x1F000000) >> 24) as u8);
+        blob.push(((value & 0xFF0000) >> 16) as u8);
+        blob.push(((value & 0xFF00) >> 8) as u8);
+        blob.push((value & 0xFF) as u8);
     }
 }
 

--- a/crates/tools/riddle/src/winmd/writer/strings.rs
+++ b/crates/tools/riddle/src/winmd/writer/strings.rs
@@ -23,7 +23,7 @@ impl Strings {
 
         match self.map.entry(value.to_string()) {
             Entry::Vacant(entry) => {
-                let offset = *entry.insert(self.stream.len() as _);
+                let offset = *entry.insert(self.stream.len() as u32);
                 self.stream.extend_from_slice(value.as_bytes());
                 self.stream.push(0);
                 offset

--- a/crates/tools/riddle/src/winmd/writer/tables.rs
+++ b/crates/tools/riddle/src/winmd/writer/tables.rs
@@ -198,7 +198,7 @@ impl Tables {
             self.TypeSpec.len(),
         ]
         .iter()
-        .any(|len| *len > u32::MAX as _)
+        .any(|len| *len > u32::MAX as usize)
         {
             panic!("metadata table too large");
         }
@@ -247,25 +247,25 @@ impl Tables {
 
         // Followed by the length of each of the valid tables...
 
-        buffer.write_u32(self.Module.len() as _);
-        buffer.write_u32(self.TypeRef.len() as _);
-        buffer.write_u32(self.TypeDef.len() as _);
-        buffer.write_u32(self.Field.len() as _);
-        buffer.write_u32(self.MethodDef.len() as _);
-        buffer.write_u32(self.Param.len() as _);
-        buffer.write_u32(self.InterfaceImpl.len() as _);
-        buffer.write_u32(self.MemberRef.len() as _);
-        buffer.write_u32(self.Constant.len() as _);
-        buffer.write_u32(self.CustomAttribute.len() as _);
-        buffer.write_u32(self.ClassLayout.len() as _);
-        buffer.write_u32(self.Property.len() as _);
-        buffer.write_u32(self.ModuleRef.len() as _);
-        buffer.write_u32(self.TypeSpec.len() as _);
-        buffer.write_u32(self.ImplMap.len() as _);
-        buffer.write_u32(self.Assembly.len() as _);
-        buffer.write_u32(self.AssemblyRef.len() as _);
-        buffer.write_u32(self.NestedClass.len() as _);
-        buffer.write_u32(self.GenericParam.len() as _);
+        buffer.write_u32(self.Module.len() as u32);
+        buffer.write_u32(self.TypeRef.len() as u32);
+        buffer.write_u32(self.TypeDef.len() as u32);
+        buffer.write_u32(self.Field.len() as u32);
+        buffer.write_u32(self.MethodDef.len() as u32);
+        buffer.write_u32(self.Param.len() as u32);
+        buffer.write_u32(self.InterfaceImpl.len() as u32);
+        buffer.write_u32(self.MemberRef.len() as u32);
+        buffer.write_u32(self.Constant.len() as u32);
+        buffer.write_u32(self.CustomAttribute.len() as u32);
+        buffer.write_u32(self.ClassLayout.len() as u32);
+        buffer.write_u32(self.Property.len() as u32);
+        buffer.write_u32(self.ModuleRef.len() as u32);
+        buffer.write_u32(self.TypeSpec.len() as u32);
+        buffer.write_u32(self.ImplMap.len() as u32);
+        buffer.write_u32(self.Assembly.len() as u32);
+        buffer.write_u32(self.AssemblyRef.len() as u32);
+        buffer.write_u32(self.NestedClass.len() as u32);
+        buffer.write_u32(self.GenericParam.len() as u32);
 
         // Followed by each table's rows...
 

--- a/crates/tools/riddle/src/winmd/writer/traits.rs
+++ b/crates/tools/riddle/src/winmd/writer/traits.rs
@@ -37,7 +37,7 @@ impl Write for Vec<u8> {
 
     fn write_code(&mut self, value: u32, size: usize) {
         if size == 2 {
-            self.write_u16(value as _);
+            self.write_u16(value as u16);
         } else {
             self.write_u32(value);
         }
@@ -64,6 +64,6 @@ pub trait Push2<T> {
 impl<T> Push2<T> for Vec<T> {
     fn push2(&mut self, value: T) -> u32 {
         self.push(value);
-        (self.len() - 1) as _
+        (self.len() - 1) as u32
     }
 }


### PR DESCRIPTION
Inferred casts are needed in some cases for genericity but in general explicit casts improve clarity and avoid masking unnecessary casts since Clippy will flag them. 