### PR TITLE
Update internal references to the current master version

### DIFF
--- a/crates/libs/bindgen/readme.md
+++ b/crates/libs/bindgen/readme.md
@@ -10,7 +10,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-targets]
-version = "0.52.1"
+version = "0.52.3"
 
 [dev-dependencies.windows-bindgen]
 version = "0.53.0"

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -18,7 +18,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies.windows-targets]
-version = "0.52.1"
+version = "0.52.3"
 path = "../targets"
 
 [dependencies.windows-result]

--- a/crates/libs/registry/Cargo.toml
+++ b/crates/libs/registry/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies.windows-targets]
-version = "0.52.1"
+version = "0.52.3"
 path = "../targets"
 
 [dependencies.windows-result]

--- a/crates/libs/result/Cargo.toml
+++ b/crates/libs/result/Cargo.toml
@@ -19,7 +19,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies.windows-targets]
-version = "0.52.1"
+version = "0.52.3"
 path = "../targets"
 
 [dev-dependencies.windows-bindgen]

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -20,7 +20,7 @@ targets = []
 all-features = true
 
 [dependencies.windows-targets]
-version = "0.52.1"
+version = "0.52.3"
 path = "../targets"
 
 [features]

--- a/crates/libs/targets/readme.md
+++ b/crates/libs/targets/readme.md
@@ -10,7 +10,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-targets]
-version = "0.52.1"
+version = "0.52.3"
 ```
 
 Use the `link`` macro to define the external functions you wish to call:

--- a/crates/libs/version/Cargo.toml
+++ b/crates/libs/version/Cargo.toml
@@ -18,7 +18,7 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies.windows-targets]
-version = "0.52.1"
+version = "0.52.3"
 path = "../targets"
 
 [dev-dependencies.windows-bindgen]

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -23,7 +23,7 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [dependencies]
 windows-core = { path = "../core", version = "0.53.0" }
-windows-targets = { path = "../targets", version = "0.52.1" }
+windows-targets = { path = "../targets", version = "0.52.3" }
 windows-implement = { path = "../implement",  version = "0.53.0", optional = true }
 windows-interface = { path = "../interface",  version = "0.53.0", optional = true }
 


### PR DESCRIPTION
This just ensures that we have internal references pointing to the current version for future maintenance.