### PR TITLE
Fix for test reliability

### DIFF
--- a/crates/tests/array/Cargo.toml
+++ b/crates/tests/array/Cargo.toml
@@ -9,4 +9,5 @@ path = "../../libs/windows"
 features = [
     "Foundation",
     "Win32_Media_MediaFoundation",
+    "Win32_System_Com",
 ]

--- a/crates/tests/array/tests/com.rs
+++ b/crates/tests/array/tests/com.rs
@@ -1,8 +1,10 @@
-use windows::{core::*, Win32::Media::MediaFoundation::*};
+use windows::{core::*, Win32::Media::MediaFoundation::*, Win32::System::Com::*};
 
 #[test]
 fn test() -> Result<()> {
     unsafe {
+        CoInitializeEx(None, COINIT_MULTITHREADED)?;
+
         let mut data = std::ptr::null_mut();
         let mut len = 0;
 


### PR DESCRIPTION
`MFTEnumEx` sometimes crashes if COM is not initialized. 