### PR TITLE
metadata: Parse new `Char` value type

### DIFF
--- a/crates/libs/metadata/default/readme.md
+++ b/crates/libs/metadata/default/readme.md
@@ -1,22 +1,25 @@
 These `.winmd` files provide the default metadata for the Windows API. This is used to
 generate the `windows` and `windows-sys` crates. To view the metadata, use a tool
-like [ILSpy](https://github.com/icsharpcode/ILSpy). 
+like [ILSpy](https://github.com/icsharpcode/ILSpy).
 
-## Windows.Win32.winmd
-- Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/
-- Version: 53.0.14
+## `Windows.Win32.winmd`
 
-## Windows.Wdk.winmd
-- Source: https://www.nuget.org/packages/Microsoft.Windows.WDK.Win32Metadata/
-- Version: 0.7.3
+- Source: <https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/>
+- Version: `53.0.14`
 
-## Windows.winmd
-- Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts
-- Version: 10.0.22621.755
+## `Windows.Wdk.winmd`
+
+- Source: <https://www.nuget.org/packages/Microsoft.Windows.WDK.Win32Metadata/>
+- Version: `0.7.3`
+
+## `Windows.winmd`
+
+- Source: <https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts>
+- Version: `10.0.22621.755`
 
 The `Windows.winmd` file was created by merging the .winmd files from the last nuget package as follows:
 
-```
+```sh
 mdmerge -o out -i . -n 1
 ```
 

--- a/crates/libs/metadata/src/blob.rs
+++ b/crates/libs/metadata/src/blob.rs
@@ -109,6 +109,10 @@ impl<'a> Blob<'a> {
         value
     }
 
+    pub fn read_char(&mut self) -> char {
+        char::from_u32(self.read_u16().into()).unwrap()
+    }
+
     pub fn read_i32(&mut self) -> i32 {
         let value = i32::from_le_bytes(self[..4].try_into().unwrap());
         self.offset(4);

--- a/crates/libs/metadata/src/file/reader.rs
+++ b/crates/libs/metadata/src/file/reader.rs
@@ -151,6 +151,7 @@ pub trait RowReader<'a> {
             Type::F32 => Value::F32(blob.read_f32()),
             Type::F64 => Value::F64(blob.read_f64()),
             Type::String => Value::String(blob.read_string()),
+            Type::Char => Value::Char(blob.read_char()),
             rest => unimplemented!("{rest:?}"),
         }
     }

--- a/crates/libs/metadata/src/lib.rs
+++ b/crates/libs/metadata/src/lib.rs
@@ -47,6 +47,7 @@ pub enum Value {
     F32(f32),
     F64(f64),
     String(String),
+    Char(char),
     TypeName(String),
     TypeRef(TypeDefOrRef),
     EnumDef(TypeDef, Box<Self>),

--- a/crates/tools/riddle/src/rust/writer.rs
+++ b/crates/tools/riddle/src/rust/writer.rs
@@ -542,6 +542,7 @@ impl<'a> Writer<'a> {
                 tokens.push('\"');
                 tokens.into()
             }
+            Value::Char(value) => format!("'{}'", value.escape_default()).into(),
             rest => unimplemented!("{rest:?}"),
         }
     }
@@ -562,6 +563,7 @@ impl<'a> Writer<'a> {
             Value::String(_) => {
                 quote! { &str = #literal }
             }
+            Value::Char(_) => quote! { char = #literal },
             rest => unimplemented!("{rest:?}"),
         }
     }


### PR DESCRIPTION
The latest metadata now contains `char` constants.

Note that `quote! { #value }` generates the actual character code in the source file, whereas we prefer the escaped literals just like in `Value::String()`.

```rust
pub const DEVPROP_FALSE: char = '\u{0}';
pub const DEVPROP_TRUE: char = '\u{ffff}';
````
