### PR TITLE
Expand WMI sample

### DIFF
--- a/crates/libs/core/src/strings/bstr.rs
+++ b/crates/libs/core/src/strings/bstr.rs
@@ -29,11 +29,17 @@ impl BSTR {
 
     /// Get the string as 16-bit wide characters (wchars).
     pub fn as_wide(&self) -> &[u16] {
-        if self.0.is_null() {
-            return &[];
-        }
+        unsafe { std::slice::from_raw_parts(self.as_ptr(), self.len()) }
+    }
 
-        unsafe { std::slice::from_raw_parts(self.0, self.len()) }
+    /// Returns a raw pointer to the `BSTR` buffer.
+    pub fn as_ptr(&self) -> *const u16 {
+        if !self.is_empty() {
+            self.0
+        } else {
+            const EMPTY: [u16; 1] = [0];
+            EMPTY.as_ptr()
+        }
     }
 
     /// Create a `BSTR` from a slice of 16 bit characters (wchars).
@@ -102,6 +108,12 @@ impl TryFrom<BSTR> for String {
 
     fn try_from(value: BSTR) -> std::result::Result<Self, Self::Error> {
         String::try_from(&value)
+    }
+}
+
+impl IntoParam<PCWSTR> for &BSTR {
+    unsafe fn into_param(self) -> Param<PCWSTR> {
+        Param::Owned(PCWSTR(self.as_ptr()))
     }
 }
 

--- a/crates/libs/core/src/variant.rs
+++ b/crates/libs/core/src/variant.rs
@@ -84,6 +84,18 @@ impl std::fmt::Debug for PROPVARIANT {
     }
 }
 
+impl std::fmt::Display for VARIANT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", BSTR::try_from(self).unwrap_or_default())
+    }
+}
+
+impl std::fmt::Display for PROPVARIANT {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::write!(f, "{}", BSTR::try_from(self).unwrap_or_default())
+    }
+}
+
 impl PartialEq for VARIANT {
     fn eq(&self, other: &Self) -> bool {
         unsafe {

--- a/crates/tests/variant/tests/tests.rs
+++ b/crates/tests/variant/tests/tests.rs
@@ -103,6 +103,7 @@ fn test_variant() -> Result<()> {
     assert_eq!(BSTR::try_from(&v)?, "3.5");
 
     assert_eq!(format!("{v:?}"), "VARIANT { type: 5, value: 3.5 }");
+    assert_eq!(format!("{v}"), "3.5");
 
     let clone = v.clone();
     assert_eq!(v, clone);
@@ -219,6 +220,7 @@ fn test_propvariant() -> Result<()> {
     assert_eq!(BSTR::try_from(&v)?, "3.5");
 
     assert_eq!(format!("{v:?}"), "PROPVARIANT { type: 5, value: 3.5 }");
+    assert_eq!(format!("{v}"), "3.5");
 
     let clone = v.clone();
     assert_eq!(v, clone);


### PR DESCRIPTION
This updates and expands the WMI sample to better use the new `VARIANT` support from #2786. 

Fixes: #2751