### PR TITLE
Remove `invalid_mut` when `writer.std`

### DIFF
--- a/crates/libs/bindgen/src/rust/constants.rs
+++ b/crates/libs/bindgen/src/rust/constants.rs
@@ -43,8 +43,6 @@ pub fn writer(writer: &Writer, def: Field) -> TokenStream {
 
             let value = if underlying_type == constant_type {
                 value
-            } else if writer.std && underlying_type == Type::ISize {
-                quote! { ::core::ptr::invalid_mut(#value as _) }
             } else {
                 quote! { #value as _ }
             };


### PR DESCRIPTION
This removes one more difference between `std` and `sys`.

The remaining two differences are in linking and handle type. The former should more or less solve itself once everyone is happy using raw-dylib. The latter requires getting either win32metadata or rust-lang/rust to shift their position on what type a `HANDLE` should be.