### PR TITLE
Address new nightly unsafe precondition check panics

### DIFF
--- a/crates/libs/core/src/event.rs
+++ b/crates/libs/core/src/event.rs
@@ -198,6 +198,7 @@ impl<T: Interface> Drop for Array<T> {
 
 /// A reference-counted buffer.
 #[repr(C)]
+#[repr(align(8))]
 struct Buffer<T>(crate::imp::RefCount, std::marker::PhantomData<T>);
 
 impl<T: Interface> Buffer<T> {

--- a/crates/libs/core/src/hresult.rs
+++ b/crates/libs/core/src/hresult.rs
@@ -86,8 +86,11 @@ impl HRESULT {
 
         unsafe {
             let size = crate::imp::FormatMessageW(crate::imp::FORMAT_MESSAGE_ALLOCATE_BUFFER | crate::imp::FORMAT_MESSAGE_FROM_SYSTEM | crate::imp::FORMAT_MESSAGE_IGNORE_INSERTS, std::ptr::null(), self.0 as u32, 0, &mut message.0 as *mut _ as *mut _, 0, std::ptr::null());
-
-            HSTRING::from_wide(crate::imp::wide_trim_end(std::slice::from_raw_parts(message.0 as *const u16, size as usize))).unwrap_or_default()
+            if !message.0.is_null() && size > 0 {
+                HSTRING::from_wide(crate::imp::wide_trim_end(std::slice::from_raw_parts(message.0 as *const u16, size as usize))).unwrap_or_default()
+            } else {
+                HSTRING::default()
+            }
         }
     }
 


### PR DESCRIPTION
Passing size=0, ptr=0 into `std::slice::from_raw_parts` is undefined behavior and is no longer safe to rely upon. Also addresses an unaligned pointer used by `Event`.

See also:
https://github.com/rust-lang/rust/issues/120902
https://github.com/rust-lang/rust/pull/120594
