### PR TITLE
Riddle 0.3

### DIFF
--- a/crates/tools/riddle/Cargo.toml
+++ b/crates/tools/riddle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "riddle"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Microsoft"]
 edition = "2021"
 rust-version = "1.60"


### PR DESCRIPTION
Need a matching version of `riddle` for `windows-bindgen` 0.55 as well.