### PR TITLE
Workaround for confusing `LocalFree` behavior

### DIFF
--- a/crates/libs/bindgen/src/rust/functions.rs
+++ b/crates/libs/bindgen/src/rust/functions.rs
@@ -258,6 +258,10 @@ fn handle_last_error(def: metadata::MethodDef, signature: &metadata::Signature) 
         if map.flags().contains(metadata::PInvokeAttributes::SupportsLastError) {
             if let metadata::Type::TypeDef(return_type, _) = &signature.return_type {
                 if metadata::type_def_is_handle(*return_type) {
+                    // https://github.com/microsoft/windows-rs/issues/2392#issuecomment-1477765781
+                    if def.name() == "LocalFree" {
+                        return false;
+                    }
                     if return_type.underlying_type().is_pointer() {
                         return true;
                     }

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -57,13 +57,12 @@ where
     (!result__.is_invalid()).then(|| result__).ok_or_else(::windows_core::Error::from_win32)
 }
 #[inline]
-pub unsafe fn LocalFree<P0>(hmem: P0) -> ::windows_core::Result<HLOCAL>
+pub unsafe fn LocalFree<P0>(hmem: P0) -> HLOCAL
 where
     P0: ::windows_core::IntoParam<HLOCAL>,
 {
     ::windows_targets::link!("kernel32.dll" "system" fn LocalFree(hmem : HLOCAL) -> HLOCAL);
-    let result__ = LocalFree(hmem.into_param().abi());
-    (!result__.is_invalid()).then(|| result__).ok_or_else(::windows_core::Error::from_win32)
+    LocalFree(hmem.into_param().abi())
 }
 #[inline]
 pub unsafe fn RtlNtStatusToDosError<P0>(status: P0) -> u32

--- a/crates/samples/windows/privileges/src/main.rs
+++ b/crates/samples/windows/privileges/src/main.rs
@@ -37,7 +37,7 @@ fn main() -> Result<()> {
             println!("{}", name.display())
         }
 
-        _ = LocalFree(buffer);
+        LocalFree(buffer);
         Ok(())
     }
 }

--- a/crates/tests/resources/tests/sys.rs
+++ b/crates/tests/resources/tests/sys.rs
@@ -8,6 +8,7 @@ use windows_sys::{
 #[test]
 fn sys() {
     unsafe {
+        SetLastError(0);
         assert_eq!(IDI_APPLICATION as u16, 32512);
         assert_ne!(LoadIconW(0, IDI_APPLICATION), 0);
         assert_eq!(GetLastError(), 0);


### PR DESCRIPTION
I doubt this will put the issue to rest, but hopefully this at least results in less frequent questions. 🥲

Fixes: https://github.com/microsoft/windows-rs/issues?q=LocalFree
