### PR TITLE
Updated Cargo.toml for create_window sample

### DIFF
--- a/crates/samples/windows/create_window/Cargo.toml
+++ b/crates/samples/windows/create_window/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 [dependencies.windows]
 path = "../../../libs/windows"
 features = [
+    "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_LibraryLoader",
     "Win32_UI_WindowsAndMessaging",


### PR DESCRIPTION
added `Win32_Foundation` to the feature list which fixes the imports in the create_window sample code

Fixes: #2754 ⬅️ 
