### PR TITLE
Remove unnecessary std usage from bindgen in writer.rs

### DIFF
--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -193,10 +193,10 @@ impl Writer {
                 quote! { *mut ::core::ffi::c_void }
             }
             metadata::Type::String => {
-                quote! { ::std::mem::MaybeUninit<::windows_core::HSTRING> }
+                quote! { ::core::mem::MaybeUninit<::windows_core::HSTRING> }
             }
             metadata::Type::BSTR => {
-                quote! { ::std::mem::MaybeUninit<::windows_core::BSTR> }
+                quote! { ::core::mem::MaybeUninit<::windows_core::BSTR> }
             }
             metadata::Type::Win32Array(kind, len) => {
                 let name = self.type_abi_name(kind);
@@ -214,7 +214,7 @@ impl Writer {
                     if metadata::type_def_is_blittable(*def) {
                         tokens
                     } else {
-                        quote! { ::std::mem::MaybeUninit<#tokens> }
+                        quote! { ::core::mem::MaybeUninit<#tokens> }
                     }
                 }
                 metadata::TypeKind::Delegate => {
@@ -616,10 +616,10 @@ impl Writer {
                     }
                 }
                 #features
-                impl<#constraints> ::std::future::Future for #ident {
+                impl<#constraints> ::core::future::Future for #ident {
                     type Output = ::windows_core::Result<#return_type>;
 
-                    fn poll(self: ::std::pin::Pin<&mut Self>, context: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
+                    fn poll(self: ::core::pin::Pin<&mut Self>, context: &mut ::core::task::Context<'_>) -> ::core::task::Poll<Self::Output> {
                         if self.Status()? == #namespace AsyncStatus::Started {
                             let waker = context.waker().clone();
 
@@ -628,9 +628,9 @@ impl Writer {
                                 Ok(())
                             }));
 
-                            ::std::task::Poll::Pending
+                            ::core::task::Poll::Pending
                         } else {
-                            ::std::task::Poll::Ready(self.GetResults())
+                            ::core::task::Poll::Ready(self.GetResults())
                         }
                     }
                 }
@@ -931,9 +931,9 @@ impl Writer {
                         }
                         metadata::SignatureParamKind::OptionalPointer => {
                             if flags.contains(metadata::ParamAttributes::Out) {
-                                quote! { ::core::mem::transmute(#name.unwrap_or(::std::ptr::null_mut())), }
+                                quote! { ::core::mem::transmute(#name.unwrap_or(::core::ptr::null_mut())), }
                             } else {
-                                quote! { ::core::mem::transmute(#name.unwrap_or(::std::ptr::null())), }
+                                quote! { ::core::mem::transmute(#name.unwrap_or(::core::ptr::null())), }
                             }
                         }
                         metadata::SignatureParamKind::ValueType => {

--- a/crates/libs/core/src/imp/com_bindings.rs
+++ b/crates/libs/core/src/imp/com_bindings.rs
@@ -168,9 +168,9 @@ unsafe impl ::windows_core::ComInterface for IErrorInfo {
 pub struct IErrorInfo_Vtbl {
     pub base__: ::windows_core::IUnknown_Vtbl,
     pub GetGUID: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pguid: *mut ::windows_core::GUID) -> ::windows_core::HRESULT,
-    pub GetSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsource: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
-    pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdescription: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
-    pub GetHelpFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrhelpfile: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
+    pub GetSource: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrsource: *mut ::core::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
+    pub GetDescription: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrdescription: *mut ::core::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
+    pub GetHelpFile: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pbstrhelpfile: *mut ::core::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
     pub GetHelpContext: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pdwhelpcontext: *mut u32) -> ::windows_core::HRESULT,
 }
 #[repr(transparent)]
@@ -481,7 +481,7 @@ pub struct IPropertyValue_Vtbl {
     pub GetDouble: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut f64) -> ::windows_core::HRESULT,
     pub GetChar16: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut u16) -> ::windows_core::HRESULT,
     pub GetBoolean: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut bool) -> ::windows_core::HRESULT,
-    pub GetString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>) -> ::windows_core::HRESULT,
+    pub GetString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>) -> ::windows_core::HRESULT,
     pub GetGuid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut ::windows_core::GUID) -> ::windows_core::HRESULT,
     pub GetDateTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut DateTime) -> ::windows_core::HRESULT,
     pub GetTimeSpan: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut TimeSpan) -> ::windows_core::HRESULT,
@@ -499,7 +499,7 @@ pub struct IPropertyValue_Vtbl {
     pub GetDoubleArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut f64) -> ::windows_core::HRESULT,
     pub GetChar16Array: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut u16) -> ::windows_core::HRESULT,
     pub GetBooleanArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut bool) -> ::windows_core::HRESULT,
