### PR TITLE
Add task dialog samples

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -63,6 +63,8 @@ jobs:
           cargo clippy -p sample_shell &&
           cargo clippy -p sample_simple &&
           cargo clippy -p sample_spellchecker &&
+          cargo clippy -p sample_task_dialog &&
+          cargo clippy -p sample_task_dialog_sys &&
           cargo clippy -p sample_thread_pool_work &&
           cargo clippy -p sample_thread_pool_work_sys &&
           cargo clippy -p sample_uiautomation &&

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,8 @@ jobs:
           cargo test -p sample_shell &&
           cargo test -p sample_simple &&
           cargo test -p sample_spellchecker &&
+          cargo test -p sample_task_dialog &&
+          cargo test -p sample_task_dialog_sys &&
           cargo test -p sample_thread_pool_work &&
           cargo test -p sample_thread_pool_work_sys &&
           cargo test -p sample_uiautomation &&
@@ -100,8 +102,8 @@ jobs:
           cargo test -p test_does_not_return &&
           cargo test -p test_enums &&
           cargo test -p test_error &&
-          cargo test -p test_event &&
           cargo clean &&
+          cargo test -p test_event &&
           cargo test -p test_extensions &&
           cargo test -p test_handles &&
           cargo test -p test_helpers &&

--- a/crates/samples/windows-sys/task_dialog/Cargo.toml
+++ b/crates/samples/windows-sys/task_dialog/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sample_task_dialog_sys"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies.windows-sys]
+path = "../../../libs/sys"
+features = [
+    "Win32_UI_Controls",
+    "Win32_UI_WindowsAndMessaging",
+]

--- a/crates/samples/windows-sys/task_dialog/build.rs
+++ b/crates/samples/windows-sys/task_dialog/build.rs
@@ -1,13 +1,16 @@
 fn main() {
-    println!("cargo:rerun-if-changed=manifest.xml");
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
 
-    println!(
-        "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
-        std::path::Path::new("manifest.xml")
-            .canonicalize()
-            .unwrap()
-            .display()
-    );
+    if std::env::var("CARGO_CFG_TARGET_ENV").unwrap() == "msvc" {
+        println!("cargo:rerun-if-changed=manifest.xml");
+        println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
+
+        println!(
+            "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
+            std::path::Path::new("manifest.xml")
+                .canonicalize()
+                .unwrap()
+                .display()
+        );
+    }
 }

--- a/crates/samples/windows-sys/task_dialog/build.rs
+++ b/crates/samples/windows-sys/task_dialog/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    println!("cargo:rerun-if-changed=manifest.xml");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
+
+    println!(
+        "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
+        std::path::Path::new("manifest.xml")
+            .canonicalize()
+            .unwrap()
+            .display()
+    );
+}

--- a/crates/samples/windows-sys/task_dialog/manifest.xml
+++ b/crates/samples/windows-sys/task_dialog/manifest.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"/>
+        </dependentAssembly>
+    </dependency>
+</assembly>

--- a/crates/samples/windows-sys/task_dialog/src/main.rs
+++ b/crates/samples/windows-sys/task_dialog/src/main.rs
@@ -1,0 +1,44 @@
+use windows_sys::{core::*, Win32::Foundation::*, Win32::UI::Controls::*};
+
+fn main() {
+    unsafe {
+        let mut config = TASKDIALOGCONFIG {
+            cbSize: std::mem::size_of::<TASKDIALOGCONFIG>() as _,
+            ..std::mem::zeroed()
+        };
+
+        let buttons = [TASKDIALOG_BUTTON {
+            nButtonID: 123,
+            pszButtonText: w!("Let's do it"),
+        }];
+
+        config.pszWindowTitle = w!("Window title");
+        config.pszMainInstruction = w!("Main instruction");
+        config.pszContent = w!("Content");
+        config.pButtons = buttons.as_ptr();
+        config.cButtons = buttons.len() as _;
+        config.pfCallback = Some(callback);
+        config.dwFlags = TDF_USE_COMMAND_LINKS | TDF_ALLOW_DIALOG_CANCELLATION;
+
+        let mut selection = 0;
+
+        TaskDialogIndirect(
+            &config,
+            &mut selection,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        );
+
+        if selection == buttons[0].nButtonID {
+            println!("custom button");
+        };
+    }
+}
+
+extern "system" fn callback(_: HWND, notification: u32, _: WPARAM, _: LPARAM, _: isize) -> HRESULT {
+    if notification == TDN_BUTTON_CLICKED as _ {
+        println!("button clicked");
+    }
+
+    0
+}

