### PR TITLE
Simplify code generation

### DIFF
--- a/crates/libs/bindgen/src/metadata.rs
+++ b/crates/libs/bindgen/src/metadata.rs
@@ -498,7 +498,7 @@ pub fn type_interfaces(ty: &Type) -> Vec<Interface> {
     result
 }
 
-fn type_name<'a>(ty: &Type) -> &'a str {
+fn type_name(ty: &Type) -> &str {
     match ty {
         Type::TypeDef(row, _) => row.name(),
         _ => "",

--- a/crates/libs/bindgen/src/metadata.rs
+++ b/crates/libs/bindgen/src/metadata.rs
@@ -812,7 +812,3 @@ pub fn type_def_vtables(row: TypeDef) -> Vec<Type> {
     }
     result
 }
-
-pub fn type_def_interfaces(row: TypeDef, generics: &[Type]) -> impl Iterator<Item = Type> + '_ {
-    row.interface_impls().map(move |imp| imp.ty(generics))
-}

--- a/crates/libs/bindgen/src/metadata.rs
+++ b/crates/libs/bindgen/src/metadata.rs
@@ -80,7 +80,7 @@ pub enum AsyncKind {
 pub struct Guid(pub u32, pub u16, pub u16, pub u8, pub u8, pub u8, pub u8, pub u8, pub u8, pub u8, pub u8);
 
 impl Guid {
-    pub fn from_args(args: &[(String, Value)]) -> Self {
+    pub fn from_args(args: &[(&str, Value)]) -> Self {
         fn unwrap_u32(value: &Value) -> u32 {
             match value {
                 Value::U32(value) => *value,
@@ -802,8 +802,7 @@ pub fn type_interfaces(ty: &Type) -> Vec<Interface> {
                     "StaticAttribute" | "ActivatableAttribute" => {
                         for (_, arg) in attribute.args() {
                             if let Value::TypeName(type_name) = arg {
-                                let type_name = parse_type_name(&type_name);
-                                let def = row.reader().get_type_def(type_name.0, type_name.1).next().expect("Type not found");
+                                let def = row.reader().get_type_def(type_name.namespace, type_name.name).next().expect("Type not found");
                                 result.push(Interface { ty: Type::TypeDef(def, Vec::new()), kind: InterfaceKind::Static });
                                 break;
                             }

--- a/crates/libs/bindgen/src/rdl/from_reader.rs
+++ b/crates/libs/bindgen/src/rdl/from_reader.rs
@@ -286,12 +286,11 @@ impl Writer {
         // TODO: then list default interface first
         // Then everything else
 
-        for imp in def.interface_impls() {
-            let ty = imp.ty(generics);
-            if imp.has_attribute("DefaultAttribute") {
-                types.insert(0, self.ty(&ty));
+        for interface in type_def_interfaces(def, generics) {
+            if interface.kind == InterfaceKind::Default {
+                types.insert(0, self.ty(&interface.ty));
             } else {
-                types.push(self.ty(&ty));
+                types.push(self.ty(&interface.ty));
             }
         }
 

--- a/crates/libs/bindgen/src/rdl/from_reader.rs
+++ b/crates/libs/bindgen/src/rdl/from_reader.rs
@@ -358,8 +358,7 @@ impl Writer {
                 }
             }
 
-            metadata::Type::TypeRef(code) => {
-                let type_name = code.type_name();
+            metadata::Type::TypeRef(type_name) => {
                 let namespace = self.namespace(type_name.namespace);
                 let name = to_ident(type_name.name);
                 quote! { #namespace #name }
@@ -379,7 +378,6 @@ impl Writer {
             metadata::Type::PCWSTR => quote! { PCWSTR },
             metadata::Type::BSTR => quote! { BSTR },
             metadata::Type::PrimitiveOrEnum(_, ty) => self.ty(ty),
-            rest => unimplemented!("{rest:?}"),
         }
     }
 

--- a/crates/libs/bindgen/src/rdl/from_reader.rs
+++ b/crates/libs/bindgen/src/rdl/from_reader.rs
@@ -378,6 +378,7 @@ impl Writer {
             metadata::Type::PCWSTR => quote! { PCWSTR },
             metadata::Type::BSTR => quote! { BSTR },
             metadata::Type::PrimitiveOrEnum(_, ty) => self.ty(ty),
+            rest => unimplemented!("{rest:?}"),
         }
     }
 

--- a/crates/libs/bindgen/src/rust/cfg.rs
+++ b/crates/libs/bindgen/src/rust/cfg.rs
@@ -58,19 +58,9 @@ pub fn type_def_cfg_impl(def: TypeDef, generics: &[Type]) -> Cfg {
 
     combine(def, generics, &mut cfg);
 
-    // TODO: why do we need both type_def_interfaces for WinRT and type_def_vtables for Win32?
-
-    for def in type_def_vtables(def) {
-        if let Type::TypeDef(def, generics) = def {
+    for interface in type_interfaces(&Type::TypeDef(def, generics.to_vec())) {
+        if let Type::TypeDef(def, generics) = interface.ty {
             combine(def, &generics, &mut cfg);
-        }
-    }
-
-    if def.flags().contains(TypeAttributes::WindowsRuntime) {
-        for interface in type_def_interfaces(def, generics) {
-            if let Type::TypeDef(def, generics) = interface {
-                combine(def, &generics, &mut cfg);
-            }
         }
     }
 
@@ -158,6 +148,7 @@ pub fn type_cfg(ty: &Type) -> Cfg {
     type_cfg_combine(ty, &mut cfg);
     cfg
 }
+
 fn type_cfg_combine(ty: &Type, cfg: &mut Cfg) {
     match ty {
         Type::TypeDef(row, generics) => type_def_cfg_combine(*row, generics, cfg),

--- a/crates/libs/bindgen/src/rust/cfg.rs
+++ b/crates/libs/bindgen/src/rust/cfg.rs
@@ -58,6 +58,8 @@ pub fn type_def_cfg_impl(def: TypeDef, generics: &[Type]) -> Cfg {
 
     combine(def, generics, &mut cfg);
 
+    // TODO: why do we need both type_def_interfaces for WinRT and type_def_vtables for Win32?
+
     for def in type_def_vtables(def) {
         if let Type::TypeDef(def, generics) = def {
             combine(def, &generics, &mut cfg);

--- a/crates/libs/bindgen/src/rust/classes.rs
+++ b/crates/libs/bindgen/src/rust/classes.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn writer(writer: &Writer, def: TypeDef) -> TokenStream {
     if writer.sys {
-        if type_def_has_default_interface(def) {
+        if def.interface_impls().next().is_some() {
             let name = to_ident(def.name());
             quote! {
                 pub type #name = *mut ::core::ffi::c_void;
@@ -64,7 +64,7 @@ fn gen_class(writer: &Writer, def: TypeDef) -> TokenStream {
         _ => None,
     });
 
-    if type_def_has_default_interface(def) {
+    if def.interface_impls().next().is_some() {
         let new = if type_def_has_default_constructor(def) {
             quote! {
                 pub fn new() -> ::windows_core::Result<Self> {
@@ -170,10 +170,6 @@ fn type_def_has_default_constructor(row: TypeDef) -> bool {
         }
     }
     false
-}
-
-fn type_def_has_default_interface(row: TypeDef) -> bool {
-    row.interface_impls().any(|imp| imp.has_attribute("DefaultAttribute"))
 }
 
 fn type_is_exclusive(ty: &Type) -> bool {

--- a/crates/libs/bindgen/src/rust/mod.rs
+++ b/crates/libs/bindgen/src/rust/mod.rs
@@ -21,7 +21,7 @@ use crate::{Error, Result, Tree};
 use cfg::*;
 use rayon::prelude::*;
 
-pub fn from_reader(reader: &metadata::Reader, mut config: std::collections::BTreeMap<&str, &str>, output: &str) -> Result<()> {
+pub fn from_reader(reader: &'static metadata::Reader, mut config: std::collections::BTreeMap<&str, &str>, output: &str) -> Result<()> {
     let mut writer = Writer::new(reader, output);
     writer.package = config.remove("package").is_some();
     writer.flatten = config.remove("flatten").is_some();
@@ -56,7 +56,7 @@ fn gen_file(writer: &Writer) -> Result<()> {
 
     if writer.flatten {
         let tokens = standalone::standalone_imp(writer);
-        crate::write_to_file(writer.output, try_format(writer, &tokens))
+        crate::write_to_file(&writer.output, try_format(writer, &tokens))
     } else {
         let mut tokens = String::new();
         let root = Tree::new(writer.reader);
@@ -65,12 +65,12 @@ fn gen_file(writer: &Writer) -> Result<()> {
             tokens.push_str(&namespace(writer, tree));
         }
 
-        crate::write_to_file(writer.output, try_format(writer, &tokens))
+        crate::write_to_file(&writer.output, try_format(writer, &tokens))
     }
 }
 
 fn gen_package(writer: &Writer) -> Result<()> {
-    let directory = crate::directory(writer.output);
+    let directory = crate::directory(&writer.output);
     let root = Tree::new(writer.reader);
     let mut root_len = 0;
 

--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -1,10 +1,10 @@
 use super::*;
 
 #[derive(Clone)]
-pub struct Writer<'a> {
-    pub reader: &'a Reader,
-    pub output: &'a str,
-    pub namespace: &'a str,
+pub struct Writer {
+    pub reader: &'static Reader,
+    pub output: String,
+    pub namespace: &'static str,
     pub implement: bool, // TODO: ideally we can use this to generate implementation traits on the fly and
     // and have a single interface definition macro for consumption that expands to include
     // impl traits when the `implement` cfg flag is set and then this writer option would be
@@ -20,11 +20,11 @@ pub struct Writer<'a> {
     pub no_inner_attributes: bool, // skips the inner attributes at the start of the file
 }
 
-impl<'a> Writer<'a> {
-    pub fn new(reader: &'a Reader, output: &'a str) -> Self {
+impl Writer {
+    pub fn new(reader: &'static Reader, output: &str) -> Self {
         Self {
             reader,
-            output,
+            output: output.to_string(),
             namespace: "",
             implement: false,
             std: false,
@@ -403,7 +403,7 @@ impl<'a> Writer<'a> {
         quote! { #arch #features }
     }
 
-    fn cfg_features_imp(&self, cfg: &'a Cfg, namespace: &'a str) -> Vec<&'a str> {
+    fn cfg_features_imp(&self, cfg: &Cfg, namespace: &str) -> Vec<&'static str> {
         let mut compact = Vec::<&'static str>::new();
         if self.package {
             for feature in cfg.types.keys() {

--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -568,7 +568,7 @@ impl Writer {
         let mut async_generics = generics.to_vec();
 
         if kind == AsyncKind::None {
-            for interface in type_def_interfaces(def, generics) {
+            for interface in def.interface_impls().map(move |imp| imp.ty(generics)) {
                 if let Type::TypeDef(interface_def, interface_generics) = &interface {
                     kind = type_def_async_kind(*interface_def);
                     if kind != AsyncKind::None {

--- a/crates/libs/bindgen/src/tree.rs
+++ b/crates/libs/bindgen/src/tree.rs
@@ -1,13 +1,13 @@
 use super::*;
 
 #[derive(Debug)]
-pub struct Tree<'a> {
-    pub namespace: &'a str,
-    pub nested: std::collections::BTreeMap<&'a str, Tree<'a>>,
+pub struct Tree {
+    pub namespace: &'static str,
+    pub nested: std::collections::BTreeMap<&'static str, Tree>,
 }
 
-impl<'a> Tree<'a> {
-    pub fn new(reader: &'a metadata::Reader) -> Self {
+impl Tree {
+    pub fn new(reader: &'static metadata::Reader) -> Self {
         let mut tree = Tree::from_namespace("");
         for ns in reader.namespaces() {
             if reader.includes_namespace(ns) {
@@ -17,10 +17,10 @@ impl<'a> Tree<'a> {
         tree
     }
 
-    fn from_namespace(namespace: &'a str) -> Self {
+    fn from_namespace(namespace: &'static str) -> Self {
         Self { namespace, nested: std::collections::BTreeMap::new() }
     }
-    fn insert_namespace(&mut self, namespace: &'a str, pos: usize) -> &mut Self {
+    fn insert_namespace(&mut self, namespace: &'static str, pos: usize) -> &mut Self {
         if let Some(next) = namespace[pos..].find('.') {
             let next = pos + next;
             self.nested.entry(&namespace[pos..next]).or_insert_with(|| Self::from_namespace(&namespace[..next])).insert_namespace(namespace, next + 1)

--- a/crates/libs/bindgen/src/winmd/from_reader.rs
+++ b/crates/libs/bindgen/src/winmd/from_reader.rs
@@ -122,7 +122,6 @@ fn winmd_type(ty: &metadata::Type) -> winmd::Type {
         metadata::Type::PCSTR => winmd::Type::PCSTR,
         metadata::Type::PCWSTR => winmd::Type::PCWSTR,
         metadata::Type::BSTR => winmd::Type::BSTR,
-        metadata::Type::TypeName => winmd::Type::TypeName,
         metadata::Type::TypeDef(def, generics) => winmd::Type::TypeRef(winmd::TypeName { namespace: def.namespace().to_string(), name: def.name().to_string(), generics: generics.iter().map(winmd_type).collect() }),
         metadata::Type::GenericParam(generic) => winmd::Type::GenericParam(generic.number()),
         metadata::Type::ConstRef(ty) => winmd::Type::ConstRef(Box::new(winmd_type(ty))),

--- a/crates/libs/bindgen/src/winmd/from_reader.rs
+++ b/crates/libs/bindgen/src/winmd/from_reader.rs
@@ -122,6 +122,7 @@ fn winmd_type(ty: &metadata::Type) -> winmd::Type {
         metadata::Type::PCSTR => winmd::Type::PCSTR,
         metadata::Type::PCWSTR => winmd::Type::PCWSTR,
         metadata::Type::BSTR => winmd::Type::BSTR,
+        metadata::Type::Type => winmd::Type::Type,
         metadata::Type::TypeDef(def, generics) => winmd::Type::TypeRef(winmd::TypeName { namespace: def.namespace().to_string(), name: def.name().to_string(), generics: generics.iter().map(winmd_type).collect() }),
         metadata::Type::GenericParam(generic) => winmd::Type::GenericParam(generic.number()),
         metadata::Type::ConstRef(ty) => winmd::Type::ConstRef(Box::new(winmd_type(ty))),

--- a/crates/libs/bindgen/src/winmd/from_reader.rs
+++ b/crates/libs/bindgen/src/winmd/from_reader.rs
@@ -36,7 +36,7 @@ pub fn from_reader(reader: &metadata::Reader, config: std::collections::BTreeMap
 
         for generic in def.generics() {
             writer.tables.GenericParam.push(writer::GenericParam {
-                Number: generic.number(),
+                Number: generic.number(), // TODO: isn't this just going to be incremental?
                 Flags: 0,
                 Owner: writer::TypeOrMethodDef::TypeDef(writer.tables.TypeDef.len() as u32 - 1).encode(),
                 Name: writer.strings.insert(generic.name()),

--- a/crates/libs/bindgen/src/winmd/from_reader.rs
+++ b/crates/libs/bindgen/src/winmd/from_reader.rs
@@ -43,9 +43,8 @@ pub fn from_reader(reader: &metadata::Reader, config: std::collections::BTreeMap
             });
         }
 
-        for imp in def.interface_impls() {
-            let ty = imp.ty(generics);
-            let ty = winmd_type(&ty);
+        for interface in metadata::type_def_interfaces(def, generics) {
+            let ty = winmd_type(&interface.ty);
 
             let reference = match &ty {
                 winmd::Type::TypeRef(type_name) if type_name.generics.is_empty() => writer.insert_type_ref(&type_name.namespace, &type_name.name),

--- a/crates/libs/bindgen/src/winmd/verify.rs
+++ b/crates/libs/bindgen/src/winmd/verify.rs
@@ -35,8 +35,8 @@ pub fn verify(reader: &metadata::Reader) -> crate::Result<()> {
 }
 
 fn not_type_ref(ty: &metadata::Type) -> crate::Result<()> {
-    if let metadata::Type::TypeRef(ty) = ty {
-        return Err(crate::Error::new(&format!("missing type definition `{}`", ty.type_name())));
+    if let metadata::Type::TypeRef(type_name) = ty {
+        return Err(crate::Error::new(&format!("missing type definition `{}`", type_name)));
     }
     Ok(())
 }

--- a/crates/libs/bindgen/src/winmd/verify.rs
+++ b/crates/libs/bindgen/src/winmd/verify.rs
@@ -35,8 +35,8 @@ pub fn verify(reader: &metadata::Reader) -> crate::Result<()> {
 }
 
 fn not_type_ref(ty: &metadata::Type) -> crate::Result<()> {
-    if let metadata::Type::TypeRef(type_name) = ty {
-        return Err(crate::Error::new(&format!("missing type definition `{}`", type_name)));
+    if let metadata::Type::TypeRef(ty) = ty {
+        return Err(crate::Error::new(&format!("missing type definition `{}`", ty)));
     }
     Ok(())
 }

--- a/crates/libs/bindgen/src/winmd/writer/mod.rs
+++ b/crates/libs/bindgen/src/winmd/writer/mod.rs
@@ -234,6 +234,11 @@ impl Writer {
                 usize_blob(1, blob); // count
                 usize_blob(*bounds, blob);
             }
+            Type::Type => {
+                let code = self.insert_type_ref("System", "Type");
+                blob.push(metadata::ELEMENT_TYPE_CLASS);
+                usize_blob(code as usize, blob);
+            }
             Type::MutPtr(ty, pointers) | Type::ConstPtr(ty, pointers) => {
                 for _ in 0..*pointers {
                     usize_blob(metadata::ELEMENT_TYPE_PTR as usize, blob);

--- a/crates/libs/bindgen/src/winmd/writer/mod.rs
+++ b/crates/libs/bindgen/src/winmd/writer/mod.rs
@@ -234,11 +234,6 @@ impl Writer {
                 usize_blob(1, blob); // count
                 usize_blob(*bounds, blob);
             }
-            Type::TypeName => {
-                let code = self.insert_type_ref("System", "Type");
-                blob.push(metadata::ELEMENT_TYPE_CLASS);
-                usize_blob(code as usize, blob);
-            }
             Type::MutPtr(ty, pointers) | Type::ConstPtr(ty, pointers) => {
                 for _ in 0..*pointers {
                     usize_blob(metadata::ELEMENT_TYPE_PTR as usize, blob);

--- a/crates/libs/bindgen/src/winmd/writer/type.rs
+++ b/crates/libs/bindgen/src/winmd/writer/type.rs
@@ -34,6 +34,7 @@ pub enum Type {
     PCSTR,
     PCWSTR,
     BSTR,
+    Type,
     TypeRef(TypeName),
     GenericParam(u16),
     MutPtr(Box<Self>, usize),

--- a/crates/libs/bindgen/src/winmd/writer/type.rs
+++ b/crates/libs/bindgen/src/winmd/writer/type.rs
@@ -34,7 +34,6 @@ pub enum Type {
     PCSTR,
     PCWSTR,
     BSTR,
-    TypeName,
     TypeRef(TypeName),
     GenericParam(u16),
     MutPtr(Box<Self>, usize),

--- a/crates/libs/metadata/src/blob.rs
+++ b/crates/libs/metadata/src/blob.rs
@@ -58,7 +58,7 @@ impl Blob {
         mods
     }
 
-    pub fn read_str(&mut self) -> &str {
+    pub fn read_str(&mut self) -> &'static str {
         let len = self.read_usize();
         let value = unsafe { std::str::from_utf8_unchecked(&self.slice[..len]) };
         self.offset(len);

--- a/crates/libs/metadata/src/filter.rs
+++ b/crates/libs/metadata/src/filter.rs
@@ -83,8 +83,8 @@ mod tests {
     use super::*;
 
     fn includes_type_name(filter: &Filter, full_name: &'static str) -> bool {
-        let type_name = crate::parse_type_name(full_name);
-        filter.includes_type_name(type_name.0, type_name.1)
+        let type_name = TypeName::parse(full_name);
+        filter.includes_type_name(type_name.namespace, type_name.name)
     }
 
     #[test]

--- a/crates/libs/metadata/src/filter.rs
+++ b/crates/libs/metadata/src/filter.rs
@@ -83,7 +83,7 @@ mod tests {
     use super::*;
 
     fn includes_type_name(filter: &Filter, full_name: &'static str) -> bool {
-        let type_name = TypeName::parse(full_name);
+        let type_name = crate::TypeName::parse(full_name);
         filter.includes_type_name(type_name.namespace, type_name.name)
     }
 

--- a/crates/libs/metadata/src/lib.rs
+++ b/crates/libs/metadata/src/lib.rs
@@ -95,7 +95,7 @@ pub enum Value {
     F32(f32),
     F64(f64),
     String(String),
-    TypeName(String),
+    TypeName(TypeName),
     EnumDef(TypeDef, Box<Self>),
 }
 

--- a/crates/libs/metadata/src/lib.rs
+++ b/crates/libs/metadata/src/lib.rs
@@ -19,7 +19,7 @@ pub use attributes::*;
 pub use bindings::*;
 pub use blob::*;
 pub use codes::*;
-pub use column::*;
+use column::*;
 pub use file::*;
 use filter::*;
 pub use r#type::*;
@@ -96,7 +96,6 @@ pub enum Value {
     F64(f64),
     String(String),
     TypeName(String),
-    TypeRef(TypeDefOrRef), // TODO: needed?
     EnumDef(TypeDef, Box<Self>),
 }
 

--- a/crates/libs/metadata/src/reader.rs
+++ b/crates/libs/metadata/src/reader.rs
@@ -252,4 +252,4 @@ impl Reader {
 pub const REMAP_TYPES: [(TypeName, TypeName); 2] = [(TypeName::D2D_MATRIX_3X2_F, TypeName::Matrix3x2), (TypeName::D3DMATRIX, TypeName::Matrix4x4)];
 
 // TODO: get rid of at least the second tuple if not the whole thing.
-pub const CORE_TYPES: [(TypeName, Type); 10] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HRESULT, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::CHAR, Type::U8)];
+pub const CORE_TYPES: [(TypeName, Type); 11] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HRESULT, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::Type, Type::Type), (TypeName::CHAR, Type::U8)];

--- a/crates/libs/metadata/src/reader.rs
+++ b/crates/libs/metadata/src/reader.rs
@@ -16,6 +16,8 @@ pub struct Reader {
     // TODO: riddle should just avoid nested structs
     nested: HashMap<TypeDef, BTreeMap<&'static str, TypeDef>>,
 
+    // The reader needs to store the filter since standalone code generation needs more than just the filtered items
+    // in order to chase dependencies automatically. This is why `Reader::filter` can't just filter everything up front.
     filter: Filter,
 }
 
@@ -170,11 +172,10 @@ impl Reader {
         if let Some(def) = self.get_type_def(full_name.namespace, full_name.name).next() {
             Type::TypeDef(def, Vec::new())
         } else {
-            Type::TypeRef(code)
+            Type::TypeRef(full_name)
         }
     }
 
-    // TODO: this shouldn't be public
     pub fn type_from_blob(&self, blob: &mut Blob, enclosing: Option<TypeDef>, generics: &[Type]) -> Type {
         // Used by WinRT to indicate that a struct input parameter is passed by reference rather than by value on the ABI.
         let is_const = blob.read_modifiers().iter().any(|def| def.type_name() == TypeName::IsConst);
@@ -251,4 +252,4 @@ impl Reader {
 pub const REMAP_TYPES: [(TypeName, TypeName); 2] = [(TypeName::D2D_MATRIX_3X2_F, TypeName::Matrix3x2), (TypeName::D3DMATRIX, TypeName::Matrix4x4)];
 
 // TODO: get rid of at least the second tuple if not the whole thing.
-pub const CORE_TYPES: [(TypeName, Type); 11] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HRESULT, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::Type, Type::TypeName), (TypeName::CHAR, Type::U8)];
+pub const CORE_TYPES: [(TypeName, Type); 10] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HRESULT, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::CHAR, Type::U8)];

--- a/crates/libs/metadata/src/tables.rs
+++ b/crates/libs/metadata/src/tables.rs
@@ -82,7 +82,7 @@ impl Attribute {
                 Type::I64 => Value::I64(values.read_i64()),
                 Type::U64 => Value::U64(values.read_u64()),
                 Type::String => Value::String(values.read_str().to_string()),
-                Type::TypeRef(type_name) if type_name == TypeName::Type => Value::TypeName(values.read_str().to_string()),
+                Type::TypeRef(type_name) if type_name == TypeName::Type => Value::TypeName(TypeName::parse(values.read_str())),
                 Type::TypeDef(def, _) => Value::EnumDef(def, Box::new(values.read_integer(def.underlying_type()))),
                 rest => unimplemented!("{rest:?}"),
             };
@@ -103,7 +103,7 @@ impl Attribute {
                 ELEMENT_TYPE_I4 => Value::I32(values.read_i32()),
                 ELEMENT_TYPE_U4 => Value::U32(values.read_u32()),
                 ELEMENT_TYPE_STRING => Value::String(values.read_str().to_string()),
-                0x50 => Value::TypeName(values.read_str().to_string()),
+                0x50 => Value::TypeName(TypeName::parse(values.read_str())),
                 0x55 => {
                     let type_name = parse_type_name(&name);
                     let def = reader.get_type_def(type_name.0, type_name.1).next().expect("Type not found");

--- a/crates/libs/metadata/src/tables.rs
+++ b/crates/libs/metadata/src/tables.rs
@@ -82,7 +82,7 @@ impl Attribute {
                 Type::I64 => Value::I64(values.read_i64()),
                 Type::U64 => Value::U64(values.read_u64()),
                 Type::String => Value::String(values.read_str().to_string()),
-                Type::TypeRef(type_name) if type_name == TypeName::Type => Value::TypeName(TypeName::parse(values.read_str())),
+                Type::Type => Value::TypeName(TypeName::parse(values.read_str())),
                 Type::TypeDef(def, _) => Value::EnumDef(def, Box::new(values.read_integer(def.underlying_type()))),
                 rest => unimplemented!("{rest:?}"),
             };

--- a/crates/libs/metadata/src/tables.rs
+++ b/crates/libs/metadata/src/tables.rs
@@ -105,8 +105,8 @@ impl Attribute {
                 ELEMENT_TYPE_STRING => Value::String(values.read_str().to_string()),
                 0x50 => Value::TypeName(TypeName::parse(values.read_str())),
                 0x55 => {
-                    let type_name = parse_type_name(&name);
-                    let def = reader.get_type_def(type_name.0, type_name.1).next().expect("Type not found");
+                    let type_name = TypeName::parse(&name);
+                    let def = reader.get_type_def(type_name.namespace, type_name.name).next().expect("Type not found");
                     name = values.read_str();
                     Value::EnumDef(def, Box::new(values.read_integer(def.underlying_type())))
                 }

--- a/crates/libs/metadata/src/tables.rs
+++ b/crates/libs/metadata/src/tables.rs
@@ -105,7 +105,7 @@ impl Attribute {
                 ELEMENT_TYPE_STRING => Value::String(values.read_str().to_string()),
                 0x50 => Value::TypeName(TypeName::parse(values.read_str())),
                 0x55 => {
-                    let type_name = TypeName::parse(&name);
+                    let type_name = TypeName::parse(name);
                     let def = reader.get_type_def(type_name.namespace, type_name.name).next().expect("Type not found");
                     name = values.read_str();
                     Value::EnumDef(def, Box::new(values.read_integer(def.underlying_type())))

--- a/crates/libs/metadata/src/tables.rs
+++ b/crates/libs/metadata/src/tables.rs
@@ -48,16 +48,14 @@ impl Attribute {
     }
 
     pub fn name(&self) -> &'static str {
-        let AttributeType::MemberRef(member) = self.ty();
-        assert_eq!(member.name(), ".ctor");
-        let MemberRefParent::TypeRef(ty) = member.parent();
+        let AttributeType::MemberRef(ctor) = self.ty();
+        let MemberRefParent::TypeRef(ty) = ctor.parent();
         ty.name()
     }
 
     pub fn type_name(&self) -> TypeName {
-        let AttributeType::MemberRef(member) = self.ty();
-        assert_eq!(member.name(), ".ctor");
-        let MemberRefParent::TypeRef(ty) = member.parent();
+        let AttributeType::MemberRef(ctor) = self.ty();
+        let MemberRefParent::TypeRef(ty) = ctor.parent();
         ty.type_name()
     }
 
@@ -84,7 +82,7 @@ impl Attribute {
                 Type::I64 => Value::I64(values.read_i64()),
                 Type::U64 => Value::U64(values.read_u64()),
                 Type::String => Value::String(values.read_str().to_string()),
-                Type::TypeName => Value::TypeName(values.read_str().to_string()),
+                Type::TypeRef(type_name) if type_name == TypeName::Type => Value::TypeName(values.read_str().to_string()),
                 Type::TypeDef(def, _) => Value::EnumDef(def, Box::new(values.read_integer(def.underlying_type()))),
                 rest => unimplemented!("{rest:?}"),
             };
@@ -117,9 +115,8 @@ impl Attribute {
             args.push((name.to_string(), arg));
         }
 
-        // TODO: can we debug assert these?
-        assert_eq!(sig.slice.len(), 0);
-        assert_eq!(values.slice.len(), 0);
+        debug_assert_eq!(sig.slice.len(), 0);
+        debug_assert_eq!(values.slice.len(), 0);
 
         args
     }

--- a/crates/libs/metadata/src/type.rs
+++ b/crates/libs/metadata/src/type.rs
@@ -23,6 +23,7 @@ pub enum Type {
     GUID,         // Both Win32 and WinRT agree that this is represented by System.Guid
     String,       // TODO: Win32 should use System.String when referring to an HSTRING
     IInspectable, // TODO: Win32 should use System.Object when referring to an IInspectable
+    Type,         // System.Type is needed since WinRT attribute use this as a parameter type.
 
     // Regular ECMA-335 types that map to metadata
     TypeRef(TypeName),

--- a/crates/libs/metadata/src/type.rs
+++ b/crates/libs/metadata/src/type.rs
@@ -24,11 +24,8 @@ pub enum Type {
     String,       // TODO: Win32 should use System.String when referring to an HSTRING
     IInspectable, // TODO: Win32 should use System.Object when referring to an IInspectable
 
-    // Meta-type indicating type name in attribute blob.
-    TypeName,
-
     // Regular ECMA-335 types that map to metadata
-    TypeRef(TypeDefOrRef), // Note: this ought to be a TypeName but that would require Type to have a lifetime reference.
+    TypeRef(TypeName),
     GenericParam(GenericParam),
     TypeDef(TypeDef, Vec<Self>),
 

--- a/crates/libs/metadata/src/type_name.rs
+++ b/crates/libs/metadata/src/type_name.rs
@@ -68,8 +68,3 @@ impl std::fmt::Display for TypeName {
         write!(fmt, "{}.{}", self.namespace, self.name)
     }
 }
-
-pub fn parse_type_name(full_name: &str) -> (&str, &str) {
-    let index = full_name.rfind('.').expect("Expected full name separated with `.`");
-    (&full_name[0..index], &full_name[index + 1..])
-}

--- a/crates/libs/metadata/src/type_name.rs
+++ b/crates/libs/metadata/src/type_name.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 
-#[derive(Copy, Clone, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct TypeName {
     pub namespace: &'static str,
     pub name: &'static str,

--- a/crates/libs/metadata/src/type_name.rs
+++ b/crates/libs/metadata/src/type_name.rs
@@ -56,6 +56,11 @@ impl TypeName {
     pub fn new(namespace: &'static str, name: &'static str) -> Self {
         Self { namespace, name: trim_tick(name) }
     }
+
+    pub fn parse(full_name: &'static str) -> Self {
+        let index = full_name.rfind('.').expect("Expected full name separated with `.`");
+        Self::new(&full_name[0..index], &full_name[index + 1..])
+    }
 }
 
 impl std::fmt::Display for TypeName {

--- a/crates/tests/metadata/tests/attribute_enum.rs
+++ b/crates/tests/metadata/tests/attribute_enum.rs
@@ -37,7 +37,7 @@ fn check_attr_arg_enum(attr: Attribute, arg_name: &str, expected_type: &str, exp
     let (_, value) = attr
         .args()
         .drain(..)
-        .find(|(name, _)| name == arg_name)
+        .find(|(name, _)| *name == arg_name)
         .unwrap();
 
     if let Value::EnumDef(ty, value) = value {


### PR DESCRIPTION
Building on https://github.com/microsoft/windows-rs/pull/2684, this update simplifies code generation primarily by avoiding a bunch of unnecessary lifetime code that is no longer needed thanks to metadata reader improvements. This update also avoids a bunch of small allocations as more of the reader and its output can be static. 