### PR TITLE
Update `windows-core` docs

### DIFF
--- a/crates/libs/core/src/param.rs
+++ b/crates/libs/core/src/param.rs
@@ -17,6 +17,7 @@ impl<T: Type<T>> Param<T> {
     }
 }
 
+#[doc(hidden)]
 pub trait CanInto<T>: Sized {
     const QUERY: bool = false;
 }

--- a/crates/libs/core/src/variant.rs
+++ b/crates/libs/core/src/variant.rs
@@ -1,8 +1,10 @@
 use super::*;
 
+/// A VARIANT ([VARIANT](https://learn.microsoft.com/en-us/windows/win32/api/oaidl/ns-oaidl-variant)) is a container that can store different types of values.
 #[repr(transparent)]
 pub struct VARIANT(imp::VARIANT);
 
+/// A PROPVARIANT ([PROPVARIANT](https://learn.microsoft.com/en-us/windows/win32/api/propidlbase/ns-propidlbase-propvariant)) is a container that can store different types of values.
 #[repr(transparent)]
 pub struct PROPVARIANT(imp::PROPVARIANT);
 
@@ -130,20 +132,28 @@ impl Eq for VARIANT {}
 impl Eq for PROPVARIANT {}
 
 impl VARIANT {
+    /// Create an empty `VARIANT`.
+    ///
+    /// This function does not allocate memory.
     pub fn new() -> Self {
         unsafe { std::mem::zeroed() }
     }
 
+    /// Returns true if the `VARIANT` is empty.
     pub const fn is_empty(&self) -> bool {
         unsafe { self.0.Anonymous.Anonymous.vt == imp::VT_EMPTY }
     }
 }
 
 impl PROPVARIANT {
+    /// Create an empty `PROPVARIANT`.
+    ///
+    /// This function does not allocate memory.    
     pub fn new() -> Self {
         unsafe { std::mem::zeroed() }
     }
 
+    /// Returns true if the `PROPVARIANT` is empty.
     pub const fn is_empty(&self) -> bool {
         unsafe { self.0.Anonymous.Anonymous.vt == imp::VT_EMPTY }
     }


### PR DESCRIPTION
Ensures that the `windows-core` crate docs are generated correctly.  

* The `CanInto` trait is internal and should not be documented. 
* The new `VARIANT` and `PROPVARIANT` types are public and needed a basic description. 