### PR TITLE
Map `TryFromIntError` to `ERROR_INVALID_DATA` in `windows-result`

### DIFF
--- a/crates/libs/result/src/bindings.rs
+++ b/crates/libs/result/src/bindings.rs
@@ -18,6 +18,7 @@
 ::windows_targets::link!("oleaut32.dll" "system" fn SysStringLen(pbstr : BSTR) -> u32);
 pub type BOOL = i32;
 pub type BSTR = *const u16;
+pub const ERROR_INVALID_DATA: WIN32_ERROR = 13u32;
 pub const ERROR_NO_UNICODE_TRANSLATION: WIN32_ERROR = 1113u32;
 pub const E_INVALIDARG: HRESULT = -2147024809i32;
 pub const E_UNEXPECTED: HRESULT = -2147418113i32;

--- a/crates/libs/result/src/error.rs
+++ b/crates/libs/result/src/error.rs
@@ -160,7 +160,7 @@ impl From<std::string::FromUtf8Error> for Error {
 impl From<std::num::TryFromIntError> for Error {
     fn from(_: std::num::TryFromIntError) -> Self {
         Self {
-            code: HRESULT(E_INVALIDARG),
+            code: HRESULT::from_win32(ERROR_INVALID_DATA),
             info: None,
         }
     }

--- a/crates/libs/result/tests/bindings.txt
+++ b/crates/libs/result/tests/bindings.txt
@@ -4,6 +4,7 @@
 --filter
     Windows.Win32.Foundation.E_INVALIDARG
     Windows.Win32.Foundation.E_UNEXPECTED
+    Windows.Win32.Foundation.ERROR_INVALID_DATA
     Windows.Win32.Foundation.ERROR_NO_UNICODE_TRANSLATION
     Windows.Win32.Foundation.GetLastError
     Windows.Win32.Foundation.SysFreeString

--- a/crates/tests/result/tests/error.rs
+++ b/crates/tests/result/tests/error.rs
@@ -53,7 +53,7 @@ fn from_win32() {
 
 #[test]
 fn try_from_int() {
-    fn call(value: usize) -> Result<u32> {
+    fn call(value: usize) -> Result<u16> {
         Ok(value.try_into()?)
     }
 

--- a/crates/tests/result/tests/error.rs
+++ b/crates/tests/result/tests/error.rs
@@ -3,6 +3,7 @@ use windows_result::*;
 const S_OK: HRESULT = HRESULT(0);
 const E_INVALIDARG: HRESULT = HRESULT(-2147024809i32);
 const ERROR_CANCELLED: u32 = 1223;
+const ERROR_INVALID_DATA: u32 = 13;
 const E_CANCELLED: HRESULT = HRESULT::from_win32(ERROR_CANCELLED);
 
 windows_targets::link!("kernel32.dll" "system" fn SetLastError(code: u32));
@@ -48,4 +49,16 @@ fn from_win32() {
     let e = Error::from_win32();
     assert!(e.as_ptr().is_null());
     assert_eq!(e.code(), E_CANCELLED);
+}
+
+#[test]
+fn try_from_int() {
+    fn call(value: usize) -> Result<u32> {
+        Ok(value.try_into()?)
+    }
+
+    assert_eq!(call(123), Ok(123));
+
+    let e = call(usize::MAX).unwrap_err();
+    assert_eq!(e.code(), HRESULT::from_win32(ERROR_INVALID_DATA));
 }


### PR DESCRIPTION
Use the more general `ERROR_INVALID_DATA` rather than `E_INVALIDARG`, which may be misleading since it can often occur without connection to API argument validation.