### PR TITLE
Adds ability to override `GetTrustLevel` return value

### DIFF
--- a/crates/libs/core/src/unknown.rs
+++ b/crates/libs/core/src/unknown.rs
@@ -72,8 +72,10 @@ pub trait IUnknownImpl {
     /// This function is safe to call as long as the interface pointer is non-null and valid for writes
     /// of an interface pointer.
     unsafe fn QueryInterface(&self, iid: *const GUID, interface: *mut *mut std::ffi::c_void) -> HRESULT;
+
     /// Increments the reference count of the interface
     fn AddRef(&self) -> u32;
+
     /// Decrements the reference count causing the interface's memory to be freed when the count is 0
     ///
     /// # Safety
@@ -81,6 +83,9 @@ pub trait IUnknownImpl {
     /// This function should only be called when the interfacer pointer is no longer used as calling `Release`
     /// on a non-aliased interface pointer and then using that interface pointer may result in use after free.
     unsafe fn Release(&self) -> u32;
+
+    /// Gets the trust level of the current object.
+    unsafe fn GetTrustLevel(&self, value: *mut i32) -> HRESULT;
 }
 
 #[cfg(feature = "implement")]

--- a/crates/tests/implement/tests/trust_level.rs
+++ b/crates/tests/implement/tests/trust_level.rs
@@ -1,0 +1,54 @@
+#![allow(non_snake_case)]
+
+use windows::core::*;
+use windows::Foundation::*;
+
+#[implement(IStringable)]
+struct BaseTrust;
+
+impl IStringable_Impl for BaseTrust {
+    fn ToString(&self) -> Result<HSTRING> {
+        Ok("BaseTrust".into())
+    }
+}
+
+#[implement(IClosable, TrustLevel = Partial, IStringable)]
+struct PartialTrust;
+
+impl IStringable_Impl for PartialTrust {
+    fn ToString(&self) -> Result<HSTRING> {
+        Ok("PartialTrust".into())
+    }
+}
+
+impl IClosable_Impl for PartialTrust {
+    fn Close(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[implement( IStringable, TrustLevel = Full)]
+struct FullTrust;
+
+impl IStringable_Impl for FullTrust {
+    fn ToString(&self) -> Result<HSTRING> {
+        Ok("FullTrust".into())
+    }
+}
+
+#[test]
+fn test() -> Result<()> {
+    let base: IStringable = BaseTrust.into();
+    assert_eq!(base.ToString()?, "BaseTrust");
+    assert_eq!(base.cast::<IInspectable>()?.GetTrustLevel()?, 0);
+
+    let partial: IStringable = PartialTrust.into();
+    assert_eq!(partial.ToString()?, "PartialTrust");
+    assert_eq!(partial.cast::<IInspectable>()?.GetTrustLevel()?, 1);
+
+    let full: IStringable = FullTrust.into();
+    assert_eq!(full.ToString()?, "FullTrust");
+    assert_eq!(full.cast::<IInspectable>()?.GetTrustLevel()?, 2);
+
+    Ok(())
+}

--- a/crates/tests/implement/tests/trust_level.rs
+++ b/crates/tests/implement/tests/trust_level.rs
@@ -27,7 +27,7 @@ impl IClosable_Impl for PartialTrust {
     }
 }
 
-#[implement( IStringable, TrustLevel = Full)]
+#[implement(IStringable, TrustLevel = Full)]
 struct FullTrust;
 
 impl IStringable_Impl for FullTrust {


### PR DESCRIPTION
In rare cases, the return value should be changed to allow partial/full trust semantics for WinRT activation. This update introduces a generalized syntax for expressing this so that future implementation customization may be supported as needed. For example:

```rust
#[implement(IStringable, TrustLevel = Full)]
struct FullTrust;
```

Fixes: #2713