### PR TITLE
Enable workspace lints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,4 +13,4 @@ exclude = [
 ]
 
 [workspace.lints.rust]
-elided-lifetimes-in-paths = "warn"
+rust_2018_idioms = "warn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,6 @@ members = [
 exclude = [
     "crates/targets/baseline",
 ]
+
+[workspace.lints.rust]
+elided-lifetimes-in-paths = "warn"

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -9,6 +9,9 @@ description = "Windows metadata compiler"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []

--- a/crates/libs/bindgen/src/rdl/mod.rs
+++ b/crates/libs/bindgen/src/rdl/mod.rs
@@ -136,7 +136,7 @@ pub struct Interface {
 syn::custom_keyword!(interface);
 syn::custom_keyword!(class);
 
-fn winrt(input: syn::parse::ParseStream) -> syn::Result<bool> {
+fn winrt(input: syn::parse::ParseStream<'_>) -> syn::Result<bool> {
     let attributes = input.call(syn::Attribute::parse_inner)?;
     if attributes.len() == 1 {
         if let syn::Meta::Path(path) = &attributes[0].meta {
@@ -154,7 +154,7 @@ fn winrt(input: syn::parse::ParseStream) -> syn::Result<bool> {
 }
 
 impl syn::parse::Parse for File {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let mut references = vec![];
         let mut modules = vec![];
         let winrt = winrt(input)?;
@@ -178,7 +178,7 @@ impl Module {
         self.namespace.rsplit_once('.').map_or(&self.namespace, |(_, name)| name)
     }
 
-    fn parse(namespace: &str, winrt: bool, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(namespace: &str, winrt: bool, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         input.parse::<syn::Token![mod]>()?;
         let name = input.parse::<syn::Ident>()?.to_string();
 
@@ -195,7 +195,7 @@ impl Module {
 }
 
 impl ModuleMember {
-    fn parse(namespace: &str, winrt: bool, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(namespace: &str, winrt: bool, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let attributes: Vec<syn::Attribute> = input.call(syn::Attribute::parse_outer)?;
         let lookahead = input.lookahead1();
         if lookahead.peek(syn::Token![mod]) {
@@ -222,7 +222,7 @@ impl ModuleMember {
 }
 
 impl Class {
-    fn parse(attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         input.parse::<class>()?;
         let name = input.parse::<syn::Ident>()?.to_string();
         let mut extends = Vec::new();
@@ -247,7 +247,7 @@ impl Class {
 }
 
 impl Interface {
-    fn parse(_namespace: &str, winrt: bool, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(_namespace: &str, winrt: bool, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         input.parse::<interface>()?;
         let name = input.parse::<syn::Ident>()?.to_string();
 
@@ -284,7 +284,7 @@ impl Interface {
 }
 
 impl Struct {
-    fn parse(_namespace: &str, winrt: bool, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(_namespace: &str, winrt: bool, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         // TODO: need to validate that the struct is valid according to the constraints of the winmd type system.
         // Same for the other types. That way we can spit out errors quickly for things like unnamed fields.
         let span = input.span();
@@ -311,7 +311,7 @@ impl Struct {
 }
 
 impl Enum {
-    fn parse(_namespace: &str, winrt: bool, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(_namespace: &str, winrt: bool, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let mut item: syn::ItemEnum = input.parse()?;
         item.attrs = attributes;
         let name = item.ident.to_string();
@@ -320,7 +320,7 @@ impl Enum {
 }
 
 impl Constant {
-    fn parse(_namespace: &str, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(_namespace: &str, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let mut item: syn::ItemConst = input.parse()?;
         item.attrs = attributes;
         let name = item.ident.to_string();
@@ -329,7 +329,7 @@ impl Constant {
 }
 
 impl Function {
-    fn parse(_namespace: &str, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(_namespace: &str, attributes: Vec<syn::Attribute>, input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let mut item: syn::TraitItemFn = input.parse()?;
         item.attrs = attributes;
         let name = item.sig.ident.to_string();

--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -618,7 +618,7 @@ impl Writer {
                 impl<#constraints> ::std::future::Future for #ident {
                     type Output = ::windows_core::Result<#return_type>;
 
-                    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+                    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
                         if self.Status()? == #namespace AsyncStatus::Started {
                             let waker = context.waker().clone();
 

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT OR Apache-2.0"
 description = "The implement macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []

--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -238,7 +238,7 @@ struct ImplementAttributes {
 }
 
 impl syn::parse::Parse for ImplementAttributes {
-    fn parse(cursor: syn::parse::ParseStream) -> syn::parse::Result<Self> {
+    fn parse(cursor: syn::parse::ParseStream<'_>) -> syn::parse::Result<Self> {
         let mut input = Self::default();
 
         while !cursor.is_empty() {
@@ -250,7 +250,7 @@ impl syn::parse::Parse for ImplementAttributes {
 }
 
 impl ImplementAttributes {
-    fn parse_implement(&mut self, cursor: syn::parse::ParseStream) -> syn::parse::Result<()> {
+    fn parse_implement(&mut self, cursor: syn::parse::ParseStream<'_>) -> syn::parse::Result<()> {
         let tree = cursor.parse::<UseTree2>()?;
         self.walk_implement(&tree, &mut String::new())?;
 
@@ -341,7 +341,7 @@ struct UseGroup2 {
 }
 
 impl syn::parse::Parse for UseTree2 {
-    fn parse(input: syn::parse::ParseStream) -> syn::parse::Result<UseTree2> {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::parse::Result<UseTree2> {
         let lookahead = input.lookahead1();
         if lookahead.peek(syn::Ident) {
             use syn::ext::IdentExt;

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -8,6 +8,9 @@ license = "MIT OR Apache-2.0"
 description = "The interface macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -374,7 +374,7 @@ impl Interface {
 }
 
 impl Parse for Interface {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let attributes = input.call(syn::Attribute::parse_outer)?;
         let mut docs = Vec::new();
         for attr in attributes.into_iter() {
@@ -475,7 +475,7 @@ impl Guid {
 }
 
 impl Parse for Guid {
-    fn parse(cursor: ParseStream) -> syn::Result<Self> {
+    fn parse(cursor: ParseStream<'_>) -> syn::Result<Self> {
         let string: Option<syn::LitStr> = cursor.parse().ok();
 
         Ok(Self(string))
@@ -514,7 +514,7 @@ impl InterfaceMethod {
 }
 
 impl syn::parse::Parse for InterfaceMethod {
-    fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+    fn parse(input: syn::parse::ParseStream<'_>) -> syn::Result<Self> {
         let docs = input.call(syn::Attribute::parse_outer)?;
         let visibility = input.parse::<syn::Visibility>()?;
         let method = input.parse::<syn::TraitItemFn>()?;

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -9,6 +9,9 @@ description = "Windows metadata reader"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []

--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -7,7 +7,6 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
 
-extern crate self as windows_sys;
 pub mod core;
 
 include!("Windows/mod.rs");

--- a/crates/libs/sys/src/lib.rs
+++ b/crates/libs/sys/src/lib.rs
@@ -7,6 +7,9 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
 
+#[allow(unused_extern_crates)]
+extern crate self as windows_sys;
+
 pub mod core;
 
 include!("Windows/mod.rs");

--- a/crates/libs/targets/Cargo.toml
+++ b/crates/libs/targets/Cargo.toml
@@ -10,6 +10,9 @@ description = "Import libs for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 
+[lints]
+workspace = true
+
 [target.'cfg(all(target_arch = "x86", target_env = "msvc", not(windows_raw_dylib)))'.dependencies]
 windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.52.0" }
 

--- a/crates/libs/version/Cargo.toml
+++ b/crates/libs/version/Cargo.toml
@@ -10,6 +10,9 @@ repository = "https://github.com/microsoft/windows-rs"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -12,6 +12,9 @@ documentation = "https://microsoft.github.io/windows-docs-rs/"
 readme = "readme.md"
 categories = ["os::windows-apis"]
 
+[lints]
+workspace = true
+
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
 targets = []

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -1254,7 +1254,7 @@ impl DeleteSmsMessageOperation {
 #[cfg(feature = "deprecated")]
 impl ::std::future::Future for DeleteSmsMessageOperation {
     type Output = ::windows_core::Result<()>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {
@@ -1362,7 +1362,7 @@ impl DeleteSmsMessagesOperation {
 #[cfg(feature = "deprecated")]
 impl ::std::future::Future for DeleteSmsMessagesOperation {
     type Output = ::windows_core::Result<()>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {
@@ -1473,7 +1473,7 @@ impl GetSmsDeviceOperation {
 #[cfg(feature = "deprecated")]
 impl ::std::future::Future for GetSmsDeviceOperation {
     type Output = ::windows_core::Result<SmsDevice>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
@@ -1584,7 +1584,7 @@ impl GetSmsMessageOperation {
 #[cfg(feature = "deprecated")]
 impl ::std::future::Future for GetSmsMessageOperation {
     type Output = ::windows_core::Result<ISmsMessage>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
@@ -1719,7 +1719,7 @@ impl GetSmsMessagesOperation {
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 impl ::std::future::Future for GetSmsMessagesOperation {
     type Output = ::windows_core::Result<super::super::Foundation::Collections::IVectorView<ISmsMessage>>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncOperationWithProgressCompletedHandler::new(move |_sender, _args| {
@@ -1827,7 +1827,7 @@ impl SendSmsMessageOperation {
 #[cfg(feature = "deprecated")]
 impl ::std::future::Future for SendSmsMessageOperation {
     type Output = ::windows_core::Result<()>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -83,7 +83,7 @@ impl IAsyncAction {
 }
 impl ::std::future::Future for IAsyncAction {
     type Output = ::windows_core::Result<()>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&AsyncActionCompletedHandler::new(move |_sender, _args| {
@@ -202,7 +202,7 @@ impl<TProgress: ::windows_core::RuntimeType + 'static> IAsyncActionWithProgress<
 }
 impl<TProgress: ::windows_core::RuntimeType + 'static> ::std::future::Future for IAsyncActionWithProgress<TProgress> {
     type Output = ::windows_core::Result<()>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&AsyncActionWithProgressCompletedHandler::new(move |_sender, _args| {
@@ -370,7 +370,7 @@ impl<TResult: ::windows_core::RuntimeType + 'static> IAsyncOperation<TResult> {
 }
 impl<TResult: ::windows_core::RuntimeType + 'static> ::std::future::Future for IAsyncOperation<TResult> {
     type Output = ::windows_core::Result<TResult>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&AsyncOperationCompletedHandler::new(move |_sender, _args| {
@@ -497,7 +497,7 @@ impl<TResult: ::windows_core::RuntimeType + 'static, TProgress: ::windows_core::
 }
 impl<TResult: ::windows_core::RuntimeType + 'static, TProgress: ::windows_core::RuntimeType + 'static> ::std::future::Future for IAsyncOperationWithProgress<TResult, TProgress> {
     type Output = ::windows_core::Result<TResult>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&AsyncOperationWithProgressCompletedHandler::new(move |_sender, _args| {

--- a/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
@@ -584,7 +584,7 @@ impl SignOutUserOperation {
 }
 impl ::std::future::Future for SignOutUserOperation {
     type Output = ::windows_core::Result<()>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::super::Foundation::AsyncActionCompletedHandler::new(move |_sender, _args| {
@@ -685,7 +685,7 @@ impl UserAuthenticationOperation {
 }
 impl ::std::future::Future for UserAuthenticationOperation {
     type Output = ::windows_core::Result<UserIdentity>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -1429,7 +1429,7 @@ impl DataReaderLoadOperation {
 }
 impl ::std::future::Future for DataReaderLoadOperation {
     type Output = ::windows_core::Result<u32>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {
@@ -1718,7 +1718,7 @@ impl DataWriterStoreOperation {
 }
 impl ::std::future::Future for DataWriterStoreOperation {
     type Output = ::windows_core::Result<u32>;
-    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context) -> ::std::task::Poll<Self::Output> {
+    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
         if self.Status()? == super::super::Foundation::AsyncStatus::Started {
             let waker = context.waker().clone();
             let _ = self.SetCompleted(&super::super::Foundation::AsyncOperationCompletedHandler::new(move |_sender, _args| {

--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -8,6 +8,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #![allow(non_snake_case, clashing_extern_declarations, non_upper_case_globals, non_camel_case_types, clippy::all)]
 #![cfg_attr(not(feature = "docs"), doc(hidden))]
 
+#[allow(unused_extern_crates)]
 extern crate self as windows;
 
 pub mod core {


### PR DESCRIPTION
As suggested in #2739, I'm enabling workspace lints to more easily enable non-default Rust and Clippy lints.

I've started with only `elided-lifetimes-in-paths` as some of the others, like `rust_2018_idioms`, has some false positives that prevent them from being turned on for this workspace.

Fixes: #2739