-    pub GetStringArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>) -> ::windows_core::HRESULT,
+    pub GetStringArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>) -> ::windows_core::HRESULT,
     pub GetInspectableArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub GetGuidArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut ::windows_core::GUID) -> ::windows_core::HRESULT,
     pub GetDateTimeArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: *mut u32, value: *mut *mut DateTime) -> ::windows_core::HRESULT,
@@ -534,7 +534,7 @@ pub struct IPropertyValueStatics_Vtbl {
     pub CreateDouble: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: f64, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateChar16: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: u16, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateBoolean: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: bool, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
-    pub CreateString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: ::std::mem::MaybeUninit<::windows_core::HSTRING>, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
+    pub CreateString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: ::core::mem::MaybeUninit<::windows_core::HSTRING>, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateInspectable: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: *mut ::core::ffi::c_void, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateGuid: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: ::windows_core::GUID, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateDateTime: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value: DateTime, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
@@ -553,7 +553,7 @@ pub struct IPropertyValueStatics_Vtbl {
     pub CreateDoubleArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const f64, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateChar16Array: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const u16, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateBooleanArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const bool, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
-    pub CreateStringArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const ::std::mem::MaybeUninit<::windows_core::HSTRING>, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
+    pub CreateStringArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const ::core::mem::MaybeUninit<::windows_core::HSTRING>, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateInspectableArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const *mut ::core::ffi::c_void, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateGuidArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const ::windows_core::GUID, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
     pub CreateDateTimeArray: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, value_array_size: u32, value: *const DateTime, result__: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT,
@@ -839,8 +839,8 @@ unsafe impl ::windows_core::ComInterface for IRestrictedErrorInfo {
 #[doc(hidden)]
 pub struct IRestrictedErrorInfo_Vtbl {
     pub base__: ::windows_core::IUnknown_Vtbl,
-    pub GetErrorDetails: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, description: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, error: *mut ::windows_core::HRESULT, restricteddescription: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, capabilitysid: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
-    pub GetReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reference: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
+    pub GetErrorDetails: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, description: *mut ::core::mem::MaybeUninit<::windows_core::BSTR>, error: *mut ::windows_core::HRESULT, restricteddescription: *mut ::core::mem::MaybeUninit<::windows_core::BSTR>, capabilitysid: *mut ::core::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
+    pub GetReference: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, reference: *mut ::core::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT,
 }
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::fmt::Debug, ::core::clone::Clone)]
@@ -868,7 +868,7 @@ unsafe impl ::windows_core::ComInterface for IStringable {
 #[doc(hidden)]
 pub struct IStringable_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
-    pub ToString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>) -> ::windows_core::HRESULT,
+    pub ToString: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>) -> ::windows_core::HRESULT,
 }
 #[repr(transparent)]
 #[derive(::core::cmp::PartialEq, ::core::cmp::Eq, ::core::fmt::Debug, ::core::clone::Clone)]

--- a/crates/tests/standalone/src/b_calendar.rs
+++ b/crates/tests/standalone/src/b_calendar.rs
@@ -1382,27 +1382,27 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub NumeralSystem: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub SetNumeralSystem: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        value: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        value: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub GetCalendarSystem: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub ChangeCalendarSystem: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        value: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        value: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub GetClock: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub ChangeClock: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        value: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        value: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub GetDateTime: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1440,12 +1440,12 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub EraAsFullString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub EraAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         ideallength: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub FirstYearInThisEra: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1473,17 +1473,17 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub YearAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub YearAsTruncatedString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         remainingdigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub YearAsPaddedString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         mindigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub FirstMonthInThisYear: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1511,30 +1511,30 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub MonthAsFullString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub MonthAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         ideallength: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub MonthAsFullSoloString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub MonthAsSoloString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         ideallength: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub MonthAsNumericString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub MonthAsPaddedNumericString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         mindigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub AddWeeks: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1566,12 +1566,12 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub DayAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub DayAsPaddedString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         mindigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub DayOfWeek: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1579,21 +1579,21 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub DayOfWeekAsFullString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub DayOfWeekAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         ideallength: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub DayOfWeekAsFullSoloString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub DayOfWeekAsSoloString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         ideallength: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub FirstPeriodInThisDay: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1621,12 +1621,12 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub PeriodAsFullString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub PeriodAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         ideallength: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub FirstHourInThisPeriod: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1654,12 +1654,12 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub HourAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub HourAsPaddedString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         mindigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Minute: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1675,12 +1675,12 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub MinuteAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub MinuteAsPaddedString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         mindigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Second: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1696,12 +1696,12 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub SecondAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub SecondAsPaddedString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         mindigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Nanosecond: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1717,12 +1717,12 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub NanosecondAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub NanosecondAsPaddedString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         mindigits: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Compare: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1764,7 +1764,7 @@ pub struct ICalendar_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub ResolvedLanguage: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub IsDaylightSavingTime: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -1795,8 +1795,8 @@ pub struct ICalendarFactory_Vtbl {
     pub CreateCalendar: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         languages: *mut ::core::ffi::c_void,
-        calendar: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
-        clock: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        calendar: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
+        clock: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
         result__: *mut *mut ::core::ffi::c_void,
     ) -> ::windows_core::HRESULT,
 }
