### PR TITLE
Harden generic type parameter binding

### DIFF
--- a/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/BOOL.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/BOOL.rs
@@ -67,7 +67,7 @@ impl ::core::ops::Not for BOOL {
     }
 }
 impl ::windows_core::IntoParam<BOOL> for bool {
-    fn into_param(self) -> ::windows_core::Param<BOOL> {
+    unsafe fn into_param(self) -> ::windows_core::Param<BOOL> {
         ::windows_core::Param::Owned(self.into())
     }
 }

--- a/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/BOOLEAN.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod/Win32/Foundation/BOOLEAN.rs
@@ -67,7 +67,7 @@ impl ::core::ops::Not for BOOLEAN {
     }
 }
 impl ::windows_core::IntoParam<BOOLEAN> for bool {
-    fn into_param(self) -> ::windows_core::Param<BOOLEAN> {
+    unsafe fn into_param(self) -> ::windows_core::Param<BOOLEAN> {
         ::windows_core::Param::Owned(self.into())
     }
 }

--- a/crates/libs/core/src/param.rs
+++ b/crates/libs/core/src/param.rs
@@ -38,7 +38,7 @@ where
     unsafe fn into_param(self) -> Param<T> {
         Param::Borrowed(match self {
             Some(item) => std::mem::transmute_copy(item),
-            None => unsafe { std::mem::zeroed() },
+            None => std::mem::zeroed(),
         })
     }
 }
@@ -51,12 +51,10 @@ where
     U: CanInto<T>,
 {
     unsafe fn into_param(self) -> Param<T> {
-        unsafe {
-            if U::QUERY {
-                self.cast().map_or(Param::Borrowed(std::mem::zeroed()), |ok| Param::Owned(ok))
-            } else {
-                Param::Borrowed(std::mem::transmute_copy(self))
-            }
+        if U::QUERY {
+            self.cast().map_or(Param::Borrowed(std::mem::zeroed()), |ok| Param::Owned(ok))
+        } else {
+            Param::Borrowed(std::mem::transmute_copy(self))
         }
     }
 }
@@ -77,6 +75,6 @@ where
     U: CanInto<T>,
 {
     unsafe fn into_param(self) -> Param<T> {
-        Param::Owned(unsafe { std::mem::transmute_copy(&self) })
+        Param::Owned(std::mem::transmute_copy(&self))
     }
 }

--- a/crates/libs/core/src/strings/hstring.rs
+++ b/crates/libs/core/src/strings/hstring.rs
@@ -398,7 +398,7 @@ impl From<HSTRING> for std::ffi::OsString {
 }
 
 impl IntoParam<PCWSTR> for &HSTRING {
-    fn into_param(self) -> Param<PCWSTR> {
+    unsafe fn into_param(self) -> Param<PCWSTR> {
         Param::Owned(PCWSTR(self.as_ptr()))
     }
 }

--- a/crates/libs/core/src/type.rs
+++ b/crates/libs/core/src/type.rs
@@ -19,10 +19,6 @@ pub trait Type<T: TypeKind, C = <T as TypeKind>::TypeKind>: TypeKind + Sized + C
     type Abi;
     type Default;
 
-    fn abi(&self) -> Self::Abi {
-        unsafe { std::mem::transmute_copy(self) }
-    }
-
     /// # Safety
     unsafe fn from_abi(abi: Self::Abi) -> Result<Self>;
     fn from_default(default: &Self::Default) -> Result<Self>;
@@ -55,7 +51,7 @@ where
     type Abi = std::mem::MaybeUninit<Self>;
     type Default = Self;
 
-    unsafe fn from_abi(abi: std::mem::MaybeUninit<Self>) -> Result<Self> {
+    unsafe fn from_abi(abi: Self::Abi) -> Result<Self> {
         Ok(abi.assume_init())
     }
 
@@ -71,7 +67,7 @@ where
     type Abi = Self;
     type Default = Self;
 
-    unsafe fn from_abi(abi: Self) -> Result<Self> {
+    unsafe fn from_abi(abi: Self::Abi) -> Result<Self> {
         Ok(abi)
     }
 

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -11572,7 +11572,7 @@ impl ::core::ops::Not for BOOL {
     }
 }
 impl ::windows_core::IntoParam<BOOL> for bool {
-    fn into_param(self) -> ::windows_core::Param<BOOL> {
+    unsafe fn into_param(self) -> ::windows_core::Param<BOOL> {
         ::windows_core::Param::Owned(self.into())
     }
 }
@@ -11645,7 +11645,7 @@ impl ::core::ops::Not for BOOLEAN {
     }
 }
 impl ::windows_core::IntoParam<BOOLEAN> for bool {
-    fn into_param(self) -> ::windows_core::Param<BOOLEAN> {
+    unsafe fn into_param(self) -> ::windows_core::Param<BOOLEAN> {
         ::windows_core::Param::Owned(self.into())
     }
 }

--- a/crates/tests/implement/tests/vector.rs
+++ b/crates/tests/implement/tests/vector.rs
@@ -284,9 +284,24 @@ fn test_2759() -> Result<()> {
     v.Append(&uri)?;
     let uri = Uri::CreateUri(h!("https://microsoft.com/"))?;
     v.Append(&uri)?;
+    v.Append(&uri.cast::<IStringable>()?)?;
 
     assert_eq!(&v.GetAt(0)?.ToString()?, h!("https://github.com/"));
     assert_eq!(&v.GetAt(1)?.ToString()?, h!("https://microsoft.com/"));
+
+    Ok(())
+}
+
+#[test]
+fn test_into_param() -> Result<()> {
+    let v: IVector<i32> = Vector::new(vec![]).into();
+    v.Append(1)?;
+    v.Append(Some(&2))?;
+    v.Append(None)?;
+
+    assert_eq!(v.GetAt(0)?, 1);
+    assert_eq!(v.GetAt(1)?, 2);
+    assert_eq!(v.GetAt(2)?, 0);
 
     Ok(())
 }


### PR DESCRIPTION
Some minor housekeeping around generic type parameter binding.

* The internal `abi` helper wasn't needed as `transmute_copy` works just fine.
* The `into_param` trait function is rightly unsafe.
* Added some more test coverage to cover all paths.