### PR TITLE
Run web.yml workflow only in original repository

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -21,6 +21,7 @@ on:
 jobs:
   web:
     name: web
+    if: github.repository == 'microsoft/windows-rs'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Don't run web.yml workflow in forks, because it fails there without enabling GitHub Pages. 