### PR TITLE
Add error translation support for `std::io::Error`

### DIFF
--- a/crates/libs/core/src/error.rs
+++ b/crates/libs/core/src/error.rs
@@ -104,6 +104,15 @@ impl From<Error> for std::io::Error {
     }
 }
 
+impl From<std::io::Error> for Error {
+    fn from(from: std::io::Error) -> Self {
+        match from.raw_os_error() {
+            Some(status) => HRESULT::from_win32(status as u32).into(),
+            None => crate::imp::E_UNEXPECTED.into(),
+        }
+    }
+}
+
 impl From<std::string::FromUtf16Error> for Error {
     fn from(_: std::string::FromUtf16Error) -> Self {
         Self { code: HRESULT::from_win32(crate::imp::ERROR_NO_UNICODE_TRANSLATION), info: None }

--- a/crates/libs/core/src/imp/com_bindings.rs
+++ b/crates/libs/core/src/imp/com_bindings.rs
@@ -66,6 +66,7 @@ pub const E_BOUNDS: ::windows_core::HRESULT = ::windows_core::HRESULT(-214748363
 pub const E_INVALIDARG: ::windows_core::HRESULT = ::windows_core::HRESULT(-2147024809i32);
 pub const E_NOINTERFACE: ::windows_core::HRESULT = ::windows_core::HRESULT(-2147467262i32);
 pub const E_OUTOFMEMORY: ::windows_core::HRESULT = ::windows_core::HRESULT(-2147024882i32);
+pub const E_UNEXPECTED: ::windows_core::HRESULT = ::windows_core::HRESULT(-2147418113i32);
 ::windows_core::imp::com_interface!(IAgileObject, IAgileObject_Vtbl, 0x94ea2b94_e9cc_49e0_c0ff_ee64ca8f5b90);
 ::windows_core::imp::interface_hierarchy!(IAgileObject, ::windows_core::IUnknown);
 impl IAgileObject {}

--- a/crates/tests/error/tests/std.rs
+++ b/crates/tests/error/tests/std.rs
@@ -51,4 +51,9 @@ fn conversions() {
         format!("{std_error}"),
         "The parameter is incorrect. (os error -2147024809)"
     );
+
+    // Starting with std::io::Error...
+    let std_error = std::io::Error::from_raw_os_error(ERROR_INVALID_DATA.0 as i32);
+    let error: windows::core::Error = std_error.into();
+    assert_eq!(error.code(), ERROR_INVALID_DATA.to_hresult());
 }

--- a/crates/tools/core/com_bindings.txt
+++ b/crates/tools/core/com_bindings.txt
@@ -13,6 +13,7 @@
     Windows.Win32.Foundation.E_INVALIDARG
     Windows.Win32.Foundation.E_NOINTERFACE
     Windows.Win32.Foundation.E_OUTOFMEMORY
+    Windows.Win32.Foundation.E_UNEXPECTED
     Windows.Win32.Foundation.JSCRIPT_E_CANTEXECUTE
     Windows.Win32.Foundation.RPC_E_DISCONNECTED
     Windows.Win32.Foundation.TYPE_E_TYPEMISMATCH


### PR DESCRIPTION
This simplifies error propagation on Windows when using the Rust standard library for I/O but need rich Windows error propagation. For example:

```rust
use std::fs::File;
use std::io::Write;

fn main() -> windows_core::Result<()> {
    let mut f = File::create("test.txt")?;
    f.write_all(&[b'R', b'u', b's', b't'])?;

    Ok(())
}
```