### PR TITLE
Fix tests which rely on English UI language

### DIFF
--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -15,3 +15,6 @@ features = [
 
 [dependencies.windows-targets]
 path = "../../libs/targets"
+
+[dev-dependencies]
+helpers = { package = "test_helpers", path = "../helpers" }

--- a/crates/tests/core/tests/error.rs
+++ b/crates/tests/core/tests/error.rs
@@ -2,6 +2,8 @@ use windows::{core::*, Win32::Foundation::*, Win32::Media::Audio::*};
 
 #[test]
 fn display_debug() {
+    assert!(helpers::set_thread_ui_language());
+
     let e = Error::from(ERROR_NO_UNICODE_TRANSLATION);
     let display = format!("{e}");
     let debug = format!("{e:?}");

--- a/crates/tests/core/tests/pcstr.rs
+++ b/crates/tests/core/tests/pcstr.rs
@@ -2,6 +2,8 @@ use windows::{core::*, Win32::Foundation::*};
 
 #[test]
 fn test() -> Result<()> {
+    assert!(helpers::set_thread_ui_language());
+
     let p: PCSTR = s!("hello");
     let s: String = unsafe { p.to_string()? };
     assert_eq!("hello", s);

--- a/crates/tests/core/tests/pcwstr.rs
+++ b/crates/tests/core/tests/pcwstr.rs
@@ -2,6 +2,8 @@ use windows::{core::*, Win32::Foundation::*};
 
 #[test]
 fn test() -> Result<()> {
+    assert!(helpers::set_thread_ui_language());
+
     let p: PCWSTR = w!("hello");
     let s: String = unsafe { p.to_string()? };
     assert_eq!("hello", s);

--- a/crates/tests/core/tests/pstr.rs
+++ b/crates/tests/core/tests/pstr.rs
@@ -2,6 +2,8 @@ use windows::{core::*, Win32::Foundation::*};
 
 #[test]
 fn test() -> Result<()> {
+    assert!(helpers::set_thread_ui_language());
+
     let p = PSTR::from_raw(s!("hello").as_ptr() as *mut _);
     let s: String = unsafe { p.to_string()? };
     assert_eq!("hello", s);

--- a/crates/tests/core/tests/pwstr.rs
+++ b/crates/tests/core/tests/pwstr.rs
@@ -2,6 +2,8 @@ use windows::{core::*, Win32::Foundation::*};
 
 #[test]
 fn test() -> Result<()> {
+    assert!(helpers::set_thread_ui_language());
+
     let p = PWSTR::from_raw(w!("hello").as_ptr() as *mut _);
     let s: String = unsafe { p.to_string()? };
     assert_eq!("hello", s);

--- a/crates/tests/enums/Cargo.toml
+++ b/crates/tests/enums/Cargo.toml
@@ -18,3 +18,6 @@ features = [
     "Win32_Foundation",
     "Win32_UI_WindowsAndMessaging",
 ]
+
+[dev-dependencies]
+helpers = { package = "test_helpers", path = "../helpers" }

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -36,6 +36,8 @@ fn const_pattern() {
 
 #[test]
 fn win32_error() {
+    assert!(helpers::set_thread_ui_language());
+
     let e: WIN32_ERROR = ERROR_ACCESS_DENIED;
     assert!(e.0 == 5);
     let h: HRESULT = ERROR_ACCESS_DENIED.into();

--- a/crates/tests/error/Cargo.toml
+++ b/crates/tests/error/Cargo.toml
@@ -11,3 +11,6 @@ features = [
     "Foundation",
     "Win32_Foundation",
 ]
+
+[dev-dependencies]
+helpers = { package = "test_helpers", path = "../helpers" }

--- a/crates/tests/error/tests/std.rs
+++ b/crates/tests/error/tests/std.rs
@@ -2,6 +2,8 @@ use windows::Win32::Foundation::*;
 
 #[test]
 fn conversions() {
+    assert!(helpers::set_thread_ui_language());
+
     // Baseline HRESULT
     assert_eq!(E_INVALIDARG.message(), "The parameter is incorrect.");
     assert_eq!(E_INVALIDARG.0, -2147024809);

--- a/crates/tests/error/tests/trim.rs
+++ b/crates/tests/error/tests/trim.rs
@@ -2,6 +2,8 @@ use windows::{core::*, Win32::Foundation::*};
 
 #[test]
 fn test() {
+    assert!(helpers::set_thread_ui_language());
+
     assert_eq!(E_FAIL.message(), "Unspecified error");
 
     assert_eq!(Error::new(E_FAIL, "Test \t\n\r".into()).message(), "Test");


### PR DESCRIPTION
Some tests didn't work on non-English Windows installations because they assume English UI language. 
This PR sets the UI language where necessary. 
