### PR TITLE
Fix for `windows-target` link doc compat

### DIFF
--- a/crates/libs/targets/src/lib.rs
+++ b/crates/libs/targets/src/lib.rs
@@ -8,7 +8,7 @@ Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs
 #[cfg(all(windows_raw_dylib, target_arch = "x86"))]
 #[macro_export]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim", import_name_type = "undecorated")]
         extern $abi {
             $(#[link_name=$link_name])?
@@ -21,7 +21,7 @@ macro_rules! link {
 #[cfg(all(windows_raw_dylib, not(target_arch = "x86")))]
 #[macro_export]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = $library, kind = "raw-dylib", modifiers = "+verbatim")]
         extern "C" {
             $(#[link_name=$link_name])?
@@ -34,7 +34,7 @@ macro_rules! link {
 #[cfg(all(windows, not(windows_raw_dylib)))]
 #[macro_export]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         #[link(name = "windows.0.52.1")]
         extern $abi {
             $(#[link_name=$link_name])?
@@ -47,7 +47,7 @@ macro_rules! link {
 #[cfg(all(not(windows), not(windows_raw_dylib)))]
 #[macro_export]
 macro_rules! link {
-    ($library:literal $abi:literal $($link_name:literal)? fn $($function:tt)*) => (
+    ($library:literal $abi:literal $($link_name:literal)? $(#[$doc:meta])? fn $($function:tt)*) => (
         extern $abi {
             pub fn $($function)*;
         }

--- a/crates/tests/targets/tests/link.rs
+++ b/crates/tests/targets/tests/link.rs
@@ -23,6 +23,17 @@ fn link_name() {
 }
 
 #[test]
+fn doc() {
+    windows_targets::link!("kernel32.dll" "system" "SetLastError" #[doc = "SetLastError"] fn SetLastError(code: u32) -> ());
+    windows_targets::link!("kernel32.dll" "system" #[doc = "GetLastError"] fn GetLastError() -> u32);
+
+    unsafe {
+        SetLastError(1234);
+        assert_eq!(GetLastError(), 1234);
+    }
+}
+
+#[test]
 fn cdecl() {
     windows_targets::link!("wldap32.dll" "cdecl" fn LdapMapErrorToWin32(code : i32) -> u32);
     const LDAP_BUSY: i32 = 51;


### PR DESCRIPTION
Just making sure we preserve link macro compatibility in some cases as shown in this test failure:

https://github.com/microsoft/windows-rs/actions/runs/8005925420/job/21866485024