### PR TITLE
Adjust Win32 return value code transformation

### DIFF
--- a/crates/libs/bindgen/src/metadata.rs
+++ b/crates/libs/bindgen/src/metadata.rs
@@ -181,6 +181,14 @@ impl Signature {
     }
 
     fn is_retval(&self) -> bool {
+        // First we check whether there's an actual retval parameter.
+        if let Some(param) = self.params.last() {
+            if param.def.has_attribute("RetValAttribute") {
+                return true;
+            }
+        }
+
+        // Then we see if we can infer retval-like behavior more conservatively.
         self.params.last().map_or(false, |param| param.is_retval())
             && self.params[..self.params.len() - 1].iter().all(|param| {
                 let flags = param.def.flags();

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/impl.rs
@@ -3089,7 +3089,7 @@ impl IVBSAXDeclHandler_Vtbl {
 #[doc = "Required features: `\"Win32_System_Com\"`"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IVBSAXEntityResolver_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
-    fn resolveEntity(&self, strpublicid: *mut ::windows_core::BSTR, strsystemid: *mut ::windows_core::BSTR, varinput: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()>;
+    fn resolveEntity(&self, strpublicid: *mut ::windows_core::BSTR, strsystemid: *mut ::windows_core::BSTR) -> ::windows_core::Result<::windows_core::VARIANT>;
 }
 #[cfg(feature = "Win32_System_Com")]
 impl ::windows_core::RuntimeName for IVBSAXEntityResolver {}
@@ -3099,7 +3099,13 @@ impl IVBSAXEntityResolver_Vtbl {
         unsafe extern "system" fn resolveEntity<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IVBSAXEntityResolver_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, strpublicid: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, strsystemid: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, varinput: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.resolveEntity(::core::mem::transmute_copy(&strpublicid), ::core::mem::transmute_copy(&strsystemid), ::core::mem::transmute_copy(&varinput)).into()
+            match this.resolveEntity(::core::mem::transmute_copy(&strpublicid), ::core::mem::transmute_copy(&strsystemid)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(varinput, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base__: super::super::super::System::Com::IDispatch_Vtbl::new::<Identity, Impl, OFFSET>(),

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/MsXml/mod.rs
@@ -2989,8 +2989,9 @@ pub struct IVBSAXDeclHandler_Vtbl {
 ::windows_core::imp::interface_hierarchy!(IVBSAXEntityResolver, ::windows_core::IUnknown, super::super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl IVBSAXEntityResolver {
-    pub unsafe fn resolveEntity(&self, strpublicid: *mut ::windows_core::BSTR, strsystemid: *mut ::windows_core::BSTR, varinput: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).resolveEntity)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(strpublicid), ::core::mem::transmute(strsystemid), ::core::mem::transmute(varinput)).ok()
+    pub unsafe fn resolveEntity(&self, strpublicid: *mut ::windows_core::BSTR, strsystemid: *mut ::windows_core::BSTR) -> ::windows_core::Result<::windows_core::VARIANT> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).resolveEntity)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(strpublicid), ::core::mem::transmute(strsystemid), &mut result__).from_abi(result__)
     }
 }
 #[cfg(feature = "Win32_System_Com")]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/impl.rs
@@ -963,7 +963,7 @@ impl IUPnPReregistrar_Vtbl {
 #[cfg(feature = "Win32_System_Com")]
 pub trait IUPnPService_Impl: Sized + super::super::super::System::Com::IDispatch_Impl {
     fn QueryStateVariable(&self, bstrvariablename: &::windows_core::BSTR) -> ::windows_core::Result<::windows_core::VARIANT>;
-    fn InvokeAction(&self, bstractionname: &::windows_core::BSTR, vinactionargs: &::windows_core::VARIANT, pvoutactionargs: *mut ::windows_core::VARIANT, pvretval: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()>;
+    fn InvokeAction(&self, bstractionname: &::windows_core::BSTR, vinactionargs: &::windows_core::VARIANT, pvoutactionargs: *mut ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn ServiceTypeIdentifier(&self) -> ::windows_core::Result<::windows_core::BSTR>;
     fn AddCallback(&self, punkcallback: ::core::option::Option<&::windows_core::IUnknown>) -> ::windows_core::Result<()>;
     fn Id(&self) -> ::windows_core::Result<::windows_core::BSTR>;
@@ -988,7 +988,13 @@ impl IUPnPService_Vtbl {
         unsafe extern "system" fn InvokeAction<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUPnPService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstractionname: ::std::mem::MaybeUninit<::windows_core::BSTR>, vinactionargs: ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvoutactionargs: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvretval: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.InvokeAction(::core::mem::transmute(&bstractionname), ::core::mem::transmute(&vinactionargs), ::core::mem::transmute_copy(&pvoutactionargs), ::core::mem::transmute_copy(&pvretval)).into()
+            match this.InvokeAction(::core::mem::transmute(&bstractionname), ::core::mem::transmute(&vinactionargs), ::core::mem::transmute_copy(&pvoutactionargs)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pvretval, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn ServiceTypeIdentifier<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUPnPService_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Enumeration/Pnp/mod.rs
@@ -791,12 +791,13 @@ impl IUPnPService {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).QueryStateVariable)(::windows_core::Interface::as_raw(self), bstrvariablename.into_param().abi(), &mut result__).from_abi(result__)
     }
-    pub unsafe fn InvokeAction<P0, P1>(&self, bstractionname: P0, vinactionargs: P1, pvoutactionargs: *mut ::windows_core::VARIANT, pvretval: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()>
+    pub unsafe fn InvokeAction<P0, P1>(&self, bstractionname: P0, vinactionargs: P1, pvoutactionargs: *mut ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<::windows_core::VARIANT>,
     {
-        (::windows_core::Interface::vtable(self).InvokeAction)(::windows_core::Interface::as_raw(self), bstractionname.into_param().abi(), vinactionargs.into_param().abi(), ::core::mem::transmute(pvoutactionargs), ::core::mem::transmute(pvretval)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).InvokeAction)(::windows_core::Interface::as_raw(self), bstractionname.into_param().abi(), vinactionargs.into_param().abi(), ::core::mem::transmute(pvoutactionargs), &mut result__).from_abi(result__)
     }
     pub unsafe fn ServiceTypeIdentifier(&self) -> ::windows_core::Result<::windows_core::BSTR> {
         let mut result__ = ::std::mem::zeroed();

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/impl.rs
@@ -3,8 +3,8 @@
 pub trait IFunctionDiscovery_Impl: Sized {
     fn GetInstanceCollection(&self, pszcategory: &::windows_core::PCWSTR, pszsubcategory: &::windows_core::PCWSTR, fincludeallsubcategories: super::super::Foundation::BOOL) -> ::windows_core::Result<IFunctionInstanceCollection>;
     fn GetInstance(&self, pszfunctioninstanceidentity: &::windows_core::PCWSTR) -> ::windows_core::Result<IFunctionInstance>;
-    fn CreateInstanceCollectionQuery(&self, pszcategory: &::windows_core::PCWSTR, pszsubcategory: &::windows_core::PCWSTR, fincludeallsubcategories: super::super::Foundation::BOOL, pifunctiondiscoverynotification: ::core::option::Option<&IFunctionDiscoveryNotification>, pfdqcquerycontext: *mut u64, ppifunctioninstancecollectionquery: *mut ::core::option::Option<IFunctionInstanceCollectionQuery>) -> ::windows_core::Result<()>;
-    fn CreateInstanceQuery(&self, pszfunctioninstanceidentity: &::windows_core::PCWSTR, pifunctiondiscoverynotification: ::core::option::Option<&IFunctionDiscoveryNotification>, pfdqcquerycontext: *mut u64, ppifunctioninstancequery: *mut ::core::option::Option<IFunctionInstanceQuery>) -> ::windows_core::Result<()>;
+    fn CreateInstanceCollectionQuery(&self, pszcategory: &::windows_core::PCWSTR, pszsubcategory: &::windows_core::PCWSTR, fincludeallsubcategories: super::super::Foundation::BOOL, pifunctiondiscoverynotification: ::core::option::Option<&IFunctionDiscoveryNotification>, pfdqcquerycontext: *mut u64) -> ::windows_core::Result<IFunctionInstanceCollectionQuery>;
+    fn CreateInstanceQuery(&self, pszfunctioninstanceidentity: &::windows_core::PCWSTR, pifunctiondiscoverynotification: ::core::option::Option<&IFunctionDiscoveryNotification>, pfdqcquerycontext: *mut u64) -> ::windows_core::Result<IFunctionInstanceQuery>;
     fn AddInstance(&self, enumsystemvisibility: SystemVisibilityFlags, pszcategory: &::windows_core::PCWSTR, pszsubcategory: &::windows_core::PCWSTR, pszcategoryidentity: &::windows_core::PCWSTR) -> ::windows_core::Result<IFunctionInstance>;
     fn RemoveInstance(&self, enumsystemvisibility: SystemVisibilityFlags, pszcategory: &::windows_core::PCWSTR, pszsubcategory: &::windows_core::PCWSTR, pszcategoryidentity: &::windows_core::PCWSTR) -> ::windows_core::Result<()>;
 }
@@ -38,12 +38,24 @@ impl IFunctionDiscovery_Vtbl {
         unsafe extern "system" fn CreateInstanceCollectionQuery<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IFunctionDiscovery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszcategory: ::windows_core::PCWSTR, pszsubcategory: ::windows_core::PCWSTR, fincludeallsubcategories: super::super::Foundation::BOOL, pifunctiondiscoverynotification: *mut ::core::ffi::c_void, pfdqcquerycontext: *mut u64, ppifunctioninstancecollectionquery: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.CreateInstanceCollectionQuery(::core::mem::transmute(&pszcategory), ::core::mem::transmute(&pszsubcategory), ::core::mem::transmute_copy(&fincludeallsubcategories), ::windows_core::from_raw_borrowed(&pifunctiondiscoverynotification), ::core::mem::transmute_copy(&pfdqcquerycontext), ::core::mem::transmute_copy(&ppifunctioninstancecollectionquery)).into()
+            match this.CreateInstanceCollectionQuery(::core::mem::transmute(&pszcategory), ::core::mem::transmute(&pszsubcategory), ::core::mem::transmute_copy(&fincludeallsubcategories), ::windows_core::from_raw_borrowed(&pifunctiondiscoverynotification), ::core::mem::transmute_copy(&pfdqcquerycontext)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppifunctioninstancecollectionquery, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn CreateInstanceQuery<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IFunctionDiscovery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszfunctioninstanceidentity: ::windows_core::PCWSTR, pifunctiondiscoverynotification: *mut ::core::ffi::c_void, pfdqcquerycontext: *mut u64, ppifunctioninstancequery: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.CreateInstanceQuery(::core::mem::transmute(&pszfunctioninstanceidentity), ::windows_core::from_raw_borrowed(&pifunctiondiscoverynotification), ::core::mem::transmute_copy(&pfdqcquerycontext), ::core::mem::transmute_copy(&ppifunctioninstancequery)).into()
+            match this.CreateInstanceQuery(::core::mem::transmute(&pszfunctioninstanceidentity), ::windows_core::from_raw_borrowed(&pifunctiondiscoverynotification), ::core::mem::transmute_copy(&pfdqcquerycontext)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppifunctioninstancequery, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn AddInstance<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IFunctionDiscovery_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, enumsystemvisibility: SystemVisibilityFlags, pszcategory: ::windows_core::PCWSTR, pszsubcategory: ::windows_core::PCWSTR, pszcategoryidentity: ::windows_core::PCWSTR, ppifunctioninstance: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -407,7 +419,7 @@ impl IFunctionInstance_Vtbl {
 #[cfg(feature = "Win32_System_Com")]
 pub trait IFunctionInstanceCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows_core::Result<u32>;
-    fn Get(&self, pszinstanceidentity: &::windows_core::PCWSTR, pdwindex: *mut u32, ppifunctioninstance: *mut ::core::option::Option<IFunctionInstance>) -> ::windows_core::Result<()>;
+    fn Get(&self, pszinstanceidentity: &::windows_core::PCWSTR, pdwindex: *mut u32) -> ::windows_core::Result<IFunctionInstance>;
     fn Item(&self, dwindex: u32) -> ::windows_core::Result<IFunctionInstance>;
     fn Add(&self, pifunctioninstance: ::core::option::Option<&IFunctionInstance>) -> ::windows_core::Result<()>;
     fn Remove(&self, dwindex: u32) -> ::windows_core::Result<IFunctionInstance>;
@@ -433,7 +445,13 @@ impl IFunctionInstanceCollection_Vtbl {
         unsafe extern "system" fn Get<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IFunctionInstanceCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszinstanceidentity: ::windows_core::PCWSTR, pdwindex: *mut u32, ppifunctioninstance: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Get(::core::mem::transmute(&pszinstanceidentity), ::core::mem::transmute_copy(&pdwindex), ::core::mem::transmute_copy(&ppifunctioninstance)).into()
+            match this.Get(::core::mem::transmute(&pszinstanceidentity), ::core::mem::transmute_copy(&pdwindex)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppifunctioninstance, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Item<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IFunctionInstanceCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwindex: u32, ppifunctioninstance: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -630,7 +648,7 @@ impl IPNPXDeviceAssociation_Vtbl {
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub trait IPropertyStoreCollection_Impl: Sized {
     fn GetCount(&self) -> ::windows_core::Result<u32>;
-    fn Get(&self, pszinstanceidentity: &::windows_core::PCWSTR, pdwindex: *mut u32, ppipropertystore: *mut ::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows_core::Result<()>;
+    fn Get(&self, pszinstanceidentity: &::windows_core::PCWSTR, pdwindex: *mut u32) -> ::windows_core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
     fn Item(&self, dwindex: u32) -> ::windows_core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
     fn Add(&self, pipropertystore: ::core::option::Option<&super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows_core::Result<()>;
     fn Remove(&self, dwindex: u32) -> ::windows_core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>;
@@ -656,7 +674,13 @@ impl IPropertyStoreCollection_Vtbl {
         unsafe extern "system" fn Get<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IPropertyStoreCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszinstanceidentity: ::windows_core::PCWSTR, pdwindex: *mut u32, ppipropertystore: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Get(::core::mem::transmute(&pszinstanceidentity), ::core::mem::transmute_copy(&pdwindex), ::core::mem::transmute_copy(&ppipropertystore)).into()
+            match this.Get(::core::mem::transmute(&pszinstanceidentity), ::core::mem::transmute_copy(&pdwindex)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppipropertystore, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Item<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IPropertyStoreCollection_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, dwindex: u32, ppipropertystore: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
@@ -19,21 +19,23 @@ impl IFunctionDiscovery {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetInstance)(::windows_core::Interface::as_raw(self), pszfunctioninstanceidentity.into_param().abi(), &mut result__).from_abi(result__)
     }
-    pub unsafe fn CreateInstanceCollectionQuery<P0, P1, P2, P3>(&self, pszcategory: P0, pszsubcategory: P1, fincludeallsubcategories: P2, pifunctiondiscoverynotification: P3, pfdqcquerycontext: *mut u64, ppifunctioninstancecollectionquery: *mut ::core::option::Option<IFunctionInstanceCollectionQuery>) -> ::windows_core::Result<()>
+    pub unsafe fn CreateInstanceCollectionQuery<P0, P1, P2, P3>(&self, pszcategory: P0, pszsubcategory: P1, fincludeallsubcategories: P2, pifunctiondiscoverynotification: P3, pfdqcquerycontext: *mut u64) -> ::windows_core::Result<IFunctionInstanceCollectionQuery>
     where
         P0: ::windows_core::IntoParam<::windows_core::PCWSTR>,
         P1: ::windows_core::IntoParam<::windows_core::PCWSTR>,
         P2: ::windows_core::IntoParam<super::super::Foundation::BOOL>,
         P3: ::windows_core::IntoParam<IFunctionDiscoveryNotification>,
     {
-        (::windows_core::Interface::vtable(self).CreateInstanceCollectionQuery)(::windows_core::Interface::as_raw(self), pszcategory.into_param().abi(), pszsubcategory.into_param().abi(), fincludeallsubcategories.into_param().abi(), pifunctiondiscoverynotification.into_param().abi(), pfdqcquerycontext, ::core::mem::transmute(ppifunctioninstancecollectionquery)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).CreateInstanceCollectionQuery)(::windows_core::Interface::as_raw(self), pszcategory.into_param().abi(), pszsubcategory.into_param().abi(), fincludeallsubcategories.into_param().abi(), pifunctiondiscoverynotification.into_param().abi(), pfdqcquerycontext, &mut result__).from_abi(result__)
     }
-    pub unsafe fn CreateInstanceQuery<P0, P1>(&self, pszfunctioninstanceidentity: P0, pifunctiondiscoverynotification: P1, pfdqcquerycontext: *mut u64, ppifunctioninstancequery: *mut ::core::option::Option<IFunctionInstanceQuery>) -> ::windows_core::Result<()>
+    pub unsafe fn CreateInstanceQuery<P0, P1>(&self, pszfunctioninstanceidentity: P0, pifunctiondiscoverynotification: P1, pfdqcquerycontext: *mut u64) -> ::windows_core::Result<IFunctionInstanceQuery>
     where
         P0: ::windows_core::IntoParam<::windows_core::PCWSTR>,
         P1: ::windows_core::IntoParam<IFunctionDiscoveryNotification>,
     {
-        (::windows_core::Interface::vtable(self).CreateInstanceQuery)(::windows_core::Interface::as_raw(self), pszfunctioninstanceidentity.into_param().abi(), pifunctiondiscoverynotification.into_param().abi(), pfdqcquerycontext, ::core::mem::transmute(ppifunctioninstancequery)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).CreateInstanceQuery)(::windows_core::Interface::as_raw(self), pszfunctioninstanceidentity.into_param().abi(), pifunctiondiscoverynotification.into_param().abi(), pfdqcquerycontext, &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -349,11 +351,12 @@ impl IFunctionInstanceCollection {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Get<P0>(&self, pszinstanceidentity: P0, pdwindex: *mut u32, ppifunctioninstance: *mut ::core::option::Option<IFunctionInstance>) -> ::windows_core::Result<()>
+    pub unsafe fn Get<P0>(&self, pszinstanceidentity: P0, pdwindex: *mut u32) -> ::windows_core::Result<IFunctionInstance>
     where
         P0: ::windows_core::IntoParam<::windows_core::PCWSTR>,
     {
-        (::windows_core::Interface::vtable(self).Get)(::windows_core::Interface::as_raw(self), pszinstanceidentity.into_param().abi(), pdwindex, ::core::mem::transmute(ppifunctioninstance)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Get)(::windows_core::Interface::as_raw(self), pszinstanceidentity.into_param().abi(), pdwindex, &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -528,11 +531,12 @@ impl IPropertyStoreCollection {
     }
     #[doc = "Required features: `\"Win32_UI_Shell_PropertiesSystem\"`"]
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
-    pub unsafe fn Get<P0>(&self, pszinstanceidentity: P0, pdwindex: *mut u32, ppipropertystore: *mut ::core::option::Option<super::super::UI::Shell::PropertiesSystem::IPropertyStore>) -> ::windows_core::Result<()>
+    pub unsafe fn Get<P0>(&self, pszinstanceidentity: P0, pdwindex: *mut u32) -> ::windows_core::Result<super::super::UI::Shell::PropertiesSystem::IPropertyStore>
     where
         P0: ::windows_core::IntoParam<::windows_core::PCWSTR>,
     {
-        (::windows_core::Interface::vtable(self).Get)(::windows_core::Interface::as_raw(self), pszinstanceidentity.into_param().abi(), pdwindex, ::core::mem::transmute(ppipropertystore)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Get)(::windows_core::Interface::as_raw(self), pszinstanceidentity.into_param().abi(), pdwindex, &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_UI_Shell_PropertiesSystem\"`"]
     #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/impl.rs
@@ -8398,10 +8398,10 @@ impl IESLicenseRenewalResultEvent_Vtbl {
 #[doc = "Required features: `\"Win32_System_Com\"`"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IESOpenMmiEvent_Impl: Sized + super::IESEvent_Impl {
-    fn GetDialogNumber(&self, pdialogrequest: *mut u32, pdialognumber: *mut u32) -> ::windows_core::Result<()>;
+    fn GetDialogNumber(&self, pdialogrequest: *mut u32) -> ::windows_core::Result<u32>;
     fn GetDialogType(&self) -> ::windows_core::Result<::windows_core::GUID>;
     fn GetDialogData(&self) -> ::windows_core::Result<*mut super::super::super::System::Com::SAFEARRAY>;
-    fn GetDialogStringData(&self, pbstrbaseurl: *mut ::windows_core::BSTR, pbstrdata: *mut ::windows_core::BSTR) -> ::windows_core::Result<()>;
+    fn GetDialogStringData(&self, pbstrbaseurl: *mut ::windows_core::BSTR) -> ::windows_core::Result<::windows_core::BSTR>;
 }
 #[cfg(feature = "Win32_System_Com")]
 impl ::windows_core::RuntimeName for IESOpenMmiEvent {}
@@ -8411,7 +8411,13 @@ impl IESOpenMmiEvent_Vtbl {
         unsafe extern "system" fn GetDialogNumber<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IESOpenMmiEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pdialogrequest: *mut u32, pdialognumber: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetDialogNumber(::core::mem::transmute_copy(&pdialogrequest), ::core::mem::transmute_copy(&pdialognumber)).into()
+            match this.GetDialogNumber(::core::mem::transmute_copy(&pdialogrequest)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pdialognumber, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetDialogType<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IESOpenMmiEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, guiddialogtype: *mut ::windows_core::GUID) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -8438,7 +8444,13 @@ impl IESOpenMmiEvent_Vtbl {
         unsafe extern "system" fn GetDialogStringData<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IESOpenMmiEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbstrbaseurl: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, pbstrdata: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetDialogStringData(::core::mem::transmute_copy(&pbstrbaseurl), ::core::mem::transmute_copy(&pbstrdata)).into()
+            match this.GetDialogStringData(::core::mem::transmute_copy(&pbstrbaseurl)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pbstrdata, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base__: super::IESEvent_Vtbl::new::<Identity, Impl, OFFSET>(),
@@ -13001,7 +13013,7 @@ pub trait IMSVidAnalogTuner_Impl: Sized + IMSVidTuner_Impl {
     fn SetCountryCode(&self, lcc: i32) -> ::windows_core::Result<()>;
     fn SAP(&self) -> ::windows_core::Result<super::super::super::Foundation::VARIANT_BOOL>;
     fn SetSAP(&self, fsapon: super::super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()>;
-    fn ChannelAvailable(&self, nchannel: i32, signalstrength: *mut i32, fsignalpresent: *mut super::super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()>;
+    fn ChannelAvailable(&self, nchannel: i32, signalstrength: *mut i32) -> ::windows_core::Result<super::super::super::Foundation::VARIANT_BOOL>;
 }
 #[cfg(feature = "Win32_System_Com")]
 impl ::windows_core::RuntimeName for IMSVidAnalogTuner {}
@@ -13081,7 +13093,13 @@ impl IMSVidAnalogTuner_Vtbl {
         unsafe extern "system" fn ChannelAvailable<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMSVidAnalogTuner_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nchannel: i32, signalstrength: *mut i32, fsignalpresent: *mut super::super::super::Foundation::VARIANT_BOOL) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.ChannelAvailable(::core::mem::transmute_copy(&nchannel), ::core::mem::transmute_copy(&signalstrength), ::core::mem::transmute_copy(&fsignalpresent)).into()
+            match this.ChannelAvailable(::core::mem::transmute_copy(&nchannel), ::core::mem::transmute_copy(&signalstrength)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(fsignalpresent, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base__: IMSVidTuner_Vtbl::new::<Identity, Impl, OFFSET>(),

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Tv/mod.rs
@@ -7056,8 +7056,9 @@ impl IESOpenMmiEvent {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.GetStringData)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetDialogNumber(&self, pdialogrequest: *mut u32, pdialognumber: *mut u32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetDialogNumber)(::windows_core::Interface::as_raw(self), pdialogrequest, pdialognumber).ok()
+    pub unsafe fn GetDialogNumber(&self, pdialogrequest: *mut u32) -> ::windows_core::Result<u32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetDialogNumber)(::windows_core::Interface::as_raw(self), pdialogrequest, &mut result__).from_abi(result__)
     }
     pub unsafe fn GetDialogType(&self) -> ::windows_core::Result<::windows_core::GUID> {
         let mut result__ = ::std::mem::zeroed();
@@ -7069,8 +7070,9 @@ impl IESOpenMmiEvent {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetDialogData)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetDialogStringData(&self, pbstrbaseurl: *mut ::windows_core::BSTR, pbstrdata: *mut ::windows_core::BSTR) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetDialogStringData)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pbstrbaseurl), ::core::mem::transmute(pbstrdata)).ok()
+    pub unsafe fn GetDialogStringData(&self, pbstrbaseurl: *mut ::windows_core::BSTR) -> ::windows_core::Result<::windows_core::BSTR> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetDialogStringData)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pbstrbaseurl), &mut result__).from_abi(result__)
     }
 }
 #[repr(C)]
@@ -10011,8 +10013,9 @@ impl IMSVidAnalogTuner {
     {
         (::windows_core::Interface::vtable(self).SetSAP)(::windows_core::Interface::as_raw(self), fsapon.into_param().abi()).ok()
     }
-    pub unsafe fn ChannelAvailable(&self, nchannel: i32, signalstrength: *mut i32, fsignalpresent: *mut super::super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).ChannelAvailable)(::windows_core::Interface::as_raw(self), nchannel, signalstrength, fsignalpresent).ok()
+    pub unsafe fn ChannelAvailable(&self, nchannel: i32, signalstrength: *mut i32) -> ::windows_core::Result<super::super::super::Foundation::VARIANT_BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).ChannelAvailable)(::windows_core::Interface::as_raw(self), nchannel, signalstrength, &mut result__).from_abi(result__)
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -10151,8 +10154,9 @@ impl IMSVidAnalogTuner2 {
     {
         (::windows_core::Interface::vtable(self).base__.SetSAP)(::windows_core::Interface::as_raw(self), fsapon.into_param().abi()).ok()
     }
-    pub unsafe fn ChannelAvailable(&self, nchannel: i32, signalstrength: *mut i32, fsignalpresent: *mut super::super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.ChannelAvailable)(::windows_core::Interface::as_raw(self), nchannel, signalstrength, fsignalpresent).ok()
+    pub unsafe fn ChannelAvailable(&self, nchannel: i32, signalstrength: *mut i32) -> ::windows_core::Result<super::super::super::Foundation::VARIANT_BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.ChannelAvailable)(::windows_core::Interface::as_raw(self), nchannel, signalstrength, &mut result__).from_abi(result__)
     }
     pub unsafe fn TVFormats(&self) -> ::windows_core::Result<i32> {
         let mut result__ = ::std::mem::zeroed();

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/impl.rs
@@ -812,7 +812,7 @@ pub trait IMbnInterface_Impl: Sized {
     fn GetHomeProvider(&self) -> ::windows_core::Result<MBN_PROVIDER>;
     fn GetPreferredProviders(&self) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn SetPreferredProviders(&self, preferredproviders: *const super::super::System::Com::SAFEARRAY) -> ::windows_core::Result<u32>;
-    fn GetVisibleProviders(&self, age: *mut u32, visibleproviders: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows_core::Result<()>;
+    fn GetVisibleProviders(&self, age: *mut u32) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn ScanNetwork(&self) -> ::windows_core::Result<u32>;
     fn GetConnection(&self) -> ::windows_core::Result<IMbnConnection>;
 }
@@ -906,7 +906,13 @@ impl IMbnInterface_Vtbl {
         unsafe extern "system" fn GetVisibleProviders<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMbnInterface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, age: *mut u32, visibleproviders: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetVisibleProviders(::core::mem::transmute_copy(&age), ::core::mem::transmute_copy(&visibleproviders)).into()
+            match this.GetVisibleProviders(::core::mem::transmute_copy(&age)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(visibleproviders, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn ScanNetwork<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMbnInterface_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, requestid: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -1093,7 +1099,7 @@ impl IMbnInterfaceManagerEvents_Vtbl {
 pub trait IMbnMultiCarrier_Impl: Sized {
     fn SetHomeProvider(&self, homeprovider: *const MBN_PROVIDER2) -> ::windows_core::Result<u32>;
     fn GetPreferredProviders(&self) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY>;
-    fn GetVisibleProviders(&self, age: *mut u32, visibleproviders: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows_core::Result<()>;
+    fn GetVisibleProviders(&self, age: *mut u32) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetSupportedCellularClasses(&self) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY>;
     fn GetCurrentCellularClass(&self) -> ::windows_core::Result<MBN_CELLULAR_CLASS>;
     fn ScanNetwork(&self) -> ::windows_core::Result<u32>;
@@ -1128,7 +1134,13 @@ impl IMbnMultiCarrier_Vtbl {
         unsafe extern "system" fn GetVisibleProviders<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMbnMultiCarrier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, age: *mut u32, visibleproviders: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetVisibleProviders(::core::mem::transmute_copy(&age), ::core::mem::transmute_copy(&visibleproviders)).into()
+            match this.GetVisibleProviders(::core::mem::transmute_copy(&age)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(visibleproviders, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetSupportedCellularClasses<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMbnMultiCarrier_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, cellularclasses: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/MobileBroadband/mod.rs
@@ -605,8 +605,9 @@ impl IMbnInterface {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GetVisibleProviders(&self, age: *mut u32, visibleproviders: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetVisibleProviders)(::windows_core::Interface::as_raw(self), age, visibleproviders).ok()
+    pub unsafe fn GetVisibleProviders(&self, age: *mut u32) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetVisibleProviders)(::windows_core::Interface::as_raw(self), age, &mut result__).from_abi(result__)
     }
     pub unsafe fn ScanNetwork(&self) -> ::windows_core::Result<u32> {
         let mut result__ = ::std::mem::zeroed();
@@ -772,8 +773,9 @@ impl IMbnMultiCarrier {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GetVisibleProviders(&self, age: *mut u32, visibleproviders: *mut *mut super::super::System::Com::SAFEARRAY) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetVisibleProviders)(::windows_core::Interface::as_raw(self), age, visibleproviders).ok()
+    pub unsafe fn GetVisibleProviders(&self, age: *mut u32) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetVisibleProviders)(::windows_core::Interface::as_raw(self), age, &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/impl.rs
@@ -182,9 +182,9 @@ impl ISdoCollection_Vtbl {
 #[doc = "Required features: `\"Win32_System_Com\"`"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISdoDictionaryOld_Impl: Sized + super::super::System::Com::IDispatch_Impl {
-    fn EnumAttributes(&self, id: *mut ::windows_core::VARIANT, pvalues: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()>;
+    fn EnumAttributes(&self, id: *mut ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn GetAttributeInfo(&self, id: ATTRIBUTEID, pinfoids: *const ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT>;
-    fn EnumAttributeValues(&self, id: ATTRIBUTEID, pvalueids: *mut ::windows_core::VARIANT, pvaluesdesc: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()>;
+    fn EnumAttributeValues(&self, id: ATTRIBUTEID, pvalueids: *mut ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn CreateAttribute(&self, id: ATTRIBUTEID) -> ::windows_core::Result<super::super::System::Com::IDispatch>;
     fn GetAttributeID(&self, bstrattributename: &::windows_core::BSTR) -> ::windows_core::Result<ATTRIBUTEID>;
 }
@@ -196,7 +196,13 @@ impl ISdoDictionaryOld_Vtbl {
         unsafe extern "system" fn EnumAttributes<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISdoDictionaryOld_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvalues: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.EnumAttributes(::core::mem::transmute_copy(&id), ::core::mem::transmute_copy(&pvalues)).into()
+            match this.EnumAttributes(::core::mem::transmute_copy(&id)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pvalues, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetAttributeInfo<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISdoDictionaryOld_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: ATTRIBUTEID, pinfoids: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pinfovalues: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -212,7 +218,13 @@ impl ISdoDictionaryOld_Vtbl {
         unsafe extern "system" fn EnumAttributeValues<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISdoDictionaryOld_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: ATTRIBUTEID, pvalueids: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvaluesdesc: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.EnumAttributeValues(::core::mem::transmute_copy(&id), ::core::mem::transmute_copy(&pvalueids), ::core::mem::transmute_copy(&pvaluesdesc)).into()
+            match this.EnumAttributeValues(::core::mem::transmute_copy(&id), ::core::mem::transmute_copy(&pvalueids)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pvaluesdesc, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn CreateAttribute<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISdoDictionaryOld_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, id: ATTRIBUTEID, ppattributeobject: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetworkPolicyServer/mod.rs
@@ -136,15 +136,17 @@ pub struct ISdoCollection_Vtbl {
 ::windows_core::imp::interface_hierarchy!(ISdoDictionaryOld, ::windows_core::IUnknown, super::super::System::Com::IDispatch);
 #[cfg(feature = "Win32_System_Com")]
 impl ISdoDictionaryOld {
-    pub unsafe fn EnumAttributes(&self, id: *mut ::windows_core::VARIANT, pvalues: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).EnumAttributes)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(id), ::core::mem::transmute(pvalues)).ok()
+    pub unsafe fn EnumAttributes(&self, id: *mut ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).EnumAttributes)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(id), &mut result__).from_abi(result__)
     }
     pub unsafe fn GetAttributeInfo(&self, id: ATTRIBUTEID, pinfoids: *const ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT> {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetAttributeInfo)(::windows_core::Interface::as_raw(self), id, ::core::mem::transmute(pinfoids), &mut result__).from_abi(result__)
     }
-    pub unsafe fn EnumAttributeValues(&self, id: ATTRIBUTEID, pvalueids: *mut ::windows_core::VARIANT, pvaluesdesc: *mut ::windows_core::VARIANT) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).EnumAttributeValues)(::windows_core::Interface::as_raw(self), id, ::core::mem::transmute(pvalueids), ::core::mem::transmute(pvaluesdesc)).ok()
+    pub unsafe fn EnumAttributeValues(&self, id: ATTRIBUTEID, pvalueids: *mut ::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).EnumAttributeValues)(::windows_core::Interface::as_raw(self), id, ::core::mem::transmute(pvalueids), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/impl.rs
@@ -6819,7 +6819,7 @@ pub trait INDESPolicy_Impl: Sized {
     fn Initialize(&self) -> ::windows_core::Result<()>;
     fn Uninitialize(&self) -> ::windows_core::Result<()>;
     fn GenerateChallenge(&self, pwsztemplate: &::windows_core::PCWSTR, pwszparams: &::windows_core::PCWSTR) -> ::windows_core::Result<::windows_core::PWSTR>;
-    fn VerifyRequest(&self, pctbrequest: *mut CERTTRANSBLOB, pctbsigningcertencoded: *mut CERTTRANSBLOB, pwsztemplate: &::windows_core::PCWSTR, pwsztransactionid: &::windows_core::PCWSTR, pfverified: *mut super::super::super::Foundation::BOOL) -> ::windows_core::Result<()>;
+    fn VerifyRequest(&self, pctbrequest: *mut CERTTRANSBLOB, pctbsigningcertencoded: *mut CERTTRANSBLOB, pwsztemplate: &::windows_core::PCWSTR, pwsztransactionid: &::windows_core::PCWSTR) -> ::windows_core::Result<super::super::super::Foundation::BOOL>;
     fn Notify(&self, pwszchallenge: &::windows_core::PCWSTR, pwsztransactionid: &::windows_core::PCWSTR, disposition: X509SCEPDisposition, lasthresult: i32, pctbissuedcertencoded: *mut CERTTRANSBLOB) -> ::windows_core::Result<()>;
 }
 impl ::windows_core::RuntimeName for INDESPolicy {}
@@ -6849,7 +6849,13 @@ impl INDESPolicy_Vtbl {
         unsafe extern "system" fn VerifyRequest<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDESPolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pctbrequest: *mut CERTTRANSBLOB, pctbsigningcertencoded: *mut CERTTRANSBLOB, pwsztemplate: ::windows_core::PCWSTR, pwsztransactionid: ::windows_core::PCWSTR, pfverified: *mut super::super::super::Foundation::BOOL) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.VerifyRequest(::core::mem::transmute_copy(&pctbrequest), ::core::mem::transmute_copy(&pctbsigningcertencoded), ::core::mem::transmute(&pwsztemplate), ::core::mem::transmute(&pwsztransactionid), ::core::mem::transmute_copy(&pfverified)).into()
+            match this.VerifyRequest(::core::mem::transmute_copy(&pctbrequest), ::core::mem::transmute_copy(&pctbsigningcertencoded), ::core::mem::transmute(&pwsztemplate), ::core::mem::transmute(&pwsztransactionid)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pfverified, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Notify<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: INDESPolicy_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pwszchallenge: ::windows_core::PCWSTR, pwsztransactionid: ::windows_core::PCWSTR, disposition: X509SCEPDisposition, lasthresult: i32, pctbissuedcertencoded: *mut CERTTRANSBLOB) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/Certificates/mod.rs
@@ -7626,12 +7626,13 @@ impl INDESPolicy {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GenerateChallenge)(::windows_core::Interface::as_raw(self), pwsztemplate.into_param().abi(), pwszparams.into_param().abi(), &mut result__).from_abi(result__)
     }
-    pub unsafe fn VerifyRequest<P0, P1>(&self, pctbrequest: *mut CERTTRANSBLOB, pctbsigningcertencoded: *mut CERTTRANSBLOB, pwsztemplate: P0, pwsztransactionid: P1, pfverified: *mut super::super::super::Foundation::BOOL) -> ::windows_core::Result<()>
+    pub unsafe fn VerifyRequest<P0, P1>(&self, pctbrequest: *mut CERTTRANSBLOB, pctbsigningcertencoded: *mut CERTTRANSBLOB, pwsztemplate: P0, pwsztransactionid: P1) -> ::windows_core::Result<super::super::super::Foundation::BOOL>
     where
         P0: ::windows_core::IntoParam<::windows_core::PCWSTR>,
         P1: ::windows_core::IntoParam<::windows_core::PCWSTR>,
     {
-        (::windows_core::Interface::vtable(self).VerifyRequest)(::windows_core::Interface::as_raw(self), pctbrequest, pctbsigningcertencoded, pwsztemplate.into_param().abi(), pwsztransactionid.into_param().abi(), pfverified).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).VerifyRequest)(::windows_core::Interface::as_raw(self), pctbrequest, pctbsigningcertencoded, pwsztemplate.into_param().abi(), pwsztransactionid.into_param().abi(), &mut result__).from_abi(result__)
     }
     pub unsafe fn Notify<P0, P1>(&self, pwszchallenge: P0, pwsztransactionid: P1, disposition: X509SCEPDisposition, lasthresult: i32, pctbissuedcertencoded: *mut CERTTRANSBLOB) -> ::windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/impl.rs
@@ -26,7 +26,7 @@ impl IAppxAppInstallerReader_Vtbl {
     }
 }
 pub trait IAppxBlockMapBlock_Impl: Sized {
-    fn GetHash(&self, buffersize: *mut u32, buffer: *mut *mut u8) -> ::windows_core::Result<()>;
+    fn GetHash(&self, buffersize: *mut u32) -> ::windows_core::Result<*mut u8>;
     fn GetCompressedSize(&self) -> ::windows_core::Result<u32>;
 }
 impl ::windows_core::RuntimeName for IAppxBlockMapBlock {}
@@ -35,7 +35,13 @@ impl IAppxBlockMapBlock_Vtbl {
         unsafe extern "system" fn GetHash<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IAppxBlockMapBlock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, buffersize: *mut u32, buffer: *mut *mut u8) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetHash(::core::mem::transmute_copy(&buffersize), ::core::mem::transmute_copy(&buffer)).into()
+            match this.GetHash(::core::mem::transmute_copy(&buffersize)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(buffer, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetCompressedSize<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IAppxBlockMapBlock_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, size: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Packaging/Appx/mod.rs
@@ -486,8 +486,9 @@ pub struct IAppxAppInstallerReader_Vtbl {
 ::windows_core::imp::com_interface!(IAppxBlockMapBlock, IAppxBlockMapBlock_Vtbl, 0x75cf3930_3244_4fe0_a8c8_e0bcb270b889);
 ::windows_core::imp::interface_hierarchy!(IAppxBlockMapBlock, ::windows_core::IUnknown);
 impl IAppxBlockMapBlock {
-    pub unsafe fn GetHash(&self, buffersize: *mut u32, buffer: *mut *mut u8) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetHash)(::windows_core::Interface::as_raw(self), buffersize, buffer).ok()
+    pub unsafe fn GetHash(&self, buffersize: *mut u32) -> ::windows_core::Result<*mut u8> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetHash)(::windows_core::Interface::as_raw(self), buffersize, &mut result__).from_abi(result__)
     }
     pub unsafe fn GetCompressedSize(&self) -> ::windows_core::Result<u32> {
         let mut result__ = ::std::mem::zeroed();

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/impl.rs
@@ -840,7 +840,7 @@ impl IXpsOMDashCollection_Vtbl {
 pub trait IXpsOMDictionary_Impl: Sized {
     fn GetOwner(&self) -> ::windows_core::Result<::windows_core::IUnknown>;
     fn GetCount(&self) -> ::windows_core::Result<u32>;
-    fn GetAt(&self, index: u32, key: *mut ::windows_core::PWSTR, entry: *mut ::core::option::Option<IXpsOMShareable>) -> ::windows_core::Result<()>;
+    fn GetAt(&self, index: u32, key: *mut ::windows_core::PWSTR) -> ::windows_core::Result<IXpsOMShareable>;
     fn GetByKey(&self, key: &::windows_core::PCWSTR, beforeentry: ::core::option::Option<&IXpsOMShareable>) -> ::windows_core::Result<IXpsOMShareable>;
     fn GetIndex(&self, entry: ::core::option::Option<&IXpsOMShareable>) -> ::windows_core::Result<u32>;
     fn Append(&self, key: &::windows_core::PCWSTR, entry: ::core::option::Option<&IXpsOMShareable>) -> ::windows_core::Result<()>;
@@ -877,7 +877,13 @@ impl IXpsOMDictionary_Vtbl {
         unsafe extern "system" fn GetAt<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IXpsOMDictionary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, index: u32, key: *mut ::windows_core::PWSTR, entry: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetAt(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&key), ::core::mem::transmute_copy(&entry)).into()
+            match this.GetAt(::core::mem::transmute_copy(&index), ::core::mem::transmute_copy(&key)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(entry, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetByKey<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IXpsOMDictionary_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, key: ::windows_core::PCWSTR, beforeentry: *mut ::core::ffi::c_void, entry: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -2330,7 +2336,7 @@ pub trait IXpsOMGradientStop_Impl: Sized {
     fn GetOwner(&self) -> ::windows_core::Result<IXpsOMGradientBrush>;
     fn GetOffset(&self) -> ::windows_core::Result<f32>;
     fn SetOffset(&self, offset: f32) -> ::windows_core::Result<()>;
-    fn GetColor(&self, color: *mut XPS_COLOR, colorprofile: *mut ::core::option::Option<IXpsOMColorProfileResource>) -> ::windows_core::Result<()>;
+    fn GetColor(&self, color: *mut XPS_COLOR) -> ::windows_core::Result<IXpsOMColorProfileResource>;
     fn SetColor(&self, color: *const XPS_COLOR, colorprofile: ::core::option::Option<&IXpsOMColorProfileResource>) -> ::windows_core::Result<()>;
     fn Clone(&self) -> ::windows_core::Result<IXpsOMGradientStop>;
 }
@@ -2367,7 +2373,13 @@ impl IXpsOMGradientStop_Vtbl {
         unsafe extern "system" fn GetColor<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IXpsOMGradientStop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, color: *mut XPS_COLOR, colorprofile: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetColor(::core::mem::transmute_copy(&color), ::core::mem::transmute_copy(&colorprofile)).into()
+            match this.GetColor(::core::mem::transmute_copy(&color)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(colorprofile, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn SetColor<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IXpsOMGradientStop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, color: *const XPS_COLOR, colorprofile: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -5365,7 +5377,7 @@ impl IXpsOMSignatureBlockResourceCollection_Vtbl {
     }
 }
 pub trait IXpsOMSolidColorBrush_Impl: Sized + IXpsOMBrush_Impl {
-    fn GetColor(&self, color: *mut XPS_COLOR, colorprofile: *mut ::core::option::Option<IXpsOMColorProfileResource>) -> ::windows_core::Result<()>;
+    fn GetColor(&self, color: *mut XPS_COLOR) -> ::windows_core::Result<IXpsOMColorProfileResource>;
     fn SetColor(&self, color: *const XPS_COLOR, colorprofile: ::core::option::Option<&IXpsOMColorProfileResource>) -> ::windows_core::Result<()>;
     fn Clone(&self) -> ::windows_core::Result<IXpsOMSolidColorBrush>;
 }
@@ -5375,7 +5387,13 @@ impl IXpsOMSolidColorBrush_Vtbl {
         unsafe extern "system" fn GetColor<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IXpsOMSolidColorBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, color: *mut XPS_COLOR, colorprofile: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetColor(::core::mem::transmute_copy(&color), ::core::mem::transmute_copy(&colorprofile)).into()
+            match this.GetColor(::core::mem::transmute_copy(&color)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(colorprofile, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn SetColor<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IXpsOMSolidColorBrush_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, color: *const XPS_COLOR, colorprofile: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/mod.rs
@@ -793,8 +793,9 @@ impl IXpsOMDictionary {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetCount)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetAt(&self, index: u32, key: *mut ::windows_core::PWSTR, entry: *mut ::core::option::Option<IXpsOMShareable>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetAt)(::windows_core::Interface::as_raw(self), index, key, ::core::mem::transmute(entry)).ok()
+    pub unsafe fn GetAt(&self, index: u32, key: *mut ::windows_core::PWSTR) -> ::windows_core::Result<IXpsOMShareable> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetAt)(::windows_core::Interface::as_raw(self), index, key, &mut result__).from_abi(result__)
     }
     pub unsafe fn GetByKey<P0, P1>(&self, key: P0, beforeentry: P1) -> ::windows_core::Result<IXpsOMShareable>
     where
@@ -1823,8 +1824,9 @@ impl IXpsOMGradientStop {
     pub unsafe fn SetOffset(&self, offset: f32) -> ::windows_core::Result<()> {
         (::windows_core::Interface::vtable(self).SetOffset)(::windows_core::Interface::as_raw(self), offset).ok()
     }
-    pub unsafe fn GetColor(&self, color: *mut XPS_COLOR, colorprofile: *mut ::core::option::Option<IXpsOMColorProfileResource>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetColor)(::windows_core::Interface::as_raw(self), color, ::core::mem::transmute(colorprofile)).ok()
+    pub unsafe fn GetColor(&self, color: *mut XPS_COLOR) -> ::windows_core::Result<IXpsOMColorProfileResource> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetColor)(::windows_core::Interface::as_raw(self), color, &mut result__).from_abi(result__)
     }
     pub unsafe fn SetColor<P0>(&self, color: *const XPS_COLOR, colorprofile: P0) -> ::windows_core::Result<()>
     where
@@ -4773,8 +4775,9 @@ impl IXpsOMSolidColorBrush {
     pub unsafe fn SetOpacity(&self, opacity: f32) -> ::windows_core::Result<()> {
         (::windows_core::Interface::vtable(self).base__.SetOpacity)(::windows_core::Interface::as_raw(self), opacity).ok()
     }
-    pub unsafe fn GetColor(&self, color: *mut XPS_COLOR, colorprofile: *mut ::core::option::Option<IXpsOMColorProfileResource>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetColor)(::windows_core::Interface::as_raw(self), color, ::core::mem::transmute(colorprofile)).ok()
+    pub unsafe fn GetColor(&self, color: *mut XPS_COLOR) -> ::windows_core::Result<IXpsOMColorProfileResource> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetColor)(::windows_core::Interface::as_raw(self), color, &mut result__).from_abi(result__)
     }
     pub unsafe fn SetColor<P0>(&self, color: *const XPS_COLOR, colorprofile: P0) -> ::windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/AssessmentTool/mod.rs
@@ -86,11 +86,12 @@ impl IAccessibleWinSAT {
     }
     #[doc = "Required features: `\"Win32_UI_Accessibility\"`"]
     #[cfg(feature = "Win32_UI_Accessibility")]
-    pub unsafe fn get_accHelpTopic<P0>(&self, pszhelpfile: *mut ::windows_core::BSTR, varchild: P0, pidtopic: *mut i32) -> ::windows_core::Result<()>
+    pub unsafe fn get_accHelpTopic<P0>(&self, pszhelpfile: *mut ::windows_core::BSTR, varchild: P0) -> ::windows_core::Result<i32>
     where
         P0: ::windows_core::IntoParam<::windows_core::VARIANT>,
     {
-        (::windows_core::Interface::vtable(self).base__.get_accHelpTopic)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pszhelpfile), varchild.into_param().abi(), pidtopic).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.get_accHelpTopic)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pszhelpfile), varchild.into_param().abi(), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_UI_Accessibility\"`"]
     #[cfg(feature = "Win32_UI_Accessibility")]

--- a/crates/libs/windows/src/Windows/Win32/System/ClrHosting/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ClrHosting/impl.rs
@@ -3276,11 +3276,11 @@ impl IObjectHandle_Vtbl {
 }
 pub trait ITypeName_Impl: Sized {
     fn GetNameCount(&self) -> ::windows_core::Result<u32>;
-    fn GetNames(&self, count: u32, rgbsznames: *mut ::windows_core::BSTR, pcount: *mut u32) -> ::windows_core::Result<()>;
+    fn GetNames(&self, count: u32, rgbsznames: *mut ::windows_core::BSTR) -> ::windows_core::Result<u32>;
     fn GetTypeArgumentCount(&self) -> ::windows_core::Result<u32>;
-    fn GetTypeArguments(&self, count: u32, rgparguments: *mut ::core::option::Option<ITypeName>, pcount: *mut u32) -> ::windows_core::Result<()>;
+    fn GetTypeArguments(&self, count: u32, rgparguments: *mut ::core::option::Option<ITypeName>) -> ::windows_core::Result<u32>;
     fn GetModifierLength(&self) -> ::windows_core::Result<u32>;
-    fn GetModifiers(&self, count: u32, rgmodifiers: *mut u32, pcount: *mut u32) -> ::windows_core::Result<()>;
+    fn GetModifiers(&self, count: u32, rgmodifiers: *mut u32) -> ::windows_core::Result<u32>;
     fn GetAssemblyName(&self) -> ::windows_core::Result<::windows_core::BSTR>;
 }
 impl ::windows_core::RuntimeName for ITypeName {}
@@ -3300,7 +3300,13 @@ impl ITypeName_Vtbl {
         unsafe extern "system" fn GetNames<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: u32, rgbsznames: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, pcount: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetNames(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&rgbsznames), ::core::mem::transmute_copy(&pcount)).into()
+            match this.GetNames(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&rgbsznames)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetTypeArgumentCount<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -3316,7 +3322,13 @@ impl ITypeName_Vtbl {
         unsafe extern "system" fn GetTypeArguments<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: u32, rgparguments: *mut *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetTypeArguments(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&rgparguments), ::core::mem::transmute_copy(&pcount)).into()
+            match this.GetTypeArguments(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&rgparguments)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetModifierLength<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pcount: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -3332,7 +3344,13 @@ impl ITypeName_Vtbl {
         unsafe extern "system" fn GetModifiers<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, count: u32, rgmodifiers: *mut u32, pcount: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetModifiers(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&rgmodifiers), ::core::mem::transmute_copy(&pcount)).into()
+            match this.GetModifiers(::core::mem::transmute_copy(&count), ::core::mem::transmute_copy(&rgmodifiers)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pcount, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetAssemblyName<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeName_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rgbszassemblynames: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -3464,7 +3482,7 @@ impl ITypeNameBuilder_Vtbl {
     }
 }
 pub trait ITypeNameFactory_Impl: Sized {
-    fn ParseTypeName(&self, szname: &::windows_core::PCWSTR, perror: *mut u32, pptypename: *mut ::core::option::Option<ITypeName>) -> ::windows_core::Result<()>;
+    fn ParseTypeName(&self, szname: &::windows_core::PCWSTR, perror: *mut u32) -> ::windows_core::Result<ITypeName>;
     fn GetTypeNameBuilder(&self) -> ::windows_core::Result<ITypeNameBuilder>;
 }
 impl ::windows_core::RuntimeName for ITypeNameFactory {}
@@ -3473,7 +3491,13 @@ impl ITypeNameFactory_Vtbl {
         unsafe extern "system" fn ParseTypeName<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeNameFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, szname: ::windows_core::PCWSTR, perror: *mut u32, pptypename: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.ParseTypeName(::core::mem::transmute(&szname), ::core::mem::transmute_copy(&perror), ::core::mem::transmute_copy(&pptypename)).into()
+            match this.ParseTypeName(::core::mem::transmute(&szname), ::core::mem::transmute_copy(&perror)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pptypename, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetTypeNameBuilder<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITypeNameFactory_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pptypebuilder: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/ClrHosting/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ClrHosting/mod.rs
@@ -2434,22 +2434,25 @@ impl ITypeName {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetNameCount)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetNames(&self, count: u32, rgbsznames: *mut ::windows_core::BSTR, pcount: *mut u32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetNames)(::windows_core::Interface::as_raw(self), count, ::core::mem::transmute(rgbsznames), pcount).ok()
+    pub unsafe fn GetNames(&self, count: u32, rgbsznames: *mut ::windows_core::BSTR) -> ::windows_core::Result<u32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetNames)(::windows_core::Interface::as_raw(self), count, ::core::mem::transmute(rgbsznames), &mut result__).from_abi(result__)
     }
     pub unsafe fn GetTypeArgumentCount(&self) -> ::windows_core::Result<u32> {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetTypeArgumentCount)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetTypeArguments(&self, count: u32, rgparguments: *mut ::core::option::Option<ITypeName>, pcount: *mut u32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetTypeArguments)(::windows_core::Interface::as_raw(self), count, ::core::mem::transmute(rgparguments), pcount).ok()
+    pub unsafe fn GetTypeArguments(&self, count: u32, rgparguments: *mut ::core::option::Option<ITypeName>) -> ::windows_core::Result<u32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetTypeArguments)(::windows_core::Interface::as_raw(self), count, ::core::mem::transmute(rgparguments), &mut result__).from_abi(result__)
     }
     pub unsafe fn GetModifierLength(&self) -> ::windows_core::Result<u32> {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetModifierLength)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetModifiers(&self, count: u32, rgmodifiers: *mut u32, pcount: *mut u32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetModifiers)(::windows_core::Interface::as_raw(self), count, rgmodifiers, pcount).ok()
+    pub unsafe fn GetModifiers(&self, count: u32, rgmodifiers: *mut u32) -> ::windows_core::Result<u32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetModifiers)(::windows_core::Interface::as_raw(self), count, rgmodifiers, &mut result__).from_abi(result__)
     }
     pub unsafe fn GetAssemblyName(&self) -> ::windows_core::Result<::windows_core::BSTR> {
         let mut result__ = ::std::mem::zeroed();
@@ -2535,11 +2538,12 @@ pub struct ITypeNameBuilder_Vtbl {
 ::windows_core::imp::com_interface!(ITypeNameFactory, ITypeNameFactory_Vtbl, 0xb81ff171_20f3_11d2_8dcc_00a0c9b00521);
 ::windows_core::imp::interface_hierarchy!(ITypeNameFactory, ::windows_core::IUnknown);
 impl ITypeNameFactory {
-    pub unsafe fn ParseTypeName<P0>(&self, szname: P0, perror: *mut u32, pptypename: *mut ::core::option::Option<ITypeName>) -> ::windows_core::Result<()>
+    pub unsafe fn ParseTypeName<P0>(&self, szname: P0, perror: *mut u32) -> ::windows_core::Result<ITypeName>
     where
         P0: ::windows_core::IntoParam<::windows_core::PCWSTR>,
     {
-        (::windows_core::Interface::vtable(self).ParseTypeName)(::windows_core::Interface::as_raw(self), szname.into_param().abi(), perror, ::core::mem::transmute(pptypename)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).ParseTypeName)(::windows_core::Interface::as_raw(self), szname.into_param().abi(), perror, &mut result__).from_abi(result__)
     }
     pub unsafe fn GetTypeNameBuilder(&self) -> ::windows_core::Result<ITypeNameBuilder> {
         let mut result__ = ::std::mem::zeroed();

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/impl.rs
@@ -1067,7 +1067,7 @@ impl IEventSubscription_Vtbl {
     }
 }
 pub trait IEventSystem_Impl: Sized + super::IDispatch_Impl {
-    fn Query(&self, progid: &::windows_core::BSTR, querycriteria: &::windows_core::BSTR, errorindex: *mut i32, ppinterface: *mut ::core::option::Option<::windows_core::IUnknown>) -> ::windows_core::Result<()>;
+    fn Query(&self, progid: &::windows_core::BSTR, querycriteria: &::windows_core::BSTR, errorindex: *mut i32) -> ::windows_core::Result<::windows_core::IUnknown>;
     fn Store(&self, progid: &::windows_core::BSTR, pinterface: ::core::option::Option<&::windows_core::IUnknown>) -> ::windows_core::Result<()>;
     fn Remove(&self, progid: &::windows_core::BSTR, querycriteria: &::windows_core::BSTR) -> ::windows_core::Result<i32>;
     fn EventObjectChangeEventClassID(&self) -> ::windows_core::Result<::windows_core::BSTR>;
@@ -1080,7 +1080,13 @@ impl IEventSystem_Vtbl {
         unsafe extern "system" fn Query<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IEventSystem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, progid: ::std::mem::MaybeUninit<::windows_core::BSTR>, querycriteria: ::std::mem::MaybeUninit<::windows_core::BSTR>, errorindex: *mut i32, ppinterface: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Query(::core::mem::transmute(&progid), ::core::mem::transmute(&querycriteria), ::core::mem::transmute_copy(&errorindex), ::core::mem::transmute_copy(&ppinterface)).into()
+            match this.Query(::core::mem::transmute(&progid), ::core::mem::transmute(&querycriteria), ::core::mem::transmute_copy(&errorindex)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppinterface, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Store<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IEventSystem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, progid: ::std::mem::MaybeUninit<::windows_core::BSTR>, pinterface: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Events/mod.rs
@@ -740,12 +740,13 @@ pub struct IEventSubscription_Vtbl {
 ::windows_core::imp::com_interface!(IEventSystem, IEventSystem_Vtbl, 0x4e14fb9f_2e22_11d1_9964_00c04fbbb345);
 ::windows_core::imp::interface_hierarchy!(IEventSystem, ::windows_core::IUnknown, super::IDispatch);
 impl IEventSystem {
-    pub unsafe fn Query<P0, P1>(&self, progid: P0, querycriteria: P1, errorindex: *mut i32, ppinterface: *mut ::core::option::Option<::windows_core::IUnknown>) -> ::windows_core::Result<()>
+    pub unsafe fn Query<P0, P1>(&self, progid: P0, querycriteria: P1, errorindex: *mut i32) -> ::windows_core::Result<::windows_core::IUnknown>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<::windows_core::BSTR>,
     {
-        (::windows_core::Interface::vtable(self).Query)(::windows_core::Interface::as_raw(self), progid.into_param().abi(), querycriteria.into_param().abi(), errorindex, ::core::mem::transmute(ppinterface)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Query)(::windows_core::Interface::as_raw(self), progid.into_param().abi(), querycriteria.into_param().abi(), errorindex, &mut result__).from_abi(result__)
     }
     pub unsafe fn Store<P0, P1>(&self, progid: P0, pinterface: P1) -> ::windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/impl.rs
@@ -893,7 +893,7 @@ impl IContactAggregationLinkCollection_Vtbl {
 }
 pub trait IContactAggregationManager_Impl: Sized {
     fn GetVersionInfo(&self, plmajorversion: *mut i32, plminorversion: *mut i32) -> ::windows_core::Result<()>;
-    fn CreateOrOpenGroup(&self, pgroupname: &::windows_core::PCWSTR, options: CONTACT_AGGREGATION_CREATE_OR_OPEN_OPTIONS, pcreatedgroup: *mut super::super::Foundation::BOOL, ppgroup: *mut ::core::option::Option<IContactAggregationGroup>) -> ::windows_core::Result<()>;
+    fn CreateOrOpenGroup(&self, pgroupname: &::windows_core::PCWSTR, options: CONTACT_AGGREGATION_CREATE_OR_OPEN_OPTIONS, pcreatedgroup: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<IContactAggregationGroup>;
     fn CreateExternalContact(&self) -> ::windows_core::Result<IContactAggregationContact>;
     fn CreateServerPerson(&self) -> ::windows_core::Result<IContactAggregationServerPerson>;
     fn CreateServerContactLink(&self) -> ::windows_core::Result<IContactAggregationLink>;
@@ -919,7 +919,13 @@ impl IContactAggregationManager_Vtbl {
         unsafe extern "system" fn CreateOrOpenGroup<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IContactAggregationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pgroupname: ::windows_core::PCWSTR, options: CONTACT_AGGREGATION_CREATE_OR_OPEN_OPTIONS, pcreatedgroup: *mut super::super::Foundation::BOOL, ppgroup: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.CreateOrOpenGroup(::core::mem::transmute(&pgroupname), ::core::mem::transmute_copy(&options), ::core::mem::transmute_copy(&pcreatedgroup), ::core::mem::transmute_copy(&ppgroup)).into()
+            match this.CreateOrOpenGroup(::core::mem::transmute(&pgroupname), ::core::mem::transmute_copy(&options), ::core::mem::transmute_copy(&pcreatedgroup)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppgroup, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn CreateExternalContact<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IContactAggregationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppitem: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
@@ -478,11 +478,12 @@ impl IContactAggregationManager {
     pub unsafe fn GetVersionInfo(&self, plmajorversion: *mut i32, plminorversion: *mut i32) -> ::windows_core::Result<()> {
         (::windows_core::Interface::vtable(self).GetVersionInfo)(::windows_core::Interface::as_raw(self), plmajorversion, plminorversion).ok()
     }
-    pub unsafe fn CreateOrOpenGroup<P0>(&self, pgroupname: P0, options: CONTACT_AGGREGATION_CREATE_OR_OPEN_OPTIONS, pcreatedgroup: *mut super::super::Foundation::BOOL, ppgroup: *mut ::core::option::Option<IContactAggregationGroup>) -> ::windows_core::Result<()>
+    pub unsafe fn CreateOrOpenGroup<P0>(&self, pgroupname: P0, options: CONTACT_AGGREGATION_CREATE_OR_OPEN_OPTIONS, pcreatedgroup: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<IContactAggregationGroup>
     where
         P0: ::windows_core::IntoParam<::windows_core::PCWSTR>,
     {
-        (::windows_core::Interface::vtable(self).CreateOrOpenGroup)(::windows_core::Interface::as_raw(self), pgroupname.into_param().abi(), options, pcreatedgroup, ::core::mem::transmute(ppgroup)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).CreateOrOpenGroup)(::windows_core::Interface::as_raw(self), pgroupname.into_param().abi(), options, pcreatedgroup, &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateExternalContact(&self) -> ::windows_core::Result<IContactAggregationContact> {
         let mut result__ = ::std::mem::zeroed();

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/impl.rs
@@ -335,7 +335,7 @@ pub trait IGPMBackup_Impl: Sized + super::Com::IDispatch_Impl {
     fn Comment(&self) -> ::windows_core::Result<::windows_core::BSTR>;
     fn BackupDir(&self) -> ::windows_core::Result<::windows_core::BSTR>;
     fn Delete(&self) -> ::windows_core::Result<()>;
-    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &::windows_core::BSTR) -> ::windows_core::Result<IGPMResult>;
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -428,7 +428,13 @@ impl IGPMBackup_Vtbl {
         unsafe extern "system" fn GenerateReport<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMBackup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GenerateReportToFile<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMBackup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, bstrtargetfilepath: ::std::mem::MaybeUninit<::windows_core::BSTR>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -1782,7 +1788,7 @@ pub trait IGPMDomain_Impl: Sized + super::Com::IDispatch_Impl {
     fn CreateGPO(&self) -> ::windows_core::Result<IGPMGPO>;
     fn GetGPO(&self, bstrguid: &::windows_core::BSTR) -> ::windows_core::Result<IGPMGPO>;
     fn SearchGPOs(&self, pigpmsearchcriteria: ::core::option::Option<&IGPMSearchCriteria>) -> ::windows_core::Result<IGPMGPOCollection>;
-    fn RestoreGPO(&self, pigpmbackup: ::core::option::Option<&IGPMBackup>, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn RestoreGPO(&self, pigpmbackup: ::core::option::Option<&IGPMBackup>, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn GetSOM(&self, bstrpath: &::windows_core::BSTR) -> ::windows_core::Result<IGPMSOM>;
     fn SearchSOMs(&self, pigpmsearchcriteria: ::core::option::Option<&IGPMSearchCriteria>) -> ::windows_core::Result<IGPMSOMCollection>;
     fn GetWMIFilter(&self, bstrpath: &::windows_core::BSTR) -> ::windows_core::Result<IGPMWMIFilter>;
@@ -1851,7 +1857,13 @@ impl IGPMDomain_Vtbl {
         unsafe extern "system" fn RestoreGPO<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMDomain_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pigpmbackup: *mut ::core::ffi::c_void, ldcflags: i32, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.RestoreGPO(::windows_core::from_raw_borrowed(&pigpmbackup), ::core::mem::transmute_copy(&ldcflags), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.RestoreGPO(::windows_core::from_raw_borrowed(&pigpmbackup), ::core::mem::transmute_copy(&ldcflags), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetSOM<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMDomain_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrpath: ::std::mem::MaybeUninit<::windows_core::BSTR>, ppsom: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -1922,8 +1934,8 @@ pub trait IGPMDomain2_Impl: Sized + IGPMDomain_Impl {
     fn CreateGPOFromStarterGPO(&self, pgpotemplate: ::core::option::Option<&IGPMStarterGPO>) -> ::windows_core::Result<IGPMGPO>;
     fn GetStarterGPO(&self, bstrguid: &::windows_core::BSTR) -> ::windows_core::Result<IGPMStarterGPO>;
     fn SearchStarterGPOs(&self, pigpmsearchcriteria: ::core::option::Option<&IGPMSearchCriteria>) -> ::windows_core::Result<IGPMStarterGPOCollection>;
-    fn LoadStarterGPO(&self, bstrloadfile: &::windows_core::BSTR, boverwrite: super::super::Foundation::VARIANT_BOOL, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
-    fn RestoreStarterGPO(&self, pigpmtmplbackup: ::core::option::Option<&IGPMStarterGPOBackup>, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn LoadStarterGPO(&self, bstrloadfile: &::windows_core::BSTR, boverwrite: super::super::Foundation::VARIANT_BOOL, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
+    fn RestoreStarterGPO(&self, pigpmtmplbackup: ::core::option::Option<&IGPMStarterGPOBackup>, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
 }
 #[cfg(feature = "Win32_System_Com")]
 impl ::windows_core::RuntimeName for IGPMDomain2 {}
@@ -1977,12 +1989,24 @@ impl IGPMDomain2_Vtbl {
         unsafe extern "system" fn LoadStarterGPO<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMDomain2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrloadfile: ::std::mem::MaybeUninit<::windows_core::BSTR>, boverwrite: super::super::Foundation::VARIANT_BOOL, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.LoadStarterGPO(::core::mem::transmute(&bstrloadfile), ::core::mem::transmute_copy(&boverwrite), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.LoadStarterGPO(::core::mem::transmute(&bstrloadfile), ::core::mem::transmute_copy(&boverwrite), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn RestoreStarterGPO<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMDomain2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pigpmtmplbackup: *mut ::core::ffi::c_void, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.RestoreStarterGPO(::windows_core::from_raw_borrowed(&pigpmtmplbackup), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.RestoreStarterGPO(::windows_core::from_raw_borrowed(&pigpmtmplbackup), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base__: IGPMDomain_Vtbl::new::<Identity, Impl, OFFSET>(),
@@ -2001,7 +2025,7 @@ impl IGPMDomain2_Vtbl {
 #[doc = "Required features: `\"Win32_System_Com\"`"]
 #[cfg(feature = "Win32_System_Com")]
 pub trait IGPMDomain3_Impl: Sized + IGPMDomain2_Impl {
-    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn InfrastructureDC(&self) -> ::windows_core::Result<::windows_core::BSTR>;
     fn SetInfrastructureDC(&self, newval: &::windows_core::BSTR) -> ::windows_core::Result<()>;
     fn SetInfrastructureFlags(&self, dwflags: u32) -> ::windows_core::Result<()>;
@@ -2014,7 +2038,13 @@ impl IGPMDomain3_Vtbl {
         unsafe extern "system" fn GenerateReport<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMDomain3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn InfrastructureDC<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMDomain3_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pval: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -2072,11 +2102,11 @@ pub trait IGPMGPO_Impl: Sized + super::Com::IDispatch_Impl {
     fn GetSecurityInfo(&self) -> ::windows_core::Result<IGPMSecurityInfo>;
     fn SetSecurityInfo(&self, psecurityinfo: ::core::option::Option<&IGPMSecurityInfo>) -> ::windows_core::Result<()>;
     fn Delete(&self) -> ::windows_core::Result<()>;
-    fn Backup(&self, bstrbackupdir: &::windows_core::BSTR, bstrcomment: &::windows_core::BSTR, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
-    fn Import(&self, lflags: i32, pigpmbackup: ::core::option::Option<&IGPMBackup>, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
-    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn Backup(&self, bstrbackupdir: &::windows_core::BSTR, bstrcomment: &::windows_core::BSTR, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
+    fn Import(&self, lflags: i32, pigpmbackup: ::core::option::Option<&IGPMBackup>, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
+    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &::windows_core::BSTR) -> ::windows_core::Result<IGPMResult>;
-    fn CopyTo(&self, lflags: i32, pigpmdomain: ::core::option::Option<&IGPMDomain>, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn CopyTo(&self, lflags: i32, pigpmdomain: ::core::option::Option<&IGPMDomain>, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn SetSecurityDescriptor(&self, lflags: i32, psd: ::core::option::Option<&super::Com::IDispatch>) -> ::windows_core::Result<()>;
     fn GetSecurityDescriptor(&self, lflags: i32) -> ::windows_core::Result<super::Com::IDispatch>;
     fn IsACLConsistent(&self) -> ::windows_core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -2274,17 +2304,35 @@ impl IGPMGPO_Vtbl {
         unsafe extern "system" fn Backup<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrbackupdir: ::std::mem::MaybeUninit<::windows_core::BSTR>, bstrcomment: ::std::mem::MaybeUninit<::windows_core::BSTR>, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Backup(::core::mem::transmute(&bstrbackupdir), ::core::mem::transmute(&bstrcomment), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.Backup(::core::mem::transmute(&bstrbackupdir), ::core::mem::transmute(&bstrcomment), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Import<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, pigpmbackup: *mut ::core::ffi::c_void, pvarmigrationtable: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Import(::core::mem::transmute_copy(&lflags), ::windows_core::from_raw_borrowed(&pigpmbackup), ::core::mem::transmute_copy(&pvarmigrationtable), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.Import(::core::mem::transmute_copy(&lflags), ::windows_core::from_raw_borrowed(&pigpmbackup), ::core::mem::transmute_copy(&pvarmigrationtable), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GenerateReport<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GenerateReportToFile<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, bstrtargetfilepath: ::std::mem::MaybeUninit<::windows_core::BSTR>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -2300,7 +2348,13 @@ impl IGPMGPO_Vtbl {
         unsafe extern "system" fn CopyTo<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, pigpmdomain: *mut ::core::ffi::c_void, pvarnewdisplayname: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvarmigrationtable: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.CopyTo(::core::mem::transmute_copy(&lflags), ::windows_core::from_raw_borrowed(&pigpmdomain), ::core::mem::transmute_copy(&pvarnewdisplayname), ::core::mem::transmute_copy(&pvarmigrationtable), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.CopyTo(::core::mem::transmute_copy(&lflags), ::windows_core::from_raw_borrowed(&pigpmdomain), ::core::mem::transmute_copy(&pvarnewdisplayname), ::core::mem::transmute_copy(&pvarmigrationtable), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn SetSecurityDescriptor<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lflags: i32, psd: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -3026,7 +3080,7 @@ pub trait IGPMRSOP_Impl: Sized + super::Com::IDispatch_Impl {
     fn LoggingEnumerateUsers(&self) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn CreateQueryResults(&self) -> ::windows_core::Result<()>;
     fn ReleaseQueryResults(&self) -> ::windows_core::Result<()>;
-    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &::windows_core::BSTR) -> ::windows_core::Result<IGPMResult>;
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -3304,7 +3358,13 @@ impl IGPMRSOP_Vtbl {
         unsafe extern "system" fn GenerateReport<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMRSOP_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GenerateReportToFile<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMRSOP_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, bstrtargetfilepath: ::std::mem::MaybeUninit<::windows_core::BSTR>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -3798,8 +3858,8 @@ pub trait IGPMStarterGPO_Impl: Sized + super::Com::IDispatch_Impl {
     fn UserVersion(&self) -> ::windows_core::Result<u16>;
     fn StarterGPOVersion(&self) -> ::windows_core::Result<::windows_core::BSTR>;
     fn Delete(&self) -> ::windows_core::Result<()>;
-    fn Save(&self, bstrsavefile: &::windows_core::BSTR, boverwrite: super::super::Foundation::VARIANT_BOOL, bsaveassystem: super::super::Foundation::VARIANT_BOOL, bstrlanguage: *const ::windows_core::VARIANT, bstrauthor: *const ::windows_core::VARIANT, bstrproduct: *const ::windows_core::VARIANT, bstruniqueid: *const ::windows_core::VARIANT, bstrversion: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
-    fn Backup(&self, bstrbackupdir: &::windows_core::BSTR, bstrcomment: &::windows_core::BSTR, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn Save(&self, bstrsavefile: &::windows_core::BSTR, boverwrite: super::super::Foundation::VARIANT_BOOL, bsaveassystem: super::super::Foundation::VARIANT_BOOL, bstrlanguage: *const ::windows_core::VARIANT, bstrauthor: *const ::windows_core::VARIANT, bstrproduct: *const ::windows_core::VARIANT, bstruniqueid: *const ::windows_core::VARIANT, bstrversion: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
+    fn Backup(&self, bstrbackupdir: &::windows_core::BSTR, bstrcomment: &::windows_core::BSTR, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn CopyTo(&self, pvarnewdisplayname: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *const ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *const ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &::windows_core::BSTR) -> ::windows_core::Result<IGPMResult>;
@@ -3963,13 +4023,24 @@ impl IGPMStarterGPO_Vtbl {
         ) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Save(::core::mem::transmute(&bstrsavefile), ::core::mem::transmute_copy(&boverwrite), ::core::mem::transmute_copy(&bsaveassystem), ::core::mem::transmute_copy(&bstrlanguage), ::core::mem::transmute_copy(&bstrauthor), ::core::mem::transmute_copy(&bstrproduct), ::core::mem::transmute_copy(&bstruniqueid), ::core::mem::transmute_copy(&bstrversion), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult))
-                .into()
+            match this.Save(::core::mem::transmute(&bstrsavefile), ::core::mem::transmute_copy(&boverwrite), ::core::mem::transmute_copy(&bsaveassystem), ::core::mem::transmute_copy(&bstrlanguage), ::core::mem::transmute_copy(&bstrauthor), ::core::mem::transmute_copy(&bstrproduct), ::core::mem::transmute_copy(&bstruniqueid), ::core::mem::transmute_copy(&bstrversion), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Backup<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMStarterGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bstrbackupdir: ::std::mem::MaybeUninit<::windows_core::BSTR>, bstrcomment: ::std::mem::MaybeUninit<::windows_core::BSTR>, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Backup(::core::mem::transmute(&bstrbackupdir), ::core::mem::transmute(&bstrcomment), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.Backup(::core::mem::transmute(&bstrbackupdir), ::core::mem::transmute(&bstrcomment), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn CopyTo<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMStarterGPO_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvarnewdisplayname: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -4061,7 +4132,7 @@ pub trait IGPMStarterGPOBackup_Impl: Sized + super::Com::IDispatch_Impl {
     fn Timestamp(&self) -> ::windows_core::Result<f64>;
     fn Type(&self) -> ::windows_core::Result<GPMStarterGPOType>;
     fn Delete(&self) -> ::windows_core::Result<()>;
-    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>;
+    fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>;
     fn GenerateReportToFile(&self, gpmreporttype: GPMReportType, bstrtargetfilepath: &::windows_core::BSTR) -> ::windows_core::Result<IGPMResult>;
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -4165,7 +4236,13 @@ impl IGPMStarterGPOBackup_Vtbl {
         unsafe extern "system" fn GenerateReport<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMStarterGPOBackup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, pvargpmprogress: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvargpmcancel: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel), ::core::mem::transmute_copy(&ppigpmresult)).into()
+            match this.GenerateReport(::core::mem::transmute_copy(&gpmreporttype), ::core::mem::transmute_copy(&pvargpmprogress), ::core::mem::transmute_copy(&pvargpmcancel)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppigpmresult, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GenerateReportToFile<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IGPMStarterGPOBackup_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, gpmreporttype: GPMReportType, bstrtargetfilepath: ::std::mem::MaybeUninit<::windows_core::BSTR>, ppigpmresult: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
@@ -715,8 +715,9 @@ impl IGPMBackup {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -1676,11 +1677,12 @@ impl IGPMDomain {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn RestoreGPO<P0>(&self, pigpmbackup: P0, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn RestoreGPO<P0>(&self, pigpmbackup: P0, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMBackup>,
     {
-        (::windows_core::Interface::vtable(self).RestoreGPO)(::windows_core::Interface::as_raw(self), pigpmbackup.into_param().abi(), ldcflags, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).RestoreGPO)(::windows_core::Interface::as_raw(self), pigpmbackup.into_param().abi(), ldcflags, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -1804,11 +1806,12 @@ impl IGPMDomain2 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn RestoreGPO<P0>(&self, pigpmbackup: P0, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn RestoreGPO<P0>(&self, pigpmbackup: P0, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMBackup>,
     {
-        (::windows_core::Interface::vtable(self).base__.RestoreGPO)(::windows_core::Interface::as_raw(self), pigpmbackup.into_param().abi(), ldcflags, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.RestoreGPO)(::windows_core::Interface::as_raw(self), pigpmbackup.into_param().abi(), ldcflags, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -1881,20 +1884,22 @@ impl IGPMDomain2 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn LoadStarterGPO<P0, P1>(&self, bstrloadfile: P0, boverwrite: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn LoadStarterGPO<P0, P1>(&self, bstrloadfile: P0, boverwrite: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<super::super::Foundation::VARIANT_BOOL>,
     {
-        (::windows_core::Interface::vtable(self).LoadStarterGPO)(::windows_core::Interface::as_raw(self), bstrloadfile.into_param().abi(), boverwrite.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).LoadStarterGPO)(::windows_core::Interface::as_raw(self), bstrloadfile.into_param().abi(), boverwrite.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn RestoreStarterGPO<P0>(&self, pigpmtmplbackup: P0, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn RestoreStarterGPO<P0>(&self, pigpmtmplbackup: P0, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMStarterGPOBackup>,
     {
-        (::windows_core::Interface::vtable(self).RestoreStarterGPO)(::windows_core::Interface::as_raw(self), pigpmtmplbackup.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).RestoreStarterGPO)(::windows_core::Interface::as_raw(self), pigpmtmplbackup.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -1972,11 +1977,12 @@ impl IGPMDomain3 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn RestoreGPO<P0>(&self, pigpmbackup: P0, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn RestoreGPO<P0>(&self, pigpmbackup: P0, ldcflags: i32, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMBackup>,
     {
-        (::windows_core::Interface::vtable(self).base__.base__.RestoreGPO)(::windows_core::Interface::as_raw(self), pigpmbackup.into_param().abi(), ldcflags, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.RestoreGPO)(::windows_core::Interface::as_raw(self), pigpmbackup.into_param().abi(), ldcflags, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -2049,25 +2055,28 @@ impl IGPMDomain3 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn LoadStarterGPO<P0, P1>(&self, bstrloadfile: P0, boverwrite: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn LoadStarterGPO<P0, P1>(&self, bstrloadfile: P0, boverwrite: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<super::super::Foundation::VARIANT_BOOL>,
     {
-        (::windows_core::Interface::vtable(self).base__.LoadStarterGPO)(::windows_core::Interface::as_raw(self), bstrloadfile.into_param().abi(), boverwrite.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.LoadStarterGPO)(::windows_core::Interface::as_raw(self), bstrloadfile.into_param().abi(), boverwrite.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn RestoreStarterGPO<P0>(&self, pigpmtmplbackup: P0, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn RestoreStarterGPO<P0>(&self, pigpmtmplbackup: P0, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMStarterGPOBackup>,
     {
-        (::windows_core::Interface::vtable(self).base__.RestoreStarterGPO)(::windows_core::Interface::as_raw(self), pigpmtmplbackup.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.RestoreStarterGPO)(::windows_core::Interface::as_raw(self), pigpmtmplbackup.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     pub unsafe fn InfrastructureDC(&self) -> ::windows_core::Result<::windows_core::BSTR> {
         let mut result__ = ::std::mem::zeroed();
@@ -2206,25 +2215,28 @@ impl IGPMGPO {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<::windows_core::BSTR>,
     {
-        (::windows_core::Interface::vtable(self).Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Import<P0>(&self, lflags: i32, pigpmbackup: P0, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Import<P0>(&self, lflags: i32, pigpmbackup: P0, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMBackup>,
     {
-        (::windows_core::Interface::vtable(self).Import)(::windows_core::Interface::as_raw(self), lflags, pigpmbackup.into_param().abi(), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Import)(::windows_core::Interface::as_raw(self), lflags, pigpmbackup.into_param().abi(), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -2237,11 +2249,12 @@ impl IGPMGPO {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn CopyTo<P0>(&self, lflags: i32, pigpmdomain: P0, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn CopyTo<P0>(&self, lflags: i32, pigpmdomain: P0, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMDomain>,
     {
-        (::windows_core::Interface::vtable(self).CopyTo)(::windows_core::Interface::as_raw(self), lflags, pigpmdomain.into_param().abi(), ::core::mem::transmute(pvarnewdisplayname), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).CopyTo)(::windows_core::Interface::as_raw(self), lflags, pigpmdomain.into_param().abi(), ::core::mem::transmute(pvarnewdisplayname), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -2443,25 +2456,28 @@ impl IGPMGPO2 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<::windows_core::BSTR>,
     {
-        (::windows_core::Interface::vtable(self).base__.Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Import<P0>(&self, lflags: i32, pigpmbackup: P0, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Import<P0>(&self, lflags: i32, pigpmbackup: P0, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMBackup>,
     {
-        (::windows_core::Interface::vtable(self).base__.Import)(::windows_core::Interface::as_raw(self), lflags, pigpmbackup.into_param().abi(), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.Import)(::windows_core::Interface::as_raw(self), lflags, pigpmbackup.into_param().abi(), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -2474,11 +2490,12 @@ impl IGPMGPO2 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn CopyTo<P0>(&self, lflags: i32, pigpmdomain: P0, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn CopyTo<P0>(&self, lflags: i32, pigpmdomain: P0, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMDomain>,
     {
-        (::windows_core::Interface::vtable(self).base__.CopyTo)(::windows_core::Interface::as_raw(self), lflags, pigpmdomain.into_param().abi(), ::core::mem::transmute(pvarnewdisplayname), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.CopyTo)(::windows_core::Interface::as_raw(self), lflags, pigpmdomain.into_param().abi(), ::core::mem::transmute(pvarnewdisplayname), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -2630,25 +2647,28 @@ impl IGPMGPO3 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<::windows_core::BSTR>,
     {
-        (::windows_core::Interface::vtable(self).base__.base__.Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Import<P0>(&self, lflags: i32, pigpmbackup: P0, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Import<P0>(&self, lflags: i32, pigpmbackup: P0, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMBackup>,
     {
-        (::windows_core::Interface::vtable(self).base__.base__.Import)(::windows_core::Interface::as_raw(self), lflags, pigpmbackup.into_param().abi(), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.Import)(::windows_core::Interface::as_raw(self), lflags, pigpmbackup.into_param().abi(), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -2661,11 +2681,12 @@ impl IGPMGPO3 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn CopyTo<P0>(&self, lflags: i32, pigpmdomain: P0, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn CopyTo<P0>(&self, lflags: i32, pigpmdomain: P0, pvarnewdisplayname: *const ::windows_core::VARIANT, pvarmigrationtable: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<IGPMDomain>,
     {
-        (::windows_core::Interface::vtable(self).base__.base__.CopyTo)(::windows_core::Interface::as_raw(self), lflags, pigpmdomain.into_param().abi(), ::core::mem::transmute(pvarnewdisplayname), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.CopyTo)(::windows_core::Interface::as_raw(self), lflags, pigpmdomain.into_param().abi(), ::core::mem::transmute(pvarnewdisplayname), ::core::mem::transmute(pvarmigrationtable), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -3255,8 +3276,9 @@ impl IGPMRSOP {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -3715,22 +3737,24 @@ impl IGPMStarterGPO {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Save<P0, P1, P2>(&self, bstrsavefile: P0, boverwrite: P1, bsaveassystem: P2, bstrlanguage: *const ::windows_core::VARIANT, bstrauthor: *const ::windows_core::VARIANT, bstrproduct: *const ::windows_core::VARIANT, bstruniqueid: *const ::windows_core::VARIANT, bstrversion: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Save<P0, P1, P2>(&self, bstrsavefile: P0, boverwrite: P1, bsaveassystem: P2, bstrlanguage: *const ::windows_core::VARIANT, bstrauthor: *const ::windows_core::VARIANT, bstrproduct: *const ::windows_core::VARIANT, bstruniqueid: *const ::windows_core::VARIANT, bstrversion: *const ::windows_core::VARIANT, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<super::super::Foundation::VARIANT_BOOL>,
         P2: ::windows_core::IntoParam<super::super::Foundation::VARIANT_BOOL>,
     {
-        (::windows_core::Interface::vtable(self).Save)(::windows_core::Interface::as_raw(self), bstrsavefile.into_param().abi(), boverwrite.into_param().abi(), bsaveassystem.into_param().abi(), ::core::mem::transmute(bstrlanguage), ::core::mem::transmute(bstrauthor), ::core::mem::transmute(bstrproduct), ::core::mem::transmute(bstruniqueid), ::core::mem::transmute(bstrversion), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Save)(::windows_core::Interface::as_raw(self), bstrsavefile.into_param().abi(), boverwrite.into_param().abi(), bsaveassystem.into_param().abi(), ::core::mem::transmute(bstrlanguage), ::core::mem::transmute(bstrauthor), ::core::mem::transmute(bstrproduct), ::core::mem::transmute(bstruniqueid), ::core::mem::transmute(bstrversion), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()>
+    pub unsafe fn Backup<P0, P1>(&self, bstrbackupdir: P0, bstrcomment: P1, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult>
     where
         P0: ::windows_core::IntoParam<::windows_core::BSTR>,
         P1: ::windows_core::IntoParam<::windows_core::BSTR>,
     {
-        (::windows_core::Interface::vtable(self).Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Backup)(::windows_core::Interface::as_raw(self), bstrbackupdir.into_param().abi(), bstrcomment.into_param().abi(), ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
@@ -3877,8 +3901,9 @@ impl IGPMStarterGPOBackup {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT, ppigpmresult: *mut ::core::option::Option<IGPMResult>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), ::core::mem::transmute(ppigpmresult)).ok()
+    pub unsafe fn GenerateReport(&self, gpmreporttype: GPMReportType, pvargpmprogress: *const ::windows_core::VARIANT, pvargpmcancel: *mut ::windows_core::VARIANT) -> ::windows_core::Result<IGPMResult> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GenerateReport)(::windows_core::Interface::as_raw(self), gpmreporttype, ::core::mem::transmute(pvargpmprogress), ::core::mem::transmute(pvargpmcancel), &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]

--- a/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/impl.rs
@@ -1012,7 +1012,7 @@ impl IConditionFactory2_Vtbl {
 pub trait IConditionGenerator_Impl: Sized {
     fn Initialize(&self, pschemaprovider: ::core::option::Option<&ISchemaProvider>) -> ::windows_core::Result<()>;
     fn RecognizeNamedEntities(&self, pszinputstring: &::windows_core::PCWSTR, lciduserlocale: u32, ptokencollection: ::core::option::Option<&ITokenCollection>, pnamedentities: ::core::option::Option<&INamedEntityCollector>) -> ::windows_core::Result<()>;
-    fn GenerateForLeaf(&self, pconditionfactory: ::core::option::Option<&IConditionFactory>, pszpropertyname: &::windows_core::PCWSTR, cop: Common::CONDITION_OPERATION, pszvaluetype: &::windows_core::PCWSTR, pszvalue: &::windows_core::PCWSTR, pszvalue2: &::windows_core::PCWSTR, ppropertynameterm: ::core::option::Option<&IRichChunk>, poperationterm: ::core::option::Option<&IRichChunk>, pvalueterm: ::core::option::Option<&IRichChunk>, automaticwildcard: super::super::Foundation::BOOL, pnostringquery: *mut super::super::Foundation::BOOL, ppqueryexpression: *mut ::core::option::Option<ICondition>) -> ::windows_core::Result<()>;
+    fn GenerateForLeaf(&self, pconditionfactory: ::core::option::Option<&IConditionFactory>, pszpropertyname: &::windows_core::PCWSTR, cop: Common::CONDITION_OPERATION, pszvaluetype: &::windows_core::PCWSTR, pszvalue: &::windows_core::PCWSTR, pszvalue2: &::windows_core::PCWSTR, ppropertynameterm: ::core::option::Option<&IRichChunk>, poperationterm: ::core::option::Option<&IRichChunk>, pvalueterm: ::core::option::Option<&IRichChunk>, automaticwildcard: super::super::Foundation::BOOL, pnostringquery: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<ICondition>;
     fn DefaultPhrase(&self, pszvaluetype: &::windows_core::PCWSTR, ppropvar: *const ::windows_core::PROPVARIANT, fuseenglish: super::super::Foundation::BOOL, ppszphrase: *mut ::windows_core::PWSTR) -> ::windows_core::Result<()>;
 }
 #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search_Common"))]
@@ -1033,7 +1033,7 @@ impl IConditionGenerator_Vtbl {
         unsafe extern "system" fn GenerateForLeaf<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IConditionGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pconditionfactory: *mut ::core::ffi::c_void, pszpropertyname: ::windows_core::PCWSTR, cop: Common::CONDITION_OPERATION, pszvaluetype: ::windows_core::PCWSTR, pszvalue: ::windows_core::PCWSTR, pszvalue2: ::windows_core::PCWSTR, ppropertynameterm: *mut ::core::ffi::c_void, poperationterm: *mut ::core::ffi::c_void, pvalueterm: *mut ::core::ffi::c_void, automaticwildcard: super::super::Foundation::BOOL, pnostringquery: *mut super::super::Foundation::BOOL, ppqueryexpression: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GenerateForLeaf(
+            match this.GenerateForLeaf(
                 ::windows_core::from_raw_borrowed(&pconditionfactory),
                 ::core::mem::transmute(&pszpropertyname),
                 ::core::mem::transmute_copy(&cop),
@@ -1045,9 +1045,13 @@ impl IConditionGenerator_Vtbl {
                 ::windows_core::from_raw_borrowed(&pvalueterm),
                 ::core::mem::transmute_copy(&automaticwildcard),
                 ::core::mem::transmute_copy(&pnostringquery),
-                ::core::mem::transmute_copy(&ppqueryexpression),
-            )
-            .into()
+            ) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppqueryexpression, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn DefaultPhrase<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IConditionGenerator_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszvaluetype: ::windows_core::PCWSTR, ppropvar: *const ::std::mem::MaybeUninit<::windows_core::PROPVARIANT>, fuseenglish: super::super::Foundation::BOOL, ppszphrase: *mut ::windows_core::PWSTR) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -2708,7 +2708,7 @@ impl IConditionGenerator {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`, `\"Win32_System_Search_Common\"`"]
     #[cfg(all(feature = "Win32_System_Com", feature = "Win32_System_Search_Common"))]
-    pub unsafe fn GenerateForLeaf<P0, P1, P2, P3, P4, P5, P6, P7, P8>(&self, pconditionfactory: P0, pszpropertyname: P1, cop: Common::CONDITION_OPERATION, pszvaluetype: P2, pszvalue: P3, pszvalue2: P4, ppropertynameterm: P5, poperationterm: P6, pvalueterm: P7, automaticwildcard: P8, pnostringquery: *mut super::super::Foundation::BOOL, ppqueryexpression: *mut ::core::option::Option<ICondition>) -> ::windows_core::Result<()>
+    pub unsafe fn GenerateForLeaf<P0, P1, P2, P3, P4, P5, P6, P7, P8>(&self, pconditionfactory: P0, pszpropertyname: P1, cop: Common::CONDITION_OPERATION, pszvaluetype: P2, pszvalue: P3, pszvalue2: P4, ppropertynameterm: P5, poperationterm: P6, pvalueterm: P7, automaticwildcard: P8, pnostringquery: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<ICondition>
     where
         P0: ::windows_core::IntoParam<IConditionFactory>,
         P1: ::windows_core::IntoParam<::windows_core::PCWSTR>,
@@ -2720,7 +2720,8 @@ impl IConditionGenerator {
         P7: ::windows_core::IntoParam<IRichChunk>,
         P8: ::windows_core::IntoParam<super::super::Foundation::BOOL>,
     {
-        (::windows_core::Interface::vtable(self).GenerateForLeaf)(::windows_core::Interface::as_raw(self), pconditionfactory.into_param().abi(), pszpropertyname.into_param().abi(), cop, pszvaluetype.into_param().abi(), pszvalue.into_param().abi(), pszvalue2.into_param().abi(), ppropertynameterm.into_param().abi(), poperationterm.into_param().abi(), pvalueterm.into_param().abi(), automaticwildcard.into_param().abi(), pnostringquery, ::core::mem::transmute(ppqueryexpression)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GenerateForLeaf)(::windows_core::Interface::as_raw(self), pconditionfactory.into_param().abi(), pszpropertyname.into_param().abi(), cop, pszvaluetype.into_param().abi(), pszvalue.into_param().abi(), pszvalue2.into_param().abi(), ppropertynameterm.into_param().abi(), poperationterm.into_param().abi(), pvalueterm.into_param().abi(), automaticwildcard.into_param().abi(), pnostringquery, &mut result__).from_abi(result__)
     }
     pub unsafe fn DefaultPhrase<P0, P1>(&self, pszvaluetype: P0, ppropvar: *const ::windows_core::PROPVARIANT, fuseenglish: P1, ppszphrase: ::core::option::Option<*mut ::windows_core::PWSTR>) -> ::windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
@@ -48,7 +48,7 @@ impl IItemEnumerator_Vtbl {
 #[cfg(feature = "Win32_System_Com")]
 pub trait ISettingsContext_Impl: Sized {
     fn Serialize(&self, pstream: ::core::option::Option<&super::Com::IStream>, ptarget: ::core::option::Option<&ITargetInfo>) -> ::windows_core::Result<()>;
-    fn Deserialize(&self, pstream: ::core::option::Option<&super::Com::IStream>, ptarget: ::core::option::Option<&ITargetInfo>, pppresults: *mut *mut ::core::option::Option<ISettingsResult>, pcresultcount: *mut usize) -> ::windows_core::Result<()>;
+    fn Deserialize(&self, pstream: ::core::option::Option<&super::Com::IStream>, ptarget: ::core::option::Option<&ITargetInfo>, pppresults: *mut *mut ::core::option::Option<ISettingsResult>) -> ::windows_core::Result<usize>;
     fn SetUserData(&self, puserdata: *const ::core::ffi::c_void) -> ::windows_core::Result<()>;
     fn GetUserData(&self) -> ::windows_core::Result<*mut ::core::ffi::c_void>;
     fn GetNamespaces(&self) -> ::windows_core::Result<IItemEnumerator>;
@@ -68,7 +68,13 @@ impl ISettingsContext_Vtbl {
         unsafe extern "system" fn Deserialize<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pstream: *mut ::core::ffi::c_void, ptarget: *mut ::core::ffi::c_void, pppresults: *mut *mut ::core::option::Option<ISettingsResult>, pcresultcount: *mut usize) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.Deserialize(::windows_core::from_raw_borrowed(&pstream), ::windows_core::from_raw_borrowed(&ptarget), ::core::mem::transmute_copy(&pppresults), ::core::mem::transmute_copy(&pcresultcount)).into()
+            match this.Deserialize(::windows_core::from_raw_borrowed(&pstream), ::windows_core::from_raw_borrowed(&ptarget), ::core::mem::transmute_copy(&pppresults)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pcresultcount, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn SetUserData<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puserdata: *const ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -139,7 +145,7 @@ pub trait ISettingsEngine_Impl: Sized {
     fn SetTargetInfo(&self, target: ::core::option::Option<&ITargetInfo>) -> ::windows_core::Result<()>;
     fn CreateSettingsContext(&self, flags: u32, reserved: *const ::core::ffi::c_void) -> ::windows_core::Result<ISettingsContext>;
     fn SetSettingsContext(&self, settingscontext: ::core::option::Option<&ISettingsContext>) -> ::windows_core::Result<()>;
-    fn ApplySettingsContext(&self, settingscontext: ::core::option::Option<&ISettingsContext>, pppwzidentities: *mut *mut ::windows_core::PWSTR, pcidentities: *mut usize) -> ::windows_core::Result<()>;
+    fn ApplySettingsContext(&self, settingscontext: ::core::option::Option<&ISettingsContext>, pppwzidentities: *mut *mut ::windows_core::PWSTR) -> ::windows_core::Result<usize>;
     fn GetSettingsContext(&self) -> ::windows_core::Result<ISettingsContext>;
 }
 #[cfg(feature = "Win32_System_Com")]
@@ -274,7 +280,13 @@ impl ISettingsEngine_Vtbl {
         unsafe extern "system" fn ApplySettingsContext<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsEngine_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, settingscontext: *mut ::core::ffi::c_void, pppwzidentities: *mut *mut ::windows_core::PWSTR, pcidentities: *mut usize) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.ApplySettingsContext(::windows_core::from_raw_borrowed(&settingscontext), ::core::mem::transmute_copy(&pppwzidentities), ::core::mem::transmute_copy(&pcidentities)).into()
+            match this.ApplySettingsContext(::windows_core::from_raw_borrowed(&settingscontext), ::core::mem::transmute_copy(&pppwzidentities)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pcidentities, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetSettingsContext<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsEngine_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, settingscontext: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -370,7 +382,7 @@ pub trait ISettingsItem_Impl: Sized {
     fn SetValue(&self, value: *const ::windows_core::VARIANT) -> ::windows_core::Result<()>;
     fn GetSettingType(&self) -> ::windows_core::Result<WcmSettingType>;
     fn GetDataType(&self) -> ::windows_core::Result<WcmDataType>;
-    fn GetValueRaw(&self, data: *mut *mut u8, datasize: *mut u32) -> ::windows_core::Result<()>;
+    fn GetValueRaw(&self, data: *mut *mut u8) -> ::windows_core::Result<u32>;
     fn SetValueRaw(&self, datatype: i32, data: *const u8, datasize: u32) -> ::windows_core::Result<()>;
     fn HasChild(&self) -> ::windows_core::Result<super::super::Foundation::BOOL>;
     fn Children(&self) -> ::windows_core::Result<IItemEnumerator>;
@@ -378,7 +390,7 @@ pub trait ISettingsItem_Impl: Sized {
     fn GetSettingByPath(&self, path: &::windows_core::PCWSTR) -> ::windows_core::Result<ISettingsItem>;
     fn CreateSettingByPath(&self, path: &::windows_core::PCWSTR) -> ::windows_core::Result<ISettingsItem>;
     fn RemoveSettingByPath(&self, path: &::windows_core::PCWSTR) -> ::windows_core::Result<()>;
-    fn GetListKeyInformation(&self, keyname: *mut ::windows_core::BSTR, datatype: *mut WcmDataType) -> ::windows_core::Result<()>;
+    fn GetListKeyInformation(&self, keyname: *mut ::windows_core::BSTR) -> ::windows_core::Result<WcmDataType>;
     fn CreateListElement(&self, keydata: *const ::windows_core::VARIANT) -> ::windows_core::Result<ISettingsItem>;
     fn RemoveListElement(&self, elementname: &::windows_core::PCWSTR) -> ::windows_core::Result<()>;
     fn Attributes(&self) -> ::windows_core::Result<IItemEnumerator>;
@@ -443,7 +455,13 @@ impl ISettingsItem_Vtbl {
         unsafe extern "system" fn GetValueRaw<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, data: *mut *mut u8, datasize: *mut u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetValueRaw(::core::mem::transmute_copy(&data), ::core::mem::transmute_copy(&datasize)).into()
+            match this.GetValueRaw(::core::mem::transmute_copy(&data)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(datasize, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn SetValueRaw<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, datatype: i32, data: *const u8, datasize: u32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -513,7 +531,13 @@ impl ISettingsItem_Vtbl {
         unsafe extern "system" fn GetListKeyInformation<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keyname: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, datatype: *mut WcmDataType) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetListKeyInformation(::core::mem::transmute_copy(&keyname), ::core::mem::transmute_copy(&datatype)).into()
+            match this.GetListKeyInformation(::core::mem::transmute_copy(&keyname)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(datatype, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn CreateListElement<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ISettingsItem_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, keydata: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, child: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
@@ -35,12 +35,13 @@ impl ISettingsContext {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Deserialize<P0, P1>(&self, pstream: P0, ptarget: P1, pppresults: *mut *mut ::core::option::Option<ISettingsResult>, pcresultcount: *mut usize) -> ::windows_core::Result<()>
+    pub unsafe fn Deserialize<P0, P1>(&self, pstream: P0, ptarget: P1, pppresults: *mut *mut ::core::option::Option<ISettingsResult>) -> ::windows_core::Result<usize>
     where
         P0: ::windows_core::IntoParam<super::Com::IStream>,
         P1: ::windows_core::IntoParam<ITargetInfo>,
     {
-        (::windows_core::Interface::vtable(self).Deserialize)(::windows_core::Interface::as_raw(self), pstream.into_param().abi(), ptarget.into_param().abi(), pppresults, pcresultcount).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).Deserialize)(::windows_core::Interface::as_raw(self), pstream.into_param().abi(), ptarget.into_param().abi(), pppresults, &mut result__).from_abi(result__)
     }
     pub unsafe fn SetUserData(&self, puserdata: *const ::core::ffi::c_void) -> ::windows_core::Result<()> {
         (::windows_core::Interface::vtable(self).SetUserData)(::windows_core::Interface::as_raw(self), puserdata).ok()
@@ -159,11 +160,12 @@ impl ISettingsEngine {
     {
         (::windows_core::Interface::vtable(self).SetSettingsContext)(::windows_core::Interface::as_raw(self), settingscontext.into_param().abi()).ok()
     }
-    pub unsafe fn ApplySettingsContext<P0>(&self, settingscontext: P0, pppwzidentities: *mut *mut ::windows_core::PWSTR, pcidentities: *mut usize) -> ::windows_core::Result<()>
+    pub unsafe fn ApplySettingsContext<P0>(&self, settingscontext: P0, pppwzidentities: *mut *mut ::windows_core::PWSTR) -> ::windows_core::Result<usize>
     where
         P0: ::windows_core::IntoParam<ISettingsContext>,
     {
-        (::windows_core::Interface::vtable(self).ApplySettingsContext)(::windows_core::Interface::as_raw(self), settingscontext.into_param().abi(), pppwzidentities, pcidentities).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).ApplySettingsContext)(::windows_core::Interface::as_raw(self), settingscontext.into_param().abi(), pppwzidentities, &mut result__).from_abi(result__)
     }
     pub unsafe fn GetSettingsContext(&self) -> ::windows_core::Result<ISettingsContext> {
         let mut result__ = ::std::mem::zeroed();
@@ -250,8 +252,9 @@ impl ISettingsItem {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).GetDataType)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetValueRaw(&self, data: *mut *mut u8, datasize: *mut u32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetValueRaw)(::windows_core::Interface::as_raw(self), data, datasize).ok()
+    pub unsafe fn GetValueRaw(&self, data: *mut *mut u8) -> ::windows_core::Result<u32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetValueRaw)(::windows_core::Interface::as_raw(self), data, &mut result__).from_abi(result__)
     }
     pub unsafe fn SetValueRaw(&self, datatype: i32, data: &[u8]) -> ::windows_core::Result<()> {
         (::windows_core::Interface::vtable(self).SetValueRaw)(::windows_core::Interface::as_raw(self), datatype, ::core::mem::transmute(data.as_ptr()), data.len().try_into().unwrap()).ok()
@@ -291,8 +294,9 @@ impl ISettingsItem {
     {
         (::windows_core::Interface::vtable(self).RemoveSettingByPath)(::windows_core::Interface::as_raw(self), path.into_param().abi()).ok()
     }
-    pub unsafe fn GetListKeyInformation(&self, keyname: *mut ::windows_core::BSTR, datatype: *mut WcmDataType) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetListKeyInformation)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(keyname), datatype).ok()
+    pub unsafe fn GetListKeyInformation(&self, keyname: *mut ::windows_core::BSTR) -> ::windows_core::Result<WcmDataType> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetListKeyInformation)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(keyname), &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateListElement(&self, keydata: *const ::windows_core::VARIANT) -> ::windows_core::Result<ISettingsItem> {
         let mut result__ = ::std::mem::zeroed();

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/impl.rs
@@ -166,7 +166,7 @@ pub trait IAccessible_Impl: Sized + super::super::System::Com::IDispatch_Impl {
     fn get_accRole(&self, varchild: &::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn get_accState(&self, varchild: &::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn get_accHelp(&self, varchild: &::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::BSTR>;
-    fn get_accHelpTopic(&self, pszhelpfile: *mut ::windows_core::BSTR, varchild: &::windows_core::VARIANT, pidtopic: *mut i32) -> ::windows_core::Result<()>;
+    fn get_accHelpTopic(&self, pszhelpfile: *mut ::windows_core::BSTR, varchild: &::windows_core::VARIANT) -> ::windows_core::Result<i32>;
     fn get_accKeyboardShortcut(&self, varchild: &::windows_core::VARIANT) -> ::windows_core::Result<::windows_core::BSTR>;
     fn accFocus(&self) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn accSelection(&self) -> ::windows_core::Result<::windows_core::VARIANT>;
@@ -286,7 +286,13 @@ impl IAccessible_Vtbl {
         unsafe extern "system" fn get_accHelpTopic<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IAccessible_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pszhelpfile: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, varchild: ::std::mem::MaybeUninit<::windows_core::VARIANT>, pidtopic: *mut i32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.get_accHelpTopic(::core::mem::transmute_copy(&pszhelpfile), ::core::mem::transmute(&varchild), ::core::mem::transmute_copy(&pidtopic)).into()
+            match this.get_accHelpTopic(::core::mem::transmute_copy(&pszhelpfile), ::core::mem::transmute(&varchild)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pidtopic, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn get_accKeyboardShortcut<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IAccessible_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, varchild: ::std::mem::MaybeUninit<::windows_core::VARIANT>, pszkeyboardshortcut: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -2687,7 +2693,7 @@ impl ITextProvider_Vtbl {
 #[cfg(feature = "Win32_System_Com")]
 pub trait ITextProvider2_Impl: Sized + ITextProvider_Impl {
     fn RangeFromAnnotation(&self, annotationelement: ::core::option::Option<&IRawElementProviderSimple>) -> ::windows_core::Result<ITextRangeProvider>;
-    fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL, pretval: *mut ::core::option::Option<ITextRangeProvider>) -> ::windows_core::Result<()>;
+    fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<ITextRangeProvider>;
 }
 #[cfg(feature = "Win32_System_Com")]
 impl ::windows_core::RuntimeName for ITextProvider2 {}
@@ -2708,7 +2714,13 @@ impl ITextProvider2_Vtbl {
         unsafe extern "system" fn GetCaretRange<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: ITextProvider2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, isactive: *mut super::super::Foundation::BOOL, pretval: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetCaretRange(::core::mem::transmute_copy(&isactive), ::core::mem::transmute_copy(&pretval)).into()
+            match this.GetCaretRange(::core::mem::transmute_copy(&isactive)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(pretval, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base__: ITextProvider_Vtbl::new::<Identity, Impl, OFFSET>(),
@@ -3184,10 +3196,10 @@ pub trait IUIAutomation_Impl: Sized {
     fn RemoveFocusChangedEventHandler(&self, handler: ::core::option::Option<&IUIAutomationFocusChangedEventHandler>) -> ::windows_core::Result<()>;
     fn RemoveAllEventHandlers(&self) -> ::windows_core::Result<()>;
     fn IntNativeArrayToSafeArray(&self, array: *const i32, arraycount: i32) -> ::windows_core::Result<*mut super::super::System::Com::SAFEARRAY>;
-    fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::Result<()>;
+    fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32) -> ::windows_core::Result<i32>;
     fn RectToVariant(&self, rc: &super::super::Foundation::RECT) -> ::windows_core::Result<::windows_core::VARIANT>;
     fn VariantToRect(&self, var: &::windows_core::VARIANT) -> ::windows_core::Result<super::super::Foundation::RECT>;
-    fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::Result<()>;
+    fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT) -> ::windows_core::Result<i32>;
     fn CreateProxyFactoryEntry(&self, factory: ::core::option::Option<&IUIAutomationProxyFactory>) -> ::windows_core::Result<IUIAutomationProxyFactoryEntry>;
     fn ProxyFactoryMapping(&self) -> ::windows_core::Result<IUIAutomationProxyFactoryMapping>;
     fn GetPropertyProgrammaticName(&self, property: UIA_PROPERTY_ID) -> ::windows_core::Result<::windows_core::BSTR>;
@@ -3588,7 +3600,13 @@ impl IUIAutomation_Vtbl {
         unsafe extern "system" fn IntSafeArrayToNativeArray<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUIAutomation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.IntSafeArrayToNativeArray(::core::mem::transmute_copy(&intarray), ::core::mem::transmute_copy(&array), ::core::mem::transmute_copy(&arraycount)).into()
+            match this.IntSafeArrayToNativeArray(::core::mem::transmute_copy(&intarray), ::core::mem::transmute_copy(&array)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(arraycount, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn RectToVariant<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUIAutomation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rc: super::super::Foundation::RECT, var: *mut ::std::mem::MaybeUninit<::windows_core::VARIANT>) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -3615,7 +3633,13 @@ impl IUIAutomation_Vtbl {
         unsafe extern "system" fn SafeArrayToRectNativeArray<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUIAutomation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.SafeArrayToRectNativeArray(::core::mem::transmute_copy(&rects), ::core::mem::transmute_copy(&rectarray), ::core::mem::transmute_copy(&rectarraycount)).into()
+            match this.SafeArrayToRectNativeArray(::core::mem::transmute_copy(&rects), ::core::mem::transmute_copy(&rectarray)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(rectarraycount, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn CreateProxyFactoryEntry<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUIAutomation_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, factory: *mut ::core::ffi::c_void, factoryentry: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -4763,7 +4787,7 @@ pub trait IUIAutomationElement_Impl: Sized {
     fn CachedDescribedBy(&self) -> ::windows_core::Result<IUIAutomationElementArray>;
     fn CachedFlowsTo(&self) -> ::windows_core::Result<IUIAutomationElementArray>;
     fn CachedProviderDescription(&self) -> ::windows_core::Result<::windows_core::BSTR>;
-    fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()>;
+    fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL>;
 }
 #[cfg(feature = "Win32_System_Com")]
 impl ::windows_core::RuntimeName for IUIAutomationElement {}
@@ -5646,7 +5670,13 @@ impl IUIAutomationElement_Vtbl {
         unsafe extern "system" fn GetClickablePoint<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUIAutomationElement_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetClickablePoint(::core::mem::transmute_copy(&clickable), ::core::mem::transmute_copy(&gotclickable)).into()
+            match this.GetClickablePoint(::core::mem::transmute_copy(&clickable)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(gotclickable, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base__: ::windows_core::IUnknown_Vtbl::new::<Identity, OFFSET>(),
@@ -9136,7 +9166,7 @@ impl IUIAutomationTextPattern_Vtbl {
 }
 pub trait IUIAutomationTextPattern2_Impl: Sized + IUIAutomationTextPattern_Impl {
     fn RangeFromAnnotation(&self, annotation: ::core::option::Option<&IUIAutomationElement>) -> ::windows_core::Result<IUIAutomationTextRange>;
-    fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL, range: *mut ::core::option::Option<IUIAutomationTextRange>) -> ::windows_core::Result<()>;
+    fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<IUIAutomationTextRange>;
 }
 impl ::windows_core::RuntimeName for IUIAutomationTextPattern2 {}
 impl IUIAutomationTextPattern2_Vtbl {
@@ -9155,7 +9185,13 @@ impl IUIAutomationTextPattern2_Vtbl {
         unsafe extern "system" fn GetCaretRange<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IUIAutomationTextPattern2_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, isactive: *mut super::super::Foundation::BOOL, range: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetCaretRange(::core::mem::transmute_copy(&isactive), ::core::mem::transmute_copy(&range)).into()
+            match this.GetCaretRange(::core::mem::transmute_copy(&isactive)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(range, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base__: IUIAutomationTextPattern_Vtbl::new::<Identity, Impl, OFFSET>(),

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -1245,11 +1245,12 @@ impl IAccessible {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).get_accHelp)(::windows_core::Interface::as_raw(self), varchild.into_param().abi(), &mut result__).from_abi(result__)
     }
-    pub unsafe fn get_accHelpTopic<P0>(&self, pszhelpfile: *mut ::windows_core::BSTR, varchild: P0, pidtopic: *mut i32) -> ::windows_core::Result<()>
+    pub unsafe fn get_accHelpTopic<P0>(&self, pszhelpfile: *mut ::windows_core::BSTR, varchild: P0) -> ::windows_core::Result<i32>
     where
         P0: ::windows_core::IntoParam<::windows_core::VARIANT>,
     {
-        (::windows_core::Interface::vtable(self).get_accHelpTopic)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pszhelpfile), varchild.into_param().abi(), pidtopic).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).get_accHelpTopic)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pszhelpfile), varchild.into_param().abi(), &mut result__).from_abi(result__)
     }
     pub unsafe fn get_accKeyboardShortcut<P0>(&self, varchild: P0) -> ::windows_core::Result<::windows_core::BSTR>
     where
@@ -2735,8 +2736,9 @@ impl ITextProvider2 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).RangeFromAnnotation)(::windows_core::Interface::as_raw(self), annotationelement.into_param().abi(), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL, pretval: *mut ::core::option::Option<ITextRangeProvider>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetCaretRange)(::windows_core::Interface::as_raw(self), isactive, ::core::mem::transmute(pretval)).ok()
+    pub unsafe fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<ITextRangeProvider> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetCaretRange)(::windows_core::Interface::as_raw(self), isactive, &mut result__).from_abi(result__)
     }
 }
 #[repr(C)]
@@ -3330,8 +3332,9 @@ impl IUIAutomation {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, arraycount).ok()
+    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, &mut result__).from_abi(result__)
     }
     pub unsafe fn RectToVariant(&self, rc: super::super::Foundation::RECT) -> ::windows_core::Result<::windows_core::VARIANT> {
         let mut result__ = ::std::mem::zeroed();
@@ -3346,8 +3349,9 @@ impl IUIAutomation {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, rectarraycount).ok()
+    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateProxyFactoryEntry<P0>(&self, factory: P0) -> ::windows_core::Result<IUIAutomationProxyFactoryEntry>
     where
@@ -3756,8 +3760,9 @@ impl IUIAutomation2 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, arraycount).ok()
+    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, &mut result__).from_abi(result__)
     }
     pub unsafe fn RectToVariant(&self, rc: super::super::Foundation::RECT) -> ::windows_core::Result<::windows_core::VARIANT> {
         let mut result__ = ::std::mem::zeroed();
@@ -3772,8 +3777,9 @@ impl IUIAutomation2 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, rectarraycount).ok()
+    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateProxyFactoryEntry<P0>(&self, factory: P0) -> ::windows_core::Result<IUIAutomationProxyFactoryEntry>
     where
@@ -4124,8 +4130,9 @@ impl IUIAutomation3 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, arraycount).ok()
+    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, &mut result__).from_abi(result__)
     }
     pub unsafe fn RectToVariant(&self, rc: super::super::Foundation::RECT) -> ::windows_core::Result<::windows_core::VARIANT> {
         let mut result__ = ::std::mem::zeroed();
@@ -4140,8 +4147,9 @@ impl IUIAutomation3 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, rectarraycount).ok()
+    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateProxyFactoryEntry<P0>(&self, factory: P0) -> ::windows_core::Result<IUIAutomationProxyFactoryEntry>
     where
@@ -4503,8 +4511,9 @@ impl IUIAutomation4 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, arraycount).ok()
+    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, &mut result__).from_abi(result__)
     }
     pub unsafe fn RectToVariant(&self, rc: super::super::Foundation::RECT) -> ::windows_core::Result<::windows_core::VARIANT> {
         let mut result__ = ::std::mem::zeroed();
@@ -4519,8 +4528,9 @@ impl IUIAutomation4 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, rectarraycount).ok()
+    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateProxyFactoryEntry<P0>(&self, factory: P0) -> ::windows_core::Result<IUIAutomationProxyFactoryEntry>
     where
@@ -4897,8 +4907,9 @@ impl IUIAutomation5 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, arraycount).ok()
+    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, &mut result__).from_abi(result__)
     }
     pub unsafe fn RectToVariant(&self, rc: super::super::Foundation::RECT) -> ::windows_core::Result<::windows_core::VARIANT> {
         let mut result__ = ::std::mem::zeroed();
@@ -4913,8 +4924,9 @@ impl IUIAutomation5 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, rectarraycount).ok()
+    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateProxyFactoryEntry<P0>(&self, factory: P0) -> ::windows_core::Result<IUIAutomationProxyFactoryEntry>
     where
@@ -5306,8 +5318,9 @@ impl IUIAutomation6 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32, arraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, arraycount).ok()
+    pub unsafe fn IntSafeArrayToNativeArray(&self, intarray: *const super::super::System::Com::SAFEARRAY, array: *mut *mut i32) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.IntSafeArrayToNativeArray)(::windows_core::Interface::as_raw(self), intarray, array, &mut result__).from_abi(result__)
     }
     pub unsafe fn RectToVariant(&self, rc: super::super::Foundation::RECT) -> ::windows_core::Result<::windows_core::VARIANT> {
         let mut result__ = ::std::mem::zeroed();
@@ -5322,8 +5335,9 @@ impl IUIAutomation6 {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT, rectarraycount: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, rectarraycount).ok()
+    pub unsafe fn SafeArrayToRectNativeArray(&self, rects: *const super::super::System::Com::SAFEARRAY, rectarray: *mut *mut super::super::Foundation::RECT) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.SafeArrayToRectNativeArray)(::windows_core::Interface::as_raw(self), rects, rectarray, &mut result__).from_abi(result__)
     }
     pub unsafe fn CreateProxyFactoryEntry<P0>(&self, factory: P0) -> ::windows_core::Result<IUIAutomationProxyFactoryEntry>
     where
@@ -6211,8 +6225,9 @@ impl IUIAutomationElement {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
 }
 #[repr(C)]
@@ -6662,8 +6677,9 @@ impl IUIAutomationElement2 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -7058,8 +7074,9 @@ impl IUIAutomationElement3 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -7462,8 +7479,9 @@ impl IUIAutomationElement4 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.base__.base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -7923,8 +7941,9 @@ impl IUIAutomationElement5 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.base__.base__.base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -8388,8 +8407,9 @@ impl IUIAutomationElement6 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -8859,8 +8879,9 @@ impl IUIAutomationElement7 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -9371,8 +9392,9 @@ impl IUIAutomationElement8 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -9888,8 +9910,9 @@ impl IUIAutomationElement9 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.base__.base__.CachedProviderDescription)(::windows_core::Interface::as_raw(self), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT, gotclickable: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, gotclickable).ok()
+    pub unsafe fn GetClickablePoint(&self, clickable: *mut super::super::Foundation::POINT) -> ::windows_core::Result<super::super::Foundation::BOOL> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.base__.base__.base__.base__.base__.base__.base__.GetClickablePoint)(::windows_core::Interface::as_raw(self), clickable, &mut result__).from_abi(result__)
     }
     pub unsafe fn CurrentOptimizeForVisualContent(&self) -> ::windows_core::Result<super::super::Foundation::BOOL> {
         let mut result__ = ::std::mem::zeroed();
@@ -11608,8 +11631,9 @@ impl IUIAutomationTextPattern2 {
         let mut result__ = ::std::mem::zeroed();
         (::windows_core::Interface::vtable(self).RangeFromAnnotation)(::windows_core::Interface::as_raw(self), annotation.into_param().abi(), &mut result__).from_abi(result__)
     }
-    pub unsafe fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL, range: *mut ::core::option::Option<IUIAutomationTextRange>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetCaretRange)(::windows_core::Interface::as_raw(self), isactive, ::core::mem::transmute(range)).ok()
+    pub unsafe fn GetCaretRange(&self, isactive: *mut super::super::Foundation::BOOL) -> ::windows_core::Result<IUIAutomationTextRange> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetCaretRange)(::windows_core::Interface::as_raw(self), isactive, &mut result__).from_abi(result__)
     }
 }
 #[repr(C)]

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/impl.rs
@@ -16465,7 +16465,7 @@ pub trait IShellLinkDual_Impl: Sized + super::super::System::Com::IDispatch_Impl
     fn ShowCommand(&self) -> ::windows_core::Result<i32>;
     fn SetShowCommand(&self, ishowcommand: i32) -> ::windows_core::Result<()>;
     fn Resolve(&self, fflags: i32) -> ::windows_core::Result<()>;
-    fn GetIconLocation(&self, pbs: *mut ::windows_core::BSTR, piicon: *mut i32) -> ::windows_core::Result<()>;
+    fn GetIconLocation(&self, pbs: *mut ::windows_core::BSTR) -> ::windows_core::Result<i32>;
     fn SetIconLocation(&self, bs: &::windows_core::BSTR, iicon: i32) -> ::windows_core::Result<()>;
     fn Save(&self, vwhere: &::windows_core::VARIANT) -> ::windows_core::Result<()>;
 }
@@ -16578,7 +16578,13 @@ impl IShellLinkDual_Vtbl {
         unsafe extern "system" fn GetIconLocation<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IShellLinkDual_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pbs: *mut ::std::mem::MaybeUninit<::windows_core::BSTR>, piicon: *mut i32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetIconLocation(::core::mem::transmute_copy(&pbs), ::core::mem::transmute_copy(&piicon)).into()
+            match this.GetIconLocation(::core::mem::transmute_copy(&pbs)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(piicon, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn SetIconLocation<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IShellLinkDual_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, bs: ::std::mem::MaybeUninit<::windows_core::BSTR>, iicon: i32) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -18438,7 +18444,7 @@ pub trait IShellWindows_Impl: Sized + super::super::System::Com::IDispatch_Impl 
     fn Revoke(&self, lcookie: i32) -> ::windows_core::Result<()>;
     fn OnNavigate(&self, lcookie: i32, pvarloc: *const ::windows_core::VARIANT) -> ::windows_core::Result<()>;
     fn OnActivated(&self, lcookie: i32, factive: super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()>;
-    fn FindWindowSW(&self, pvarloc: *const ::windows_core::VARIANT, pvarlocroot: *const ::windows_core::VARIANT, swclass: ShellWindowTypeConstants, phwnd: *mut i32, swfwoptions: ShellWindowFindWindowOptions, ppdispout: *mut ::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows_core::Result<()>;
+    fn FindWindowSW(&self, pvarloc: *const ::windows_core::VARIANT, pvarlocroot: *const ::windows_core::VARIANT, swclass: ShellWindowTypeConstants, phwnd: *mut i32, swfwoptions: ShellWindowFindWindowOptions) -> ::windows_core::Result<super::super::System::Com::IDispatch>;
     fn OnCreated(&self, lcookie: i32, punk: ::core::option::Option<&::windows_core::IUnknown>) -> ::windows_core::Result<()>;
     fn ProcessAttachDetach(&self, fattach: super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()>;
 }
@@ -18520,7 +18526,13 @@ impl IShellWindows_Vtbl {
         unsafe extern "system" fn FindWindowSW<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IShellWindows_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pvarloc: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, pvarlocroot: *const ::std::mem::MaybeUninit<::windows_core::VARIANT>, swclass: ShellWindowTypeConstants, phwnd: *mut i32, swfwoptions: ShellWindowFindWindowOptions, ppdispout: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.FindWindowSW(::core::mem::transmute_copy(&pvarloc), ::core::mem::transmute_copy(&pvarlocroot), ::core::mem::transmute_copy(&swclass), ::core::mem::transmute_copy(&phwnd), ::core::mem::transmute_copy(&swfwoptions), ::core::mem::transmute_copy(&ppdispout)).into()
+            match this.FindWindowSW(::core::mem::transmute_copy(&pvarloc), ::core::mem::transmute_copy(&pvarlocroot), ::core::mem::transmute_copy(&swclass), ::core::mem::transmute_copy(&phwnd), ::core::mem::transmute_copy(&swfwoptions)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppdispout, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn OnCreated<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IShellWindows_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, lcookie: i32, punk: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/mod.rs
@@ -22586,8 +22586,9 @@ impl IShellLinkDual {
     pub unsafe fn Resolve(&self, fflags: i32) -> ::windows_core::Result<()> {
         (::windows_core::Interface::vtable(self).Resolve)(::windows_core::Interface::as_raw(self), fflags).ok()
     }
-    pub unsafe fn GetIconLocation(&self, pbs: *mut ::windows_core::BSTR, piicon: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).GetIconLocation)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pbs), piicon).ok()
+    pub unsafe fn GetIconLocation(&self, pbs: *mut ::windows_core::BSTR) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetIconLocation)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pbs), &mut result__).from_abi(result__)
     }
     pub unsafe fn SetIconLocation<P0>(&self, bs: P0, iicon: i32) -> ::windows_core::Result<()>
     where
@@ -22692,8 +22693,9 @@ impl IShellLinkDual2 {
     pub unsafe fn Resolve(&self, fflags: i32) -> ::windows_core::Result<()> {
         (::windows_core::Interface::vtable(self).base__.Resolve)(::windows_core::Interface::as_raw(self), fflags).ok()
     }
-    pub unsafe fn GetIconLocation(&self, pbs: *mut ::windows_core::BSTR, piicon: *mut i32) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).base__.GetIconLocation)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pbs), piicon).ok()
+    pub unsafe fn GetIconLocation(&self, pbs: *mut ::windows_core::BSTR) -> ::windows_core::Result<i32> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).base__.GetIconLocation)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pbs), &mut result__).from_abi(result__)
     }
     pub unsafe fn SetIconLocation<P0>(&self, bs: P0, iicon: i32) -> ::windows_core::Result<()>
     where
@@ -26846,8 +26848,9 @@ impl IShellWindows {
     }
     #[doc = "Required features: `\"Win32_System_Com\"`"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn FindWindowSW(&self, pvarloc: *const ::windows_core::VARIANT, pvarlocroot: *const ::windows_core::VARIANT, swclass: ShellWindowTypeConstants, phwnd: *mut i32, swfwoptions: ShellWindowFindWindowOptions, ppdispout: *mut ::core::option::Option<super::super::System::Com::IDispatch>) -> ::windows_core::Result<()> {
-        (::windows_core::Interface::vtable(self).FindWindowSW)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pvarloc), ::core::mem::transmute(pvarlocroot), swclass, phwnd, swfwoptions, ::core::mem::transmute(ppdispout)).ok()
+    pub unsafe fn FindWindowSW(&self, pvarloc: *const ::windows_core::VARIANT, pvarlocroot: *const ::windows_core::VARIANT, swclass: ShellWindowTypeConstants, phwnd: *mut i32, swfwoptions: ShellWindowFindWindowOptions) -> ::windows_core::Result<super::super::System::Com::IDispatch> {
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).FindWindowSW)(::windows_core::Interface::as_raw(self), ::core::mem::transmute(pvarloc), ::core::mem::transmute(pvarlocroot), swclass, phwnd, swfwoptions, &mut result__).from_abi(result__)
     }
     pub unsafe fn OnCreated<P0>(&self, lcookie: i32, punk: P0) -> ::windows_core::Result<()>
     where

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/impl.rs
@@ -434,8 +434,8 @@ pub trait IMILBitmapEffectImpl_Impl: Sized {
     fn SetParentEffect(&self, pparenteffect: ::core::option::Option<&IMILBitmapEffectGroup>) -> ::windows_core::Result<()>;
     fn GetInputSource(&self, uiindex: u32) -> ::windows_core::Result<super::super::Graphics::Imaging::IWICBitmapSource>;
     fn GetInputSourceBounds(&self, uiindex: u32, prect: *mut MilRectD) -> ::windows_core::Result<()>;
-    fn GetInputBitmapSource(&self, uiindex: u32, prendercontext: ::core::option::Option<&IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows_core::Result<()>;
-    fn GetOutputBitmapSource(&self, uiindex: u32, prendercontext: ::core::option::Option<&IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows_core::Result<()>;
+    fn GetInputBitmapSource(&self, uiindex: u32, prendercontext: ::core::option::Option<&IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<super::super::Graphics::Imaging::IWICBitmapSource>;
+    fn GetOutputBitmapSource(&self, uiindex: u32, prendercontext: ::core::option::Option<&IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<super::super::Graphics::Imaging::IWICBitmapSource>;
     fn Initialize(&self, pinner: ::core::option::Option<&::windows_core::IUnknown>) -> ::windows_core::Result<()>;
 }
 #[cfg(feature = "Win32_Graphics_Imaging")]
@@ -478,12 +478,24 @@ impl IMILBitmapEffectImpl_Vtbl {
         unsafe extern "system" fn GetInputBitmapSource<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMILBitmapEffectImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uiindex: u32, prendercontext: *mut ::core::ffi::c_void, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetInputBitmapSource(::core::mem::transmute_copy(&uiindex), ::windows_core::from_raw_borrowed(&prendercontext), ::core::mem::transmute_copy(&pfmodifyinplace), ::core::mem::transmute_copy(&ppbitmapsource)).into()
+            match this.GetInputBitmapSource(::core::mem::transmute_copy(&uiindex), ::windows_core::from_raw_borrowed(&prendercontext), ::core::mem::transmute_copy(&pfmodifyinplace)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppbitmapsource, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetOutputBitmapSource<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMILBitmapEffectImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uiindex: u32, prendercontext: *mut ::core::ffi::c_void, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetOutputBitmapSource(::core::mem::transmute_copy(&uiindex), ::windows_core::from_raw_borrowed(&prendercontext), ::core::mem::transmute_copy(&pfmodifyinplace), ::core::mem::transmute_copy(&ppbitmapsource)).into()
+            match this.GetOutputBitmapSource(::core::mem::transmute_copy(&uiindex), ::windows_core::from_raw_borrowed(&prendercontext), ::core::mem::transmute_copy(&pfmodifyinplace)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppbitmapsource, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn Initialize<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMILBitmapEffectImpl_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, pinner: *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
@@ -653,7 +665,7 @@ impl IMILBitmapEffectOutputConnectorImpl_Vtbl {
 #[doc = "Required features: `\"Win32_Graphics_Dwm\"`, `\"Win32_Graphics_Imaging\"`"]
 #[cfg(all(feature = "Win32_Graphics_Dwm", feature = "Win32_Graphics_Imaging"))]
 pub trait IMILBitmapEffectPrimitive_Impl: Sized {
-    fn GetOutput(&self, uiindex: u32, pcontext: ::core::option::Option<&IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows_core::Result<()>;
+    fn GetOutput(&self, uiindex: u32, pcontext: ::core::option::Option<&IMILBitmapEffectRenderContext>, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<super::super::Graphics::Imaging::IWICBitmapSource>;
     fn TransformPoint(&self, uiindex: u32, p: *mut MilPoint2D, fforwardtransform: super::super::Foundation::VARIANT_BOOL, pcontext: ::core::option::Option<&IMILBitmapEffectRenderContext>, pfpointtransformed: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()>;
     fn TransformRect(&self, uiindex: u32, p: *mut MilRectD, fforwardtransform: super::super::Foundation::VARIANT_BOOL, pcontext: ::core::option::Option<&IMILBitmapEffectRenderContext>) -> ::windows_core::Result<()>;
     fn HasAffineTransform(&self, uiindex: u32) -> ::windows_core::Result<super::super::Foundation::VARIANT_BOOL>;
@@ -668,7 +680,13 @@ impl IMILBitmapEffectPrimitive_Vtbl {
         unsafe extern "system" fn GetOutput<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMILBitmapEffectPrimitive_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uiindex: u32, pcontext: *mut ::core::ffi::c_void, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;
             let this = (*this).get_impl();
-            this.GetOutput(::core::mem::transmute_copy(&uiindex), ::windows_core::from_raw_borrowed(&pcontext), ::core::mem::transmute_copy(&pfmodifyinplace), ::core::mem::transmute_copy(&ppbitmapsource)).into()
+            match this.GetOutput(::core::mem::transmute_copy(&uiindex), ::windows_core::from_raw_borrowed(&pcontext), ::core::mem::transmute_copy(&pfmodifyinplace)) {
+                ::core::result::Result::Ok(ok__) => {
+                    ::core::ptr::write(ppbitmapsource, ::core::mem::transmute(ok__));
+                    ::windows_core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn TransformPoint<Identity: ::windows_core::IUnknownImpl<Impl = Impl>, Impl: IMILBitmapEffectPrimitive_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, uiindex: u32, p: *mut MilPoint2D, fforwardtransform: super::super::Foundation::VARIANT_BOOL, pcontext: *mut ::core::ffi::c_void, pfpointtransformed: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::HRESULT {
             let this = (this as *const *const ()).offset(OFFSET) as *const Identity;

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
@@ -276,19 +276,21 @@ impl IMILBitmapEffectImpl {
     }
     #[doc = "Required features: `\"Win32_Graphics_Imaging\"`"]
     #[cfg(feature = "Win32_Graphics_Imaging")]
-    pub unsafe fn GetInputBitmapSource<P0>(&self, uiindex: u32, prendercontext: P0, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows_core::Result<()>
+    pub unsafe fn GetInputBitmapSource<P0>(&self, uiindex: u32, prendercontext: P0, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<super::super::Graphics::Imaging::IWICBitmapSource>
     where
         P0: ::windows_core::IntoParam<IMILBitmapEffectRenderContext>,
     {
-        (::windows_core::Interface::vtable(self).GetInputBitmapSource)(::windows_core::Interface::as_raw(self), uiindex, prendercontext.into_param().abi(), pfmodifyinplace, ::core::mem::transmute(ppbitmapsource)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetInputBitmapSource)(::windows_core::Interface::as_raw(self), uiindex, prendercontext.into_param().abi(), pfmodifyinplace, &mut result__).from_abi(result__)
     }
     #[doc = "Required features: `\"Win32_Graphics_Imaging\"`"]
     #[cfg(feature = "Win32_Graphics_Imaging")]
-    pub unsafe fn GetOutputBitmapSource<P0>(&self, uiindex: u32, prendercontext: P0, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows_core::Result<()>
+    pub unsafe fn GetOutputBitmapSource<P0>(&self, uiindex: u32, prendercontext: P0, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<super::super::Graphics::Imaging::IWICBitmapSource>
     where
         P0: ::windows_core::IntoParam<IMILBitmapEffectRenderContext>,
     {
-        (::windows_core::Interface::vtable(self).GetOutputBitmapSource)(::windows_core::Interface::as_raw(self), uiindex, prendercontext.into_param().abi(), pfmodifyinplace, ::core::mem::transmute(ppbitmapsource)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetOutputBitmapSource)(::windows_core::Interface::as_raw(self), uiindex, prendercontext.into_param().abi(), pfmodifyinplace, &mut result__).from_abi(result__)
     }
     pub unsafe fn Initialize<P0>(&self, pinner: P0) -> ::windows_core::Result<()>
     where
@@ -462,11 +464,12 @@ pub struct IMILBitmapEffectOutputConnectorImpl_Vtbl {
 impl IMILBitmapEffectPrimitive {
     #[doc = "Required features: `\"Win32_Graphics_Imaging\"`"]
     #[cfg(feature = "Win32_Graphics_Imaging")]
-    pub unsafe fn GetOutput<P0>(&self, uiindex: u32, pcontext: P0, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL, ppbitmapsource: *mut ::core::option::Option<super::super::Graphics::Imaging::IWICBitmapSource>) -> ::windows_core::Result<()>
+    pub unsafe fn GetOutput<P0>(&self, uiindex: u32, pcontext: P0, pfmodifyinplace: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<super::super::Graphics::Imaging::IWICBitmapSource>
     where
         P0: ::windows_core::IntoParam<IMILBitmapEffectRenderContext>,
     {
-        (::windows_core::Interface::vtable(self).GetOutput)(::windows_core::Interface::as_raw(self), uiindex, pcontext.into_param().abi(), pfmodifyinplace, ::core::mem::transmute(ppbitmapsource)).ok()
+        let mut result__ = ::std::mem::zeroed();
+        (::windows_core::Interface::vtable(self).GetOutput)(::windows_core::Interface::as_raw(self), uiindex, pcontext.into_param().abi(), pfmodifyinplace, &mut result__).from_abi(result__)
     }
     pub unsafe fn TransformPoint<P0, P1>(&self, uiindex: u32, p: *mut MilPoint2D, fforwardtransform: P0, pcontext: P1, pfpointtransformed: *mut super::super::Foundation::VARIANT_BOOL) -> ::windows_core::Result<()>
     where

--- a/crates/samples/windows/shell/src/main.rs
+++ b/crates/samples/windows/shell/src/main.rs
@@ -42,20 +42,17 @@ fn shell_execute_from_explorer(
 fn find_desktop_folder_view<T: Interface>() -> Result<T> {
     unsafe {
         let windows: IShellWindows = CoCreateInstance(&ShellWindows, None, CLSCTX_ALL)?;
-        let mut dispatch = None;
         let mut handle = 0;
 
-        // TODO: find out why this retval isn't kicking in
-        windows.FindWindowSW(
+        let desktop = windows.FindWindowSW(
             &VARIANT::from(CSIDL_DESKTOP),
             &VARIANT::default(),
             SWC_DESKTOP,
             &mut handle,
             SWFO_NEEDDISPATCH,
-            &mut dispatch,
         )?;
 
-        let provider: IServiceProvider = dispatch.unwrap().cast()?;
+        let provider: IServiceProvider = desktop.cast()?;
         let browser: IShellBrowser = provider.QueryService(&SID_STopLevelBrowser)?;
         let view = browser.QueryActiveShellView()?;
         view.cast()


### PR DESCRIPTION
Many trialing Win32 parameters include a `retval` attribute indicating that languages should turn these parameters into a logical return value if possible. The trouble is that this attribute is not broadly applied, so `windows-bindgen` attempts to infer it in more cases. This inference is necessarily conservative to avoid producing invalid or inefficient transformations. I did however notice that APIs that explicitly include the `retval` attribute were being skipped due to the conservative heuristic, so this update just ensures that explicit `retval` parameters are always transformed. This simplifies the new Windows shell sample #2789. 