### PR TITLE
Remove support for the defunct `StaticLibrary` attribute

### DIFF
--- a/crates/libs/bindgen/src/metadata/mod.rs
+++ b/crates/libs/bindgen/src/metadata/mod.rs
@@ -575,16 +575,6 @@ pub fn method_def_special_name(reader: &Reader, row: MethodDef) -> String {
     }
 }
 
-pub fn method_def_static_lib(reader: &Reader, row: MethodDef) -> Option<String> {
-    reader.find_attribute(row, "StaticLibraryAttribute").and_then(|attribute| {
-        let args = reader.attribute_args(attribute);
-        if let Value::String(value) = &args[0].1 {
-            return Some(value.clone());
-        }
-        None
-    })
-}
-
 pub fn method_def_extern_abi(reader: &Reader, def: MethodDef) -> &'static str {
     let impl_map = reader.method_def_impl_map(def).expect("ImplMap not found");
     let flags = reader.impl_map_flags(impl_map);

--- a/crates/libs/bindgen/src/rust/functions.rs
+++ b/crates/libs/bindgen/src/rust/functions.rs
@@ -225,14 +225,6 @@ fn gen_link(writer: &Writer, namespace: &str, signature: &Signature, cfg: &Cfg) 
                 pub fn #ident(#(#params,)* #vararg) #return_type;
             }
         }
-    } else if let Some(library) = method_def_static_lib(writer.reader, signature.def) {
-        quote! {
-            #[link(name = #library, kind = "static")]
-            extern #abi {
-                #link_name
-                pub fn #ident(#(#params,)* #vararg) #return_type;
-            }
-        }
     } else {
         let symbol = if symbol != name { format!(" \"{symbol}\"") } else { String::new() };
 


### PR DESCRIPTION
This attribute was never well supported or adopted. This just removes the dead code from the repo. 

Fixes: #2637