### PR TITLE
Minor tooling improvements

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -86,7 +86,7 @@ jobs:
           cargo clippy -p test_core &&
           cargo clippy -p test_debug &&
           cargo clippy -p test_debug_inspectable &&
-          cargo clippy -p test_debugger_visualizer_x &&
+          cargo clippy -p test_debugger_visualizer &&
           cargo clippy -p test_deprecated &&
           cargo clippy -p test_dispatch &&
           cargo clippy -p test_does_not_return &&

--- a/.github/workflows/debugger_visualizer.yml
+++ b/.github/workflows/debugger_visualizer.yml
@@ -30,4 +30,4 @@ jobs:
         run: rustup target add ${{ matrix.target }}
 
       - name: Test
-        run: cargo test -p test_debugger_visualizer_x -- --test-threads=1
+        run: cargo test -p test_debugger_visualizer -- --test-threads=1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,14 +93,15 @@ jobs:
           cargo test -p test_core &&
           cargo test -p test_debug &&
           cargo test -p test_debug_inspectable &&
+          cargo test -p test_debugger_visualizer &&
           cargo test -p test_deprecated &&
           cargo test -p test_dispatch &&
           cargo test -p test_does_not_return &&
           cargo test -p test_enums &&
           cargo test -p test_error &&
           cargo test -p test_event &&
-          cargo test -p test_extensions &&
           cargo clean &&
+          cargo test -p test_extensions &&
           cargo test -p test_handles &&
           cargo test -p test_helpers &&
           cargo test -p test_implement &&

--- a/crates/tests/debugger_visualizer/Cargo.toml
+++ b/crates/tests/debugger_visualizer/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "test_debugger_visualizer_x"
+name = "test_debugger_visualizer"
 version = "0.0.0"
 edition = "2021"
 publish = false

--- a/crates/tests/targets/Cargo.toml
+++ b/crates/tests/targets/Cargo.toml
@@ -14,3 +14,6 @@ features = [ "Win32_Foundation", "Win32_Security_Authentication_Identity" ]
 [dependencies.windows-sys]
 path = "../../libs/sys"
 features = [ "Win32_Foundation", "Win32_Security_Authentication_Identity" ]
+
+[dependencies.tool_lib]
+path = "../../tools/lib"

--- a/crates/tests/targets/tests/files.rs
+++ b/crates/tests/targets/tests/files.rs
@@ -3,6 +3,10 @@
 
 #[test]
 fn test() {
+    let targets = tool_lib::crates("../../targets");
+    assert_eq!(7, targets.len());
+    assert!(targets.iter().all(|(_, version)| version == "0.52.0"));
+
     std::include_bytes!("../../../targets/aarch64_gnullvm/lib/libwindows.0.52.0.a");
     std::include_bytes!("../../../targets/aarch64_msvc/lib/windows.0.52.0.lib");
     std::include_bytes!("../../../targets/i686_gnu/lib/libwindows.0.52.0.a");

--- a/crates/tools/lib/Cargo.toml
+++ b/crates/tools/lib/Cargo.toml
@@ -5,4 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
+regex = "1.7"
 metadata = { package = "windows-metadata", path = "../../libs/metadata" }

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -1,5 +1,5 @@
-use std::collections::BTreeMap;
 use regex::Regex;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 pub enum CallingConvention {
@@ -102,16 +102,10 @@ fn find<P: AsRef<Path>>(path: P, regex: &Regex) -> Vec<(String, String)> {
                     names.append(&mut find(file.path(), regex));
                 } else if file.file_name() == "Cargo.toml" {
                     let text = std::fs::read_to_string(file.path()).expect("Cargo.toml");
-                    let captures = regex
-                    .captures(&text)
-                    .expect("captures");
-                    let name = captures
-                        .get(1)
-                        .expect("name");
-                        let version = captures
-                        .get(2)
-                        .expect("version");
-                        names.push((name.as_str().to_string(), version.as_str().to_string()));
+                    let captures = regex.captures(&text).expect("captures");
+                    let name = captures.get(1).expect("name");
+                    let version = captures.get(2).expect("version");
+                    names.push((name.as_str().to_string(), version.as_str().to_string()));
                 }
             }
         }

--- a/crates/tools/yml/Cargo.toml
+++ b/crates/tools/yml/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 publish = false
 
 [dependencies]
-regex = "1.7"
+lib = { package = "tool_lib", path = "../lib" }


### PR DESCRIPTION
Internal test and tooling crates used the `_x` suffix to denote they needed a nightly build of Rust. This is no longer needed so I've removed this filtering. I also moved the `crates` function into the tooling library so that it can be used for more carefully validating target lib file names match target lib crate versions.