### PR TITLE
Format extension files 

### DIFF
--- a/crates/libs/bindgen/src/rust/extensions/impl/Foundation/Collections/Iterable.rs
+++ b/crates/libs/bindgen/src/rust/extensions/impl/Foundation/Collections/Iterable.rs
@@ -16,11 +16,7 @@ where
         unsafe {
             // TODO: ideally we can do an AddRef rather than a QI here (via cast)...
             // and then we can get rid of the unsafe as well.
-            Ok(StockIterator {
-                owner: self.cast()?,
-                current: 0.into(),
-            }
-            .into())
+            Ok(StockIterator { owner: self.cast()?, current: 0.into() }.into())
         }
     }
 }
@@ -63,8 +59,7 @@ where
         let current = self.current.load(std::sync::atomic::Ordering::Relaxed);
 
         if current < owner.values.len() {
-            self.current
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.current.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
 
         Ok(owner.values.len() > current + 1)
@@ -77,8 +72,7 @@ where
         let actual = std::cmp::min(owner.values.len() - current, values.len());
         let (values, _) = values.split_at_mut(actual);
         values.clone_from_slice(&owner.values[current..current + actual]);
-        self.current
-            .fetch_add(actual, std::sync::atomic::Ordering::Relaxed);
+        self.current.fetch_add(actual, std::sync::atomic::Ordering::Relaxed);
         Ok(actual as u32)
     }
 }

--- a/crates/libs/bindgen/src/rust/extensions/impl/Foundation/Collections/MapView.rs
+++ b/crates/libs/bindgen/src/rust/extensions/impl/Foundation/Collections/MapView.rs
@@ -20,11 +20,7 @@ where
         unsafe {
             // TODO: ideally we can do an AddRef rather than a QI here (via cast)...
             // and then we can get rid of the unsafe as well.
-            Ok(StockMapViewIterator::<K, V> {
-                _owner: self.cast()?,
-                current: std::sync::RwLock::new(self.map.iter()),
-            }
-            .into())
+            Ok(StockMapViewIterator::<K, V> { _owner: self.cast()?, current: std::sync::RwLock::new(self.map.iter()) }.into())
         }
     }
 }
