### PR TITLE
String trait refactoring

### DIFF
--- a/crates/libs/core/src/param.rs
+++ b/crates/libs/core/src/param.rs
@@ -79,3 +79,15 @@ where
         Param::Owned(std::mem::transmute_copy(&self))
     }
 }
+
+impl IntoParam<PCWSTR> for &BSTR {
+    unsafe fn into_param(self) -> Param<PCWSTR> {
+        Param::Owned(PCWSTR(self.as_ptr()))
+    }
+}
+
+impl IntoParam<PCWSTR> for &HSTRING {
+    unsafe fn into_param(self) -> Param<PCWSTR> {
+        Param::Owned(PCWSTR(self.as_ptr()))
+    }
+}

--- a/crates/libs/core/src/runtime_type.rs
+++ b/crates/libs/core/src/runtime_type.rs
@@ -28,3 +28,7 @@ primitives! {
     (f32, b"f4"),
     (f64, b"f8")
 }
+
+impl RuntimeType for HSTRING {
+    const SIGNATURE: crate::imp::ConstBuffer = crate::imp::ConstBuffer::from_slice(b"string");
+}

--- a/crates/libs/core/src/strings/bstr.rs
+++ b/crates/libs/core/src/strings/bstr.rs
@@ -111,12 +111,6 @@ impl TryFrom<BSTR> for String {
     }
 }
 
-impl IntoParam<PCWSTR> for &BSTR {
-    unsafe fn into_param(self) -> Param<PCWSTR> {
-        Param::Owned(PCWSTR(self.as_ptr()))
-    }
-}
-
 impl Default for BSTR {
     fn default() -> Self {
         Self(std::ptr::null_mut())
@@ -167,8 +161,4 @@ impl Drop for BSTR {
             unsafe { crate::imp::SysFreeString(self.0) }
         }
     }
-}
-
-impl TypeKind for BSTR {
-    type TypeKind = ValueType;
 }

--- a/crates/libs/core/src/strings/hstring.rs
+++ b/crates/libs/core/src/strings/hstring.rs
@@ -87,14 +87,6 @@ impl HSTRING {
     }
 }
 
-impl RuntimeType for HSTRING {
-    const SIGNATURE: crate::imp::ConstBuffer = crate::imp::ConstBuffer::from_slice(b"string");
-}
-
-impl TypeKind for HSTRING {
-    type TypeKind = ValueType;
-}
-
 impl Default for HSTRING {
     fn default() -> Self {
         Self::new()
@@ -394,12 +386,6 @@ impl<'a> From<&'a HSTRING> for std::ffi::OsString {
 impl From<HSTRING> for std::ffi::OsString {
     fn from(hstring: HSTRING) -> Self {
         Self::from(&hstring)
-    }
-}
-
-impl IntoParam<PCWSTR> for &HSTRING {
-    unsafe fn into_param(self) -> Param<PCWSTR> {
-        Param::Owned(PCWSTR(self.as_ptr()))
     }
 }
 

--- a/crates/libs/core/src/strings/mod.rs
+++ b/crates/libs/core/src/strings/mod.rs
@@ -25,8 +25,7 @@ extern "C" {
 }
 
 /// An internal helper for decoding an iterator of chars and displaying them
-#[doc(hidden)]
-pub struct Decode<F>(pub F);
+struct Decode<F>(pub F);
 
 impl<F, R, E> std::fmt::Display for Decode<F>
 where

--- a/crates/libs/core/src/strings/pcstr.rs
+++ b/crates/libs/core/src/strings/pcstr.rs
@@ -54,20 +54,3 @@ impl PCSTR {
         Decode(move || decode_utf8(self.as_bytes()))
     }
 }
-
-impl TypeKind for PCSTR {
-    type TypeKind = CopyType;
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn can_display() {
-        // 💖 followed by an invalid byte sequence and then an incomplete one
-        let s = [240, 159, 146, 150, 255, 240, 159, 0];
-        let s = PCSTR::from_raw(s.as_ptr());
-        assert_eq!("💖�", format!("{}", unsafe { s.display() }));
-    }
-}

--- a/crates/libs/core/src/strings/pcwstr.rs
+++ b/crates/libs/core/src/strings/pcwstr.rs
@@ -63,7 +63,3 @@ impl PCWSTR {
         Decode(move || std::char::decode_utf16(self.as_wide().iter().cloned()))
     }
 }
-
-impl TypeKind for PCWSTR {
-    type TypeKind = CopyType;
-}

--- a/crates/libs/core/src/strings/pstr.rs
+++ b/crates/libs/core/src/strings/pstr.rs
@@ -54,7 +54,3 @@ impl PSTR {
         Decode(move || decode_utf8(self.as_bytes()))
     }
 }
-
-impl TypeKind for PSTR {
-    type TypeKind = CopyType;
-}

--- a/crates/libs/core/src/strings/pwstr.rs
+++ b/crates/libs/core/src/strings/pwstr.rs
@@ -63,7 +63,3 @@ impl PWSTR {
         Decode(move || std::char::decode_utf16(self.as_wide().iter().cloned()))
     }
 }
-
-impl TypeKind for PWSTR {
-    type TypeKind = CopyType;
-}

--- a/crates/libs/core/src/type.rs
+++ b/crates/libs/core/src/type.rs
@@ -98,3 +98,27 @@ primitives!(bool, i8, u8, i16, u16, i32, u32, i64, u64, f32, f64, usize, isize);
 
 #[doc(hidden)]
 pub type AbiType<T> = <T as Type<T>>::Abi;
+
+impl TypeKind for PWSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for PSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for PCWSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for PCSTR {
+    type TypeKind = CopyType;
+}
+
+impl TypeKind for HSTRING {
+    type TypeKind = ValueType;
+}
+
+impl TypeKind for BSTR {
+    type TypeKind = ValueType;
+}

--- a/crates/tests/core/tests/pcstr.rs
+++ b/crates/tests/core/tests/pcstr.rs
@@ -20,3 +20,11 @@ fn test() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn can_display() {
+    // 💖 followed by an invalid byte sequence and then an incomplete one
+    let s = [240, 159, 146, 150, 255, 240, 159, 0];
+    let s = PCSTR::from_raw(s.as_ptr());
+    assert_eq!("💖�", format!("{}", unsafe { s.display() }));
+}


### PR DESCRIPTION
Just moving `windows-core` trait implementations for strings to make future string refactoring easier. 