### PR TITLE
Relax the build target checks in windows-targets sub-crates

### DIFF
--- a/crates/targets/aarch64_gnullvm/build.rs
+++ b/crates/targets/aarch64_gnullvm/build.rs
@@ -1,6 +1,9 @@
 fn main() {
+    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
     let target = std::env::var("TARGET").unwrap();
-    if target != "aarch64-pc-windows-gnullvm" {
+    if family != "windows" || arch != "aarch64" || env != "gnu" || !target.ends_with("-gnullvm") {
         return;
     }
 

--- a/crates/targets/aarch64_msvc/build.rs
+++ b/crates/targets/aarch64_msvc/build.rs
@@ -1,6 +1,8 @@
 fn main() {
-    let target = std::env::var("TARGET").unwrap();
-    if target != "aarch64-pc-windows-msvc" && target != "aarch64-uwp-windows-msvc" {
+    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+    if family != "windows" || arch != "aarch64" || env != "msvc" {
         return;
     }
 

--- a/crates/targets/i686_gnu/build.rs
+++ b/crates/targets/i686_gnu/build.rs
@@ -1,6 +1,8 @@
 fn main() {
-    let target = std::env::var("TARGET").unwrap();
-    if target != "i686-pc-windows-gnu" && target != "i686-uwp-windows-gnu" {
+    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+    if family != "windows" || arch != "x86" || env != "gnu" {
         return;
     }
 

--- a/crates/targets/i686_msvc/build.rs
+++ b/crates/targets/i686_msvc/build.rs
@@ -1,6 +1,8 @@
 fn main() {
-    let target = std::env::var("TARGET").unwrap();
-    if target != "i686-pc-windows-msvc" && target != "i686-uwp-windows-msvc" {
+    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+    if family != "windows" || arch != "x86" || env != "msvc" {
         return;
     }
 

--- a/crates/targets/x86_64_gnu/build.rs
+++ b/crates/targets/x86_64_gnu/build.rs
@@ -1,6 +1,9 @@
 fn main() {
+    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
     let target = std::env::var("TARGET").unwrap();
-    if target != "x86_64-pc-windows-gnu" && target != "x86_64-uwp-windows-gnu" {
+    if family != "windows" || arch != "x86_64" || env != "gnu" || !target.ends_with("-gnu") {
         return;
     }
 

--- a/crates/targets/x86_64_gnullvm/build.rs
+++ b/crates/targets/x86_64_gnullvm/build.rs
@@ -1,6 +1,9 @@
 fn main() {
+    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
     let target = std::env::var("TARGET").unwrap();
-    if target != "x86_64-pc-windows-gnullvm" {
+    if family != "windows" || arch != "x86_64" || env != "gnu" || !target.ends_with("-gnullvm") {
         return;
     }
 

--- a/crates/targets/x86_64_msvc/build.rs
+++ b/crates/targets/x86_64_msvc/build.rs
@@ -1,6 +1,8 @@
 fn main() {
-    let target = std::env::var("TARGET").unwrap();
-    if target != "x86_64-pc-windows-msvc" && target != "x86_64-uwp-windows-msvc" {
+    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
+    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
+    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
+    if family != "windows" || arch != "x86_64" || env != "msvc" {
         return;
     }
 


### PR DESCRIPTION
I've done this change for Rust9x initially, but realized that the [recently-added tier3 `win7` targets](https://github.com/rust-lang/rust/pull/118150) also fail to link with the strict check in the target crates:

```plain
> cargo +nightly build --target x86_64-win7-windows-msvc -Zbuild-std
[...]

error: linking with `link.exe` failed: exit code: 1181
  |
  = note: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Preview\\VC\\Tools\\MSVC\\14.39.33321\\bin\\HostX64\\x64\\link.exe" "/NOLOGO" [...]
  = note: LINK : fatal error LNK1181: cannot open input file 'windows.0.52.0.lib'
```

This change aligns the checks for the msvc targets with the checks in `crates\libs\targets\Cargo.toml`.
I didn't touch the gnu/gnullvm ones since I'm unclear about `target_abi` actually being stable/checkable yet. LMK if I should add the respective checks.

Also please feel free to close if this doesn't align with windows-rs. For example, technically it could be interpreted as support for unsupported target vendors.

CC @roblabla 