### PR TITLE
Support additional `VARIANT` types

### DIFF
--- a/crates/libs/bindgen/src/rust/extensions/mod.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod.rs
@@ -15,6 +15,7 @@ pub fn gen_mod(writer: &Writer, namespace: &str) -> TokenStream {
         "Windows.Win32.Foundation" => concat!(include_str!("mod/Win32/Foundation/BOOL.rs"), include_str!("mod/Win32/Foundation/BOOLEAN.rs"), include_str!("mod/Win32/Foundation/NTSTATUS.rs"), include_str!("mod/Win32/Foundation/VARIANT_BOOL.rs"), include_str!("mod/Win32/Foundation/WIN32_ERROR.rs"),),
         "Windows.Win32.Networking.WinSock" => concat!(include_str!("mod/Win32/Networking/WinSock/IN_ADDR.rs"), include_str!("mod/Win32/Networking/WinSock/IN6_ADDR.rs"), include_str!("mod/Win32/Networking/WinSock/SOCKADDR_IN.rs"), include_str!("mod/Win32/Networking/WinSock/SOCKADDR_IN6.rs"), include_str!("mod/Win32/Networking/WinSock/SOCKADDR_INET.rs"),),
         "Windows.Win32.System.Rpc" => include_str!("mod/Win32/System/Rpc/RPC_STATUS.rs"),
+        "Windows.Win32.System.Com" => include_str!("mod/Win32/System/Com/IDispatch.rs"),
         "Windows.Win32.UI.WindowsAndMessaging" => {
             include_str!("mod/Win32/UI/WindowsAndMessaging/WindowLong.rs")
         }

--- a/crates/libs/bindgen/src/rust/extensions/mod/Win32/System/Com/IDispatch.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod/Win32/System/Com/IDispatch.rs
@@ -1,0 +1,65 @@
+impl From<IDispatch> for ::windows_core::VARIANT {
+    fn from(value: IDispatch) -> Self {
+        unsafe {
+            Self::from_raw(::windows_core::imp::VARIANT {
+                Anonymous: ::windows_core::imp::VARIANT_0 {
+                    Anonymous: ::windows_core::imp::VARIANT_0_0 {
+                        vt: 9,
+                        wReserved1: 0,
+                        wReserved2: 0,
+                        wReserved3: 0,
+                        Anonymous: ::windows_core::imp::VARIANT_0_0_0 { pdispVal: ::std::mem::transmute(value) },
+                    },
+                },
+            })
+        }
+    }
+}
+
+impl From<IDispatch> for ::windows_core::PROPVARIANT {
+    fn from(value: IDispatch) -> Self {
+        unsafe {
+            Self::from_raw(::windows_core::imp::PROPVARIANT {
+                Anonymous: ::windows_core::imp::PROPVARIANT_0 {
+                    Anonymous: ::windows_core::imp::PROPVARIANT_0_0 {
+                        vt: 9,
+                        wReserved1: 0,
+                        wReserved2: 0,
+                        wReserved3: 0,
+                        Anonymous: ::windows_core::imp::PROPVARIANT_0_0_0 { pdispVal: ::std::mem::transmute(value) },
+                    },
+                },
+            })
+        }
+    }
+}
+
+impl TryFrom<&::windows_core::VARIANT> for IDispatch {
+    type Error = ::windows_core::Error;
+    fn try_from(from: &::windows_core::VARIANT) -> ::windows_core::Result<Self> {
+        let from = from.as_raw();
+        unsafe {
+            if from.Anonymous.Anonymous.vt == 9 && !from.Anonymous.Anonymous.Anonymous.pdispVal.is_null() {
+                let dispatch: &IDispatch = std::mem::transmute(&from.Anonymous.Anonymous.Anonymous.pdispVal);
+                Ok(dispatch.clone())
+            } else {
+                Err(::windows_core::Error::from_hresult(::windows_core::imp::TYPE_E_TYPEMISMATCH))
+            }
+        }
+    }
+}
+
+impl TryFrom<&::windows_core::PROPVARIANT> for IDispatch {
+    type Error = ::windows_core::Error;
+    fn try_from(from: &::windows_core::PROPVARIANT) -> ::windows_core::Result<Self> {
+        let from = from.as_raw();
+        unsafe {
+            if from.Anonymous.Anonymous.vt == 9 && !from.Anonymous.Anonymous.Anonymous.pdispVal.is_null() {
+                let dispatch: &IDispatch = std::mem::transmute(&from.Anonymous.Anonymous.Anonymous.pdispVal);
+                Ok(dispatch.clone())
+            } else {
+                Err(::windows_core::Error::from_hresult(::windows_core::imp::TYPE_E_TYPEMISMATCH))
+            }
+        }
+    }
+}

--- a/crates/libs/core/src/variant.rs
+++ b/crates/libs/core/src/variant.rs
@@ -143,6 +143,20 @@ impl VARIANT {
     pub const fn is_empty(&self) -> bool {
         unsafe { self.0.Anonymous.Anonymous.vt == imp::VT_EMPTY }
     }
+
+    /// Creates a `VARIANT` by taking ownership of the raw data.
+    ///
+    /// # Safety
+    ///
+    /// The raw data must be owned by the caller and represent a valid `VARIANT` data structure.
+    pub unsafe fn from_raw(raw: imp::VARIANT) -> Self {
+        Self(raw)
+    }
+    
+    /// Returns the underlying raw data for the `VARIANT`.
+    pub fn as_raw(&self) -> &imp::VARIANT {
+        &self.0
+    }
 }
 
 impl PROPVARIANT {
@@ -156,6 +170,20 @@ impl PROPVARIANT {
     /// Returns true if the `PROPVARIANT` is empty.
     pub const fn is_empty(&self) -> bool {
         unsafe { self.0.Anonymous.Anonymous.vt == imp::VT_EMPTY }
+    }
+
+    /// Creates a `PROPVARIANT` by taking ownership of the raw data.
+    ///
+    /// # Safety
+    ///
+    /// The raw data must be owned by the caller and represent a valid `PROPVARIANT` data structure.
+    pub unsafe fn from_raw(raw: imp::PROPVARIANT) -> Self {
+        Self(raw)
+    }
+    
+    /// Returns the underlying raw data for the `PROPVARIANT`.
+    pub fn as_raw(&self) -> &imp::PROPVARIANT {
+        &self.0
     }
 }
 

--- a/crates/libs/core/src/variant.rs
+++ b/crates/libs/core/src/variant.rs
@@ -152,7 +152,7 @@ impl VARIANT {
     pub unsafe fn from_raw(raw: imp::VARIANT) -> Self {
         Self(raw)
     }
-    
+
     /// Returns the underlying raw data for the `VARIANT`.
     pub fn as_raw(&self) -> &imp::VARIANT {
         &self.0
@@ -180,7 +180,7 @@ impl PROPVARIANT {
     pub unsafe fn from_raw(raw: imp::PROPVARIANT) -> Self {
         Self(raw)
     }
-    
+
     /// Returns the underlying raw data for the `PROPVARIANT`.
     pub fn as_raw(&self) -> &imp::PROPVARIANT {
         &self.0

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -8137,5 +8137,58 @@ pub type LPEXCEPFINO_DEFERRED_FILLIN = ::core::option::Option<unsafe extern "sys
 pub type LPFNCANUNLOADNOW = ::core::option::Option<unsafe extern "system" fn() -> ::windows_core::HRESULT>;
 pub type LPFNGETCLASSOBJECT = ::core::option::Option<unsafe extern "system" fn(param0: *const ::windows_core::GUID, param1: *const ::windows_core::GUID, param2: *mut *mut ::core::ffi::c_void) -> ::windows_core::HRESULT>;
 pub type PFNCONTEXTCALL = ::core::option::Option<unsafe extern "system" fn(pparam: *mut ComCallData) -> ::windows_core::HRESULT>;
+impl From<IDispatch> for ::windows_core::VARIANT {
+    fn from(value: IDispatch) -> Self {
+        unsafe {
+            Self::from_raw(::windows_core::imp::VARIANT {
+                Anonymous: ::windows_core::imp::VARIANT_0 {
+                    Anonymous: ::windows_core::imp::VARIANT_0_0 { vt: 9, wReserved1: 0, wReserved2: 0, wReserved3: 0, Anonymous: ::windows_core::imp::VARIANT_0_0_0 { pdispVal: ::std::mem::transmute(value) } },
+                },
+            })
+        }
+    }
+}
+
+impl From<IDispatch> for ::windows_core::PROPVARIANT {
+    fn from(value: IDispatch) -> Self {
+        unsafe {
+            Self::from_raw(::windows_core::imp::PROPVARIANT {
+                Anonymous: ::windows_core::imp::PROPVARIANT_0 {
+                    Anonymous: ::windows_core::imp::PROPVARIANT_0_0 { vt: 9, wReserved1: 0, wReserved2: 0, wReserved3: 0, Anonymous: ::windows_core::imp::PROPVARIANT_0_0_0 { pdispVal: ::std::mem::transmute(value) } },
+                },
+            })
+        }
+    }
+}
+
+impl TryFrom<&::windows_core::VARIANT> for IDispatch {
+    type Error = ::windows_core::Error;
+    fn try_from(from: &::windows_core::VARIANT) -> ::windows_core::Result<Self> {
+        let from = from.as_raw();
+        unsafe {
+            if from.Anonymous.Anonymous.vt == 9 && !from.Anonymous.Anonymous.Anonymous.pdispVal.is_null() {
+                let dispatch: &IDispatch = std::mem::transmute(&from.Anonymous.Anonymous.Anonymous.pdispVal);
+                Ok(dispatch.clone())
+            } else {
+                Err(::windows_core::Error::from_hresult(::windows_core::imp::TYPE_E_TYPEMISMATCH))
+            }
+        }
+    }
+}
+
+impl TryFrom<&::windows_core::PROPVARIANT> for IDispatch {
+    type Error = ::windows_core::Error;
+    fn try_from(from: &::windows_core::PROPVARIANT) -> ::windows_core::Result<Self> {
+        let from = from.as_raw();
+        unsafe {
+            if from.Anonymous.Anonymous.vt == 9 && !from.Anonymous.Anonymous.Anonymous.pdispVal.is_null() {
+                let dispatch: &IDispatch = std::mem::transmute(&from.Anonymous.Anonymous.Anonymous.pdispVal);
+                Ok(dispatch.clone())
+            } else {
+                Err(::windows_core::Error::from_hresult(::windows_core::imp::TYPE_E_TYPEMISMATCH))
+            }
+        }
+    }
+}
 #[cfg(feature = "implement")]
 ::core::include!("impl.rs");

--- a/crates/tests/variant/Cargo.toml
+++ b/crates/tests/variant/Cargo.toml
@@ -12,4 +12,5 @@ path = "../../libs/windows"
 features = [
     "Foundation",
     "Win32_Foundation",
+    "Win32_System_Com_Events",
 ]


### PR DESCRIPTION
This update adds support for converting between `VARIANT` and `IDispatch` as well as providing low-level `as_raw` and `from_raw` functions for interacting with the underlying raw data structures when needed. 

Fixes: #2877