### PR TITLE
Fix `BOOLEAN` parameter binding

### DIFF
--- a/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/BOOLEAN.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/BOOLEAN.rs
@@ -66,3 +66,8 @@ impl ::core::ops::Not for BOOLEAN {
         }
     }
 }
+impl ::windows_core::IntoParam<BOOLEAN> for bool {
+    fn into_param(self) -> ::windows_core::Param<BOOLEAN> {
+        ::windows_core::Param::Owned(self.into())
+    }
+}

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -21677,6 +21677,11 @@ impl ::core::ops::Not for BOOLEAN {
         }
     }
 }
+impl ::windows_core::IntoParam<BOOLEAN> for bool {
+    fn into_param(self) -> ::windows_core::Param<BOOLEAN> {
+        ::windows_core::Param::Owned(self.into())
+    }
+}
 impl NTSTATUS {
     #[inline]
     pub const fn is_ok(self) -> bool {

--- a/crates/tests/extensions/Cargo.toml
+++ b/crates/tests/extensions/Cargo.toml
@@ -9,4 +9,8 @@ path = "../../libs/windows"
 features = [
     "Win32_Foundation",
     "Win32_Security_Cryptography",   
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_NetworkManagement_Ndis",
+    "Win32_Networking_WinSock",
+    "Win32_System_Threading",
 ]

--- a/crates/tests/extensions/tests/bool32.rs
+++ b/crates/tests/extensions/tests/bool32.rs
@@ -1,4 +1,4 @@
-use windows::Win32::Foundation::*;
+use windows::{Win32::Foundation::*, Win32::System::Threading::*};
 
 #[test]
 fn test() {
@@ -20,4 +20,13 @@ fn test() {
     assert_eq!(result.is_ok(), false);
     let error = result.unwrap_err();
     assert_eq!(error.code(), E_ACCESSDENIED);
+}
+
+#[test]
+#[ignore]
+fn no_run() {
+    unsafe {
+        _ = CreateEventA(None, false, true, None);
+        _ = CreateEventA(None, BOOL(0), BOOL(1), None);
+    }
 }

--- a/crates/tests/extensions/tests/boolean.rs
+++ b/crates/tests/extensions/tests/boolean.rs
@@ -1,4 +1,4 @@
-use windows::Win32::Foundation::*;
+use windows::{Win32::Foundation::*, Win32::NetworkManagement::IpHelper::*};
 
 #[test]
 fn test() {
@@ -20,4 +20,25 @@ fn test() {
     assert_eq!(result.is_ok(), false);
     let error = result.unwrap_err();
     assert_eq!(error.code(), E_ACCESSDENIED);
+}
+
+#[test]
+#[ignore]
+fn no_run() {
+    unsafe {
+        _ = NotifyUnicastIpAddressChange(
+            Default::default(),
+            None,
+            None,
+            true,
+            std::ptr::null_mut(),
+        );
+        _ = NotifyUnicastIpAddressChange(
+            Default::default(),
+            None,
+            None,
+            BOOLEAN(1),
+            std::ptr::null_mut(),
+        );
+    }
 }


### PR DESCRIPTION
Also added tests for both `BOOLEAN` and `BOOL` parameter bindings to ensure this doesn't regress. 

Fixes: #2632