@@ -37,10 +33,7 @@ where
     V::Default: Clone,
 {
     fn Lookup(&self, key: &K::Default) -> windows_core::Result<V> {
-        let value = self
-            .map
-            .get(key)
-            .ok_or_else(|| windows_core::Error::from(windows_core::imp::E_BOUNDS))?;
+        let value = self.map.get(key).ok_or_else(|| windows_core::Error::from(windows_core::imp::E_BOUNDS))?;
         V::from_default(value)
     }
     fn Size(&self) -> windows_core::Result<u32> {
@@ -49,11 +42,7 @@ where
     fn HasKey(&self, key: &K::Default) -> windows_core::Result<bool> {
         Ok(self.map.contains_key(key))
     }
-    fn Split(
-        &self,
-        first: &mut Option<IMapView<K, V>>,
-        second: &mut Option<IMapView<K, V>>,
-    ) -> windows_core::Result<()> {
+    fn Split(&self, first: &mut Option<IMapView<K, V>>, second: &mut Option<IMapView<K, V>>) -> windows_core::Result<()> {
         *first = None;
         *second = None;
         Ok(())
@@ -83,11 +72,7 @@ where
         let mut current = self.current.read().unwrap().clone().peekable();
 
         if let Some((key, value)) = current.peek() {
-            Ok(StockKeyValuePair {
-                key: (*key).clone(),
-                value: (*value).clone(),
-            }
-            .into())
+            Ok(StockKeyValuePair { key: (*key).clone(), value: (*value).clone() }.into())
         } else {
             Err(windows_core::Error::from(windows_core::imp::E_BOUNDS))
         }
@@ -112,13 +97,7 @@ where
 
         for pair in pairs {
             if let Some((key, value)) = current.next() {
-                *pair = Some(
-                    StockKeyValuePair {
-                        key: (*key).clone(),
-                        value: (*value).clone(),
-                    }
-                    .into(),
-                );
+                *pair = Some(StockKeyValuePair { key: (*key).clone(), value: (*value).clone() }.into());
                 actual += 1;
             } else {
                 break;
@@ -156,8 +135,7 @@ where
     }
 }
 
-impl<K, V> TryFrom<std::collections::BTreeMap<K::Default, V::Default>>
-    for IMapView<K, V>
+impl<K, V> TryFrom<std::collections::BTreeMap<K::Default, V::Default>> for IMapView<K, V>
 where
     K: windows_core::RuntimeType,
     V: windows_core::RuntimeType,
@@ -165,9 +143,7 @@ where
     V::Default: Clone,
 {
     type Error = windows_core::Error;
-    fn try_from(
-        map: std::collections::BTreeMap<K::Default, V::Default>,
-    ) -> windows_core::Result<Self> {
+    fn try_from(map: std::collections::BTreeMap<K::Default, V::Default>) -> windows_core::Result<Self> {
         // TODO: should provide a fallible try_into or more explicit allocator
         Ok(StockMapView { map }.into())
     }

--- a/crates/libs/bindgen/src/rust/extensions/impl/Foundation/Collections/VectorView.rs
+++ b/crates/libs/bindgen/src/rust/extensions/impl/Foundation/Collections/VectorView.rs
@@ -16,11 +16,7 @@ where
         unsafe {
             // TODO: ideally we can do an AddRef rather than a QI here (via cast)...
             // and then we can get rid of the unsafe as well.
-            Ok(StockVectorViewIterator {
-                owner: self.cast()?,
-                current: 0.into(),
-            }
-            .into())
+            Ok(StockVectorViewIterator { owner: self.cast()?, current: 0.into() }.into())
         }
     }
 }
@@ -31,10 +27,7 @@ where
     T::Default: Clone + PartialEq,
 {
     fn GetAt(&self, index: u32) -> windows_core::Result<T> {
-        let item = self
-            .values
-            .get(index as usize)
-            .ok_or_else(|| windows_core::Error::from(windows_core::imp::E_BOUNDS))?;
+        let item = self.values.get(index as usize).ok_or_else(|| windows_core::Error::from(windows_core::imp::E_BOUNDS))?;
         T::from_default(item)
     }
     fn Size(&self) -> windows_core::Result<u32> {
@@ -99,8 +92,7 @@ where
         let current = self.current.load(std::sync::atomic::Ordering::Relaxed);
 
         if current < owner.values.len() {
-            self.current
-                .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            self.current.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         }
 
         Ok(owner.values.len() > current + 1)
@@ -113,8 +105,7 @@ where
         let actual = std::cmp::min(owner.values.len() - current, values.len());
         let (values, _) = values.split_at_mut(actual);
         values.clone_from_slice(&owner.values[current..current + actual]);
-        self.current
-            .fetch_add(actual, std::sync::atomic::Ordering::Relaxed);
+        self.current.fetch_add(actual, std::sync::atomic::Ordering::Relaxed);
         Ok(actual as u32)
     }
 }

--- a/crates/libs/bindgen/src/rust/extensions/mod/Win32/Networking/WinSock/SOCKADDR_INET.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod/Win32/Networking/WinSock/SOCKADDR_INET.rs
@@ -1,4 +1,3 @@
-
 impl From<std::net::SocketAddrV4> for SOCKADDR_INET {
     fn from(addr: std::net::SocketAddrV4) -> Self {
         SOCKADDR_INET { Ipv4: addr.into() }

--- a/crates/libs/bindgen/src/rust/extensions/mod/Win32/System/Com/IDispatch.rs
+++ b/crates/libs/bindgen/src/rust/extensions/mod/Win32/System/Com/IDispatch.rs
@@ -3,13 +3,7 @@ impl From<IDispatch> for windows_core::VARIANT {
         unsafe {
             Self::from_raw(windows_core::imp::VARIANT {
                 Anonymous: windows_core::imp::VARIANT_0 {
-                    Anonymous: windows_core::imp::VARIANT_0_0 {
-                        vt: 9,
-                        wReserved1: 0,
-                        wReserved2: 0,
-                        wReserved3: 0,
-                        Anonymous: windows_core::imp::VARIANT_0_0_0 { pdispVal: std::mem::transmute(value) },
-                    },
+                    Anonymous: windows_core::imp::VARIANT_0_0 { vt: 9, wReserved1: 0, wReserved2: 0, wReserved3: 0, Anonymous: windows_core::imp::VARIANT_0_0_0 { pdispVal: std::mem::transmute(value) } },
                 },
             })
         }
@@ -21,13 +15,7 @@ impl From<IDispatch> for windows_core::PROPVARIANT {
         unsafe {
             Self::from_raw(windows_core::imp::PROPVARIANT {
                 Anonymous: windows_core::imp::PROPVARIANT_0 {
-                    Anonymous: windows_core::imp::PROPVARIANT_0_0 {
-                        vt: 9,
-                        wReserved1: 0,
-                        wReserved2: 0,
-                        wReserved3: 0,
-                        Anonymous: windows_core::imp::PROPVARIANT_0_0_0 { pdispVal: std::mem::transmute(value) },
-                    },
+                    Anonymous: windows_core::imp::PROPVARIANT_0_0 { vt: 9, wReserved1: 0, wReserved2: 0, wReserved3: 0, Anonymous: windows_core::imp::PROPVARIANT_0_0_0 { pdispVal: std::mem::transmute(value) } },
                 },
             })
         }

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -14048,7 +14048,6 @@ impl From<std::net::SocketAddrV6> for SOCKADDR_IN6 {
         }
     }
 }
-
 impl From<std::net::SocketAddrV4> for SOCKADDR_INET {
     fn from(addr: std::net::SocketAddrV4) -> Self {
         SOCKADDR_INET { Ipv4: addr.into() }


### PR DESCRIPTION
The repo is formatted with `cargo fmt` but unfortunately that skips over .rs files that are injected by `windows-bindgen` and unknown to Cargo. This is just a maintenance update to ensure the extension files are formatted until I find a better way to automate this.

```
for /r %v in (*.rs) do rustfmt %v
```
