### PR TITLE
Add link to the generated documentation to often-seen readmes

### DIFF
--- a/crates/libs/windows/readme.md
+++ b/crates/libs/windows/readme.md
@@ -5,6 +5,7 @@ The [windows](https://crates.io/crates/windows) and [windows-sys](https://crates
 * [Getting started](https://kennykerr.ca/rust-getting-started/)
 * [Samples](https://github.com/microsoft/windows-rs/tree/0.52.0/crates/samples) <!-- link to samples for upcoming release -->
 * [Releases](https://github.com/microsoft/windows-rs/releases)
+* [API Documentation](https://microsoft.github.io/windows-docs-rs/doc/windows)
 
 Start by adding the following to your Cargo.toml file:
 

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -5,6 +5,7 @@ The [windows](https://crates.io/crates/windows) and [windows-sys](https://crates
 * [Getting started](https://kennykerr.ca/rust-getting-started/)
 * [Samples](https://github.com/microsoft/windows-rs/tree/master/crates/samples)  <!-- link to latest samples on repo -->
 * [Releases](https://github.com/microsoft/windows-rs/releases)
+* [API Documentation](https://microsoft.github.io/windows-docs-rs/doc/windows)
 
 This repo is the home of the following crates (and other supporting crates):
 


### PR DESCRIPTION
Just a tiny bit of friction I hit sometimes - there's actually no link to the generated documentation inside the readmes, and thus no easy way to get to the docs from GitHub either. The only link I can find is in the sidebar on crates.io. Usually googling (or hoping it's in the browser history) seems to be faster than finding it that way.

This PR just adds it to the main readme file, and to the readme for the windows crate itself.