### PR TITLE
Detect unused `bindgen`/`riddle` filters

### DIFF
--- a/crates/libs/bindgen/src/error.rs
+++ b/crates/libs/bindgen/src/error.rs
@@ -44,12 +44,4 @@ impl Error {
     pub(crate) fn with_path(self, path: &str) -> Self {
         Self { path: path.to_string(), ..self }
     }
-
-    // pub(crate) fn with_span(self, span: proc_macro2::Span) -> Self {
-    //     let start = span.start();
-    //     Self {
-    //         span: Some((start.line, start.column)),
-    //         ..self
-    //     }
-    // }
 }

--- a/crates/libs/bindgen/src/winmd/verify.rs
+++ b/crates/libs/bindgen/src/winmd/verify.rs
@@ -2,6 +2,18 @@ use super::*;
 use metadata::RowReader;
 
 pub fn verify(reader: &metadata::Reader, filter: &metadata::Filter) -> crate::Result<()> {
+    let unused: Vec<&str> = filter.unused(reader).collect();
+
+    if !unused.is_empty() {
+        let mut message = "unused filters".to_string();
+
+        for unused in unused {
+            message.push_str(&format!("\n  {unused}"));
+        }
+
+        return Err(crate::Error::new(&message));
+    }
+
     for item in reader.items(filter) {
         // TODO: cover all variants
         let metadata::Item::Type(def) = item else {

--- a/crates/libs/metadata/src/filter.rs
+++ b/crates/libs/metadata/src/filter.rs
@@ -70,6 +70,10 @@ impl<'a> Filter<'a> {
     fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
+
+    pub fn unused(&self, reader: &'a Reader) -> impl Iterator<Item = &str> + '_ {
+        self.0.iter().filter_map(|(name, _)| if reader.unused(name) { Some(*name) } else { None })
+    }
 }
 
 fn match_type_name(rule: &str, namespace: &str, name: &str) -> bool {

--- a/crates/tests/metadata/tests/unused.rs
+++ b/crates/tests/metadata/tests/unused.rs
@@ -1,0 +1,14 @@
+use metadata::*;
+
+#[test]
+fn test() {
+    let files = tool_lib::default_metadata();
+    let reader = &Reader::new(&files);
+    let filter = Filter::new(
+        &["Windows", "BadNamespace", "Windows.AI"],
+        &["Windows.Foundation.Rect", "Windows.Foundation.BadType"],
+    );
+    let unused: Vec<&str> = filter.unused(reader).collect();
+
+    assert_eq!(unused, ["Windows.Foundation.BadType", "BadNamespace"]);
+}

--- a/crates/tests/riddle/src/lib.rs
+++ b/crates/tests/riddle/src/lib.rs
@@ -18,6 +18,7 @@ pub fn run_riddle(name: &str, dialect: &str, etc: &[&str]) -> Vec<windows_metada
     let before = std::fs::read_to_string(&rdl).expect("Failed to read input");
 
     // Convert .rdl to .winmd
+    std::fs::remove_file(&winmd).expect("Failed to delete output");
     let mut command = Command::new("cargo");
     command.args([
         "run", "-p", "riddle", "--", "--in", &rdl, "--out", &winmd, "--filter", "Test",
@@ -25,6 +26,7 @@ pub fn run_riddle(name: &str, dialect: &str, etc: &[&str]) -> Vec<windows_metada
     assert!(command.status().unwrap().success());
 
     // Convert .winmd back to .rdl
+    std::fs::remove_file(&rdl).expect("Failed to delete output");
     let mut command = Command::new("cargo");
     command.args([
         "run", "-p", "riddle", "--", "--in", &winmd, "--out", &rdl, "--filter", "Test", "--config",
@@ -37,6 +39,7 @@ pub fn run_riddle(name: &str, dialect: &str, etc: &[&str]) -> Vec<windows_metada
     assert_eq!(before, after, "no equal {}", rdl);
 
     // Convert .rdl to .rs
+    std::fs::remove_file(&rs).expect("Failed to delete output");
     let mut command = Command::new("cargo");
     command.args([
         "run", "-p", "riddle", "--", "--in", &rdl, "--out", &rs, "--filter", "Test",

--- a/crates/tests/riddle/src/lib.rs
+++ b/crates/tests/riddle/src/lib.rs
@@ -18,7 +18,7 @@ pub fn run_riddle(name: &str, dialect: &str, etc: &[&str]) -> Vec<windows_metada
     let before = std::fs::read_to_string(&rdl).expect("Failed to read input");
 
     // Convert .rdl to .winmd
-    std::fs::remove_file(&winmd).expect("Failed to delete output");
+    _ = std::fs::remove_file(&winmd);
     let mut command = Command::new("cargo");
     command.args([
         "run", "-p", "riddle", "--", "--in", &rdl, "--out", &winmd, "--filter", "Test",

--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -150,6 +150,8 @@ fn write_std(output: &str, filter: &[&str]) {
 }
 
 fn riddle(output: &str, filter: &[&str], config: &[&str]) {
+    std::fs::remove_file(output).expect("Failed to delete output");
+
     let mut command = std::process::Command::new("cargo");
 
     command.args([


### PR DESCRIPTION
As an example:

```
> riddle.exe -i windows.winmd -o output.rs -f Windows.Foundation.Rect WIndows !Windows.Fondation
error: unused filters
  Windows.Fondation
  WIndows
```

Fixes: #2630