### PR TITLE
Enable all features for docs.rs generation

### DIFF
--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -16,6 +16,7 @@ categories = ["os::windows-apis"]
 default-target = "x86_64-pc-windows-msvc"
 targets = []
 rustc-args = ["--cfg", "docsrs"]
+all-features = true
 
 [dependencies]
 windows-core = { path = "../core", version = "0.52.0" }


### PR DESCRIPTION
The current docs.rs documentation for the `windows-rs` crate is useless currently: https://docs.rs/windows/latest/windows/

This enables all features so docs for all items will be available.