### PR TITLE
Tweak Win32 error code conversion to handle `HRESULT` input

### DIFF
--- a/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/WIN32_ERROR.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/WIN32_ERROR.rs
@@ -9,7 +9,7 @@ impl WIN32_ERROR {
     }
     #[inline]
     pub const fn to_hresult(self) -> ::windows_core::HRESULT {
-        ::windows_core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as i32)
+        ::windows_core::HRESULT::from_win32(self.0)
     }
     #[inline]
     pub fn from_error(error: &::windows_core::Error) -> ::core::option::Option<Self> {

--- a/crates/libs/core/src/hresult.rs
+++ b/crates/libs/core/src/hresult.rs
@@ -92,8 +92,8 @@ impl HRESULT {
     }
 
     /// Maps a Win32 error code to an HRESULT value.
-    pub(crate) fn from_win32(error: u32) -> Self {
-        Self(if error == 0 { 0 } else { (error & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as i32)
+    pub const fn from_win32(error: u32) -> Self {
+        Self(if error as i32 <= 0 { error } else { (error & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as i32)
     }
 }
 

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -21793,7 +21793,7 @@ impl WIN32_ERROR {
     }
     #[inline]
     pub const fn to_hresult(self) -> ::windows_core::HRESULT {
-        ::windows_core::HRESULT(if self.0 == 0 { self.0 } else { (self.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as i32)
+        ::windows_core::HRESULT::from_win32(self.0)
     }
     #[inline]
     pub fn from_error(error: &::windows_core::Error) -> ::core::option::Option<Self> {

--- a/crates/tests/core/tests/error.rs
+++ b/crates/tests/core/tests/error.rs
@@ -1,6 +1,8 @@
+use windows::{core::*, Win32::Foundation::*, Win32::Media::Audio::*};
+
 #[test]
-fn test() {
-    let e = windows::core::Error::from(windows::Win32::Foundation::ERROR_NO_UNICODE_TRANSLATION);
+fn display_debug() {
+    let e = Error::from(ERROR_NO_UNICODE_TRANSLATION);
     let display = format!("{e}");
     let debug = format!("{e:?}");
     assert_eq!(display, "No mapping for the Unicode character exists in the target multi-byte code page. (0x80070459)");
@@ -9,9 +11,19 @@ fn test() {
         r#"Error { code: HRESULT(0x80070459), message: "No mapping for the Unicode character exists in the target multi-byte code page." }"#
     );
 
-    let e = windows::core::Error::from(windows::Win32::Media::Audio::AUDCLNT_E_UNSUPPORTED_FORMAT);
+    let e = Error::from(AUDCLNT_E_UNSUPPORTED_FORMAT);
     let display = format!("{e}");
     let debug = format!("{e:?}");
     assert_eq!(display, "0x88890008");
     assert_eq!(debug, r#"Error { code: HRESULT(0x88890008), message: "" }"#);
+}
+
+#[test]
+fn hresult_last_error() {
+    unsafe {
+        assert_eq!(CRYPT_E_NOT_FOUND.0, 0x80092004u32 as i32);
+        SetLastError(WIN32_ERROR(CRYPT_E_NOT_FOUND.0 as u32));
+        let e = GetLastError().unwrap_err();
+        assert_eq!(e.code(), CRYPT_E_NOT_FOUND);
+    }
 }


### PR DESCRIPTION
In some cases, the result of `GetLastError` will be an `HRESULT` rather than a Win32 error code despite the fact that the Win32 metadata incorrectly indicates that `GetLastError` returns a Win32 error code. That is a separate issue we'll have to deal with.

For now, this just hardens the `windows-core` crate to deal with error codes consistent with how `HRESULT_FROM_WIN32` behaves in C++.

Fixes: #2639