@@ -1818,9 +1818,9 @@ pub struct ICalendarFactory2_Vtbl {
     pub CreateCalendarWithTimeZone: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         languages: *mut ::core::ffi::c_void,
-        calendar: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
-        clock: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
-        timezoneid: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        calendar: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
+        clock: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
+        timezoneid: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
         result__: *mut *mut ::core::ffi::c_void,
     ) -> ::windows_core::HRESULT,
 }
@@ -2033,20 +2033,20 @@ pub struct ITimeZoneOnCalendar_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub GetTimeZone: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub ChangeTimeZone: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        timezoneid: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        timezoneid: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub TimeZoneAsFullString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub TimeZoneAsString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
         ideallength: i32,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
 }
 #[repr(transparent)]

--- a/crates/tests/standalone/src/b_stringable.rs
+++ b/crates/tests/standalone/src/b_stringable.rs
@@ -45,6 +45,6 @@ pub struct IStringable_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub ToString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
 }

--- a/crates/tests/standalone/src/b_uri.rs
+++ b/crates/tests/standalone/src/b_uri.rs
@@ -237,7 +237,7 @@ pub struct IStringable_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub ToString: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
 }
 #[doc(hidden)]
@@ -257,13 +257,13 @@ pub struct IUriEscapeStatics_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub UnescapeComponent: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        tounescape: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        tounescape: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub EscapeComponent: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        toescape: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        toescape: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
 }
 #[doc(hidden)]
@@ -283,39 +283,39 @@ pub struct IUriRuntimeClass_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub AbsoluteUri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub DisplayUri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Domain: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Extension: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Fragment: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Host: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Password: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Path: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Query: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub QueryParsed: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -323,15 +323,15 @@ pub struct IUriRuntimeClass_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub RawUri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub SchemeName: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub UserName: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Port: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
@@ -348,7 +348,7 @@ pub struct IUriRuntimeClass_Vtbl {
     ) -> ::windows_core::HRESULT,
     pub CombineUri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        relativeuri: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        relativeuri: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
         result__: *mut *mut ::core::ffi::c_void,
     ) -> ::windows_core::HRESULT,
 }
@@ -369,13 +369,13 @@ pub struct IUriRuntimeClassFactory_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub CreateUri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        uri: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        uri: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
         result__: *mut *mut ::core::ffi::c_void,
     ) -> ::windows_core::HRESULT,
     pub CreateWithRelativeUri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        baseuri: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
-        relativeuri: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        baseuri: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
+        relativeuri: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
         result__: *mut *mut ::core::ffi::c_void,
     ) -> ::windows_core::HRESULT,
 }
@@ -396,11 +396,11 @@ pub struct IUriRuntimeClassWithAbsoluteCanonicalUri_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub AbsoluteCanonicalUri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub DisplayIri: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
 }
 #[repr(transparent)]
@@ -626,11 +626,11 @@ pub struct IWwwFormUrlDecoderEntry_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub Name: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
     pub Value: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
 }
 #[doc(hidden)]
@@ -650,8 +650,8 @@ pub struct IWwwFormUrlDecoderRuntimeClass_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub GetFirstValueByName: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        name: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
-        result__: *mut ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        name: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
+        result__: *mut ::core::mem::MaybeUninit<::windows_core::HSTRING>,
     ) -> ::windows_core::HRESULT,
 }
 #[doc(hidden)]
@@ -671,7 +671,7 @@ pub struct IWwwFormUrlDecoderRuntimeClassFactory_Vtbl {
     pub base__: ::windows_core::IInspectable_Vtbl,
     pub CreateWwwFormUrlDecoder: unsafe extern "system" fn(
         this: *mut ::core::ffi::c_void,
-        query: ::std::mem::MaybeUninit<::windows_core::HSTRING>,
+        query: ::core::mem::MaybeUninit<::windows_core::HSTRING>,
         result__: *mut *mut ::core::ffi::c_void,
     ) -> ::windows_core::HRESULT,
 }


### PR DESCRIPTION
Recently ran into some issues while attempting to use `windows-bindgen` in a `no_std` crate. The generated code contains almost all `::core` usage except for a few areas where `::std` is used instead.