--- a/crates/samples/windows/task_dialog/Cargo.toml
+++ b/crates/samples/windows/task_dialog/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "sample_task_dialog"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[dependencies.windows]
+path = "../../../libs/windows"
+features = [
+    "Win32_UI_Controls",
+    "Win32_UI_WindowsAndMessaging",
+]

--- a/crates/samples/windows/task_dialog/build.rs
+++ b/crates/samples/windows/task_dialog/build.rs
@@ -1,13 +1,16 @@
 fn main() {
-    println!("cargo:rerun-if-changed=manifest.xml");
     println!("cargo:rerun-if-changed=build.rs");
-    println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
 
-    println!(
-        "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
-        std::path::Path::new("manifest.xml")
-            .canonicalize()
-            .unwrap()
-            .display()
-    );
+    if std::env::var("CARGO_CFG_TARGET_ENV").unwrap() == "msvc" {
+        println!("cargo:rerun-if-changed=manifest.xml");
+        println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
+
+        println!(
+            "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
+            std::path::Path::new("manifest.xml")
+                .canonicalize()
+                .unwrap()
+                .display()
+        );
+    }
 }

--- a/crates/samples/windows/task_dialog/build.rs
+++ b/crates/samples/windows/task_dialog/build.rs
@@ -1,0 +1,13 @@
+fn main() {
+    println!("cargo:rerun-if-changed=manifest.xml");
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rustc-link-arg-bins=/MANIFEST:EMBED");
+
+    println!(
+        "cargo:rustc-link-arg-bins=/MANIFESTINPUT:{}",
+        std::path::Path::new("manifest.xml")
+            .canonicalize()
+            .unwrap()
+            .display()
+    );
+}

--- a/crates/samples/windows/task_dialog/manifest.xml
+++ b/crates/samples/windows/task_dialog/manifest.xml
@@ -1,0 +1,19 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+    <dependency>
+        <dependentAssembly>
+            <assemblyIdentity
+                type="win32"
+                name="Microsoft.Windows.Common-Controls"
+                version="6.0.0.0"
+                processorArchitecture="*"
+                publicKeyToken="6595b64144ccf1df"
+                language="*"/>
+        </dependentAssembly>
+    </dependency>
+</assembly>

--- a/crates/samples/windows/task_dialog/src/main.rs
+++ b/crates/samples/windows/task_dialog/src/main.rs
@@ -1,0 +1,43 @@
+use windows::{core::*, Win32::Foundation::*, Win32::UI::Controls::*};
+
+fn main() -> Result<()> {
+    unsafe {
+        let mut config = TASKDIALOGCONFIG {
+            cbSize: std::mem::size_of::<TASKDIALOGCONFIG>() as _,
+            ..Default::default()
+        };
+
+        let buttons = [TASKDIALOG_BUTTON {
+            nButtonID: 123,
+            pszButtonText: w!("Let's do it"),
+        }];
+
+        config.pszWindowTitle = w!("Window title");
+        config.pszMainInstruction = w!("Main instruction");
+        config.pszContent = w!("Content");
+        config.pButtons = buttons.as_ptr();
+        config.cButtons = buttons.len() as _;
+        config.pfCallback = Some(callback);
+
+        config.dwFlags =
+            TASKDIALOG_FLAGS(TDF_USE_COMMAND_LINKS.0 | TDF_ALLOW_DIALOG_CANCELLATION.0);
+
+        let mut selection = 0;
+
+        TaskDialogIndirect(&config, Some(&mut selection), None, None)?;
+
+        if selection == buttons[0].nButtonID {
+            println!("custom button");
+        };
+
+        Ok(())
+    }
+}
+
+extern "system" fn callback(_: HWND, notification: u32, _: WPARAM, _: LPARAM, _: isize) -> HRESULT {
+    if notification == TDN_BUTTON_CLICKED.0 as _ {
+        println!("button clicked");
+    }
+
+    HRESULT(0)
+}


### PR DESCRIPTION
Adds a pair of samples illustrating how to use the `TaskDialogIndirect` function. This is a versatile alternative when you need some minimal UI and don't want the overhead of a UI framework. I [wrote about this API many years ago](https://weblogs.asp.net/kennykerr/Windows-Vista-for-Developers-_1320_-Part-2-_1320_-Task-Dialogs-in-Depth). 