### PR TITLE
Truncate standalone test files instead of removing

### DIFF
--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -167,7 +167,7 @@ fn write_no_inner_attr(output: &str, filter: &[&str]) {
 fn riddle(output: &str, filter: &[&str], config: &[&str]) {
     // Rust-analyzer may re-run build scripts whenever a source file is deleted
     // which causes an endless loop if the file is deleted from a build script.
-    // To workaroud this, we truncate the file instead of deleting it.
+    // To workaround this, we truncate the file instead of deleting it.
     // See https://github.com/microsoft/windows-rs/issues/2777
     _ = std::fs::File::options()
         .truncate(true)

--- a/crates/tests/standalone/build.rs
+++ b/crates/tests/standalone/build.rs
@@ -165,7 +165,14 @@ fn write_no_inner_attr(output: &str, filter: &[&str]) {
 }
 
 fn riddle(output: &str, filter: &[&str], config: &[&str]) {
-    _ = std::fs::remove_file(output);
+    // Rust-analyzer may re-run build scripts whenever a source file is deleted
+    // which causes an endless loop if the file is deleted from a build script.
+    // To workaroud this, we truncate the file instead of deleting it.
+    // See https://github.com/microsoft/windows-rs/issues/2777
+    _ = std::fs::File::options()
+        .truncate(true)
+        .write(true)
+        .open(output);
 
     let mut command = std::process::Command::new("cargo");
 


### PR DESCRIPTION
Attempts to fix #2777 by truncating the test files instead of removing them. This may help avoid an endless loop in rust-analyzer (see also https://github.com/rust-lang/rust-analyzer/issues/16250).

cc @RalfJung would you be able to test if this helps?