### PR TITLE
Version 0.51.0

### DIFF
--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-core"
-version = "0.50.0"
+version = "0.51.0"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,7 +16,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies.windows-targets]
-version = "0.48.1"
+version = "0.48.2"
 path = "../targets"
 
 [features]

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-implement"
-version = "0.48.0"
+version = "0.51.0"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-interface"
-version = "0.48.0"
+version = "0.51.0"
 edition = "2021"
 authors = ["Microsoft"]
 license = "MIT OR Apache-2.0"

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -17,7 +17,7 @@ targets = []
 all-features = true
 
 [dependencies.windows-targets]
-version = "0.48.1"
+version = "0.48.2"
 path = "../targets"
 
 [features]

--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,22 +10,22 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "../../../docs/readme.md"
 
 [target.'cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))'.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.48.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.48.2" }
 
 [target.'cfg(all(target_arch = "x86_64", target_env = "msvc", not(windows_raw_dylib)))'.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.48.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.48.2" }
 
 [target.'cfg(all(target_arch = "aarch64", target_env = "msvc", not(windows_raw_dylib)))'.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.48.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.48.2" }
 
 [target.'cfg(all(target_arch = "x86", target_env = "gnu", not(windows_raw_dylib)))'.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.48.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.48.2" }
 
 [target.'cfg(all(target_arch = "x86_64", target_env = "gnu", not(target_abi = "llvm"), not(windows_raw_dylib)))'.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.48.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.48.2" }
 
 [target.x86_64-pc-windows-gnullvm.dependencies]
-windows_x86_64_gnullvm = { path = "../../targets/x86_64_gnullvm", version = "0.48.0" }
+windows_x86_64_gnullvm = { path = "../../targets/x86_64_gnullvm", version = "0.48.2" }
 
 [target.aarch64-pc-windows-gnullvm.dependencies]
-windows_aarch64_gnullvm = { path = "../../targets/aarch64_gnullvm", version = "0.48.0" }
+windows_aarch64_gnullvm = { path = "../../targets/aarch64_gnullvm", version = "0.48.2" }

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.48.0"
+version = "0.51.0"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -18,10 +18,10 @@ targets = []
 rustc-args = ["--cfg", "docsrs"]
 
 [dependencies]
-windows-core = { path = "../core", version = "0.50.0" }
-windows-targets = { path = "../targets", version = "0.48.1" }
-windows-implement = { path = "../implement",  version = "0.48.0", optional = true }
-windows-interface = { path = "../interface",  version = "0.48.0", optional = true }
+windows-core = { path = "../core", version = "0.51.0" }
+windows-targets = { path = "../targets", version = "0.48.2" }
+windows-implement = { path = "../implement",  version = "0.51.0", optional = true }
+windows-interface = { path = "../interface",  version = "0.51.0", optional = true }
 
 [features]
 default = []

--- a/crates/targets/aarch64_gnullvm/Cargo.toml
+++ b/crates/targets/aarch64_gnullvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnullvm/Cargo.toml
+++ b/crates/targets/x86_64_gnullvm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.2"
 authors = ["Microsoft"]
 edition = "2021"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
As requested by #2603, this update includes the first published update to the [windows](https://crates.io/crates/windows) crate in 5 months. As a reminder, updates are only published by request. 

* This includes a semver-compatible update to the [windows-targets](https://crates.io/crates/windows-targets) crate.
* The `windows` crate now depends on the [windows-core](https://crates.io/crates/windows-core) crate.
* The `windows`, `windows-core`, `windows-implement`, and `windows-interface` crates have been bumped to version 0.51.0 as there have been breaking changes. 
* The `windows-targets` crate has been bumped to version 0.48.2 as it remains compatible with previous versions. 
* Notably, an expanded set of WDK APIs are now available. 
* Other crates will not be updated at this time.

Fixes: #2603