### PR TITLE
Fix generic class signature calculation

### DIFF
--- a/crates/libs/bindgen/src/rust/interfaces.rs
+++ b/crates/libs/bindgen/src/rust/interfaces.rs
@@ -166,12 +166,12 @@ fn gen_win_interface(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
             }
         });
 
-        tokens.combine(&writer.interface_winrt_trait(def, generics, &ident, &constraints, &phantoms, &features));
         tokens.combine(&writer.async_get(def, generics, &ident, &constraints, &phantoms, &features));
         tokens.combine(&iterators::writer(writer, def, generics, &ident, &constraints, &phantoms, &cfg));
         tokens.combine(&writer.agile(def, &ident, &constraints, &features));
     }
 
+    tokens.combine(&writer.interface_winrt_trait(def, generics, &ident, &constraints, &phantoms, &features));
     tokens.combine(&writer.interface_trait(def, generics, &ident, &constraints, &features, has_unknown_base));
     tokens.combine(&writer.interface_vtbl(def, generics, &constraints, &features));
     tokens

--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -656,7 +656,9 @@ impl Writer {
     pub fn interface_winrt_trait(&self, def: metadata::TypeDef, generics: &[metadata::Type], ident: &TokenStream, constraints: &TokenStream, _phantoms: &TokenStream, features: &TokenStream) -> TokenStream {
         if def.flags().contains(metadata::TypeAttributes::WindowsRuntime) {
             let type_signature = if def.kind() == metadata::TypeKind::Class {
-                quote! { windows_core::imp::ConstBuffer::for_class::<Self>() }
+                let default = metadata::type_def_default_interface(def).expect("missing default interface");
+                let default_name = self.type_name(&default);
+                quote! { windows_core::imp::ConstBuffer::for_class::<Self, #default_name>() }
             } else if generics.is_empty() {
                 quote! { windows_core::imp::ConstBuffer::for_interface::<Self>() }
             } else {

--- a/crates/libs/core/src/imp/com_bindings.rs
+++ b/crates/libs/core/src/imp/com_bindings.rs
@@ -352,6 +352,9 @@ pub struct IPropertyValue_Vtbl {
     pub GetRectArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPropertyValueStatics, IPropertyValueStatics_Vtbl, 0x629bdbc8_d932_4ff4_96b9_8d96c5c1e858);
+impl windows_core::RuntimeType for IPropertyValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPropertyValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/core/src/imp/sha1.rs
+++ b/crates/libs/core/src/imp/sha1.rs
@@ -16,8 +16,8 @@ pub struct ConstBuffer {
 }
 
 impl ConstBuffer {
-    pub const fn for_class<T: crate::RuntimeName + crate::Interface>() -> Self {
-        Self::new().push_slice(b"rc(").push_slice(T::NAME.as_bytes()).push(b';').push_guid(&T::IID).push(b')')
+    pub const fn for_class<C: crate::RuntimeName, I: crate::RuntimeType>() -> Self {
+        Self::new().push_slice(b"rc(").push_slice(C::NAME.as_bytes()).push(b';').push_other(I::SIGNATURE).push(b')')
     }
 
     pub const fn for_interface<T: crate::Interface>() -> Self {

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IImageFeatureDescriptor, IImageFeatureDescriptor_Vtbl, 0x365585a5_171a_4a2a_985f_265159d3895a);
+impl windows_core::RuntimeType for IImageFeatureDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageFeatureDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,12 +17,18 @@ pub struct IImageFeatureDescriptor_Vtbl {
     pub Height: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageFeatureDescriptor2, IImageFeatureDescriptor2_Vtbl, 0x2b27cca7_d533_5862_bb98_1611b155b0e1);
+impl windows_core::RuntimeType for IImageFeatureDescriptor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageFeatureDescriptor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PixelRange: unsafe extern "system" fn(*mut core::ffi::c_void, *mut LearningModelPixelRange) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageFeatureValue, IImageFeatureValue_Vtbl, 0xf0414fd9_c9aa_4405_b7fb_94f87c8a3037);
+impl windows_core::RuntimeType for IImageFeatureValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageFeatureValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +38,9 @@ pub struct IImageFeatureValue_Vtbl {
     VideoFrame: usize,
 }
 windows_core::imp::define_interface!(IImageFeatureValueStatics, IImageFeatureValueStatics_Vtbl, 0x1bc317fd_23cb_4610_b085_c8e1c87ebaa0);
+impl windows_core::RuntimeType for IImageFeatureValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageFeatureValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,6 +50,9 @@ pub struct IImageFeatureValueStatics_Vtbl {
     CreateFromVideoFrame: usize,
 }
 windows_core::imp::define_interface!(ILearningModel, ILearningModel_Vtbl, 0x5b8e4920_489f_4e86_9128_265a327b78fa);
+impl windows_core::RuntimeType for ILearningModel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +75,9 @@ pub struct ILearningModel_Vtbl {
     OutputFeatures: usize,
 }
 windows_core::imp::define_interface!(ILearningModelBinding, ILearningModelBinding_Vtbl, 0xea312f20_168f_4f8c_94fe_2e7ac31b4aa8);
+impl windows_core::RuntimeType for ILearningModelBinding {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelBinding_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,12 +89,18 @@ pub struct ILearningModelBinding_Vtbl {
     pub Clear: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelBindingFactory, ILearningModelBindingFactory_Vtbl, 0xc95f7a7a_e788_475e_8917_23aa381faf0b);
+impl windows_core::RuntimeType for ILearningModelBindingFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelBindingFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFromSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelDevice, ILearningModelDevice_Vtbl, 0xf5c2c8fe_3f56_4a8c_ac5f_fdb92d8b8252);
+impl windows_core::RuntimeType for ILearningModelDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,12 +114,18 @@ pub struct ILearningModelDevice_Vtbl {
     Direct3D11Device: usize,
 }
 windows_core::imp::define_interface!(ILearningModelDeviceFactory, ILearningModelDeviceFactory_Vtbl, 0x9cffd74d_b1e5_4f20_80ad_0a56690db06b);
+impl windows_core::RuntimeType for ILearningModelDeviceFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelDeviceFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, LearningModelDeviceKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelDeviceStatics, ILearningModelDeviceStatics_Vtbl, 0x49f32107_a8bf_42bb_92c7_10b12dc5d21f);
+impl windows_core::RuntimeType for ILearningModelDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,6 +135,9 @@ pub struct ILearningModelDeviceStatics_Vtbl {
     CreateFromDirect3D11Device: usize,
 }
 windows_core::imp::define_interface!(ILearningModelEvaluationResult, ILearningModelEvaluationResult_Vtbl, 0xb2f9bfcd_960e_49c0_8593_eb190ae3eee2);
+impl windows_core::RuntimeType for ILearningModelEvaluationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelEvaluationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +222,9 @@ pub struct ILearningModelOperatorProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ILearningModelSession, ILearningModelSession_Vtbl, 0x8e58f8f6_b787_4c11_90f0_7129aeca74a9);
+impl windows_core::RuntimeType for ILearningModelSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -210,6 +246,9 @@ pub struct ILearningModelSession_Vtbl {
     EvaluateFeatures: usize,
 }
 windows_core::imp::define_interface!(ILearningModelSessionFactory, ILearningModelSessionFactory_Vtbl, 0x0f6b881d_1c9b_47b6_bfe0_f1cf62a67579);
+impl windows_core::RuntimeType for ILearningModelSessionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelSessionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -217,12 +256,18 @@ pub struct ILearningModelSessionFactory_Vtbl {
     pub CreateFromModelOnDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelSessionFactory2, ILearningModelSessionFactory2_Vtbl, 0x4e5c88bf_0a1f_5fec_ade0_2fd91e4ef29b);
+impl windows_core::RuntimeType for ILearningModelSessionFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelSessionFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFromModelOnDeviceWithSessionOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelSessionOptions, ILearningModelSessionOptions_Vtbl, 0xb8f63fa1_134d_5133_8cff_3a5c3c263beb);
+impl windows_core::RuntimeType for ILearningModelSessionOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelSessionOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -230,6 +275,9 @@ pub struct ILearningModelSessionOptions_Vtbl {
     pub SetBatchSizeOverride: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelSessionOptions2, ILearningModelSessionOptions2_Vtbl, 0x6fcd1dc4_175f_5bd2_8de5_2f2006a25adf);
+impl windows_core::RuntimeType for ILearningModelSessionOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelSessionOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -237,12 +285,18 @@ pub struct ILearningModelSessionOptions2_Vtbl {
     pub SetCloseModelOnSessionCreation: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelSessionOptions3, ILearningModelSessionOptions3_Vtbl, 0x58e15cee_d8c2_56fc_92e8_76d751081086);
+impl windows_core::RuntimeType for ILearningModelSessionOptions3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelSessionOptions3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OverrideNamedDimension: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILearningModelStatics, ILearningModelStatics_Vtbl, 0xe3b977e8_6952_4e47_8ef4_1f7f07897c6d);
+impl windows_core::RuntimeType for ILearningModelStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILearningModelStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +328,9 @@ pub struct ILearningModelStatics_Vtbl {
     LoadFromStreamWithOperatorProvider: usize,
 }
 windows_core::imp::define_interface!(IMapFeatureDescriptor, IMapFeatureDescriptor_Vtbl, 0x530424bd_a257_436d_9e60_c2981f7cc5c4);
+impl windows_core::RuntimeType for IMapFeatureDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapFeatureDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +338,9 @@ pub struct IMapFeatureDescriptor_Vtbl {
     pub ValueDescriptor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISequenceFeatureDescriptor, ISequenceFeatureDescriptor_Vtbl, 0x84f6945a_562b_4d62_a851_739aced96668);
+impl windows_core::RuntimeType for ISequenceFeatureDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISequenceFeatureDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -326,6 +386,9 @@ pub struct ITensor_Vtbl {
     Shape: usize,
 }
 windows_core::imp::define_interface!(ITensorBoolean, ITensorBoolean_Vtbl, 0x50f311ed_29e9_4a5c_a44d_8fc512584eed);
+impl windows_core::RuntimeType for ITensorBoolean {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorBoolean_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -335,6 +398,9 @@ pub struct ITensorBoolean_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorBooleanStatics, ITensorBooleanStatics_Vtbl, 0x2796862c_2357_49a7_b476_d0aa3dfe6866);
+impl windows_core::RuntimeType for ITensorBooleanStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorBooleanStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -353,6 +419,9 @@ pub struct ITensorBooleanStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorBooleanStatics2, ITensorBooleanStatics2_Vtbl, 0xa3a4a501_6a2d_52d7_b04b_c435baee0115);
+impl windows_core::RuntimeType for ITensorBooleanStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorBooleanStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -363,6 +432,9 @@ pub struct ITensorBooleanStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorDouble, ITensorDouble_Vtbl, 0x91e41252_7a8f_4f0e_a28f_9637ffc8a3d0);
+impl windows_core::RuntimeType for ITensorDouble {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorDouble_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -372,6 +444,9 @@ pub struct ITensorDouble_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorDoubleStatics, ITensorDoubleStatics_Vtbl, 0xa86693c5_9538_44e7_a3ca_5df374a5a70c);
+impl windows_core::RuntimeType for ITensorDoubleStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorDoubleStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -390,6 +465,9 @@ pub struct ITensorDoubleStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorDoubleStatics2, ITensorDoubleStatics2_Vtbl, 0x93a570de_5e9a_5094_85c8_592c655e68ac);
+impl windows_core::RuntimeType for ITensorDoubleStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorDoubleStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -400,6 +478,9 @@ pub struct ITensorDoubleStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorFeatureDescriptor, ITensorFeatureDescriptor_Vtbl, 0x74455c80_946a_4310_a19c_ee0af028fce4);
+impl windows_core::RuntimeType for ITensorFeatureDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorFeatureDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -410,6 +491,9 @@ pub struct ITensorFeatureDescriptor_Vtbl {
     Shape: usize,
 }
 windows_core::imp::define_interface!(ITensorFloat, ITensorFloat_Vtbl, 0xf2282d82_aa02_42c8_a0c8_df1efc9676e1);
+impl windows_core::RuntimeType for ITensorFloat {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorFloat_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -419,6 +503,9 @@ pub struct ITensorFloat_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorFloat16Bit, ITensorFloat16Bit_Vtbl, 0x0ab994fc_5b89_4c3c_b5e4_5282a5316c0a);
+impl windows_core::RuntimeType for ITensorFloat16Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorFloat16Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -428,6 +515,9 @@ pub struct ITensorFloat16Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorFloat16BitStatics, ITensorFloat16BitStatics_Vtbl, 0xa52db6f5_318a_44d4_820b_0cdc7054a84a);
+impl windows_core::RuntimeType for ITensorFloat16BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorFloat16BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -446,6 +536,9 @@ pub struct ITensorFloat16BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorFloat16BitStatics2, ITensorFloat16BitStatics2_Vtbl, 0x68545726_2dc7_51bf_b470_0b344cc2a1bc);
+impl windows_core::RuntimeType for ITensorFloat16BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorFloat16BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -456,6 +549,9 @@ pub struct ITensorFloat16BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorFloatStatics, ITensorFloatStatics_Vtbl, 0xdbcd395b_3ba3_452f_b10d_3c135e573fa9);
+impl windows_core::RuntimeType for ITensorFloatStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorFloatStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -474,6 +570,9 @@ pub struct ITensorFloatStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorFloatStatics2, ITensorFloatStatics2_Vtbl, 0x24610bc1_5e44_5713_b281_8f4ad4d555e8);
+impl windows_core::RuntimeType for ITensorFloatStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorFloatStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -484,6 +583,9 @@ pub struct ITensorFloatStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorInt16Bit, ITensorInt16Bit_Vtbl, 0x98a32d39_e6d6_44af_8afa_baebc44dc020);
+impl windows_core::RuntimeType for ITensorInt16Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt16Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -493,6 +595,9 @@ pub struct ITensorInt16Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorInt16BitStatics, ITensorInt16BitStatics_Vtbl, 0x98646293_266e_4b1a_821f_e60d70898b91);
+impl windows_core::RuntimeType for ITensorInt16BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt16BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -511,6 +616,9 @@ pub struct ITensorInt16BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorInt16BitStatics2, ITensorInt16BitStatics2_Vtbl, 0x0cd70cf4_696c_5e5f_95d8_5ebf9670148b);
+impl windows_core::RuntimeType for ITensorInt16BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt16BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -521,6 +629,9 @@ pub struct ITensorInt16BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorInt32Bit, ITensorInt32Bit_Vtbl, 0x2c0c28d3_207c_4486_a7d2_884522c5e589);
+impl windows_core::RuntimeType for ITensorInt32Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt32Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -530,6 +641,9 @@ pub struct ITensorInt32Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorInt32BitStatics, ITensorInt32BitStatics_Vtbl, 0x6539864b_52fa_4e35_907c_834cac417b50);
+impl windows_core::RuntimeType for ITensorInt32BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt32BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -548,6 +662,9 @@ pub struct ITensorInt32BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorInt32BitStatics2, ITensorInt32BitStatics2_Vtbl, 0x7c4b079a_e956_5ce0_a3bd_157d9d79b5ec);
+impl windows_core::RuntimeType for ITensorInt32BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt32BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -558,6 +675,9 @@ pub struct ITensorInt32BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorInt64Bit, ITensorInt64Bit_Vtbl, 0x499665ba_1fa2_45ad_af25_a0bd9bda4c87);
+impl windows_core::RuntimeType for ITensorInt64Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt64Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -567,6 +687,9 @@ pub struct ITensorInt64Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorInt64BitStatics, ITensorInt64BitStatics_Vtbl, 0x9648ad9d_1198_4d74_9517_783ab62b9cc2);
+impl windows_core::RuntimeType for ITensorInt64BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt64BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -585,6 +708,9 @@ pub struct ITensorInt64BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorInt64BitStatics2, ITensorInt64BitStatics2_Vtbl, 0x6d3d9dcb_ff40_5ec2_89fe_084e2b6bc6db);
+impl windows_core::RuntimeType for ITensorInt64BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt64BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -595,6 +721,9 @@ pub struct ITensorInt64BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorInt8Bit, ITensorInt8Bit_Vtbl, 0xcddd97c5_ffd8_4fef_aefb_30e1a485b2ee);
+impl windows_core::RuntimeType for ITensorInt8Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt8Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -604,6 +733,9 @@ pub struct ITensorInt8Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorInt8BitStatics, ITensorInt8BitStatics_Vtbl, 0xb1a12284_095c_4c76_a661_ac4cee1f3e8b);
+impl windows_core::RuntimeType for ITensorInt8BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt8BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -622,6 +754,9 @@ pub struct ITensorInt8BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorInt8BitStatics2, ITensorInt8BitStatics2_Vtbl, 0xc0d59637_c468_56fb_9535_c052bdb93dc0);
+impl windows_core::RuntimeType for ITensorInt8BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorInt8BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -632,6 +767,9 @@ pub struct ITensorInt8BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorString, ITensorString_Vtbl, 0x582335c8_bdb1_4610_bc75_35e9cbf009b7);
+impl windows_core::RuntimeType for ITensorString {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorString_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -641,6 +779,9 @@ pub struct ITensorString_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorStringStatics, ITensorStringStatics_Vtbl, 0x83623324_cf26_4f17_a2d4_20ef8d097d53);
+impl windows_core::RuntimeType for ITensorStringStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorStringStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -659,12 +800,18 @@ pub struct ITensorStringStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorStringStatics2, ITensorStringStatics2_Vtbl, 0x9e355ed0_c8e2_5254_9137_0193a3668fd8);
+impl windows_core::RuntimeType for ITensorStringStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorStringStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFromShapeArrayAndDataArray: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const i64, u32, *const std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITensorUInt16Bit, ITensorUInt16Bit_Vtbl, 0x68140f4b_23c0_42f3_81f6_a891c011bc3f);
+impl windows_core::RuntimeType for ITensorUInt16Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt16Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -674,6 +821,9 @@ pub struct ITensorUInt16Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt16BitStatics, ITensorUInt16BitStatics_Vtbl, 0x5df745dd_028a_481a_a27c_c7e6435e52dd);
+impl windows_core::RuntimeType for ITensorUInt16BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt16BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -692,6 +842,9 @@ pub struct ITensorUInt16BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt16BitStatics2, ITensorUInt16BitStatics2_Vtbl, 0x8af40c64_d69f_5315_9348_490877bbd642);
+impl windows_core::RuntimeType for ITensorUInt16BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt16BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -702,6 +855,9 @@ pub struct ITensorUInt16BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt32Bit, ITensorUInt32Bit_Vtbl, 0xd8c9c2ff_7511_45a3_bfac_c38f370d2237);
+impl windows_core::RuntimeType for ITensorUInt32Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt32Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -711,6 +867,9 @@ pub struct ITensorUInt32Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt32BitStatics, ITensorUInt32BitStatics_Vtbl, 0x417c3837_e773_4378_8e7f_0cc33dbea697);
+impl windows_core::RuntimeType for ITensorUInt32BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt32BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -729,6 +888,9 @@ pub struct ITensorUInt32BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt32BitStatics2, ITensorUInt32BitStatics2_Vtbl, 0xef1a1f1c_314e_569d_b496_5c8447d20cd2);
+impl windows_core::RuntimeType for ITensorUInt32BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt32BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -739,6 +901,9 @@ pub struct ITensorUInt32BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt64Bit, ITensorUInt64Bit_Vtbl, 0x2e70ffad_04bf_4825_839a_82baef8c7886);
+impl windows_core::RuntimeType for ITensorUInt64Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt64Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -748,6 +913,9 @@ pub struct ITensorUInt64Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt64BitStatics, ITensorUInt64BitStatics_Vtbl, 0x7a7e20eb_242f_47cb_a9c6_f602ecfbfee4);
+impl windows_core::RuntimeType for ITensorUInt64BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt64BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -766,6 +934,9 @@ pub struct ITensorUInt64BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt64BitStatics2, ITensorUInt64BitStatics2_Vtbl, 0x085a687d_67e1_5b1e_b232_4fabe9ca20b3);
+impl windows_core::RuntimeType for ITensorUInt64BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt64BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -776,6 +947,9 @@ pub struct ITensorUInt64BitStatics2_Vtbl {
     CreateFromBuffer: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt8Bit, ITensorUInt8Bit_Vtbl, 0x58e1ae27_622b_48e3_be22_d867aed1daac);
+impl windows_core::RuntimeType for ITensorUInt8Bit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt8Bit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -785,6 +959,9 @@ pub struct ITensorUInt8Bit_Vtbl {
     GetAsVectorView: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt8BitStatics, ITensorUInt8BitStatics_Vtbl, 0x05f67583_bc24_4220_8a41_2dcd8c5ed33c);
+impl windows_core::RuntimeType for ITensorUInt8BitStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt8BitStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -803,6 +980,9 @@ pub struct ITensorUInt8BitStatics_Vtbl {
     CreateFromIterable: usize,
 }
 windows_core::imp::define_interface!(ITensorUInt8BitStatics2, ITensorUInt8BitStatics2_Vtbl, 0x2ba042d6_373e_5a3a_a2fc_a6c41bd52789);
+impl windows_core::RuntimeType for ITensorUInt8BitStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITensorUInt8BitStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -885,7 +1065,7 @@ impl ImageFeatureDescriptor {
     }
 }
 impl windows_core::RuntimeType for ImageFeatureDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageFeatureDescriptor>();
 }
 unsafe impl windows_core::Interface for ImageFeatureDescriptor {
     type Vtable = IImageFeatureDescriptor_Vtbl;
@@ -934,7 +1114,7 @@ impl ImageFeatureValue {
     }
 }
 impl windows_core::RuntimeType for ImageFeatureValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageFeatureValue>();
 }
 unsafe impl windows_core::Interface for ImageFeatureValue {
     type Vtable = IImageFeatureValue_Vtbl;
@@ -1099,7 +1279,7 @@ impl LearningModel {
     }
 }
 impl windows_core::RuntimeType for LearningModel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILearningModel>();
 }
 unsafe impl windows_core::Interface for LearningModel {
     type Vtable = ILearningModel_Vtbl;
@@ -1190,7 +1370,7 @@ impl LearningModelBinding {
     }
 }
 impl windows_core::RuntimeType for LearningModelBinding {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILearningModelBinding>();
 }
 unsafe impl windows_core::Interface for LearningModelBinding {
     type Vtable = ILearningModelBinding_Vtbl;
@@ -1266,7 +1446,7 @@ impl LearningModelDevice {
     }
 }
 impl windows_core::RuntimeType for LearningModelDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILearningModelDevice>();
 }
 unsafe impl windows_core::Interface for LearningModelDevice {
     type Vtable = ILearningModelDevice_Vtbl;
@@ -1313,7 +1493,7 @@ impl LearningModelEvaluationResult {
     }
 }
 impl windows_core::RuntimeType for LearningModelEvaluationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILearningModelEvaluationResult>();
 }
 unsafe impl windows_core::Interface for LearningModelEvaluationResult {
     type Vtable = ILearningModelEvaluationResult_Vtbl;
@@ -1440,7 +1620,7 @@ impl LearningModelSession {
     }
 }
 impl windows_core::RuntimeType for LearningModelSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILearningModelSession>();
 }
 unsafe impl windows_core::Interface for LearningModelSession {
     type Vtable = ILearningModelSession_Vtbl;
@@ -1491,7 +1671,7 @@ impl LearningModelSessionOptions {
     }
 }
 impl windows_core::RuntimeType for LearningModelSessionOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILearningModelSessionOptions>();
 }
 unsafe impl windows_core::Interface for LearningModelSessionOptions {
     type Vtable = ILearningModelSessionOptions_Vtbl;
@@ -1552,7 +1732,7 @@ impl MapFeatureDescriptor {
     }
 }
 impl windows_core::RuntimeType for MapFeatureDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapFeatureDescriptor>();
 }
 unsafe impl windows_core::Interface for MapFeatureDescriptor {
     type Vtable = IMapFeatureDescriptor_Vtbl;
@@ -1606,7 +1786,7 @@ impl SequenceFeatureDescriptor {
     }
 }
 impl windows_core::RuntimeType for SequenceFeatureDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISequenceFeatureDescriptor>();
 }
 unsafe impl windows_core::Interface for SequenceFeatureDescriptor {
     type Vtable = ISequenceFeatureDescriptor_Vtbl;
@@ -1729,7 +1909,7 @@ impl TensorBoolean {
     }
 }
 impl windows_core::RuntimeType for TensorBoolean {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorBoolean>();
 }
 unsafe impl windows_core::Interface for TensorBoolean {
     type Vtable = ITensorBoolean_Vtbl;
@@ -1852,7 +2032,7 @@ impl TensorDouble {
     }
 }
 impl windows_core::RuntimeType for TensorDouble {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorDouble>();
 }
 unsafe impl windows_core::Interface for TensorDouble {
     type Vtable = ITensorDouble_Vtbl;
@@ -1914,7 +2094,7 @@ impl TensorFeatureDescriptor {
     }
 }
 impl windows_core::RuntimeType for TensorFeatureDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorFeatureDescriptor>();
 }
 unsafe impl windows_core::Interface for TensorFeatureDescriptor {
     type Vtable = ITensorFeatureDescriptor_Vtbl;
@@ -2037,7 +2217,7 @@ impl TensorFloat {
     }
 }
 impl windows_core::RuntimeType for TensorFloat {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorFloat>();
 }
 unsafe impl windows_core::Interface for TensorFloat {
     type Vtable = ITensorFloat_Vtbl;
@@ -2160,7 +2340,7 @@ impl TensorFloat16Bit {
     }
 }
 impl windows_core::RuntimeType for TensorFloat16Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorFloat16Bit>();
 }
 unsafe impl windows_core::Interface for TensorFloat16Bit {
     type Vtable = ITensorFloat16Bit_Vtbl;
@@ -2283,7 +2463,7 @@ impl TensorInt16Bit {
     }
 }
 impl windows_core::RuntimeType for TensorInt16Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorInt16Bit>();
 }
 unsafe impl windows_core::Interface for TensorInt16Bit {
     type Vtable = ITensorInt16Bit_Vtbl;
@@ -2406,7 +2586,7 @@ impl TensorInt32Bit {
     }
 }
 impl windows_core::RuntimeType for TensorInt32Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorInt32Bit>();
 }
 unsafe impl windows_core::Interface for TensorInt32Bit {
     type Vtable = ITensorInt32Bit_Vtbl;
@@ -2529,7 +2709,7 @@ impl TensorInt64Bit {
     }
 }
 impl windows_core::RuntimeType for TensorInt64Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorInt64Bit>();
 }
 unsafe impl windows_core::Interface for TensorInt64Bit {
     type Vtable = ITensorInt64Bit_Vtbl;
@@ -2652,7 +2832,7 @@ impl TensorInt8Bit {
     }
 }
 impl windows_core::RuntimeType for TensorInt8Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorInt8Bit>();
 }
 unsafe impl windows_core::Interface for TensorInt8Bit {
     type Vtable = ITensorInt8Bit_Vtbl;
@@ -2765,7 +2945,7 @@ impl TensorString {
     }
 }
 impl windows_core::RuntimeType for TensorString {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorString>();
 }
 unsafe impl windows_core::Interface for TensorString {
     type Vtable = ITensorString_Vtbl;
@@ -2888,7 +3068,7 @@ impl TensorUInt16Bit {
     }
 }
 impl windows_core::RuntimeType for TensorUInt16Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorUInt16Bit>();
 }
 unsafe impl windows_core::Interface for TensorUInt16Bit {
     type Vtable = ITensorUInt16Bit_Vtbl;
@@ -3011,7 +3191,7 @@ impl TensorUInt32Bit {
     }
 }
 impl windows_core::RuntimeType for TensorUInt32Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorUInt32Bit>();
 }
 unsafe impl windows_core::Interface for TensorUInt32Bit {
     type Vtable = ITensorUInt32Bit_Vtbl;
@@ -3134,7 +3314,7 @@ impl TensorUInt64Bit {
     }
 }
 impl windows_core::RuntimeType for TensorUInt64Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorUInt64Bit>();
 }
 unsafe impl windows_core::Interface for TensorUInt64Bit {
     type Vtable = ITensorUInt64Bit_Vtbl;
@@ -3257,7 +3437,7 @@ impl TensorUInt8Bit {
     }
 }
 impl windows_core::RuntimeType for TensorUInt8Bit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITensorUInt8Bit>();
 }
 unsafe impl windows_core::Interface for TensorUInt8Bit {
     type Vtable = ITensorUInt8Bit_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
@@ -636,6 +636,9 @@ pub struct ICommandLineActivatedEventArgs_Vtbl {
     pub Operation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICommandLineActivationOperation, ICommandLineActivationOperation_Vtbl, 0x994b2841_c59e_4f69_bcfd_b61ed4e622eb);
+impl windows_core::RuntimeType for ICommandLineActivationOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICommandLineActivationOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2519,6 +2522,9 @@ pub struct IShareTargetActivatedEventArgs_Vtbl {
     ShareOperation: usize,
 }
 windows_core::imp::define_interface!(ISplashScreen, ISplashScreen_Vtbl, 0xca4d975c_d4d6_43f0_97c0_0833c6391c24);
+impl windows_core::RuntimeType for ISplashScreen {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISplashScreen_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2568,6 +2574,9 @@ pub struct IStartupTaskActivatedEventArgs_Vtbl {
     pub TaskId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITileActivatedInfo, ITileActivatedInfo_Vtbl, 0x80e4a3b1_3980_4f17_b738_89194e0b8f65);
+impl windows_core::RuntimeType for ITileActivatedInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileActivatedInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2989,7 +2998,7 @@ impl AppointmentsProviderAddAppointmentActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentsProviderAddAppointmentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentsProviderAddAppointmentActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentsProviderAddAppointmentActivatedEventArgs {
     type Vtable = IAppointmentsProviderAddAppointmentActivatedEventArgs_Vtbl;
@@ -3052,7 +3061,7 @@ impl AppointmentsProviderRemoveAppointmentActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentsProviderRemoveAppointmentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentsProviderRemoveAppointmentActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentsProviderRemoveAppointmentActivatedEventArgs {
     type Vtable = IAppointmentsProviderRemoveAppointmentActivatedEventArgs_Vtbl;
@@ -3115,7 +3124,7 @@ impl AppointmentsProviderReplaceAppointmentActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentsProviderReplaceAppointmentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentsProviderReplaceAppointmentActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentsProviderReplaceAppointmentActivatedEventArgs {
     type Vtable = IAppointmentsProviderReplaceAppointmentActivatedEventArgs_Vtbl;
@@ -3191,7 +3200,7 @@ impl AppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
     type Vtable = IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs_Vtbl;
@@ -3260,7 +3269,7 @@ impl AppointmentsProviderShowTimeFrameActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentsProviderShowTimeFrameActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentsProviderShowTimeFrameActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentsProviderShowTimeFrameActivatedEventArgs {
     type Vtable = IAppointmentsProviderShowTimeFrameActivatedEventArgs_Vtbl;
@@ -3287,7 +3296,7 @@ impl BackgroundActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BackgroundActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for BackgroundActivatedEventArgs {
     type Vtable = IBackgroundActivatedEventArgs_Vtbl;
@@ -3342,7 +3351,7 @@ impl BarcodeScannerPreviewActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerPreviewActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerPreviewActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerPreviewActivatedEventArgs {
     type Vtable = IBarcodeScannerPreviewActivatedEventArgs_Vtbl;
@@ -3398,7 +3407,7 @@ impl CachedFileUpdaterActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CachedFileUpdaterActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICachedFileUpdaterActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for CachedFileUpdaterActivatedEventArgs {
     type Vtable = ICachedFileUpdaterActivatedEventArgs_Vtbl;
@@ -3452,7 +3461,7 @@ impl CameraSettingsActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CameraSettingsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraSettingsActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for CameraSettingsActivatedEventArgs {
     type Vtable = ICameraSettingsActivatedEventArgs_Vtbl;
@@ -3507,7 +3516,7 @@ impl CommandLineActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CommandLineActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICommandLineActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for CommandLineActivatedEventArgs {
     type Vtable = ICommandLineActivatedEventArgs_Vtbl;
@@ -3557,7 +3566,7 @@ impl CommandLineActivationOperation {
     }
 }
 impl windows_core::RuntimeType for CommandLineActivationOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICommandLineActivationOperation>();
 }
 unsafe impl windows_core::Interface for CommandLineActivationOperation {
     type Vtable = ICommandLineActivationOperation_Vtbl;
@@ -3626,7 +3635,7 @@ impl ContactCallActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactCallActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactCallActivatedEventArgs {
     type Vtable = IContactCallActivatedEventArgs_Vtbl;
@@ -3689,7 +3698,7 @@ impl ContactMapActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactMapActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactMapActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactMapActivatedEventArgs {
     type Vtable = IContactMapActivatedEventArgs_Vtbl;
@@ -3758,7 +3767,7 @@ impl ContactMessageActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactMessageActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactMessageActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactMessageActivatedEventArgs {
     type Vtable = IContactMessageActivatedEventArgs_Vtbl;
@@ -3822,7 +3831,7 @@ impl ContactPanelActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactPanelActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPanelActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactPanelActivatedEventArgs {
     type Vtable = IContactPanelActivatedEventArgs_Vtbl;
@@ -3870,7 +3879,7 @@ impl ContactPickerActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactPickerActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPickerActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactPickerActivatedEventArgs {
     type Vtable = IContactPickerActivatedEventArgs_Vtbl;
@@ -3939,7 +3948,7 @@ impl ContactPostActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactPostActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPostActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactPostActivatedEventArgs {
     type Vtable = IContactPostActivatedEventArgs_Vtbl;
@@ -4008,7 +4017,7 @@ impl ContactVideoCallActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactVideoCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactVideoCallActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactVideoCallActivatedEventArgs {
     type Vtable = IContactVideoCallActivatedEventArgs_Vtbl;
@@ -4085,7 +4094,7 @@ impl DeviceActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DeviceActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for DeviceActivatedEventArgs {
     type Vtable = IDeviceActivatedEventArgs_Vtbl;
@@ -4141,7 +4150,7 @@ impl DevicePairingActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DevicePairingActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePairingActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for DevicePairingActivatedEventArgs {
     type Vtable = IDevicePairingActivatedEventArgs_Vtbl;
@@ -4225,7 +4234,7 @@ impl DialReceiverActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DialReceiverActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialReceiverActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for DialReceiverActivatedEventArgs {
     type Vtable = IDialReceiverActivatedEventArgs_Vtbl;
@@ -4318,7 +4327,7 @@ impl FileActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for FileActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for FileActivatedEventArgs {
     type Vtable = IFileActivatedEventArgs_Vtbl;
@@ -4381,7 +4390,7 @@ impl FileOpenPickerActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for FileOpenPickerActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileOpenPickerActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for FileOpenPickerActivatedEventArgs {
     type Vtable = IFileOpenPickerActivatedEventArgs_Vtbl;
@@ -4450,7 +4459,7 @@ impl FileOpenPickerContinuationEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for FileOpenPickerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileOpenPickerContinuationEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for FileOpenPickerContinuationEventArgs {
@@ -4524,7 +4533,7 @@ impl FileSavePickerActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for FileSavePickerActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileSavePickerActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for FileSavePickerActivatedEventArgs {
     type Vtable = IFileSavePickerActivatedEventArgs_Vtbl;
@@ -4593,7 +4602,7 @@ impl FileSavePickerContinuationEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for FileSavePickerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileSavePickerContinuationEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for FileSavePickerContinuationEventArgs {
@@ -4666,7 +4675,7 @@ impl FolderPickerContinuationEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for FolderPickerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFolderPickerContinuationEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for FolderPickerContinuationEventArgs {
@@ -4761,7 +4770,7 @@ impl LaunchActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LaunchActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILaunchActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for LaunchActivatedEventArgs {
     type Vtable = ILaunchActivatedEventArgs_Vtbl;
@@ -4816,7 +4825,7 @@ impl LockScreenActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LockScreenActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for LockScreenActivatedEventArgs {
     type Vtable = ILockScreenActivatedEventArgs_Vtbl;
@@ -4893,7 +4902,7 @@ impl LockScreenCallActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LockScreenCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenCallActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for LockScreenCallActivatedEventArgs {
     type Vtable = ILockScreenCallActivatedEventArgs_Vtbl;
@@ -4933,7 +4942,7 @@ impl LockScreenComponentActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LockScreenComponentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for LockScreenComponentActivatedEventArgs {
     type Vtable = IActivatedEventArgs_Vtbl;
@@ -4988,7 +4997,7 @@ impl PhoneCallActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PhoneCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for PhoneCallActivatedEventArgs {
     type Vtable = IPhoneCallActivatedEventArgs_Vtbl;
@@ -5035,7 +5044,7 @@ impl PickerReturnedActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PickerReturnedActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPickerReturnedActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for PickerReturnedActivatedEventArgs {
     type Vtable = IPickerReturnedActivatedEventArgs_Vtbl;
@@ -5083,7 +5092,7 @@ impl Print3DWorkflowActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for Print3DWorkflowActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DWorkflowActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for Print3DWorkflowActivatedEventArgs {
     type Vtable = IPrint3DWorkflowActivatedEventArgs_Vtbl;
@@ -5131,7 +5140,7 @@ impl PrintTaskSettingsActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintTaskSettingsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskSettingsActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintTaskSettingsActivatedEventArgs {
     type Vtable = IPrintTaskSettingsActivatedEventArgs_Vtbl;
@@ -5216,7 +5225,7 @@ impl ProtocolActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ProtocolActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtocolActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ProtocolActivatedEventArgs {
     type Vtable = IProtocolActivatedEventArgs_Vtbl;
@@ -5309,7 +5318,7 @@ impl ProtocolForResultsActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ProtocolForResultsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtocolForResultsActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ProtocolForResultsActivatedEventArgs {
     type Vtable = IProtocolForResultsActivatedEventArgs_Vtbl;
@@ -5364,7 +5373,7 @@ impl RestrictedLaunchActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RestrictedLaunchActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRestrictedLaunchActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for RestrictedLaunchActivatedEventArgs {
     type Vtable = IRestrictedLaunchActivatedEventArgs_Vtbl;
@@ -5449,7 +5458,7 @@ impl SearchActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SearchActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for SearchActivatedEventArgs {
     type Vtable = ISearchActivatedEventArgs_Vtbl;
@@ -5505,7 +5514,7 @@ impl ShareTargetActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ShareTargetActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareTargetActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ShareTargetActivatedEventArgs {
     type Vtable = IShareTargetActivatedEventArgs_Vtbl;
@@ -5544,7 +5553,7 @@ impl SplashScreen {
     }
 }
 impl windows_core::RuntimeType for SplashScreen {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISplashScreen>();
 }
 unsafe impl windows_core::Interface for SplashScreen {
     type Vtable = ISplashScreen_Vtbl;
@@ -5597,7 +5606,7 @@ impl StartupTaskActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for StartupTaskActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStartupTaskActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for StartupTaskActivatedEventArgs {
     type Vtable = IStartupTaskActivatedEventArgs_Vtbl;
@@ -5623,7 +5632,7 @@ impl TileActivatedInfo {
     }
 }
 impl windows_core::RuntimeType for TileActivatedInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITileActivatedInfo>();
 }
 unsafe impl windows_core::Interface for TileActivatedInfo {
     type Vtable = ITileActivatedInfo_Vtbl;
@@ -5693,7 +5702,7 @@ impl ToastNotificationActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotificationActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ToastNotificationActivatedEventArgs {
     type Vtable = IToastNotificationActivatedEventArgs_Vtbl;
@@ -5741,7 +5750,7 @@ impl UserDataAccountProviderActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountProviderActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountProviderActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataAccountProviderActivatedEventArgs {
     type Vtable = IUserDataAccountProviderActivatedEventArgs_Vtbl;
@@ -5797,7 +5806,7 @@ impl VoiceCommandActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for VoiceCommandActivatedEventArgs {
     type Vtable = IVoiceCommandActivatedEventArgs_Vtbl;
@@ -5866,7 +5875,7 @@ impl WalletActionActivatedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletActionActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletActionActivatedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletActionActivatedEventArgs {
@@ -5926,7 +5935,7 @@ impl WebAccountProviderActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderActivatedEventArgs {
     type Vtable = IWebAccountProviderActivatedEventArgs_Vtbl;
@@ -5982,7 +5991,7 @@ impl WebAuthenticationBrokerContinuationEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebAuthenticationBrokerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAuthenticationBrokerContinuationEventArgs>();
 }
 unsafe impl windows_core::Interface for WebAuthenticationBrokerContinuationEventArgs {
     type Vtable = IWebAuthenticationBrokerContinuationEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/AppExtensions/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/AppExtensions/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppExtension, IAppExtension_Vtbl, 0x8450902c_15ed_4faf_93ea_2237bbf8cbd6);
+impl windows_core::RuntimeType for IAppExtension {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtension_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,12 +20,18 @@ pub struct IAppExtension_Vtbl {
     GetPublicFolderAsync: usize,
 }
 windows_core::imp::define_interface!(IAppExtension2, IAppExtension2_Vtbl, 0xab3b15f0_14f9_4b9f_9419_a349a242ef38);
+impl windows_core::RuntimeType for IAppExtension2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtension2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AppUserModelId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppExtensionCatalog, IAppExtensionCatalog_Vtbl, 0x97872032_8426_4ad1_9084_92e88c2da200);
+impl windows_core::RuntimeType for IAppExtensionCatalog {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtensionCatalog_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,12 +52,18 @@ pub struct IAppExtensionCatalog_Vtbl {
     pub RemovePackageStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppExtensionCatalogStatics, IAppExtensionCatalogStatics_Vtbl, 0x3c36668a_5f18_4f0b_9ce5_cab61d196f11);
+impl windows_core::RuntimeType for IAppExtensionCatalogStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtensionCatalogStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Open: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppExtensionPackageInstalledEventArgs, IAppExtensionPackageInstalledEventArgs_Vtbl, 0x39e59234_3351_4a8d_9745_e7d3dd45bc48);
+impl windows_core::RuntimeType for IAppExtensionPackageInstalledEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtensionPackageInstalledEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +75,9 @@ pub struct IAppExtensionPackageInstalledEventArgs_Vtbl {
     Extensions: usize,
 }
 windows_core::imp::define_interface!(IAppExtensionPackageStatusChangedEventArgs, IAppExtensionPackageStatusChangedEventArgs_Vtbl, 0x1ce17433_1153_44fd_87b1_8ae1050303df);
+impl windows_core::RuntimeType for IAppExtensionPackageStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtensionPackageStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +85,9 @@ pub struct IAppExtensionPackageStatusChangedEventArgs_Vtbl {
     pub Package: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppExtensionPackageUninstallingEventArgs, IAppExtensionPackageUninstallingEventArgs_Vtbl, 0x60f160c5_171e_40ff_ae98_ab2c20dd4d75);
+impl windows_core::RuntimeType for IAppExtensionPackageUninstallingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtensionPackageUninstallingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -74,6 +95,9 @@ pub struct IAppExtensionPackageUninstallingEventArgs_Vtbl {
     pub Package: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppExtensionPackageUpdatedEventArgs, IAppExtensionPackageUpdatedEventArgs_Vtbl, 0x3a83c43f_797e_44b5_ba24_a4c8b5a543d7);
+impl windows_core::RuntimeType for IAppExtensionPackageUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtensionPackageUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,6 +109,9 @@ pub struct IAppExtensionPackageUpdatedEventArgs_Vtbl {
     Extensions: usize,
 }
 windows_core::imp::define_interface!(IAppExtensionPackageUpdatingEventArgs, IAppExtensionPackageUpdatingEventArgs_Vtbl, 0x7ed59329_1a65_4800_a700_b321009e306a);
+impl windows_core::RuntimeType for IAppExtensionPackageUpdatingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExtensionPackageUpdatingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,7 +183,7 @@ impl AppExtension {
     }
 }
 impl windows_core::RuntimeType for AppExtension {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExtension>();
 }
 unsafe impl windows_core::Interface for AppExtension {
     type Vtable = IAppExtension_Vtbl;
@@ -270,7 +297,7 @@ impl AppExtensionCatalog {
     }
 }
 impl windows_core::RuntimeType for AppExtensionCatalog {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExtensionCatalog>();
 }
 unsafe impl windows_core::Interface for AppExtensionCatalog {
     type Vtable = IAppExtensionCatalog_Vtbl;
@@ -308,7 +335,7 @@ impl AppExtensionPackageInstalledEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppExtensionPackageInstalledEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExtensionPackageInstalledEventArgs>();
 }
 unsafe impl windows_core::Interface for AppExtensionPackageInstalledEventArgs {
     type Vtable = IAppExtensionPackageInstalledEventArgs_Vtbl;
@@ -340,7 +367,7 @@ impl AppExtensionPackageStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppExtensionPackageStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExtensionPackageStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppExtensionPackageStatusChangedEventArgs {
     type Vtable = IAppExtensionPackageStatusChangedEventArgs_Vtbl;
@@ -372,7 +399,7 @@ impl AppExtensionPackageUninstallingEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppExtensionPackageUninstallingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExtensionPackageUninstallingEventArgs>();
 }
 unsafe impl windows_core::Interface for AppExtensionPackageUninstallingEventArgs {
     type Vtable = IAppExtensionPackageUninstallingEventArgs_Vtbl;
@@ -412,7 +439,7 @@ impl AppExtensionPackageUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppExtensionPackageUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExtensionPackageUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppExtensionPackageUpdatedEventArgs {
     type Vtable = IAppExtensionPackageUpdatedEventArgs_Vtbl;
@@ -444,7 +471,7 @@ impl AppExtensionPackageUpdatingEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppExtensionPackageUpdatingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExtensionPackageUpdatingEventArgs>();
 }
 unsafe impl windows_core::Interface for AppExtensionPackageUpdatingEventArgs {
     type Vtable = IAppExtensionPackageUpdatingEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppServiceCatalogStatics, IAppServiceCatalogStatics_Vtbl, 0xef0d2507_d132_4c85_8395_3c31d5a1e941);
+impl windows_core::RuntimeType for IAppServiceCatalogStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceCatalogStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct IAppServiceCatalogStatics_Vtbl {
     FindAppServiceProvidersAsync: usize,
 }
 windows_core::imp::define_interface!(IAppServiceClosedEventArgs, IAppServiceClosedEventArgs_Vtbl, 0xde6016f6_cb03_4d35_ac8d_cc6303239731);
+impl windows_core::RuntimeType for IAppServiceClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppServiceClosedStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceConnection, IAppServiceConnection_Vtbl, 0x9dd474a2_871f_4d52_89a9_9e090531bd27);
+impl windows_core::RuntimeType for IAppServiceConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +41,9 @@ pub struct IAppServiceConnection_Vtbl {
     pub RemoveServiceClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceConnection2, IAppServiceConnection2_Vtbl, 0x8bdfcd5f_2302_4fbd_8061_52511c2f8bf9);
+impl windows_core::RuntimeType for IAppServiceConnection2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceConnection2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,6 +61,9 @@ pub struct IAppServiceConnection2_Vtbl {
     SetUser: usize,
 }
 windows_core::imp::define_interface!(IAppServiceConnectionStatics, IAppServiceConnectionStatics_Vtbl, 0xadc56ce9_d408_5673_8637_827a4b274168);
+impl windows_core::RuntimeType for IAppServiceConnectionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceConnectionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,12 +73,18 @@ pub struct IAppServiceConnectionStatics_Vtbl {
     SendStatelessMessageAsync: usize,
 }
 windows_core::imp::define_interface!(IAppServiceDeferral, IAppServiceDeferral_Vtbl, 0x7e1b5322_eab0_4248_ae04_fdf93838e472);
+impl windows_core::RuntimeType for IAppServiceDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceRequest, IAppServiceRequest_Vtbl, 0x20e58d9d_18de_4b01_80ba_90a76204e3c8);
+impl windows_core::RuntimeType for IAppServiceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +98,9 @@ pub struct IAppServiceRequest_Vtbl {
     SendResponseAsync: usize,
 }
 windows_core::imp::define_interface!(IAppServiceRequestReceivedEventArgs, IAppServiceRequestReceivedEventArgs_Vtbl, 0x6e122360_ff65_44ae_9e45_857fe4180681);
+impl windows_core::RuntimeType for IAppServiceRequestReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceRequestReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +108,9 @@ pub struct IAppServiceRequestReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceResponse, IAppServiceResponse_Vtbl, 0x8d503cec_9aa3_4e68_9559_9de63e372ce4);
+impl windows_core::RuntimeType for IAppServiceResponse {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceResponse_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +121,9 @@ pub struct IAppServiceResponse_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppServiceResponseStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceTriggerDetails, IAppServiceTriggerDetails_Vtbl, 0x88a2dcac_ad28_41b8_80bb_bdf1b2169e19);
+impl windows_core::RuntimeType for IAppServiceTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,24 +132,36 @@ pub struct IAppServiceTriggerDetails_Vtbl {
     pub AppServiceConnection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceTriggerDetails2, IAppServiceTriggerDetails2_Vtbl, 0xe83d54b2_28cc_43f2_b465_c0482e59e2dc);
+impl windows_core::RuntimeType for IAppServiceTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsRemoteSystemConnection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceTriggerDetails3, IAppServiceTriggerDetails3_Vtbl, 0xfbd71e21_7939_4e68_9e3c_7780147aabb6);
+impl windows_core::RuntimeType for IAppServiceTriggerDetails3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceTriggerDetails3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CheckCallerForCapabilityAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppServiceTriggerDetails4, IAppServiceTriggerDetails4_Vtbl, 0x1185b180_8861_5e30_ab55_1cf4d08bbf6d);
+impl windows_core::RuntimeType for IAppServiceTriggerDetails4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppServiceTriggerDetails4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CallerRemoteConnectionToken: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStatelessAppServiceResponse, IStatelessAppServiceResponse_Vtbl, 0x43754af7_a9ec_52fe_82e7_939b68dc9388);
+impl windows_core::RuntimeType for IStatelessAppServiceResponse {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStatelessAppServiceResponse_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,7 +203,7 @@ impl AppServiceClosedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppServiceClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppServiceClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppServiceClosedEventArgs {
     type Vtable = IAppServiceClosedEventArgs_Vtbl;
@@ -303,7 +345,7 @@ impl AppServiceConnection {
     }
 }
 impl windows_core::RuntimeType for AppServiceConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppServiceConnection>();
 }
 unsafe impl windows_core::Interface for AppServiceConnection {
     type Vtable = IAppServiceConnection_Vtbl;
@@ -325,7 +367,7 @@ impl AppServiceDeferral {
     }
 }
 impl windows_core::RuntimeType for AppServiceDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppServiceDeferral>();
 }
 unsafe impl windows_core::Interface for AppServiceDeferral {
     type Vtable = IAppServiceDeferral_Vtbl;
@@ -362,7 +404,7 @@ impl AppServiceRequest {
     }
 }
 impl windows_core::RuntimeType for AppServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppServiceRequest>();
 }
 unsafe impl windows_core::Interface for AppServiceRequest {
     type Vtable = IAppServiceRequest_Vtbl;
@@ -394,7 +436,7 @@ impl AppServiceRequestReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppServiceRequestReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppServiceRequestReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppServiceRequestReceivedEventArgs {
     type Vtable = IAppServiceRequestReceivedEventArgs_Vtbl;
@@ -427,7 +469,7 @@ impl AppServiceResponse {
     }
 }
 impl windows_core::RuntimeType for AppServiceResponse {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppServiceResponse>();
 }
 unsafe impl windows_core::Interface for AppServiceResponse {
     type Vtable = IAppServiceResponse_Vtbl;
@@ -487,7 +529,7 @@ impl AppServiceTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for AppServiceTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppServiceTriggerDetails>();
 }
 unsafe impl windows_core::Interface for AppServiceTriggerDetails {
     type Vtable = IAppServiceTriggerDetails_Vtbl;
@@ -520,7 +562,7 @@ impl StatelessAppServiceResponse {
     }
 }
 impl windows_core::RuntimeType for StatelessAppServiceResponse {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStatelessAppServiceResponse>();
 }
 unsafe impl windows_core::Interface for StatelessAppServiceResponse {
     type Vtable = IStatelessAppServiceResponse_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/AppointmentsProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/AppointmentsProvider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAddAppointmentOperation, IAddAppointmentOperation_Vtbl, 0xec4a9af3_620d_4c69_add7_9794e918081f);
+impl windows_core::RuntimeType for IAddAppointmentOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAddAppointmentOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IAddAppointmentOperation_Vtbl {
     pub DismissUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentsProviderLaunchActionVerbsStatics, IAppointmentsProviderLaunchActionVerbsStatics_Vtbl, 0x36dbba28_9e2e_49c6_8ef7_3ab7a5dcc8b8);
+impl windows_core::RuntimeType for IAppointmentsProviderLaunchActionVerbsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentsProviderLaunchActionVerbsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,12 +25,18 @@ pub struct IAppointmentsProviderLaunchActionVerbsStatics_Vtbl {
     pub ShowTimeFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentsProviderLaunchActionVerbsStatics2, IAppointmentsProviderLaunchActionVerbsStatics2_Vtbl, 0xef9049a4_af21_473c_88dc_76cd89f60ca5);
+impl windows_core::RuntimeType for IAppointmentsProviderLaunchActionVerbsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentsProviderLaunchActionVerbsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShowAppointmentDetails: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoveAppointmentOperation, IRemoveAppointmentOperation_Vtbl, 0x08b66aba_fe33_46cd_a50c_a8ffb3260537);
+impl windows_core::RuntimeType for IRemoveAppointmentOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoveAppointmentOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +49,9 @@ pub struct IRemoveAppointmentOperation_Vtbl {
     pub DismissUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReplaceAppointmentOperation, IReplaceAppointmentOperation_Vtbl, 0xf4903d9b_9e61_4de2_a732_2687c07d1de8);
+impl windows_core::RuntimeType for IReplaceAppointmentOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReplaceAppointmentOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,7 +101,7 @@ impl AddAppointmentOperation {
     }
 }
 impl windows_core::RuntimeType for AddAppointmentOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAddAppointmentOperation>();
 }
 unsafe impl windows_core::Interface for AddAppointmentOperation {
     type Vtable = IAddAppointmentOperation_Vtbl;
@@ -187,7 +202,7 @@ impl RemoveAppointmentOperation {
     }
 }
 impl windows_core::RuntimeType for RemoveAppointmentOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoveAppointmentOperation>();
 }
 unsafe impl windows_core::Interface for RemoveAppointmentOperation {
     type Vtable = IRemoveAppointmentOperation_Vtbl;
@@ -249,7 +264,7 @@ impl ReplaceAppointmentOperation {
     }
 }
 impl windows_core::RuntimeType for ReplaceAppointmentOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IReplaceAppointmentOperation>();
 }
 unsafe impl windows_core::Interface for ReplaceAppointmentOperation {
     type Vtable = IReplaceAppointmentOperation_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/DataProvider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppointmentCalendarCancelMeetingRequest, IAppointmentCalendarCancelMeetingRequest_Vtbl, 0x49460f8d_6434_40d7_ad46_6297419314d1);
+impl windows_core::RuntimeType for IAppointmentCalendarCancelMeetingRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarCancelMeetingRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct IAppointmentCalendarCancelMeetingRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarCancelMeetingRequestEventArgs, IAppointmentCalendarCancelMeetingRequestEventArgs_Vtbl, 0x1a79be16_7f30_4e35_beef_9d2c7b6dcae1);
+impl windows_core::RuntimeType for IAppointmentCalendarCancelMeetingRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarCancelMeetingRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +25,9 @@ pub struct IAppointmentCalendarCancelMeetingRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarCreateOrUpdateAppointmentRequest, IAppointmentCalendarCreateOrUpdateAppointmentRequest_Vtbl, 0x2e62f2b2_ca96_48ac_9124_406b19fefa70);
+impl windows_core::RuntimeType for IAppointmentCalendarCreateOrUpdateAppointmentRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarCreateOrUpdateAppointmentRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +42,9 @@ pub struct IAppointmentCalendarCreateOrUpdateAppointmentRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs, IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs_Vtbl, 0xcf8ded28_002e_4bf7_8e9d_5e20d49aa3ba);
+impl windows_core::RuntimeType for IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +52,9 @@ pub struct IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarForwardMeetingRequest, IAppointmentCalendarForwardMeetingRequest_Vtbl, 0x82e5ee56_26b6_4253_8a8f_6cf5f2ff7884);
+impl windows_core::RuntimeType for IAppointmentCalendarForwardMeetingRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarForwardMeetingRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +72,9 @@ pub struct IAppointmentCalendarForwardMeetingRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarForwardMeetingRequestEventArgs, IAppointmentCalendarForwardMeetingRequestEventArgs_Vtbl, 0x3109151a_23a2_42fd_9c82_c9a60d59f8a8);
+impl windows_core::RuntimeType for IAppointmentCalendarForwardMeetingRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarForwardMeetingRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,6 +82,9 @@ pub struct IAppointmentCalendarForwardMeetingRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarProposeNewTimeForMeetingRequest, IAppointmentCalendarProposeNewTimeForMeetingRequest_Vtbl, 0xce1c63f5_edf6_43c3_82b7_be6b368c6900);
+impl windows_core::RuntimeType for IAppointmentCalendarProposeNewTimeForMeetingRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarProposeNewTimeForMeetingRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +99,9 @@ pub struct IAppointmentCalendarProposeNewTimeForMeetingRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs, IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs_Vtbl, 0xd2d777d8_fed1_4280_a3ba_2e1f47609aa2);
+impl windows_core::RuntimeType for IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,6 +109,9 @@ pub struct IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarSyncManagerSyncRequest, IAppointmentCalendarSyncManagerSyncRequest_Vtbl, 0x12ab382b_7163_4a56_9a4e_7223a84adf46);
+impl windows_core::RuntimeType for IAppointmentCalendarSyncManagerSyncRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarSyncManagerSyncRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,6 +120,9 @@ pub struct IAppointmentCalendarSyncManagerSyncRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarSyncManagerSyncRequestEventArgs, IAppointmentCalendarSyncManagerSyncRequestEventArgs_Vtbl, 0xca17c6f7_0284_4edd_87ba_4d8f69dcf5c0);
+impl windows_core::RuntimeType for IAppointmentCalendarSyncManagerSyncRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarSyncManagerSyncRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,6 +130,9 @@ pub struct IAppointmentCalendarSyncManagerSyncRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarUpdateMeetingResponseRequest, IAppointmentCalendarUpdateMeetingResponseRequest_Vtbl, 0xa36d608c_c29d_4b94_b086_7e9ff7bd84a0);
+impl windows_core::RuntimeType for IAppointmentCalendarUpdateMeetingResponseRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarUpdateMeetingResponseRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +147,9 @@ pub struct IAppointmentCalendarUpdateMeetingResponseRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarUpdateMeetingResponseRequestEventArgs, IAppointmentCalendarUpdateMeetingResponseRequestEventArgs_Vtbl, 0x88759883_97bf_479d_aed5_0be8ce567d1e);
+impl windows_core::RuntimeType for IAppointmentCalendarUpdateMeetingResponseRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarUpdateMeetingResponseRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -121,6 +157,9 @@ pub struct IAppointmentCalendarUpdateMeetingResponseRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentDataProviderConnection, IAppointmentDataProviderConnection_Vtbl, 0xf3dd9d83_3254_465f_abdb_928046552cf4);
+impl windows_core::RuntimeType for IAppointmentDataProviderConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentDataProviderConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +178,9 @@ pub struct IAppointmentDataProviderConnection_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentDataProviderTriggerDetails, IAppointmentDataProviderTriggerDetails_Vtbl, 0xb3283c01_7e12_4e5e_b1ef_74fb68ac6f2a);
+impl windows_core::RuntimeType for IAppointmentDataProviderTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentDataProviderTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,7 +249,7 @@ impl AppointmentCalendarCancelMeetingRequest {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarCancelMeetingRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarCancelMeetingRequest>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarCancelMeetingRequest {
     type Vtable = IAppointmentCalendarCancelMeetingRequest_Vtbl;
@@ -239,7 +281,7 @@ impl AppointmentCalendarCancelMeetingRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarCancelMeetingRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarCancelMeetingRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarCancelMeetingRequestEventArgs {
     type Vtable = IAppointmentCalendarCancelMeetingRequestEventArgs_Vtbl;
@@ -303,7 +345,7 @@ impl AppointmentCalendarCreateOrUpdateAppointmentRequest {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarCreateOrUpdateAppointmentRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarCreateOrUpdateAppointmentRequest>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarCreateOrUpdateAppointmentRequest {
     type Vtable = IAppointmentCalendarCreateOrUpdateAppointmentRequest_Vtbl;
@@ -335,7 +377,7 @@ impl AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs {
     type Vtable = IAppointmentCalendarCreateOrUpdateAppointmentRequestEventArgs_Vtbl;
@@ -417,7 +459,7 @@ impl AppointmentCalendarForwardMeetingRequest {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarForwardMeetingRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarForwardMeetingRequest>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarForwardMeetingRequest {
     type Vtable = IAppointmentCalendarForwardMeetingRequest_Vtbl;
@@ -449,7 +491,7 @@ impl AppointmentCalendarForwardMeetingRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarForwardMeetingRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarForwardMeetingRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarForwardMeetingRequestEventArgs {
     type Vtable = IAppointmentCalendarForwardMeetingRequestEventArgs_Vtbl;
@@ -530,7 +572,7 @@ impl AppointmentCalendarProposeNewTimeForMeetingRequest {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarProposeNewTimeForMeetingRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarProposeNewTimeForMeetingRequest>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarProposeNewTimeForMeetingRequest {
     type Vtable = IAppointmentCalendarProposeNewTimeForMeetingRequest_Vtbl;
@@ -562,7 +604,7 @@ impl AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarProposeNewTimeForMeetingRequestEventArgs {
     type Vtable = IAppointmentCalendarProposeNewTimeForMeetingRequestEventArgs_Vtbl;
@@ -601,7 +643,7 @@ impl AppointmentCalendarSyncManagerSyncRequest {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarSyncManagerSyncRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarSyncManagerSyncRequest>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarSyncManagerSyncRequest {
     type Vtable = IAppointmentCalendarSyncManagerSyncRequest_Vtbl;
@@ -633,7 +675,7 @@ impl AppointmentCalendarSyncManagerSyncRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarSyncManagerSyncRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarSyncManagerSyncRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarSyncManagerSyncRequestEventArgs {
     type Vtable = IAppointmentCalendarSyncManagerSyncRequestEventArgs_Vtbl;
@@ -714,7 +756,7 @@ impl AppointmentCalendarUpdateMeetingResponseRequest {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarUpdateMeetingResponseRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarUpdateMeetingResponseRequest>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarUpdateMeetingResponseRequest {
     type Vtable = IAppointmentCalendarUpdateMeetingResponseRequest_Vtbl;
@@ -746,7 +788,7 @@ impl AppointmentCalendarUpdateMeetingResponseRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarUpdateMeetingResponseRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarUpdateMeetingResponseRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarUpdateMeetingResponseRequestEventArgs {
     type Vtable = IAppointmentCalendarUpdateMeetingResponseRequestEventArgs_Vtbl;
@@ -852,7 +894,7 @@ impl AppointmentDataProviderConnection {
     }
 }
 impl windows_core::RuntimeType for AppointmentDataProviderConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentDataProviderConnection>();
 }
 unsafe impl windows_core::Interface for AppointmentDataProviderConnection {
     type Vtable = IAppointmentDataProviderConnection_Vtbl;
@@ -877,7 +919,7 @@ impl AppointmentDataProviderTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for AppointmentDataProviderTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentDataProviderTriggerDetails>();
 }
 unsafe impl windows_core::Interface for AppointmentDataProviderTriggerDetails {
     type Vtable = IAppointmentDataProviderTriggerDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
@@ -3,6 +3,9 @@ pub mod AppointmentsProvider;
 #[cfg(feature = "ApplicationModel_Appointments_DataProvider")]
 pub mod DataProvider;
 windows_core::imp::define_interface!(IAppointment, IAppointment_Vtbl, 0xdd002f2f_2bdd_4076_90a3_22c275312965);
+impl windows_core::RuntimeType for IAppointment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +39,9 @@ pub struct IAppointment_Vtbl {
     pub SetUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointment2, IAppointment2_Vtbl, 0x5e85983c_540f_3452_9b5c_0dd7ad4c65a2);
+impl windows_core::RuntimeType for IAppointment2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointment2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +67,9 @@ pub struct IAppointment2_Vtbl {
     pub SetIsOrganizedByUser: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointment3, IAppointment3_Vtbl, 0xbfcc45a9_8961_4991_934b_c48768e5a96c);
+impl windows_core::RuntimeType for IAppointment3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointment3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +80,9 @@ pub struct IAppointment3_Vtbl {
     pub SetDetailsKind: unsafe extern "system" fn(*mut core::ffi::c_void, AppointmentDetailsKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendar, IAppointmentCalendar_Vtbl, 0x5273819d_8339_3d4f_a02f_64084452bb5d);
+impl windows_core::RuntimeType for IAppointmentCalendar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,6 +138,9 @@ pub struct IAppointmentCalendar_Vtbl {
     pub SaveAppointmentAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendar2, IAppointmentCalendar2_Vtbl, 0x18e7e422_2467_4e1c_a459_d8a29303d092);
+impl windows_core::RuntimeType for IAppointmentCalendar2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendar2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -162,12 +177,18 @@ pub struct IAppointmentCalendar2_Vtbl {
     pub TryUpdateMeetingResponseAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, AppointmentParticipantResponse, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendar3, IAppointmentCalendar3_Vtbl, 0xeb23d22b_a685_42ae_8495_b3119adb4167);
+impl windows_core::RuntimeType for IAppointmentCalendar3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendar3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RegisterSyncManagerAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarSyncManager, IAppointmentCalendarSyncManager_Vtbl, 0x2b21b3a0_4aff_4392_bc5f_5645ffcffb17);
+impl windows_core::RuntimeType for IAppointmentCalendarSyncManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarSyncManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,6 +200,9 @@ pub struct IAppointmentCalendarSyncManager_Vtbl {
     pub RemoveSyncStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentCalendarSyncManager2, IAppointmentCalendarSyncManager2_Vtbl, 0x647528ad_0d29_4c7c_aaa7_bf996805537c);
+impl windows_core::RuntimeType for IAppointmentCalendarSyncManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentCalendarSyncManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -187,6 +211,9 @@ pub struct IAppointmentCalendarSyncManager2_Vtbl {
     pub SetLastAttemptedSyncTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentConflictResult, IAppointmentConflictResult_Vtbl, 0xd5cdf0be_2f2f_3b7d_af0a_a7e20f3a46e3);
+impl windows_core::RuntimeType for IAppointmentConflictResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentConflictResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -194,6 +221,9 @@ pub struct IAppointmentConflictResult_Vtbl {
     pub Date: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentException, IAppointmentException_Vtbl, 0xa2076767_16f6_4bce_9f5a_8600b8019fcb);
+impl windows_core::RuntimeType for IAppointmentException {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentException_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -205,6 +235,9 @@ pub struct IAppointmentException_Vtbl {
     pub IsDeleted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentInvitee, IAppointmentInvitee_Vtbl, 0x13bf0796_9842_495b_b0e7_ef8f79c0701d);
+impl windows_core::RuntimeType for IAppointmentInvitee {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentInvitee_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,6 +247,9 @@ pub struct IAppointmentInvitee_Vtbl {
     pub SetResponse: unsafe extern "system" fn(*mut core::ffi::c_void, AppointmentParticipantResponse) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentManagerForUser, IAppointmentManagerForUser_Vtbl, 0x70261423_73cc_4660_b318_b01365302a03);
+impl windows_core::RuntimeType for IAppointmentManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -251,6 +287,9 @@ pub struct IAppointmentManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IAppointmentManagerStatics, IAppointmentManagerStatics_Vtbl, 0x3a30fa01_5c40_499d_b33f_a43050f74fc4);
+impl windows_core::RuntimeType for IAppointmentManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -280,6 +319,9 @@ pub struct IAppointmentManagerStatics_Vtbl {
     pub ShowTimeFrameAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime, super::super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentManagerStatics2, IAppointmentManagerStatics2_Vtbl, 0x0a81f60d_d04f_4034_af72_a36573b45ff0);
+impl windows_core::RuntimeType for IAppointmentManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -289,6 +331,9 @@ pub struct IAppointmentManagerStatics2_Vtbl {
     pub RequestStoreAsync: unsafe extern "system" fn(*mut core::ffi::c_void, AppointmentStoreAccessType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentManagerStatics3, IAppointmentManagerStatics3_Vtbl, 0x2f9ae09c_b34c_4dc7_a35d_cafd88ae3ec6);
+impl windows_core::RuntimeType for IAppointmentManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -335,6 +380,9 @@ pub struct IAppointmentParticipant_Vtbl {
     pub SetAddress: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentPropertiesStatics, IAppointmentPropertiesStatics_Vtbl, 0x25141fe9_68ae_3aae_855f_bc4441caa234);
+impl windows_core::RuntimeType for IAppointmentPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -366,6 +414,9 @@ pub struct IAppointmentPropertiesStatics_Vtbl {
     DefaultProperties: usize,
 }
 windows_core::imp::define_interface!(IAppointmentPropertiesStatics2, IAppointmentPropertiesStatics2_Vtbl, 0xdffc434b_b017_45dd_8af5_d163d10801bb);
+impl windows_core::RuntimeType for IAppointmentPropertiesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentPropertiesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -374,6 +425,9 @@ pub struct IAppointmentPropertiesStatics2_Vtbl {
     pub DetailsKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentRecurrence, IAppointmentRecurrence_Vtbl, 0xd87b3e83_15a6_487b_b959_0c361e60e954);
+impl windows_core::RuntimeType for IAppointmentRecurrence {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentRecurrence_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -395,6 +449,9 @@ pub struct IAppointmentRecurrence_Vtbl {
     pub SetDay: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentRecurrence2, IAppointmentRecurrence2_Vtbl, 0x3df3a2e0_05a7_4f50_9f86_b03f9436254d);
+impl windows_core::RuntimeType for IAppointmentRecurrence2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentRecurrence2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -403,12 +460,18 @@ pub struct IAppointmentRecurrence2_Vtbl {
     pub SetTimeZone: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentRecurrence3, IAppointmentRecurrence3_Vtbl, 0x89ff96d9_da4d_4a17_8dd2_1cebc2b5ff9d);
+impl windows_core::RuntimeType for IAppointmentRecurrence3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentRecurrence3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CalendarIdentifier: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStore, IAppointmentStore_Vtbl, 0xa461918c_7a47_4d96_96c9_15cd8a05a735);
+impl windows_core::RuntimeType for IAppointmentStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -456,6 +519,9 @@ pub struct IAppointmentStore_Vtbl {
     FindLocalIdsFromRoamingIdAsync: usize,
 }
 windows_core::imp::define_interface!(IAppointmentStore2, IAppointmentStore2_Vtbl, 0x25c48c20_1c41_424f_8084_67c1cfe0a854);
+impl windows_core::RuntimeType for IAppointmentStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -464,12 +530,18 @@ pub struct IAppointmentStore2_Vtbl {
     pub CreateAppointmentCalendarInAccountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStore3, IAppointmentStore3_Vtbl, 0x4251940b_b078_470a_9a40_c2e01761f72f);
+impl windows_core::RuntimeType for IAppointmentStore3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStore3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetChangeTracker: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreChange, IAppointmentStoreChange_Vtbl, 0xa5a6e035_0a33_3654_8463_b543e90c3b79);
+impl windows_core::RuntimeType for IAppointmentStoreChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -477,12 +549,18 @@ pub struct IAppointmentStoreChange_Vtbl {
     pub ChangeType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppointmentStoreChangeType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreChange2, IAppointmentStoreChange2_Vtbl, 0xb37d0dce_5211_4402_a608_a96fe70b8ee2);
+impl windows_core::RuntimeType for IAppointmentStoreChange2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreChange2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AppointmentCalendar: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreChangeReader, IAppointmentStoreChangeReader_Vtbl, 0x8b2409f1_65f3_42a0_961d_4c209bf30370);
+impl windows_core::RuntimeType for IAppointmentStoreChangeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreChangeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -494,6 +572,9 @@ pub struct IAppointmentStoreChangeReader_Vtbl {
     pub AcceptChangesThrough: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreChangeTracker, IAppointmentStoreChangeTracker_Vtbl, 0x1b25f4b1_8ece_4f17_93c8_e6412458fd5c);
+impl windows_core::RuntimeType for IAppointmentStoreChangeTracker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreChangeTracker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -502,29 +583,44 @@ pub struct IAppointmentStoreChangeTracker_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreChangeTracker2, IAppointmentStoreChangeTracker2_Vtbl, 0xb66aaf45_9542_4cf7_8550_eb370e0c08d3);
+impl windows_core::RuntimeType for IAppointmentStoreChangeTracker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreChangeTracker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsTracking: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreChangedDeferral, IAppointmentStoreChangedDeferral_Vtbl, 0x4cb82026_fedb_4bc3_9662_95a9befdf4df);
+impl windows_core::RuntimeType for IAppointmentStoreChangedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreChangedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreChangedEventArgs, IAppointmentStoreChangedEventArgs_Vtbl, 0x2285f8b9_0791_417e_bfea_cc6d41636c8c);
+impl windows_core::RuntimeType for IAppointmentStoreChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppointmentStoreNotificationTriggerDetails, IAppointmentStoreNotificationTriggerDetails_Vtbl, 0x9b33cb11_c301_421e_afef_047ecfa76adb);
+impl windows_core::RuntimeType for IAppointmentStoreNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IFindAppointmentsOptions, IFindAppointmentsOptions_Vtbl, 0x55f7dc55_9942_3086_82b5_2cb29f64d5f5);
+impl windows_core::RuntimeType for IFindAppointmentsOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFindAppointmentsOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -855,7 +951,7 @@ impl Appointment {
     }
 }
 impl windows_core::RuntimeType for Appointment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointment>();
 }
 unsafe impl windows_core::Interface for Appointment {
     type Vtable = IAppointment_Vtbl;
@@ -1233,7 +1329,7 @@ impl AppointmentCalendar {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendar>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendar {
     type Vtable = IAppointmentCalendar_Vtbl;
@@ -1305,7 +1401,7 @@ impl AppointmentCalendarSyncManager {
     }
 }
 impl windows_core::RuntimeType for AppointmentCalendarSyncManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentCalendarSyncManager>();
 }
 unsafe impl windows_core::Interface for AppointmentCalendarSyncManager {
     type Vtable = IAppointmentCalendarSyncManager_Vtbl;
@@ -1337,7 +1433,7 @@ impl AppointmentConflictResult {
     }
 }
 impl windows_core::RuntimeType for AppointmentConflictResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentConflictResult>();
 }
 unsafe impl windows_core::Interface for AppointmentConflictResult {
     type Vtable = IAppointmentConflictResult_Vtbl;
@@ -1377,7 +1473,7 @@ impl AppointmentException {
     }
 }
 impl windows_core::RuntimeType for AppointmentException {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentException>();
 }
 unsafe impl windows_core::Interface for AppointmentException {
     type Vtable = IAppointmentException_Vtbl;
@@ -1447,7 +1543,7 @@ impl AppointmentInvitee {
     }
 }
 impl windows_core::RuntimeType for AppointmentInvitee {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentInvitee>();
 }
 unsafe impl windows_core::Interface for AppointmentInvitee {
     type Vtable = IAppointmentInvitee_Vtbl;
@@ -1719,7 +1815,7 @@ impl AppointmentManagerForUser {
     }
 }
 impl windows_core::RuntimeType for AppointmentManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentManagerForUser>();
 }
 unsafe impl windows_core::Interface for AppointmentManagerForUser {
     type Vtable = IAppointmentManagerForUser_Vtbl;
@@ -1767,7 +1863,7 @@ impl AppointmentOrganizer {
     }
 }
 impl windows_core::RuntimeType for AppointmentOrganizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentParticipant>();
 }
 unsafe impl windows_core::Interface for AppointmentOrganizer {
     type Vtable = IAppointmentParticipant_Vtbl;
@@ -2084,7 +2180,7 @@ impl AppointmentRecurrence {
     }
 }
 impl windows_core::RuntimeType for AppointmentRecurrence {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentRecurrence>();
 }
 unsafe impl windows_core::Interface for AppointmentRecurrence {
     type Vtable = IAppointmentRecurrence_Vtbl;
@@ -2309,7 +2405,7 @@ impl AppointmentStore {
     }
 }
 impl windows_core::RuntimeType for AppointmentStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStore>();
 }
 unsafe impl windows_core::Interface for AppointmentStore {
     type Vtable = IAppointmentStore_Vtbl;
@@ -2348,7 +2444,7 @@ impl AppointmentStoreChange {
     }
 }
 impl windows_core::RuntimeType for AppointmentStoreChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStoreChange>();
 }
 unsafe impl windows_core::Interface for AppointmentStoreChange {
     type Vtable = IAppointmentStoreChange_Vtbl;
@@ -2385,7 +2481,7 @@ impl AppointmentStoreChangeReader {
     }
 }
 impl windows_core::RuntimeType for AppointmentStoreChangeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStoreChangeReader>();
 }
 unsafe impl windows_core::Interface for AppointmentStoreChangeReader {
     type Vtable = IAppointmentStoreChangeReader_Vtbl;
@@ -2425,7 +2521,7 @@ impl AppointmentStoreChangeTracker {
     }
 }
 impl windows_core::RuntimeType for AppointmentStoreChangeTracker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStoreChangeTracker>();
 }
 unsafe impl windows_core::Interface for AppointmentStoreChangeTracker {
     type Vtable = IAppointmentStoreChangeTracker_Vtbl;
@@ -2447,7 +2543,7 @@ impl AppointmentStoreChangedDeferral {
     }
 }
 impl windows_core::RuntimeType for AppointmentStoreChangedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStoreChangedDeferral>();
 }
 unsafe impl windows_core::Interface for AppointmentStoreChangedDeferral {
     type Vtable = IAppointmentStoreChangedDeferral_Vtbl;
@@ -2472,7 +2568,7 @@ impl AppointmentStoreChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppointmentStoreChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStoreChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppointmentStoreChangedEventArgs {
     type Vtable = IAppointmentStoreChangedEventArgs_Vtbl;
@@ -2489,7 +2585,7 @@ pub struct AppointmentStoreNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppointmentStoreNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl AppointmentStoreNotificationTriggerDetails {}
 impl windows_core::RuntimeType for AppointmentStoreNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStoreNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for AppointmentStoreNotificationTriggerDetails {
     type Vtable = IAppointmentStoreNotificationTriggerDetails_Vtbl;
@@ -2552,7 +2648,7 @@ impl FindAppointmentsOptions {
     }
 }
 impl windows_core::RuntimeType for FindAppointmentsOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFindAppointmentsOptions>();
 }
 unsafe impl windows_core::Interface for FindAppointmentsOptions {
     type Vtable = IFindAppointmentsOptions_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IActivitySensorTrigger, IActivitySensorTrigger_Vtbl, 0xd0dd4342_e37b_4823_a5fe_6b31dfefdeb0);
+impl windows_core::RuntimeType for IActivitySensorTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensorTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,12 +17,18 @@ pub struct IActivitySensorTrigger_Vtbl {
     pub MinimumReportInterval: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivitySensorTriggerFactory, IActivitySensorTriggerFactory_Vtbl, 0xa72691c3_3837_44f7_831b_0132cc872bc3);
+impl windows_core::RuntimeType for IActivitySensorTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensorTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAlarmApplicationManagerStatics, IAlarmApplicationManagerStatics_Vtbl, 0xca03fa3b_cce6_4de2_b09b_9628bd33bbbe);
+impl windows_core::RuntimeType for IAlarmApplicationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAlarmApplicationManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +36,9 @@ pub struct IAlarmApplicationManagerStatics_Vtbl {
     pub GetAccessStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AlarmAccessStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastTrigger, IAppBroadcastTrigger_Vtbl, 0x74d4f496_8d37_44ec_9481_2a0b9854eb48);
+impl windows_core::RuntimeType for IAppBroadcastTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,12 +46,18 @@ pub struct IAppBroadcastTrigger_Vtbl {
     pub ProviderInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastTriggerFactory, IAppBroadcastTriggerFactory_Vtbl, 0x280b9f44_22f4_4618_a02e_e7e411eb7238);
+impl windows_core::RuntimeType for IAppBroadcastTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateAppBroadcastTrigger: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastTriggerProviderInfo, IAppBroadcastTriggerProviderInfo_Vtbl, 0xf219352d_9de8_4420_9ce2_5eff8f17376b);
+impl windows_core::RuntimeType for IAppBroadcastTriggerProviderInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastTriggerProviderInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +75,9 @@ pub struct IAppBroadcastTriggerProviderInfo_Vtbl {
     pub MaxVideoHeight: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationTrigger, IApplicationTrigger_Vtbl, 0x0b468630_9574_492c_9e93_1a3ae6335fe9);
+impl windows_core::RuntimeType for IApplicationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +88,9 @@ pub struct IApplicationTrigger_Vtbl {
     RequestAsyncWithArguments: usize,
 }
 windows_core::imp::define_interface!(IApplicationTriggerDetails, IApplicationTriggerDetails_Vtbl, 0x97dc6ab2_2219_4a9e_9c5e_41d047f76e82);
+impl windows_core::RuntimeType for IApplicationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +100,9 @@ pub struct IApplicationTriggerDetails_Vtbl {
     Arguments: usize,
 }
 windows_core::imp::define_interface!(IAppointmentStoreNotificationTrigger, IAppointmentStoreNotificationTrigger_Vtbl, 0x64d4040c_c201_42ad_aa2a_e21ba3425b6d);
+impl windows_core::RuntimeType for IAppointmentStoreNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppointmentStoreNotificationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,6 +118,9 @@ pub struct IBackgroundCondition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IBackgroundExecutionManagerStatics, IBackgroundExecutionManagerStatics_Vtbl, 0xe826ea58_66a9_4d41_83d4_b4c18c87b846);
+impl windows_core::RuntimeType for IBackgroundExecutionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundExecutionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,12 +132,18 @@ pub struct IBackgroundExecutionManagerStatics_Vtbl {
     pub GetAccessStatusForApplication: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut BackgroundAccessStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundExecutionManagerStatics2, IBackgroundExecutionManagerStatics2_Vtbl, 0x469b24ef_9bbb_4e18_999a_fd6512931be9);
+impl windows_core::RuntimeType for IBackgroundExecutionManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundExecutionManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestAccessKindAsync: unsafe extern "system" fn(*mut core::ffi::c_void, BackgroundAccessRequestKind, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundExecutionManagerStatics3, IBackgroundExecutionManagerStatics3_Vtbl, 0x98a5d3f6_5a25_5b6c_9192_d77a43dfedc4);
+impl windows_core::RuntimeType for IBackgroundExecutionManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundExecutionManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,6 +171,9 @@ pub struct IBackgroundTask_Vtbl {
     pub Run: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskBuilder, IBackgroundTaskBuilder_Vtbl, 0x0351550e_3e64_4572_a93a_84075a37c917);
+impl windows_core::RuntimeType for IBackgroundTaskBuilder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskBuilder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,6 +186,9 @@ pub struct IBackgroundTaskBuilder_Vtbl {
     pub Register: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskBuilder2, IBackgroundTaskBuilder2_Vtbl, 0x6ae7cfb1_104f_406d_8db6_844a570f42bb);
+impl windows_core::RuntimeType for IBackgroundTaskBuilder2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskBuilder2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,6 +196,9 @@ pub struct IBackgroundTaskBuilder2_Vtbl {
     pub CancelOnConditionLoss: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskBuilder3, IBackgroundTaskBuilder3_Vtbl, 0x28c74f4a_8ba9_4c09_a24f_19683e2c924c);
+impl windows_core::RuntimeType for IBackgroundTaskBuilder3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskBuilder3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +206,9 @@ pub struct IBackgroundTaskBuilder3_Vtbl {
     pub IsNetworkRequested: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskBuilder4, IBackgroundTaskBuilder4_Vtbl, 0x4755e522_cba2_4e35_bd16_a6da7f1c19aa);
+impl windows_core::RuntimeType for IBackgroundTaskBuilder4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskBuilder4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -168,12 +216,18 @@ pub struct IBackgroundTaskBuilder4_Vtbl {
     pub SetTaskGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskBuilder5, IBackgroundTaskBuilder5_Vtbl, 0x077103f6_99f5_4af4_bcad_4731d0330d43);
+impl windows_core::RuntimeType for IBackgroundTaskBuilder5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskBuilder5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetTaskEntryPointClsid: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskCompletedEventArgs, IBackgroundTaskCompletedEventArgs_Vtbl, 0x565d25cf_f209_48f4_9967_2b184f7bfbf0);
+impl windows_core::RuntimeType for IBackgroundTaskCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,6 +235,9 @@ pub struct IBackgroundTaskCompletedEventArgs_Vtbl {
     pub CheckResult: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskDeferral, IBackgroundTaskDeferral_Vtbl, 0x93cc156d_af27_4dd3_846e_24ee40cadd25);
+impl windows_core::RuntimeType for IBackgroundTaskDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -431,6 +488,9 @@ pub struct IBackgroundTaskInstance4_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IBackgroundTaskProgressEventArgs, IBackgroundTaskProgressEventArgs_Vtbl, 0xfb1468ac_8332_4d0a_9532_03eae684da31);
+impl windows_core::RuntimeType for IBackgroundTaskProgressEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskProgressEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -634,6 +694,9 @@ pub struct IBackgroundTaskRegistration3_Vtbl {
     pub TaskGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskRegistrationGroup, IBackgroundTaskRegistrationGroup_Vtbl, 0x2ab1919a_871b_4167_8a76_055cd67b5b23);
+impl windows_core::RuntimeType for IBackgroundTaskRegistrationGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskRegistrationGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -650,6 +713,9 @@ pub struct IBackgroundTaskRegistrationGroup_Vtbl {
     AllTasks: usize,
 }
 windows_core::imp::define_interface!(IBackgroundTaskRegistrationGroupFactory, IBackgroundTaskRegistrationGroupFactory_Vtbl, 0x83d92b69_44cf_4631_9740_03c7d8741bc5);
+impl windows_core::RuntimeType for IBackgroundTaskRegistrationGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskRegistrationGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -657,6 +723,9 @@ pub struct IBackgroundTaskRegistrationGroupFactory_Vtbl {
     pub CreateWithName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTaskRegistrationStatics, IBackgroundTaskRegistrationStatics_Vtbl, 0x4c542f69_b000_42ba_a093_6a563c65e3f8);
+impl windows_core::RuntimeType for IBackgroundTaskRegistrationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskRegistrationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -666,6 +735,9 @@ pub struct IBackgroundTaskRegistrationStatics_Vtbl {
     AllTasks: usize,
 }
 windows_core::imp::define_interface!(IBackgroundTaskRegistrationStatics2, IBackgroundTaskRegistrationStatics2_Vtbl, 0x174b671e_b20d_4fa9_ad9a_e93ad6c71e01);
+impl windows_core::RuntimeType for IBackgroundTaskRegistrationStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTaskRegistrationStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -686,12 +758,18 @@ pub struct IBackgroundTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IBackgroundWorkCostStatics, IBackgroundWorkCostStatics_Vtbl, 0xc740a662_c310_4b82_b3e3_3bcfb9e4c77d);
+impl windows_core::RuntimeType for IBackgroundWorkCostStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundWorkCostStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CurrentBackgroundWorkCost: unsafe extern "system" fn(*mut core::ffi::c_void, *mut BackgroundWorkCostValue) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisherTrigger, IBluetoothLEAdvertisementPublisherTrigger_Vtbl, 0xab3e2612_25d3_48ae_8724_d81877ae6129);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisherTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisherTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -701,6 +779,9 @@ pub struct IBluetoothLEAdvertisementPublisherTrigger_Vtbl {
     Advertisement: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisherTrigger2, IBluetoothLEAdvertisementPublisherTrigger2_Vtbl, 0xaa28d064_38f4_597d_b597_4e55588c6503);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisherTrigger2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisherTrigger2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -714,6 +795,9 @@ pub struct IBluetoothLEAdvertisementPublisherTrigger2_Vtbl {
     pub SetIncludeTransmitPowerLevel: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementWatcherTrigger, IBluetoothLEAdvertisementWatcherTrigger_Vtbl, 0x1aab1819_bce1_48eb_a827_59fb7cee52a6);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementWatcherTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementWatcherTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -739,6 +823,9 @@ pub struct IBluetoothLEAdvertisementWatcherTrigger_Vtbl {
     SetAdvertisementFilter: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementWatcherTrigger2, IBluetoothLEAdvertisementWatcherTrigger2_Vtbl, 0x39b56799_eb39_5ab6_9932_aa9e4549604d);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementWatcherTrigger2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementWatcherTrigger2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -746,11 +833,17 @@ pub struct IBluetoothLEAdvertisementWatcherTrigger2_Vtbl {
     pub SetAllowExtendedAdvertisements: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICachedFileUpdaterTrigger, ICachedFileUpdaterTrigger_Vtbl, 0xe21caeeb_32f2_4d31_b553_b9e01bde37e0);
+impl windows_core::RuntimeType for ICachedFileUpdaterTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICachedFileUpdaterTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICachedFileUpdaterTriggerDetails, ICachedFileUpdaterTriggerDetails_Vtbl, 0x71838c13_1314_47b4_9597_dc7e248c17cc);
+impl windows_core::RuntimeType for ICachedFileUpdaterTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICachedFileUpdaterTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -765,38 +858,59 @@ pub struct ICachedFileUpdaterTriggerDetails_Vtbl {
     pub CanRequestUserInput: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageNotificationTrigger, IChatMessageNotificationTrigger_Vtbl, 0x513b43bf_1d40_5c5d_78f5_c923fee3739e);
+impl windows_core::RuntimeType for IChatMessageNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageNotificationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IChatMessageReceivedNotificationTrigger, IChatMessageReceivedNotificationTrigger_Vtbl, 0x3ea3760e_baf5_4077_88e9_060cf6f0c6d5);
+impl windows_core::RuntimeType for IChatMessageReceivedNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageReceivedNotificationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICommunicationBlockingAppSetAsActiveTrigger, ICommunicationBlockingAppSetAsActiveTrigger_Vtbl, 0xfb91f28a_16a5_486d_974c_7835a8477be2);
+impl windows_core::RuntimeType for ICommunicationBlockingAppSetAsActiveTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICommunicationBlockingAppSetAsActiveTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IContactStoreNotificationTrigger, IContactStoreNotificationTrigger_Vtbl, 0xc833419b_4705_4571_9a16_06b997bf9c96);
+impl windows_core::RuntimeType for IContactStoreNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStoreNotificationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IContentPrefetchTrigger, IContentPrefetchTrigger_Vtbl, 0x710627ee_04fa_440b_80c0_173202199e5d);
+impl windows_core::RuntimeType for IContentPrefetchTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentPrefetchTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub WaitInterval: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContentPrefetchTriggerFactory, IContentPrefetchTriggerFactory_Vtbl, 0xc2643eda_8a03_409e_b8c4_88814c28ccb6);
+impl windows_core::RuntimeType for IContentPrefetchTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentPrefetchTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICustomSystemEventTrigger, ICustomSystemEventTrigger_Vtbl, 0xf3596798_cf6b_4ef4_a0ca_29cf4a278c87);
+impl windows_core::RuntimeType for ICustomSystemEventTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSystemEventTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -804,12 +918,18 @@ pub struct ICustomSystemEventTrigger_Vtbl {
     pub Recurrence: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CustomSystemEventTriggerRecurrence) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICustomSystemEventTriggerFactory, ICustomSystemEventTriggerFactory_Vtbl, 0x6bcb16c5_f2dc_41b2_9efd_b96bdcd13ced);
+impl windows_core::RuntimeType for ICustomSystemEventTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSystemEventTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, CustomSystemEventTriggerRecurrence, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceConnectionChangeTrigger, IDeviceConnectionChangeTrigger_Vtbl, 0x90875e64_3cdd_4efb_ab1c_5b3b6a60ce34);
+impl windows_core::RuntimeType for IDeviceConnectionChangeTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceConnectionChangeTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -819,6 +939,9 @@ pub struct IDeviceConnectionChangeTrigger_Vtbl {
     pub SetMaintainConnection: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceConnectionChangeTriggerStatics, IDeviceConnectionChangeTriggerStatics_Vtbl, 0xc3ea246a_4efd_4498_aa60_a4e4e3b17ab9);
+impl windows_core::RuntimeType for IDeviceConnectionChangeTriggerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceConnectionChangeTriggerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -826,6 +949,10 @@ pub struct IDeviceConnectionChangeTriggerStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IDeviceManufacturerNotificationTrigger, IDeviceManufacturerNotificationTrigger_Vtbl, 0x81278ab5_41ab_16da_86c2_7f7bf0912f5b);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IDeviceManufacturerNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IDeviceManufacturerNotificationTrigger_Vtbl {
@@ -842,6 +969,10 @@ pub struct IDeviceManufacturerNotificationTrigger_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IDeviceManufacturerNotificationTriggerFactory, IDeviceManufacturerNotificationTriggerFactory_Vtbl, 0x7955de75_25bb_4153_a1a2_3029fcabb652);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IDeviceManufacturerNotificationTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IDeviceManufacturerNotificationTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -851,6 +982,9 @@ pub struct IDeviceManufacturerNotificationTriggerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IDeviceServicingTrigger, IDeviceServicingTrigger_Vtbl, 0x1ab217ad_6e34_49d3_9e6f_17f1b6dfa881);
+impl windows_core::RuntimeType for IDeviceServicingTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceServicingTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -858,6 +992,9 @@ pub struct IDeviceServicingTrigger_Vtbl {
     pub RequestAsyncWithArguments: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, super::super::Foundation::TimeSpan, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceUseTrigger, IDeviceUseTrigger_Vtbl, 0x0da68011_334f_4d57_b6ec_6dca64b412e4);
+impl windows_core::RuntimeType for IDeviceUseTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceUseTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -865,16 +1002,25 @@ pub struct IDeviceUseTrigger_Vtbl {
     pub RequestAsyncWithArguments: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceWatcherTrigger, IDeviceWatcherTrigger_Vtbl, 0xa4617fdd_8573_4260_befc_5bec89cb693d);
+impl windows_core::RuntimeType for IDeviceWatcherTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceWatcherTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IEmailStoreNotificationTrigger, IEmailStoreNotificationTrigger_Vtbl, 0x986d06da_47eb_4268_a4f2_f3f77188388a);
+impl windows_core::RuntimeType for IEmailStoreNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailStoreNotificationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IGattCharacteristicNotificationTrigger, IGattCharacteristicNotificationTrigger_Vtbl, 0xe25f8fc8_0696_474f_a732_f292b0cebc5d);
+impl windows_core::RuntimeType for IGattCharacteristicNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicNotificationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -884,6 +1030,9 @@ pub struct IGattCharacteristicNotificationTrigger_Vtbl {
     Characteristic: usize,
 }
 windows_core::imp::define_interface!(IGattCharacteristicNotificationTrigger2, IGattCharacteristicNotificationTrigger2_Vtbl, 0x9322a2c4_ae0e_42f2_b28c_f51372e69245);
+impl windows_core::RuntimeType for IGattCharacteristicNotificationTrigger2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicNotificationTrigger2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -893,6 +1042,9 @@ pub struct IGattCharacteristicNotificationTrigger2_Vtbl {
     EventTriggeringMode: usize,
 }
 windows_core::imp::define_interface!(IGattCharacteristicNotificationTriggerFactory, IGattCharacteristicNotificationTriggerFactory_Vtbl, 0x57ba1995_b143_4575_9f6b_fd59d93ace1a);
+impl windows_core::RuntimeType for IGattCharacteristicNotificationTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicNotificationTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -902,6 +1054,9 @@ pub struct IGattCharacteristicNotificationTriggerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IGattCharacteristicNotificationTriggerFactory2, IGattCharacteristicNotificationTriggerFactory2_Vtbl, 0x5998e91f_8a53_4e9f_a32c_23cd33664cee);
+impl windows_core::RuntimeType for IGattCharacteristicNotificationTriggerFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicNotificationTriggerFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -911,6 +1066,9 @@ pub struct IGattCharacteristicNotificationTriggerFactory2_Vtbl {
     CreateWithEventTriggeringMode: usize,
 }
 windows_core::imp::define_interface!(IGattServiceProviderTrigger, IGattServiceProviderTrigger_Vtbl, 0xddc6a3e9_1557_4bd8_8542_468aa0c696f6);
+impl windows_core::RuntimeType for IGattServiceProviderTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -929,6 +1087,9 @@ pub struct IGattServiceProviderTrigger_Vtbl {
     AdvertisingParameters: usize,
 }
 windows_core::imp::define_interface!(IGattServiceProviderTriggerResult, IGattServiceProviderTriggerResult_Vtbl, 0x3c4691b1_b198_4e84_bad4_cf4ad299ed3a);
+impl windows_core::RuntimeType for IGattServiceProviderTriggerResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderTriggerResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -939,12 +1100,18 @@ pub struct IGattServiceProviderTriggerResult_Vtbl {
     Error: usize,
 }
 windows_core::imp::define_interface!(IGattServiceProviderTriggerStatics, IGattServiceProviderTriggerStatics_Vtbl, 0xb413a36a_e294_4591_a5a6_64891a828153);
+impl windows_core::RuntimeType for IGattServiceProviderTriggerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderTriggerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeovisitTrigger, IGeovisitTrigger_Vtbl, 0x4818edaa_04e1_4127_9a4c_19351b8a80a4);
+impl windows_core::RuntimeType for IGeovisitTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeovisitTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -958,18 +1125,27 @@ pub struct IGeovisitTrigger_Vtbl {
     SetMonitoringScope: usize,
 }
 windows_core::imp::define_interface!(ILocationTrigger, ILocationTrigger_Vtbl, 0x47666a1c_6877_481e_8026_ff7e14a811a0);
+impl windows_core::RuntimeType for ILocationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TriggerType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut LocationTriggerType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILocationTriggerFactory, ILocationTriggerFactory_Vtbl, 0x1106bb07_ff69_4e09_aa8b_1384ea475e98);
+impl windows_core::RuntimeType for ILocationTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocationTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, LocationTriggerType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMaintenanceTrigger, IMaintenanceTrigger_Vtbl, 0x68184c83_fc22_4ce5_841a_7239a9810047);
+impl windows_core::RuntimeType for IMaintenanceTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMaintenanceTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -977,12 +1153,18 @@ pub struct IMaintenanceTrigger_Vtbl {
     pub OneShot: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMaintenanceTriggerFactory, IMaintenanceTriggerFactory_Vtbl, 0x4b3ddb2e_97dd_4629_88b0_b06cf9482ae5);
+impl windows_core::RuntimeType for IMaintenanceTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMaintenanceTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaProcessingTrigger, IMediaProcessingTrigger_Vtbl, 0x9a95be65_8a52_4b30_9011_cf38040ea8b0);
+impl windows_core::RuntimeType for IMediaProcessingTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaProcessingTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -993,23 +1175,35 @@ pub struct IMediaProcessingTrigger_Vtbl {
     RequestAsyncWithArguments: usize,
 }
 windows_core::imp::define_interface!(INetworkOperatorHotspotAuthenticationTrigger, INetworkOperatorHotspotAuthenticationTrigger_Vtbl, 0xe756c791_3001_4de5_83c7_de61d88831d0);
+impl windows_core::RuntimeType for INetworkOperatorHotspotAuthenticationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorHotspotAuthenticationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(INetworkOperatorNotificationTrigger, INetworkOperatorNotificationTrigger_Vtbl, 0x90089cc6_63cd_480c_95d1_6e6aef801e4a);
+impl windows_core::RuntimeType for INetworkOperatorNotificationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorNotificationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub NetworkAccountId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorNotificationTriggerFactory, INetworkOperatorNotificationTriggerFactory_Vtbl, 0x0a223e00_27d7_4353_adb9_9265aaea579d);
+impl windows_core::RuntimeType for INetworkOperatorNotificationTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorNotificationTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneTrigger, IPhoneTrigger_Vtbl, 0x8dcfe99b_d4c5_49f1_b7d3_82e87a0e9dde);
+impl windows_core::RuntimeType for IPhoneTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1020,6 +1214,9 @@ pub struct IPhoneTrigger_Vtbl {
     TriggerType: usize,
 }
 windows_core::imp::define_interface!(IPhoneTriggerFactory, IPhoneTriggerFactory_Vtbl, 0xa0d93cda_5fc1_48fb_a546_32262040157b);
+impl windows_core::RuntimeType for IPhoneTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1029,17 +1226,26 @@ pub struct IPhoneTriggerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IPushNotificationTriggerFactory, IPushNotificationTriggerFactory_Vtbl, 0x6dd8ed1b_458e_4fc2_bc2e_d5664f77ed19);
+impl windows_core::RuntimeType for IPushNotificationTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsEndUserMessageAvailableTrigger, IRcsEndUserMessageAvailableTrigger_Vtbl, 0x986d0d6a_b2f6_467f_a978_a44091c11a66);
+impl windows_core::RuntimeType for IRcsEndUserMessageAvailableTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsEndUserMessageAvailableTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IRfcommConnectionTrigger, IRfcommConnectionTrigger_Vtbl, 0xe8c4cae2_0b53_4464_9394_fd875654de64);
+impl windows_core::RuntimeType for IRfcommConnectionTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommConnectionTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1073,16 +1279,26 @@ pub struct IRfcommConnectionTrigger_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISecondaryAuthenticationFactorAuthenticationTrigger, ISecondaryAuthenticationFactorAuthenticationTrigger_Vtbl, 0xf237f327_5181_4f24_96a7_700a4e5fac62);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISecondaryAuthenticationFactorAuthenticationTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISecondaryAuthenticationFactorAuthenticationTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISensorDataThresholdTrigger, ISensorDataThresholdTrigger_Vtbl, 0x5bc0f372_d48b_4b7f_abec_15f9bacc12e2);
+impl windows_core::RuntimeType for ISensorDataThresholdTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISensorDataThresholdTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISensorDataThresholdTriggerFactory, ISensorDataThresholdTriggerFactory_Vtbl, 0x921fe675_7df0_4da3_97b3_e544ee857fe6);
+impl windows_core::RuntimeType for ISensorDataThresholdTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISensorDataThresholdTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1092,6 +1308,9 @@ pub struct ISensorDataThresholdTriggerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ISmartCardTrigger, ISmartCardTrigger_Vtbl, 0xf53bc5ac_84ca_4972_8ce9_e58f97b37a50);
+impl windows_core::RuntimeType for ISmartCardTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1101,6 +1320,9 @@ pub struct ISmartCardTrigger_Vtbl {
     TriggerType: usize,
 }
 windows_core::imp::define_interface!(ISmartCardTriggerFactory, ISmartCardTriggerFactory_Vtbl, 0x63bf54c3_89c1_4e00_a9d3_97c629269dad);
+impl windows_core::RuntimeType for ISmartCardTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1110,6 +1332,9 @@ pub struct ISmartCardTriggerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ISmsMessageReceivedTriggerFactory, ISmsMessageReceivedTriggerFactory_Vtbl, 0xea3ad8c8_6ba4_4ab2_8d21_bc6b09c77564);
+impl windows_core::RuntimeType for ISmsMessageReceivedTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsMessageReceivedTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1119,12 +1344,18 @@ pub struct ISmsMessageReceivedTriggerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ISocketActivityTrigger, ISocketActivityTrigger_Vtbl, 0xa9bbf810_9dde_4f8a_83e3_b0e0e7a50d70);
+impl windows_core::RuntimeType for ISocketActivityTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISocketActivityTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsWakeFromLowPowerSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryChangeTrackerTriggerFactory, IStorageLibraryChangeTrackerTriggerFactory_Vtbl, 0x1eb0ffd0_5a85_499e_a888_824607124f50);
+impl windows_core::RuntimeType for IStorageLibraryChangeTrackerTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChangeTrackerTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1134,11 +1365,17 @@ pub struct IStorageLibraryChangeTrackerTriggerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IStorageLibraryContentChangedTrigger, IStorageLibraryContentChangedTrigger_Vtbl, 0x1637e0a7_829c_45bc_929b_a1e7ea78d89b);
+impl windows_core::RuntimeType for IStorageLibraryContentChangedTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryContentChangedTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IStorageLibraryContentChangedTriggerStatics, IStorageLibraryContentChangedTriggerStatics_Vtbl, 0x7f9f1b39_5f90_4e12_914e_a7d8e0bbfb18);
+impl windows_core::RuntimeType for IStorageLibraryContentChangedTriggerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryContentChangedTriggerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1152,18 +1389,27 @@ pub struct IStorageLibraryContentChangedTriggerStatics_Vtbl {
     CreateFromLibraries: usize,
 }
 windows_core::imp::define_interface!(ISystemCondition, ISystemCondition_Vtbl, 0xc15fb476_89c5_420b_abd3_fb3030472128);
+impl windows_core::RuntimeType for ISystemCondition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemCondition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ConditionType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SystemConditionType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemConditionFactory, ISystemConditionFactory_Vtbl, 0xd269d1f1_05a7_49ae_87d7_16b2b8b9a553);
+impl windows_core::RuntimeType for ISystemConditionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemConditionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, SystemConditionType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemTrigger, ISystemTrigger_Vtbl, 0x1d80c776_3748_4463_8d7e_276dc139ac1c);
+impl windows_core::RuntimeType for ISystemTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1171,12 +1417,18 @@ pub struct ISystemTrigger_Vtbl {
     pub TriggerType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SystemTriggerType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemTriggerFactory, ISystemTriggerFactory_Vtbl, 0xe80423d4_8791_4579_8126_87ec8aaa407a);
+impl windows_core::RuntimeType for ISystemTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, SystemTriggerType, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimeTrigger, ITimeTrigger_Vtbl, 0x656e5556_0b2a_4377_ba70_3b45a935547f);
+impl windows_core::RuntimeType for ITimeTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimeTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1184,24 +1436,36 @@ pub struct ITimeTrigger_Vtbl {
     pub OneShot: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimeTriggerFactory, ITimeTriggerFactory_Vtbl, 0x38c682fe_9b54_45e6_b2f3_269b87a6f734);
+impl windows_core::RuntimeType for ITimeTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimeTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationActionTriggerFactory, IToastNotificationActionTriggerFactory_Vtbl, 0xb09dfc27_6480_4349_8125_97b3efaa0a3a);
+impl windows_core::RuntimeType for IToastNotificationActionTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationActionTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationHistoryChangedTriggerFactory, IToastNotificationHistoryChangedTriggerFactory_Vtbl, 0x81c6faad_8797_4785_81b4_b0cccb73d1d9);
+impl windows_core::RuntimeType for IToastNotificationHistoryChangedTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationHistoryChangedTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserNotificationChangedTriggerFactory, IUserNotificationChangedTriggerFactory_Vtbl, 0xcad4436c_69ab_4e18_a48a_5ed2ac435957);
+impl windows_core::RuntimeType for IUserNotificationChangedTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserNotificationChangedTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1259,7 +1523,7 @@ impl ActivitySensorTrigger {
     }
 }
 impl windows_core::RuntimeType for ActivitySensorTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivitySensorTrigger>();
 }
 unsafe impl windows_core::Interface for ActivitySensorTrigger {
     type Vtable = IActivitySensorTrigger_Vtbl;
@@ -1326,7 +1590,7 @@ impl AppBroadcastTrigger {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastTrigger>();
 }
 unsafe impl windows_core::Interface for AppBroadcastTrigger {
     type Vtable = IAppBroadcastTrigger_Vtbl;
@@ -1410,7 +1674,7 @@ impl AppBroadcastTriggerProviderInfo {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastTriggerProviderInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastTriggerProviderInfo>();
 }
 unsafe impl windows_core::Interface for AppBroadcastTriggerProviderInfo {
     type Vtable = IAppBroadcastTriggerProviderInfo_Vtbl;
@@ -1454,7 +1718,7 @@ impl ApplicationTrigger {
     }
 }
 impl windows_core::RuntimeType for ApplicationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationTrigger>();
 }
 unsafe impl windows_core::Interface for ApplicationTrigger {
     type Vtable = IApplicationTrigger_Vtbl;
@@ -1480,7 +1744,7 @@ impl ApplicationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for ApplicationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for ApplicationTriggerDetails {
     type Vtable = IApplicationTriggerDetails_Vtbl;
@@ -1506,7 +1770,7 @@ impl AppointmentStoreNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for AppointmentStoreNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppointmentStoreNotificationTrigger>();
 }
 unsafe impl windows_core::Interface for AppointmentStoreNotificationTrigger {
     type Vtable = IAppointmentStoreNotificationTrigger_Vtbl;
@@ -1689,7 +1953,7 @@ impl BackgroundTaskBuilder {
     }
 }
 impl windows_core::RuntimeType for BackgroundTaskBuilder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTaskBuilder>();
 }
 unsafe impl windows_core::Interface for BackgroundTaskBuilder {
     type Vtable = IBackgroundTaskBuilder_Vtbl;
@@ -1716,7 +1980,7 @@ impl BackgroundTaskCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BackgroundTaskCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTaskCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for BackgroundTaskCompletedEventArgs {
     type Vtable = IBackgroundTaskCompletedEventArgs_Vtbl;
@@ -1738,7 +2002,7 @@ impl BackgroundTaskDeferral {
     }
 }
 impl windows_core::RuntimeType for BackgroundTaskDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTaskDeferral>();
 }
 unsafe impl windows_core::Interface for BackgroundTaskDeferral {
     type Vtable = IBackgroundTaskDeferral_Vtbl;
@@ -1770,7 +2034,7 @@ impl BackgroundTaskProgressEventArgs {
     }
 }
 impl windows_core::RuntimeType for BackgroundTaskProgressEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTaskProgressEventArgs>();
 }
 unsafe impl windows_core::Interface for BackgroundTaskProgressEventArgs {
     type Vtable = IBackgroundTaskProgressEventArgs_Vtbl;
@@ -1879,7 +2143,7 @@ impl BackgroundTaskRegistration {
     }
 }
 impl windows_core::RuntimeType for BackgroundTaskRegistration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTaskRegistration>();
 }
 unsafe impl windows_core::Interface for BackgroundTaskRegistration {
     type Vtable = IBackgroundTaskRegistration_Vtbl;
@@ -1951,7 +2215,7 @@ impl BackgroundTaskRegistrationGroup {
     }
 }
 impl windows_core::RuntimeType for BackgroundTaskRegistrationGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTaskRegistrationGroup>();
 }
 unsafe impl windows_core::Interface for BackgroundTaskRegistrationGroup {
     type Vtable = IBackgroundTaskRegistrationGroup_Vtbl;
@@ -2049,7 +2313,7 @@ impl BluetoothLEAdvertisementPublisherTrigger {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementPublisherTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementPublisherTrigger>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementPublisherTrigger {
     type Vtable = IBluetoothLEAdvertisementPublisherTrigger_Vtbl;
@@ -2146,7 +2410,7 @@ impl BluetoothLEAdvertisementWatcherTrigger {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementWatcherTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementWatcherTrigger>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementWatcherTrigger {
     type Vtable = IBluetoothLEAdvertisementWatcherTrigger_Vtbl;
@@ -2172,7 +2436,7 @@ impl CachedFileUpdaterTrigger {
     }
 }
 impl windows_core::RuntimeType for CachedFileUpdaterTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICachedFileUpdaterTrigger>();
 }
 unsafe impl windows_core::Interface for CachedFileUpdaterTrigger {
     type Vtable = ICachedFileUpdaterTrigger_Vtbl;
@@ -2213,7 +2477,7 @@ impl CachedFileUpdaterTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for CachedFileUpdaterTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICachedFileUpdaterTriggerDetails>();
 }
 unsafe impl windows_core::Interface for CachedFileUpdaterTriggerDetails {
     type Vtable = ICachedFileUpdaterTriggerDetails_Vtbl;
@@ -2239,7 +2503,7 @@ impl ChatMessageNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for ChatMessageNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageNotificationTrigger>();
 }
 unsafe impl windows_core::Interface for ChatMessageNotificationTrigger {
     type Vtable = IChatMessageNotificationTrigger_Vtbl;
@@ -2265,7 +2529,7 @@ impl ChatMessageReceivedNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for ChatMessageReceivedNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageReceivedNotificationTrigger>();
 }
 unsafe impl windows_core::Interface for ChatMessageReceivedNotificationTrigger {
     type Vtable = IChatMessageReceivedNotificationTrigger_Vtbl;
@@ -2291,7 +2555,7 @@ impl CommunicationBlockingAppSetAsActiveTrigger {
     }
 }
 impl windows_core::RuntimeType for CommunicationBlockingAppSetAsActiveTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICommunicationBlockingAppSetAsActiveTrigger>();
 }
 unsafe impl windows_core::Interface for CommunicationBlockingAppSetAsActiveTrigger {
     type Vtable = ICommunicationBlockingAppSetAsActiveTrigger_Vtbl;
@@ -2317,7 +2581,7 @@ impl ContactStoreNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for ContactStoreNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactStoreNotificationTrigger>();
 }
 unsafe impl windows_core::Interface for ContactStoreNotificationTrigger {
     type Vtable = IContactStoreNotificationTrigger_Vtbl;
@@ -2361,7 +2625,7 @@ impl ContentPrefetchTrigger {
     }
 }
 impl windows_core::RuntimeType for ContentPrefetchTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContentPrefetchTrigger>();
 }
 unsafe impl windows_core::Interface for ContentPrefetchTrigger {
     type Vtable = IContentPrefetchTrigger_Vtbl;
@@ -2385,7 +2649,7 @@ impl ConversationalAgentTrigger {
     }
 }
 impl windows_core::RuntimeType for ConversationalAgentTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for ConversationalAgentTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -2427,7 +2691,7 @@ impl CustomSystemEventTrigger {
     }
 }
 impl windows_core::RuntimeType for CustomSystemEventTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICustomSystemEventTrigger>();
 }
 unsafe impl windows_core::Interface for CustomSystemEventTrigger {
     type Vtable = ICustomSystemEventTrigger_Vtbl;
@@ -2480,7 +2744,7 @@ impl DeviceConnectionChangeTrigger {
     }
 }
 impl windows_core::RuntimeType for DeviceConnectionChangeTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceConnectionChangeTrigger>();
 }
 unsafe impl windows_core::Interface for DeviceConnectionChangeTrigger {
     type Vtable = IDeviceConnectionChangeTrigger_Vtbl;
@@ -2533,7 +2797,7 @@ impl DeviceManufacturerNotificationTrigger {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for DeviceManufacturerNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceManufacturerNotificationTrigger>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for DeviceManufacturerNotificationTrigger {
@@ -2573,7 +2837,7 @@ impl DeviceServicingTrigger {
     }
 }
 impl windows_core::RuntimeType for DeviceServicingTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceServicingTrigger>();
 }
 unsafe impl windows_core::Interface for DeviceServicingTrigger {
     type Vtable = IDeviceServicingTrigger_Vtbl;
@@ -2613,7 +2877,7 @@ impl DeviceUseTrigger {
     }
 }
 impl windows_core::RuntimeType for DeviceUseTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceUseTrigger>();
 }
 unsafe impl windows_core::Interface for DeviceUseTrigger {
     type Vtable = IDeviceUseTrigger_Vtbl;
@@ -2631,7 +2895,7 @@ windows_core::imp::interface_hierarchy!(DeviceWatcherTrigger, windows_core::IUnk
 windows_core::imp::required_hierarchy!(DeviceWatcherTrigger, IBackgroundTrigger);
 impl DeviceWatcherTrigger {}
 impl windows_core::RuntimeType for DeviceWatcherTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceWatcherTrigger>();
 }
 unsafe impl windows_core::Interface for DeviceWatcherTrigger {
     type Vtable = IDeviceWatcherTrigger_Vtbl;
@@ -2655,7 +2919,7 @@ impl EmailStoreNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for EmailStoreNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailStoreNotificationTrigger>();
 }
 unsafe impl windows_core::Interface for EmailStoreNotificationTrigger {
     type Vtable = IEmailStoreNotificationTrigger_Vtbl;
@@ -2720,7 +2984,7 @@ impl GattCharacteristicNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for GattCharacteristicNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattCharacteristicNotificationTrigger>();
 }
 unsafe impl windows_core::Interface for GattCharacteristicNotificationTrigger {
     type Vtable = IGattCharacteristicNotificationTrigger_Vtbl;
@@ -2781,7 +3045,7 @@ impl GattServiceProviderTrigger {
     }
 }
 impl windows_core::RuntimeType for GattServiceProviderTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProviderTrigger>();
 }
 unsafe impl windows_core::Interface for GattServiceProviderTrigger {
     type Vtable = IGattServiceProviderTrigger_Vtbl;
@@ -2814,7 +3078,7 @@ impl GattServiceProviderTriggerResult {
     }
 }
 impl windows_core::RuntimeType for GattServiceProviderTriggerResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProviderTriggerResult>();
 }
 unsafe impl windows_core::Interface for GattServiceProviderTriggerResult {
     type Vtable = IGattServiceProviderTriggerResult_Vtbl;
@@ -2853,7 +3117,7 @@ impl GeovisitTrigger {
     }
 }
 impl windows_core::RuntimeType for GeovisitTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeovisitTrigger>();
 }
 unsafe impl windows_core::Interface for GeovisitTrigger {
     type Vtable = IGeovisitTrigger_Vtbl;
@@ -2890,7 +3154,7 @@ impl LocationTrigger {
     }
 }
 impl windows_core::RuntimeType for LocationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILocationTrigger>();
 }
 unsafe impl windows_core::Interface for LocationTrigger {
     type Vtable = ILocationTrigger_Vtbl;
@@ -2934,7 +3198,7 @@ impl MaintenanceTrigger {
     }
 }
 impl windows_core::RuntimeType for MaintenanceTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMaintenanceTrigger>();
 }
 unsafe impl windows_core::Interface for MaintenanceTrigger {
     type Vtable = IMaintenanceTrigger_Vtbl;
@@ -2976,7 +3240,7 @@ impl MediaProcessingTrigger {
     }
 }
 impl windows_core::RuntimeType for MediaProcessingTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaProcessingTrigger>();
 }
 unsafe impl windows_core::Interface for MediaProcessingTrigger {
     type Vtable = IMediaProcessingTrigger_Vtbl;
@@ -3000,7 +3264,7 @@ impl MobileBroadbandDeviceServiceNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceServiceNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceServiceNotificationTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3026,7 +3290,7 @@ impl MobileBroadbandPcoDataChangeTrigger {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPcoDataChangeTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPcoDataChangeTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3052,7 +3316,7 @@ impl MobileBroadbandPinLockStateChangeTrigger {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPinLockStateChangeTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPinLockStateChangeTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3078,7 +3342,7 @@ impl MobileBroadbandRadioStateChangeTrigger {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandRadioStateChangeTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandRadioStateChangeTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3104,7 +3368,7 @@ impl MobileBroadbandRegistrationStateChangeTrigger {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandRegistrationStateChangeTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandRegistrationStateChangeTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3130,7 +3394,7 @@ impl NetworkOperatorDataUsageTrigger {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorDataUsageTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorDataUsageTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3156,7 +3420,7 @@ impl NetworkOperatorHotspotAuthenticationTrigger {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorHotspotAuthenticationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorHotspotAuthenticationTrigger>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorHotspotAuthenticationTrigger {
     type Vtable = INetworkOperatorHotspotAuthenticationTrigger_Vtbl;
@@ -3191,7 +3455,7 @@ impl NetworkOperatorNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorNotificationTrigger>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorNotificationTrigger {
     type Vtable = INetworkOperatorNotificationTrigger_Vtbl;
@@ -3215,7 +3479,7 @@ impl PaymentAppCanMakePaymentTrigger {
     }
 }
 impl windows_core::RuntimeType for PaymentAppCanMakePaymentTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for PaymentAppCanMakePaymentTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3261,7 +3525,7 @@ impl PhoneTrigger {
     }
 }
 impl windows_core::RuntimeType for PhoneTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneTrigger>();
 }
 unsafe impl windows_core::Interface for PhoneTrigger {
     type Vtable = IPhoneTrigger_Vtbl;
@@ -3298,7 +3562,7 @@ impl PushNotificationTrigger {
     }
 }
 impl windows_core::RuntimeType for PushNotificationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for PushNotificationTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3324,7 +3588,7 @@ impl RcsEndUserMessageAvailableTrigger {
     }
 }
 impl windows_core::RuntimeType for RcsEndUserMessageAvailableTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsEndUserMessageAvailableTrigger>();
 }
 unsafe impl windows_core::Interface for RcsEndUserMessageAvailableTrigger {
     type Vtable = IRcsEndUserMessageAvailableTrigger_Vtbl;
@@ -3406,7 +3670,7 @@ impl RfcommConnectionTrigger {
     }
 }
 impl windows_core::RuntimeType for RfcommConnectionTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommConnectionTrigger>();
 }
 unsafe impl windows_core::Interface for RfcommConnectionTrigger {
     type Vtable = IRfcommConnectionTrigger_Vtbl;
@@ -3437,7 +3701,7 @@ impl SecondaryAuthenticationFactorAuthenticationTrigger {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SecondaryAuthenticationFactorAuthenticationTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISecondaryAuthenticationFactorAuthenticationTrigger>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SecondaryAuthenticationFactorAuthenticationTrigger {
@@ -3471,7 +3735,7 @@ impl SensorDataThresholdTrigger {
     }
 }
 impl windows_core::RuntimeType for SensorDataThresholdTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISensorDataThresholdTrigger>();
 }
 unsafe impl windows_core::Interface for SensorDataThresholdTrigger {
     type Vtable = ISensorDataThresholdTrigger_Vtbl;
@@ -3510,7 +3774,7 @@ impl SmartCardTrigger {
     }
 }
 impl windows_core::RuntimeType for SmartCardTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardTrigger>();
 }
 unsafe impl windows_core::Interface for SmartCardTrigger {
     type Vtable = ISmartCardTrigger_Vtbl;
@@ -3542,7 +3806,7 @@ impl SmsMessageReceivedTrigger {
     }
 }
 impl windows_core::RuntimeType for SmsMessageReceivedTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for SmsMessageReceivedTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3575,7 +3839,7 @@ impl SocketActivityTrigger {
     }
 }
 impl windows_core::RuntimeType for SocketActivityTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for SocketActivityTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3609,7 +3873,7 @@ impl StorageLibraryChangeTrackerTrigger {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryChangeTrackerTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for StorageLibraryChangeTrackerTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3653,7 +3917,7 @@ impl StorageLibraryContentChangedTrigger {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryContentChangedTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryContentChangedTrigger>();
 }
 unsafe impl windows_core::Interface for StorageLibraryContentChangedTrigger {
     type Vtable = IStorageLibraryContentChangedTrigger_Vtbl;
@@ -3688,7 +3952,7 @@ impl SystemCondition {
     }
 }
 impl windows_core::RuntimeType for SystemCondition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemCondition>();
 }
 unsafe impl windows_core::Interface for SystemCondition {
     type Vtable = ISystemCondition_Vtbl;
@@ -3730,7 +3994,7 @@ impl SystemTrigger {
     }
 }
 impl windows_core::RuntimeType for SystemTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemTrigger>();
 }
 unsafe impl windows_core::Interface for SystemTrigger {
     type Vtable = ISystemTrigger_Vtbl;
@@ -3754,7 +4018,7 @@ impl TetheringEntitlementCheckTrigger {
     }
 }
 impl windows_core::RuntimeType for TetheringEntitlementCheckTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for TetheringEntitlementCheckTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3798,7 +4062,7 @@ impl TimeTrigger {
     }
 }
 impl windows_core::RuntimeType for TimeTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimeTrigger>();
 }
 unsafe impl windows_core::Interface for TimeTrigger {
     type Vtable = ITimeTrigger_Vtbl;
@@ -3833,7 +4097,7 @@ impl ToastNotificationActionTrigger {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationActionTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for ToastNotificationActionTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3870,7 +4134,7 @@ impl ToastNotificationHistoryChangedTrigger {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationHistoryChangedTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for ToastNotificationHistoryChangedTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3901,7 +4165,7 @@ impl UserNotificationChangedTrigger {
     }
 }
 impl windows_core::RuntimeType for UserNotificationChangedTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for UserNotificationChangedTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3927,7 +4191,7 @@ impl WiFiOnDemandHotspotConnectTrigger {
     }
 }
 impl windows_core::RuntimeType for WiFiOnDemandHotspotConnectTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for WiFiOnDemandHotspotConnectTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;
@@ -3953,7 +4217,7 @@ impl WiFiOnDemandHotspotUpdateMetadataTrigger {
     }
 }
 impl windows_core::RuntimeType for WiFiOnDemandHotspotUpdateMetadataTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTrigger>();
 }
 unsafe impl windows_core::Interface for WiFiOnDemandHotspotUpdateMetadataTrigger {
     type Vtable = IBackgroundTrigger_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPhoneCallBlockedTriggerDetails, IPhoneCallBlockedTriggerDetails_Vtbl, 0xa4a690a2_e4c1_427f_864e_e470477ddb67);
+impl windows_core::RuntimeType for IPhoneCallBlockedTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallBlockedTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,10 @@ pub struct IPhoneCallBlockedTriggerDetails_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneCallOriginDataRequestTriggerDetails, IPhoneCallOriginDataRequestTriggerDetails_Vtbl, 0x6e9b5b3f_c54b_4e82_4cc9_e329a4184592);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneCallOriginDataRequestTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneCallOriginDataRequestTriggerDetails_Vtbl {
@@ -23,6 +30,10 @@ pub struct IPhoneCallOriginDataRequestTriggerDetails_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneIncomingCallDismissedTriggerDetails, IPhoneIncomingCallDismissedTriggerDetails_Vtbl, 0xbad30276_83b6_5732_9c38_0c206546196a);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneIncomingCallDismissedTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneIncomingCallDismissedTriggerDetails_Vtbl {
@@ -53,6 +64,9 @@ pub struct IPhoneIncomingCallDismissedTriggerDetails_Vtbl {
     Reason: usize,
 }
 windows_core::imp::define_interface!(IPhoneIncomingCallNotificationTriggerDetails, IPhoneIncomingCallNotificationTriggerDetails_Vtbl, 0x2b0e6044_9b32_5d42_8222_d2812e39fb21);
+impl windows_core::RuntimeType for IPhoneIncomingCallNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneIncomingCallNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +74,9 @@ pub struct IPhoneIncomingCallNotificationTriggerDetails_Vtbl {
     pub CallId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineChangedTriggerDetails, IPhoneLineChangedTriggerDetails_Vtbl, 0xc6d321e7_d11d_40d8_b2b7_e40a01d66249);
+impl windows_core::RuntimeType for IPhoneLineChangedTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineChangedTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,6 +85,9 @@ pub struct IPhoneLineChangedTriggerDetails_Vtbl {
     pub HasLinePropertyChanged: unsafe extern "system" fn(*mut core::ffi::c_void, PhoneLineProperties, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneNewVoicemailMessageTriggerDetails, IPhoneNewVoicemailMessageTriggerDetails_Vtbl, 0x13a8c01b_b831_48d3_8ba9_8d22a6580dcf);
+impl windows_core::RuntimeType for IPhoneNewVoicemailMessageTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneNewVoicemailMessageTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,7 +123,7 @@ impl PhoneCallBlockedTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneCallBlockedTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallBlockedTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PhoneCallBlockedTriggerDetails {
     type Vtable = IPhoneCallBlockedTriggerDetails_Vtbl;
@@ -141,7 +161,7 @@ impl PhoneCallOriginDataRequestTriggerDetails {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PhoneCallOriginDataRequestTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallOriginDataRequestTriggerDetails>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PhoneCallOriginDataRequestTriggerDetails {
@@ -215,7 +235,7 @@ impl PhoneIncomingCallDismissedTriggerDetails {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PhoneIncomingCallDismissedTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneIncomingCallDismissedTriggerDetails>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PhoneIncomingCallDismissedTriggerDetails {
@@ -251,7 +271,7 @@ impl PhoneIncomingCallNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneIncomingCallNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneIncomingCallNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PhoneIncomingCallNotificationTriggerDetails {
     type Vtable = IPhoneIncomingCallNotificationTriggerDetails_Vtbl;
@@ -290,7 +310,7 @@ impl PhoneLineChangedTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneLineChangedTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineChangedTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PhoneLineChangedTriggerDetails {
     type Vtable = IPhoneLineChangedTriggerDetails_Vtbl;
@@ -329,7 +349,7 @@ impl PhoneNewVoicemailMessageTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneNewVoicemailMessageTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneNewVoicemailMessageTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PhoneNewVoicemailMessageTriggerDetails {
     type Vtable = IPhoneNewVoicemailMessageTriggerDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Provider/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneCallOrigin, IPhoneCallOrigin_Vtbl, 0x20613479_0ef9_4454_871c_afb66a14b6a5);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneCallOrigin {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneCallOrigin_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +36,10 @@ pub struct IPhoneCallOrigin_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneCallOrigin2, IPhoneCallOrigin2_Vtbl, 0x04c7e980_9ac2_4768_b536_b68da4957d02);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneCallOrigin2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneCallOrigin2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +55,10 @@ pub struct IPhoneCallOrigin2_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneCallOrigin3, IPhoneCallOrigin3_Vtbl, 0x49330fb4_d1a7_43a2_aeee_c07b6dbaf068);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneCallOrigin3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneCallOrigin3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +73,10 @@ pub struct IPhoneCallOrigin3_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneCallOriginManagerStatics, IPhoneCallOriginManagerStatics_Vtbl, 0xccfc5a0a_9af7_6149_39d0_e076fcce1395);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneCallOriginManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneCallOriginManagerStatics_Vtbl {
@@ -81,6 +97,10 @@ pub struct IPhoneCallOriginManagerStatics_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneCallOriginManagerStatics2, IPhoneCallOriginManagerStatics2_Vtbl, 0x8bf3ee3f_40f4_4380_8c7c_aea2c9b8dd7a);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneCallOriginManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneCallOriginManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,6 +111,10 @@ pub struct IPhoneCallOriginManagerStatics2_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPhoneCallOriginManagerStatics3, IPhoneCallOriginManagerStatics3_Vtbl, 0x2ed69764_a6e3_50f0_b76a_d67cb39bdfde);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPhoneCallOriginManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPhoneCallOriginManagerStatics3_Vtbl {
@@ -186,7 +210,7 @@ impl PhoneCallOrigin {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PhoneCallOrigin {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallOrigin>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PhoneCallOrigin {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
@@ -3,30 +3,45 @@ pub mod Background;
 #[cfg(feature = "ApplicationModel_Calls_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(ICallAnswerEventArgs, ICallAnswerEventArgs_Vtbl, 0xfd789617_2dd7_4c8c_b2bd_95d17a5bb733);
+impl windows_core::RuntimeType for ICallAnswerEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICallAnswerEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AcceptedMedia: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VoipPhoneCallMedia) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICallRejectEventArgs, ICallRejectEventArgs_Vtbl, 0xda47fad7_13d4_4d92_a1c2_b77811ee37ec);
+impl windows_core::RuntimeType for ICallRejectEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICallRejectEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RejectReason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VoipPhoneCallRejectReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICallStateChangeEventArgs, ICallStateChangeEventArgs_Vtbl, 0xeab2349e_66f5_47f9_9fb5_459c5198c720);
+impl windows_core::RuntimeType for ICallStateChangeEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICallStateChangeEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VoipPhoneCallState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenCallEndCallDeferral, ILockScreenCallEndCallDeferral_Vtbl, 0x2dd7ed0d_98ed_4041_9632_50ff812b773f);
+impl windows_core::RuntimeType for ILockScreenCallEndCallDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenCallEndCallDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenCallEndRequestedEventArgs, ILockScreenCallEndRequestedEventArgs_Vtbl, 0x8190a363_6f27_46e9_aeb6_c0ae83e47dc7);
+impl windows_core::RuntimeType for ILockScreenCallEndRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenCallEndRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +49,9 @@ pub struct ILockScreenCallEndRequestedEventArgs_Vtbl {
     pub Deadline: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenCallUI, ILockScreenCallUI_Vtbl, 0xc596fd8d_73c9_4a14_b021_ec1c50a3b727);
+impl windows_core::RuntimeType for ILockScreenCallUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenCallUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,12 +64,18 @@ pub struct ILockScreenCallUI_Vtbl {
     pub SetCallTitle: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMuteChangeEventArgs, IMuteChangeEventArgs_Vtbl, 0x8585e159_0c41_432c_814d_c5f1fdf530be);
+impl windows_core::RuntimeType for IMuteChangeEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMuteChangeEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Muted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCall, IPhoneCall_Vtbl, 0xc14ed0f8_c17d_59d2_9628_66e545b6cd21);
+impl windows_core::RuntimeType for IPhoneCall {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCall_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -87,6 +111,9 @@ pub struct IPhoneCall_Vtbl {
     pub ChangeAudioDeviceAsync: unsafe extern "system" fn(*mut core::ffi::c_void, PhoneCallAudioDevice, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallBlockingStatics, IPhoneCallBlockingStatics_Vtbl, 0x19646f84_2b79_26f1_a46f_694be043f313);
+impl windows_core::RuntimeType for IPhoneCallBlockingStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallBlockingStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,6 +127,9 @@ pub struct IPhoneCallBlockingStatics_Vtbl {
     SetCallBlockingListAsync: usize,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryEntry, IPhoneCallHistoryEntry_Vtbl, 0xfab0e129_32a4_4b85_83d1_f90d8c23a857);
+impl windows_core::RuntimeType for IPhoneCallHistoryEntry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryEntry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +169,9 @@ pub struct IPhoneCallHistoryEntry_Vtbl {
     pub SetStartTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryEntryAddress, IPhoneCallHistoryEntryAddress_Vtbl, 0x30f159da_3955_4042_84e6_66eebf82e67f);
+impl windows_core::RuntimeType for IPhoneCallHistoryEntryAddress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryEntryAddress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,12 +185,18 @@ pub struct IPhoneCallHistoryEntryAddress_Vtbl {
     pub SetRawAddressKind: unsafe extern "system" fn(*mut core::ffi::c_void, PhoneCallHistoryEntryRawAddressKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryEntryAddressFactory, IPhoneCallHistoryEntryAddressFactory_Vtbl, 0xfb0fadba_c7f0_4bb6_9f6b_ba5d73209aca);
+impl windows_core::RuntimeType for IPhoneCallHistoryEntryAddressFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryEntryAddressFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, PhoneCallHistoryEntryRawAddressKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryEntryQueryOptions, IPhoneCallHistoryEntryQueryOptions_Vtbl, 0x9c5fe15c_8bed_40ca_b06e_c4ca8eae5c87);
+impl windows_core::RuntimeType for IPhoneCallHistoryEntryQueryOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryEntryQueryOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +208,9 @@ pub struct IPhoneCallHistoryEntryQueryOptions_Vtbl {
     SourceIds: usize,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryEntryReader, IPhoneCallHistoryEntryReader_Vtbl, 0x61ece4be_8d86_479f_8404_a9846920fee6);
+impl windows_core::RuntimeType for IPhoneCallHistoryEntryReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryEntryReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +220,9 @@ pub struct IPhoneCallHistoryEntryReader_Vtbl {
     ReadBatchAsync: usize,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryManagerForUser, IPhoneCallHistoryManagerForUser_Vtbl, 0xd925c523_f55f_4353_9db4_0205a5265a55);
+impl windows_core::RuntimeType for IPhoneCallHistoryManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,12 +233,18 @@ pub struct IPhoneCallHistoryManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryManagerStatics, IPhoneCallHistoryManagerStatics_Vtbl, 0xf5a6da39_b31f_4f45_ac8e_1b08893c1b50);
+impl windows_core::RuntimeType for IPhoneCallHistoryManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestStoreAsync: unsafe extern "system" fn(*mut core::ffi::c_void, PhoneCallHistoryStoreAccessType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryManagerStatics2, IPhoneCallHistoryManagerStatics2_Vtbl, 0xefd474f0_a2db_4188_9e92_bc3cfa6813cf);
+impl windows_core::RuntimeType for IPhoneCallHistoryManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,6 +254,9 @@ pub struct IPhoneCallHistoryManagerStatics2_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IPhoneCallHistoryStore, IPhoneCallHistoryStore_Vtbl, 0x2f907db8_b40e_422b_8545_cb1910a61c52);
+impl windows_core::RuntimeType for IPhoneCallHistoryStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallHistoryStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -232,6 +286,9 @@ pub struct IPhoneCallHistoryStore_Vtbl {
     MarkSourcesAsSeenAsync: usize,
 }
 windows_core::imp::define_interface!(IPhoneCallInfo, IPhoneCallInfo_Vtbl, 0x22b42577_3e4d_5dc6_89c2_469fe5ffc189);
+impl windows_core::RuntimeType for IPhoneCallInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -243,12 +300,18 @@ pub struct IPhoneCallInfo_Vtbl {
     pub CallDirection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PhoneCallDirection) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallManagerStatics, IPhoneCallManagerStatics_Vtbl, 0x60edac78_78a6_4872_a3ef_98325ec8b843);
+impl windows_core::RuntimeType for IPhoneCallManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShowPhoneCallUI: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallManagerStatics2, IPhoneCallManagerStatics2_Vtbl, 0xc7e3c8bc_2370_431c_98fd_43be5f03086d);
+impl windows_core::RuntimeType for IPhoneCallManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -260,12 +323,18 @@ pub struct IPhoneCallManagerStatics2_Vtbl {
     pub RequestStoreAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallStatics, IPhoneCallStatics_Vtbl, 0x2218eeab_f60b_53e7_ba13_5aeafbc22957);
+impl windows_core::RuntimeType for IPhoneCallStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetFromId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallStore, IPhoneCallStore_Vtbl, 0x5f610748_18a6_4173_86d1_28be9dc62dba);
+impl windows_core::RuntimeType for IPhoneCallStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,18 +343,27 @@ pub struct IPhoneCallStore_Vtbl {
     pub RequestLineWatcher: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallVideoCapabilities, IPhoneCallVideoCapabilities_Vtbl, 0x02382786_b16a_4fdb_be3b_c4240e13ad0d);
+impl windows_core::RuntimeType for IPhoneCallVideoCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallVideoCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsVideoCallingCapable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallVideoCapabilitiesManagerStatics, IPhoneCallVideoCapabilitiesManagerStatics_Vtbl, 0xf3c64b56_f00b_4a1c_a0c6_ee1910749ce7);
+impl windows_core::RuntimeType for IPhoneCallVideoCapabilitiesManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallVideoCapabilitiesManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetCapabilitiesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneCallsResult, IPhoneCallsResult_Vtbl, 0x1bfad365_57cf_57dd_986d_b057c91eac33);
+impl windows_core::RuntimeType for IPhoneCallsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -296,6 +374,9 @@ pub struct IPhoneCallsResult_Vtbl {
     AllActivePhoneCalls: usize,
 }
 windows_core::imp::define_interface!(IPhoneDialOptions, IPhoneDialOptions_Vtbl, 0xb639c4b8_f06f_36cb_a863_823742b5f2d4);
+impl windows_core::RuntimeType for IPhoneDialOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneDialOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -325,6 +406,9 @@ pub struct IPhoneDialOptions_Vtbl {
     pub SetAudioEndpoint: unsafe extern "system" fn(*mut core::ffi::c_void, PhoneAudioRoutingEndpoint) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLine, IPhoneLine_Vtbl, 0x27c66f30_6a69_34ca_a2ba_65302530c311);
+impl windows_core::RuntimeType for IPhoneLine {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLine_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -350,6 +434,9 @@ pub struct IPhoneLine_Vtbl {
     pub DialWithOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLine2, IPhoneLine2_Vtbl, 0x0167f56a_5344_5d64_8af3_a31a950e916a);
+impl windows_core::RuntimeType for IPhoneLine2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLine2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -360,6 +447,9 @@ pub struct IPhoneLine2_Vtbl {
     pub TransportDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLine3, IPhoneLine3_Vtbl, 0xe2e33cf7_2406_57f3_826a_e5a5f40d6fb5);
+impl windows_core::RuntimeType for IPhoneLine3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLine3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -369,6 +459,9 @@ pub struct IPhoneLine3_Vtbl {
     pub GetAllActivePhoneCallsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineCellularDetails, IPhoneLineCellularDetails_Vtbl, 0x192601d5_147c_4769_b673_98a5ec8426cb);
+impl windows_core::RuntimeType for IPhoneLineCellularDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineCellularDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -379,6 +472,9 @@ pub struct IPhoneLineCellularDetails_Vtbl {
     pub GetNetworkOperatorDisplayText: unsafe extern "system" fn(*mut core::ffi::c_void, PhoneLineNetworkOperatorDisplayTextLocation, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineConfiguration, IPhoneLineConfiguration_Vtbl, 0xfe265862_f64f_4312_b2a8_4e257721aa95);
+impl windows_core::RuntimeType for IPhoneLineConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -389,6 +485,9 @@ pub struct IPhoneLineConfiguration_Vtbl {
     ExtendedProperties: usize,
 }
 windows_core::imp::define_interface!(IPhoneLineDialResult, IPhoneLineDialResult_Vtbl, 0xe825a30a_5c7f_546f_b918_3ad2fe70fb34);
+impl windows_core::RuntimeType for IPhoneLineDialResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineDialResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -396,12 +495,18 @@ pub struct IPhoneLineDialResult_Vtbl {
     pub DialedCall: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineStatics, IPhoneLineStatics_Vtbl, 0xf38b5f23_ceb0_404f_bcf2_ba9f697d8adf);
+impl windows_core::RuntimeType for IPhoneLineStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineTransportDevice, IPhoneLineTransportDevice_Vtbl, 0xefa8f889_cffa_59f4_97e4_74705b7dc490);
+impl windows_core::RuntimeType for IPhoneLineTransportDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineTransportDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -426,6 +531,9 @@ pub struct IPhoneLineTransportDevice_Vtbl {
     pub ConnectAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineTransportDevice2, IPhoneLineTransportDevice2_Vtbl, 0x64c885f2_ecf4_5761_8c04_3c248ce61690);
+impl windows_core::RuntimeType for IPhoneLineTransportDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineTransportDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -437,6 +545,9 @@ pub struct IPhoneLineTransportDevice2_Vtbl {
     pub RemoveInBandRingingEnabledChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineTransportDeviceStatics, IPhoneLineTransportDeviceStatics_Vtbl, 0x0f3121ac_d609_51a1_96f3_fb00d1819252);
+impl windows_core::RuntimeType for IPhoneLineTransportDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineTransportDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -445,6 +556,9 @@ pub struct IPhoneLineTransportDeviceStatics_Vtbl {
     pub GetDeviceSelectorForPhoneLineTransport: unsafe extern "system" fn(*mut core::ffi::c_void, PhoneLineTransport, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineWatcher, IPhoneLineWatcher_Vtbl, 0x8a45cd0a_6323_44e0_a6f6_9f21f64dc90a);
+impl windows_core::RuntimeType for IPhoneLineWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -463,12 +577,18 @@ pub struct IPhoneLineWatcher_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PhoneLineWatcherStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineWatcherEventArgs, IPhoneLineWatcherEventArgs_Vtbl, 0xd07c753e_9e12_4a37_82b7_ad535dad6a67);
+impl windows_core::RuntimeType for IPhoneLineWatcherEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineWatcherEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LineId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneVoicemail, IPhoneVoicemail_Vtbl, 0xc9ce77f6_6e9f_3a8b_b727_6e0cf6998224);
+impl windows_core::RuntimeType for IPhoneVoicemail {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneVoicemail_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -478,6 +598,9 @@ pub struct IPhoneVoicemail_Vtbl {
     pub DialVoicemailAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipCallCoordinator, IVoipCallCoordinator_Vtbl, 0x4f118bcf_e8ef_4434_9c5f_a8d893fafe79);
+impl windows_core::RuntimeType for IVoipCallCoordinator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipCallCoordinator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -494,12 +617,18 @@ pub struct IVoipCallCoordinator_Vtbl {
     pub CancelUpgrade: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipCallCoordinator2, IVoipCallCoordinator2_Vtbl, 0xbeb4a9f3_c704_4234_89ce_e88cc0d28fbe);
+impl windows_core::RuntimeType for IVoipCallCoordinator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipCallCoordinator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetupNewAcceptedCall: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, VoipPhoneCallMedia, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipCallCoordinator3, IVoipCallCoordinator3_Vtbl, 0x338d0cbf_9b55_4021_87ca_e64b9bd666c7);
+impl windows_core::RuntimeType for IVoipCallCoordinator3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipCallCoordinator3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -507,18 +636,27 @@ pub struct IVoipCallCoordinator3_Vtbl {
     pub RequestNewIncomingCallWithContactRemoteId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, VoipPhoneCallMedia, super::super::Foundation::TimeSpan, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipCallCoordinator4, IVoipCallCoordinator4_Vtbl, 0x83737239_9311_468f_bb49_47e0dfb5d93e);
+impl windows_core::RuntimeType for IVoipCallCoordinator4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipCallCoordinator4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReserveOneProcessCallResourcesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipCallCoordinatorStatics, IVoipCallCoordinatorStatics_Vtbl, 0x7f5d1f2b_e04a_4d10_b31a_a55c922cc2fb);
+impl windows_core::RuntimeType for IVoipCallCoordinatorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipCallCoordinatorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipPhoneCall, IVoipPhoneCall_Vtbl, 0x6cf1f19a_7794_4a5a_8c68_ae87947a6990);
+impl windows_core::RuntimeType for IVoipPhoneCall {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipPhoneCall_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -544,12 +682,18 @@ pub struct IVoipPhoneCall_Vtbl {
     pub NotifyCallReady: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipPhoneCall2, IVoipPhoneCall2_Vtbl, 0x741b46e1_245f_41f3_9399_3141d25b52e3);
+impl windows_core::RuntimeType for IVoipPhoneCall2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipPhoneCall2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryShowAppUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoipPhoneCall3, IVoipPhoneCall3_Vtbl, 0x0d891522_e258_4aa9_907a_1aa413c25523);
+impl windows_core::RuntimeType for IVoipPhoneCall3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoipPhoneCall3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -569,7 +713,7 @@ impl CallAnswerEventArgs {
     }
 }
 impl windows_core::RuntimeType for CallAnswerEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICallAnswerEventArgs>();
 }
 unsafe impl windows_core::Interface for CallAnswerEventArgs {
     type Vtable = ICallAnswerEventArgs_Vtbl;
@@ -594,7 +738,7 @@ impl CallRejectEventArgs {
     }
 }
 impl windows_core::RuntimeType for CallRejectEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICallRejectEventArgs>();
 }
 unsafe impl windows_core::Interface for CallRejectEventArgs {
     type Vtable = ICallRejectEventArgs_Vtbl;
@@ -619,7 +763,7 @@ impl CallStateChangeEventArgs {
     }
 }
 impl windows_core::RuntimeType for CallStateChangeEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICallStateChangeEventArgs>();
 }
 unsafe impl windows_core::Interface for CallStateChangeEventArgs {
     type Vtable = ICallStateChangeEventArgs_Vtbl;
@@ -641,7 +785,7 @@ impl LockScreenCallEndCallDeferral {
     }
 }
 impl windows_core::RuntimeType for LockScreenCallEndCallDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenCallEndCallDeferral>();
 }
 unsafe impl windows_core::Interface for LockScreenCallEndCallDeferral {
     type Vtable = ILockScreenCallEndCallDeferral_Vtbl;
@@ -673,7 +817,7 @@ impl LockScreenCallEndRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LockScreenCallEndRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenCallEndRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for LockScreenCallEndRequestedEventArgs {
     type Vtable = ILockScreenCallEndRequestedEventArgs_Vtbl;
@@ -734,7 +878,7 @@ impl LockScreenCallUI {
     }
 }
 impl windows_core::RuntimeType for LockScreenCallUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenCallUI>();
 }
 unsafe impl windows_core::Interface for LockScreenCallUI {
     type Vtable = ILockScreenCallUI_Vtbl;
@@ -759,7 +903,7 @@ impl MuteChangeEventArgs {
     }
 }
 impl windows_core::RuntimeType for MuteChangeEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMuteChangeEventArgs>();
 }
 unsafe impl windows_core::Interface for MuteChangeEventArgs {
     type Vtable = IMuteChangeEventArgs_Vtbl;
@@ -998,7 +1142,7 @@ impl PhoneCall {
     }
 }
 impl windows_core::RuntimeType for PhoneCall {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCall>();
 }
 unsafe impl windows_core::Interface for PhoneCall {
     type Vtable = IPhoneCall_Vtbl;
@@ -1258,7 +1402,7 @@ impl PhoneCallHistoryEntry {
     }
 }
 impl windows_core::RuntimeType for PhoneCallHistoryEntry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallHistoryEntry>();
 }
 unsafe impl windows_core::Interface for PhoneCallHistoryEntry {
     type Vtable = IPhoneCallHistoryEntry_Vtbl;
@@ -1338,7 +1482,7 @@ impl PhoneCallHistoryEntryAddress {
     }
 }
 impl windows_core::RuntimeType for PhoneCallHistoryEntryAddress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallHistoryEntryAddress>();
 }
 unsafe impl windows_core::Interface for PhoneCallHistoryEntryAddress {
     type Vtable = IPhoneCallHistoryEntryAddress_Vtbl;
@@ -1382,7 +1526,7 @@ impl PhoneCallHistoryEntryQueryOptions {
     }
 }
 impl windows_core::RuntimeType for PhoneCallHistoryEntryQueryOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallHistoryEntryQueryOptions>();
 }
 unsafe impl windows_core::Interface for PhoneCallHistoryEntryQueryOptions {
     type Vtable = IPhoneCallHistoryEntryQueryOptions_Vtbl;
@@ -1408,7 +1552,7 @@ impl PhoneCallHistoryEntryReader {
     }
 }
 impl windows_core::RuntimeType for PhoneCallHistoryEntryReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallHistoryEntryReader>();
 }
 unsafe impl windows_core::Interface for PhoneCallHistoryEntryReader {
     type Vtable = IPhoneCallHistoryEntryReader_Vtbl;
@@ -1473,7 +1617,7 @@ impl PhoneCallHistoryManagerForUser {
     }
 }
 impl windows_core::RuntimeType for PhoneCallHistoryManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallHistoryManagerForUser>();
 }
 unsafe impl windows_core::Interface for PhoneCallHistoryManagerForUser {
     type Vtable = IPhoneCallHistoryManagerForUser_Vtbl;
@@ -1603,7 +1747,7 @@ impl PhoneCallHistoryStore {
     }
 }
 impl windows_core::RuntimeType for PhoneCallHistoryStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallHistoryStore>();
 }
 unsafe impl windows_core::Interface for PhoneCallHistoryStore {
     type Vtable = IPhoneCallHistoryStore_Vtbl;
@@ -1663,7 +1807,7 @@ impl PhoneCallInfo {
     }
 }
 impl windows_core::RuntimeType for PhoneCallInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallInfo>();
 }
 unsafe impl windows_core::Interface for PhoneCallInfo {
     type Vtable = IPhoneCallInfo_Vtbl;
@@ -1754,7 +1898,7 @@ impl PhoneCallStore {
     }
 }
 impl windows_core::RuntimeType for PhoneCallStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallStore>();
 }
 unsafe impl windows_core::Interface for PhoneCallStore {
     type Vtable = IPhoneCallStore_Vtbl;
@@ -1779,7 +1923,7 @@ impl PhoneCallVideoCapabilities {
     }
 }
 impl windows_core::RuntimeType for PhoneCallVideoCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallVideoCapabilities>();
 }
 unsafe impl windows_core::Interface for PhoneCallVideoCapabilities {
     type Vtable = IPhoneCallVideoCapabilities_Vtbl;
@@ -1829,7 +1973,7 @@ impl PhoneCallsResult {
     }
 }
 impl windows_core::RuntimeType for PhoneCallsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallsResult>();
 }
 unsafe impl windows_core::Interface for PhoneCallsResult {
     type Vtable = IPhoneCallsResult_Vtbl;
@@ -1930,7 +2074,7 @@ impl PhoneDialOptions {
     }
 }
 impl windows_core::RuntimeType for PhoneDialOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneDialOptions>();
 }
 unsafe impl windows_core::Interface for PhoneDialOptions {
     type Vtable = IPhoneDialOptions_Vtbl;
@@ -2116,7 +2260,7 @@ impl PhoneLine {
     }
 }
 impl windows_core::RuntimeType for PhoneLine {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLine>();
 }
 unsafe impl windows_core::Interface for PhoneLine {
     type Vtable = IPhoneLine_Vtbl;
@@ -2169,7 +2313,7 @@ impl PhoneLineCellularDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneLineCellularDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineCellularDetails>();
 }
 unsafe impl windows_core::Interface for PhoneLineCellularDetails {
     type Vtable = IPhoneLineCellularDetails_Vtbl;
@@ -2202,7 +2346,7 @@ impl PhoneLineConfiguration {
     }
 }
 impl windows_core::RuntimeType for PhoneLineConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineConfiguration>();
 }
 unsafe impl windows_core::Interface for PhoneLineConfiguration {
     type Vtable = IPhoneLineConfiguration_Vtbl;
@@ -2234,7 +2378,7 @@ impl PhoneLineDialResult {
     }
 }
 impl windows_core::RuntimeType for PhoneLineDialResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineDialResult>();
 }
 unsafe impl windows_core::Interface for PhoneLineDialResult {
     type Vtable = IPhoneLineDialResult_Vtbl;
@@ -2384,7 +2528,7 @@ impl PhoneLineTransportDevice {
     }
 }
 impl windows_core::RuntimeType for PhoneLineTransportDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineTransportDevice>();
 }
 unsafe impl windows_core::Interface for PhoneLineTransportDevice {
     type Vtable = IPhoneLineTransportDevice_Vtbl;
@@ -2487,7 +2631,7 @@ impl PhoneLineWatcher {
     }
 }
 impl windows_core::RuntimeType for PhoneLineWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineWatcher>();
 }
 unsafe impl windows_core::Interface for PhoneLineWatcher {
     type Vtable = IPhoneLineWatcher_Vtbl;
@@ -2512,7 +2656,7 @@ impl PhoneLineWatcherEventArgs {
     }
 }
 impl windows_core::RuntimeType for PhoneLineWatcherEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineWatcherEventArgs>();
 }
 unsafe impl windows_core::Interface for PhoneLineWatcherEventArgs {
     type Vtable = IPhoneLineWatcherEventArgs_Vtbl;
@@ -2558,7 +2702,7 @@ impl PhoneVoicemail {
     }
 }
 impl windows_core::RuntimeType for PhoneVoicemail {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneVoicemail>();
 }
 unsafe impl windows_core::Interface for PhoneVoicemail {
     type Vtable = IPhoneVoicemail_Vtbl;
@@ -2695,7 +2839,7 @@ impl VoipCallCoordinator {
     }
 }
 impl windows_core::RuntimeType for VoipCallCoordinator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoipCallCoordinator>();
 }
 unsafe impl windows_core::Interface for VoipCallCoordinator {
     type Vtable = IVoipCallCoordinator_Vtbl;
@@ -2840,7 +2984,7 @@ impl VoipPhoneCall {
     }
 }
 impl windows_core::RuntimeType for VoipPhoneCall {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoipPhoneCall>();
 }
 unsafe impl windows_core::Interface for VoipPhoneCall {
     type Vtable = IVoipPhoneCall_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IChatCapabilities, IChatCapabilities_Vtbl, 0x3aff77bc_39c9_4dd1_ad2d_3964dd9d403f);
+impl windows_core::RuntimeType for IChatCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IChatCapabilities_Vtbl {
     pub IsIntegratedMessagingCapable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatCapabilitiesManagerStatics, IChatCapabilitiesManagerStatics_Vtbl, 0xb57a2f30_7041_458e_b0cf_7c0d9fea333a);
+impl windows_core::RuntimeType for IChatCapabilitiesManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatCapabilitiesManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +22,9 @@ pub struct IChatCapabilitiesManagerStatics_Vtbl {
     pub GetCapabilitiesFromNetworkAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatCapabilitiesManagerStatics2, IChatCapabilitiesManagerStatics2_Vtbl, 0xe30d4274_d5c1_4ac9_9ffc_40e69184fec8);
+impl windows_core::RuntimeType for IChatCapabilitiesManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatCapabilitiesManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +32,9 @@ pub struct IChatCapabilitiesManagerStatics2_Vtbl {
     pub GetCapabilitiesFromNetworkForTransportAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatConversation, IChatConversation_Vtbl, 0xa58c080d_1a6f_46dc_8f3d_f5028660b6ee);
+impl windows_core::RuntimeType for IChatConversation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatConversation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,6 +61,9 @@ pub struct IChatConversation_Vtbl {
     pub RemoveRemoteParticipantComposingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatConversation2, IChatConversation2_Vtbl, 0x0a030cd1_983a_47aa_9a90_ee48ee997b59);
+impl windows_core::RuntimeType for IChatConversation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatConversation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +71,9 @@ pub struct IChatConversation2_Vtbl {
     pub SetCanModifyParticipants: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatConversationReader, IChatConversationReader_Vtbl, 0x055136d2_de32_4a47_a93a_b3dc0833852b);
+impl windows_core::RuntimeType for IChatConversationReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatConversationReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +87,9 @@ pub struct IChatConversationReader_Vtbl {
     ReadBatchWithCountAsync: usize,
 }
 windows_core::imp::define_interface!(IChatConversationThreadingInfo, IChatConversationThreadingInfo_Vtbl, 0x331c21dc_7a07_4422_a32c_24be7c6dab24);
+impl windows_core::RuntimeType for IChatConversationThreadingInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatConversationThreadingInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,6 +126,9 @@ pub struct IChatItem_Vtbl {
     pub ItemKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ChatItemKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessage, IChatMessage_Vtbl, 0x4b39052a_1142_5089_76da_f2db3d17cd05);
+impl windows_core::RuntimeType for IChatMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -136,6 +160,9 @@ pub struct IChatMessage_Vtbl {
     pub SetTransportId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessage2, IChatMessage2_Vtbl, 0x86668332_543f_49f5_ac71_6c2afc6565fd);
+impl windows_core::RuntimeType for IChatMessage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,12 +199,18 @@ pub struct IChatMessage2_Vtbl {
     RecipientsDeliveryInfos: usize,
 }
 windows_core::imp::define_interface!(IChatMessage3, IChatMessage3_Vtbl, 0x74eb2fb0_3ba7_459f_8e0b_e8af0febd9ad);
+impl windows_core::RuntimeType for IChatMessage3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessage3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessage4, IChatMessage4_Vtbl, 0x2d144b0f_d2bf_460c_aa68_6d3f8483c9bf);
+impl windows_core::RuntimeType for IChatMessage4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessage4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -185,6 +218,9 @@ pub struct IChatMessage4_Vtbl {
     pub SetSyncId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageAttachment, IChatMessageAttachment_Vtbl, 0xc7c4fd74_bf63_58eb_508c_8b863ff16b67);
+impl windows_core::RuntimeType for IChatMessageAttachment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageAttachment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -204,6 +240,9 @@ pub struct IChatMessageAttachment_Vtbl {
     pub SetText: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageAttachment2, IChatMessageAttachment2_Vtbl, 0x5ed99270_7dd1_4a87_a8ce_acdd87d80dc8);
+impl windows_core::RuntimeType for IChatMessageAttachment2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageAttachment2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +260,9 @@ pub struct IChatMessageAttachment2_Vtbl {
     pub SetOriginalFileName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageAttachmentFactory, IChatMessageAttachmentFactory_Vtbl, 0x205852a2_a356_5b71_6ca9_66c985b7d0d5);
+impl windows_core::RuntimeType for IChatMessageAttachmentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageAttachmentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -230,12 +272,18 @@ pub struct IChatMessageAttachmentFactory_Vtbl {
     CreateChatMessageAttachment: usize,
 }
 windows_core::imp::define_interface!(IChatMessageBlockingStatic, IChatMessageBlockingStatic_Vtbl, 0xf6b9a380_cdea_11e4_8830_0800200c9a66);
+impl windows_core::RuntimeType for IChatMessageBlockingStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageBlockingStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MarkMessageAsBlockedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageChange, IChatMessageChange_Vtbl, 0x1c18c355_421e_54b8_6d38_6b3a6c82fccc);
+impl windows_core::RuntimeType for IChatMessageChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -243,6 +291,9 @@ pub struct IChatMessageChange_Vtbl {
     pub Message: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageChangeReader, IChatMessageChangeReader_Vtbl, 0x14267020_28ce_5f26_7b05_9a5c7cce87ca);
+impl windows_core::RuntimeType for IChatMessageChangeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageChangeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +305,9 @@ pub struct IChatMessageChangeReader_Vtbl {
     ReadBatchAsync: usize,
 }
 windows_core::imp::define_interface!(IChatMessageChangeTracker, IChatMessageChangeTracker_Vtbl, 0x60b7f066_70a0_5224_508c_242ef7c1d06f);
+impl windows_core::RuntimeType for IChatMessageChangeTracker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageChangeTracker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -262,18 +316,27 @@ pub struct IChatMessageChangeTracker_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageChangedDeferral, IChatMessageChangedDeferral_Vtbl, 0xfbc6b30c_788c_4dcc_ace7_6282382968cf);
+impl windows_core::RuntimeType for IChatMessageChangedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageChangedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageChangedEventArgs, IChatMessageChangedEventArgs_Vtbl, 0xb6b73e2d_691c_4edf_8660_6eb9896892e3);
+impl windows_core::RuntimeType for IChatMessageChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageManager2Statics, IChatMessageManager2Statics_Vtbl, 0x1d45390f_9f4f_4e35_964e_1b9ca61ac044);
+impl windows_core::RuntimeType for IChatMessageManager2Statics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageManager2Statics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +344,9 @@ pub struct IChatMessageManager2Statics_Vtbl {
     pub GetTransportAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageManagerStatic, IChatMessageManagerStatic_Vtbl, 0xf15c60f7_d5e8_5e92_556d_e03b60253104);
+impl windows_core::RuntimeType for IChatMessageManagerStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageManagerStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -293,18 +359,27 @@ pub struct IChatMessageManagerStatic_Vtbl {
     pub ShowSmsSettings: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageManagerStatics3, IChatMessageManagerStatics3_Vtbl, 0x208b830d_6755_48cc_9ab3_fd03c463fc92);
+impl windows_core::RuntimeType for IChatMessageManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestSyncManagerAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageNotificationTriggerDetails, IChatMessageNotificationTriggerDetails_Vtbl, 0xfd344dfb_3063_4e17_8586_c6c08262e6c0);
+impl windows_core::RuntimeType for IChatMessageNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ChatMessage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageNotificationTriggerDetails2, IChatMessageNotificationTriggerDetails2_Vtbl, 0x6bb522e0_aa07_4fd1_9471_77934fb75ee6);
+impl windows_core::RuntimeType for IChatMessageNotificationTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageNotificationTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +389,9 @@ pub struct IChatMessageNotificationTriggerDetails2_Vtbl {
     pub ShouldUpdateActionCenter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageReader, IChatMessageReader_Vtbl, 0xb6ea78ce_4489_56f9_76aa_e204682514cf);
+impl windows_core::RuntimeType for IChatMessageReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -323,6 +401,9 @@ pub struct IChatMessageReader_Vtbl {
     ReadBatchAsync: usize,
 }
 windows_core::imp::define_interface!(IChatMessageReader2, IChatMessageReader2_Vtbl, 0x89643683_64bb_470d_9df4_0de8be1a05bf);
+impl windows_core::RuntimeType for IChatMessageReader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageReader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -332,6 +413,9 @@ pub struct IChatMessageReader2_Vtbl {
     ReadBatchWithCountAsync: usize,
 }
 windows_core::imp::define_interface!(IChatMessageStore, IChatMessageStore_Vtbl, 0x31f2fd01_ccf6_580b_4976_0a07dd5d3b47);
+impl windows_core::RuntimeType for IChatMessageStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -349,6 +433,9 @@ pub struct IChatMessageStore_Vtbl {
     pub RemoveMessageChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageStore2, IChatMessageStore2_Vtbl, 0xad4dc4ee_3ad4_491b_b311_abdf9bb22768);
+impl windows_core::RuntimeType for IChatMessageStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -386,12 +473,18 @@ pub struct IChatMessageStore2_Vtbl {
     pub RemoveStoreChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageStore3, IChatMessageStore3_Vtbl, 0x9adbbb09_4345_4ec1_8b74_b7338243719c);
+impl windows_core::RuntimeType for IChatMessageStore3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageStore3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetMessageBySyncIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageStoreChangedEventArgs, IChatMessageStoreChangedEventArgs_Vtbl, 0x65c66fac_fe8c_46d4_9119_57b8410311d5);
+impl windows_core::RuntimeType for IChatMessageStoreChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageStoreChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -399,6 +492,9 @@ pub struct IChatMessageStoreChangedEventArgs_Vtbl {
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ChatStoreChangedEventKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageTransport, IChatMessageTransport_Vtbl, 0x63a9dbf8_e6b3_5c9a_5f85_d47925b9bd18);
+impl windows_core::RuntimeType for IChatMessageTransport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageTransport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -409,6 +505,9 @@ pub struct IChatMessageTransport_Vtbl {
     pub RequestSetAsNotificationProviderAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageTransport2, IChatMessageTransport2_Vtbl, 0x90a75622_d84a_4c22_a94d_544444edc8a1);
+impl windows_core::RuntimeType for IChatMessageTransport2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageTransport2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -416,6 +515,9 @@ pub struct IChatMessageTransport2_Vtbl {
     pub TransportKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ChatMessageTransportKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatMessageTransportConfiguration, IChatMessageTransportConfiguration_Vtbl, 0x879ff725_1a08_4aca_a075_3355126312e6);
+impl windows_core::RuntimeType for IChatMessageTransportConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageTransportConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -432,6 +534,9 @@ pub struct IChatMessageTransportConfiguration_Vtbl {
     ExtendedProperties: usize,
 }
 windows_core::imp::define_interface!(IChatMessageValidationResult, IChatMessageValidationResult_Vtbl, 0x25e93a03_28ec_5889_569b_7e486b126f18);
+impl windows_core::RuntimeType for IChatMessageValidationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatMessageValidationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -441,6 +546,9 @@ pub struct IChatMessageValidationResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ChatMessageValidationStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatQueryOptions, IChatQueryOptions_Vtbl, 0x2fd364a6_bf36_42f7_b7e7_923c0aabfe16);
+impl windows_core::RuntimeType for IChatQueryOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatQueryOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -448,6 +556,9 @@ pub struct IChatQueryOptions_Vtbl {
     pub SetSearchString: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatRecipientDeliveryInfo, IChatRecipientDeliveryInfo_Vtbl, 0xffc7b2a2_283c_4c0a_8a0e_8c33bdbf0545);
+impl windows_core::RuntimeType for IChatRecipientDeliveryInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatRecipientDeliveryInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -464,6 +575,9 @@ pub struct IChatRecipientDeliveryInfo_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ChatMessageStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatSearchReader, IChatSearchReader_Vtbl, 0x4665fe49_9020_4752_980d_39612325f589);
+impl windows_core::RuntimeType for IChatSearchReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatSearchReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -477,6 +591,9 @@ pub struct IChatSearchReader_Vtbl {
     ReadBatchWithCountAsync: usize,
 }
 windows_core::imp::define_interface!(IChatSyncConfiguration, IChatSyncConfiguration_Vtbl, 0x09f869b2_69f4_4aff_82b6_06992ff402d2);
+impl windows_core::RuntimeType for IChatSyncConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatSyncConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -486,6 +603,9 @@ pub struct IChatSyncConfiguration_Vtbl {
     pub SetRestoreHistorySpan: unsafe extern "system" fn(*mut core::ffi::c_void, ChatRestoreHistorySpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChatSyncManager, IChatSyncManager_Vtbl, 0x7ba52c63_2650_486f_b4b4_6bd9d3d63c84);
+impl windows_core::RuntimeType for IChatSyncManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChatSyncManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -503,6 +623,9 @@ pub struct IChatSyncManager_Vtbl {
     pub SetConfigurationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsEndUserMessage, IRcsEndUserMessage_Vtbl, 0xd7cda5eb_cbd7_4f3b_8526_b506dec35c53);
+impl windows_core::RuntimeType for IRcsEndUserMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsEndUserMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -518,12 +641,18 @@ pub struct IRcsEndUserMessage_Vtbl {
     pub SendResponseWithPinAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsEndUserMessageAction, IRcsEndUserMessageAction_Vtbl, 0x92378737_9b42_46d3_9d5e_3c1b2dae7cb8);
+impl windows_core::RuntimeType for IRcsEndUserMessageAction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsEndUserMessageAction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Label: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsEndUserMessageAvailableEventArgs, IRcsEndUserMessageAvailableEventArgs_Vtbl, 0x2d45ae01_3f89_41ea_9702_9e9ed411aa98);
+impl windows_core::RuntimeType for IRcsEndUserMessageAvailableEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsEndUserMessageAvailableEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -531,6 +660,9 @@ pub struct IRcsEndUserMessageAvailableEventArgs_Vtbl {
     pub Message: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsEndUserMessageAvailableTriggerDetails, IRcsEndUserMessageAvailableTriggerDetails_Vtbl, 0x5b97742d_351f_4692_b41e_1b035dc18986);
+impl windows_core::RuntimeType for IRcsEndUserMessageAvailableTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsEndUserMessageAvailableTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -538,6 +670,9 @@ pub struct IRcsEndUserMessageAvailableTriggerDetails_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsEndUserMessageManager, IRcsEndUserMessageManager_Vtbl, 0x3054ae5a_4d1f_4b59_9433_126c734e86a6);
+impl windows_core::RuntimeType for IRcsEndUserMessageManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsEndUserMessageManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -545,6 +680,9 @@ pub struct IRcsEndUserMessageManager_Vtbl {
     pub RemoveMessageAvailableChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsManagerStatics, IRcsManagerStatics_Vtbl, 0x7d270ac5_0abd_4f31_9b99_a59e71a7b731);
+impl windows_core::RuntimeType for IRcsManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -557,6 +695,9 @@ pub struct IRcsManagerStatics_Vtbl {
     pub LeaveConversationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsManagerStatics2, IRcsManagerStatics2_Vtbl, 0xcd49ad18_ad8a_42aa_8eeb_a798a8808959);
+impl windows_core::RuntimeType for IRcsManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -564,12 +705,18 @@ pub struct IRcsManagerStatics2_Vtbl {
     pub RemoveTransportListChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsServiceKindSupportedChangedEventArgs, IRcsServiceKindSupportedChangedEventArgs_Vtbl, 0xf47ea244_e783_4866_b3a7_4e5ccf023070);
+impl windows_core::RuntimeType for IRcsServiceKindSupportedChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsServiceKindSupportedChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ServiceKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RcsServiceKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsTransport, IRcsTransport_Vtbl, 0xfea34759_f37c_4319_8546_ec84d21d30ff);
+impl windows_core::RuntimeType for IRcsTransport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsTransport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -587,6 +734,9 @@ pub struct IRcsTransport_Vtbl {
     pub RemoveServiceKindSupportedChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRcsTransportConfiguration, IRcsTransportConfiguration_Vtbl, 0x1fccb102_2472_4bb9_9988_c1211c83e8a9);
+impl windows_core::RuntimeType for IRcsTransportConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRcsTransportConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -598,6 +748,9 @@ pub struct IRcsTransportConfiguration_Vtbl {
     pub WarningFileSizeInKilobytes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteParticipantComposingChangedEventArgs, IRemoteParticipantComposingChangedEventArgs_Vtbl, 0x1ec045a7_cfc9_45c9_9876_449f2bc180f5);
+impl windows_core::RuntimeType for IRemoteParticipantComposingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteParticipantComposingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -647,7 +800,7 @@ impl ChatCapabilities {
     }
 }
 impl windows_core::RuntimeType for ChatCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatCapabilities>();
 }
 unsafe impl windows_core::Interface for ChatCapabilities {
     type Vtable = IChatCapabilities_Vtbl;
@@ -839,7 +992,7 @@ impl ChatConversation {
     }
 }
 impl windows_core::RuntimeType for ChatConversation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatConversation>();
 }
 unsafe impl windows_core::Interface for ChatConversation {
     type Vtable = IChatConversation_Vtbl;
@@ -873,7 +1026,7 @@ impl ChatConversationReader {
     }
 }
 impl windows_core::RuntimeType for ChatConversationReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatConversationReader>();
 }
 unsafe impl windows_core::Interface for ChatConversationReader {
     type Vtable = IChatConversationReader_Vtbl;
@@ -950,7 +1103,7 @@ impl ChatConversationThreadingInfo {
     }
 }
 impl windows_core::RuntimeType for ChatConversationThreadingInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatConversationThreadingInfo>();
 }
 unsafe impl windows_core::Interface for ChatConversationThreadingInfo {
     type Vtable = IChatConversationThreadingInfo_Vtbl;
@@ -1266,7 +1419,7 @@ impl ChatMessage {
     }
 }
 impl windows_core::RuntimeType for ChatMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessage>();
 }
 unsafe impl windows_core::Interface for ChatMessage {
     type Vtable = IChatMessage_Vtbl;
@@ -1386,7 +1539,7 @@ impl ChatMessageAttachment {
     }
 }
 impl windows_core::RuntimeType for ChatMessageAttachment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageAttachment>();
 }
 unsafe impl windows_core::Interface for ChatMessageAttachment {
     type Vtable = IChatMessageAttachment_Vtbl;
@@ -1435,7 +1588,7 @@ impl ChatMessageChange {
     }
 }
 impl windows_core::RuntimeType for ChatMessageChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageChange>();
 }
 unsafe impl windows_core::Interface for ChatMessageChange {
     type Vtable = IChatMessageChange_Vtbl;
@@ -1472,7 +1625,7 @@ impl ChatMessageChangeReader {
     }
 }
 impl windows_core::RuntimeType for ChatMessageChangeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageChangeReader>();
 }
 unsafe impl windows_core::Interface for ChatMessageChangeReader {
     type Vtable = IChatMessageChangeReader_Vtbl;
@@ -1505,7 +1658,7 @@ impl ChatMessageChangeTracker {
     }
 }
 impl windows_core::RuntimeType for ChatMessageChangeTracker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageChangeTracker>();
 }
 unsafe impl windows_core::Interface for ChatMessageChangeTracker {
     type Vtable = IChatMessageChangeTracker_Vtbl;
@@ -1527,7 +1680,7 @@ impl ChatMessageChangedDeferral {
     }
 }
 impl windows_core::RuntimeType for ChatMessageChangedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageChangedDeferral>();
 }
 unsafe impl windows_core::Interface for ChatMessageChangedDeferral {
     type Vtable = IChatMessageChangedDeferral_Vtbl;
@@ -1552,7 +1705,7 @@ impl ChatMessageChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ChatMessageChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ChatMessageChangedEventArgs {
     type Vtable = IChatMessageChangedEventArgs_Vtbl;
@@ -1669,7 +1822,7 @@ impl ChatMessageNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for ChatMessageNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for ChatMessageNotificationTriggerDetails {
     type Vtable = IChatMessageNotificationTriggerDetails_Vtbl;
@@ -1703,7 +1856,7 @@ impl ChatMessageReader {
     }
 }
 impl windows_core::RuntimeType for ChatMessageReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageReader>();
 }
 unsafe impl windows_core::Interface for ChatMessageReader {
     type Vtable = IChatMessageReader_Vtbl;
@@ -1966,7 +2119,7 @@ impl ChatMessageStore {
     }
 }
 impl windows_core::RuntimeType for ChatMessageStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageStore>();
 }
 unsafe impl windows_core::Interface for ChatMessageStore {
     type Vtable = IChatMessageStore_Vtbl;
@@ -1998,7 +2151,7 @@ impl ChatMessageStoreChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ChatMessageStoreChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageStoreChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ChatMessageStoreChangedEventArgs {
     type Vtable = IChatMessageStoreChangedEventArgs_Vtbl;
@@ -2065,7 +2218,7 @@ impl ChatMessageTransport {
     }
 }
 impl windows_core::RuntimeType for ChatMessageTransport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageTransport>();
 }
 unsafe impl windows_core::Interface for ChatMessageTransport {
     type Vtable = IChatMessageTransport_Vtbl;
@@ -2120,7 +2273,7 @@ impl ChatMessageTransportConfiguration {
     }
 }
 impl windows_core::RuntimeType for ChatMessageTransportConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageTransportConfiguration>();
 }
 unsafe impl windows_core::Interface for ChatMessageTransportConfiguration {
     type Vtable = IChatMessageTransportConfiguration_Vtbl;
@@ -2166,7 +2319,7 @@ impl ChatMessageValidationResult {
     }
 }
 impl windows_core::RuntimeType for ChatMessageValidationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatMessageValidationResult>();
 }
 unsafe impl windows_core::Interface for ChatMessageValidationResult {
     type Vtable = IChatMessageValidationResult_Vtbl;
@@ -2202,7 +2355,7 @@ impl ChatQueryOptions {
     }
 }
 impl windows_core::RuntimeType for ChatQueryOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatQueryOptions>();
 }
 unsafe impl windows_core::Interface for ChatQueryOptions {
     type Vtable = IChatQueryOptions_Vtbl;
@@ -2301,7 +2454,7 @@ impl ChatRecipientDeliveryInfo {
     }
 }
 impl windows_core::RuntimeType for ChatRecipientDeliveryInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatRecipientDeliveryInfo>();
 }
 unsafe impl windows_core::Interface for ChatRecipientDeliveryInfo {
     type Vtable = IChatRecipientDeliveryInfo_Vtbl;
@@ -2335,7 +2488,7 @@ impl ChatSearchReader {
     }
 }
 impl windows_core::RuntimeType for ChatSearchReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatSearchReader>();
 }
 unsafe impl windows_core::Interface for ChatSearchReader {
     type Vtable = IChatSearchReader_Vtbl;
@@ -2375,7 +2528,7 @@ impl ChatSyncConfiguration {
     }
 }
 impl windows_core::RuntimeType for ChatSyncConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatSyncConfiguration>();
 }
 unsafe impl windows_core::Interface for ChatSyncConfiguration {
     type Vtable = IChatSyncConfiguration_Vtbl;
@@ -2443,7 +2596,7 @@ impl ChatSyncManager {
     }
 }
 impl windows_core::RuntimeType for ChatSyncManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChatSyncManager>();
 }
 unsafe impl windows_core::Interface for ChatSyncManager {
     type Vtable = IChatSyncManager_Vtbl;
@@ -2517,7 +2670,7 @@ impl RcsEndUserMessage {
     }
 }
 impl windows_core::RuntimeType for RcsEndUserMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsEndUserMessage>();
 }
 unsafe impl windows_core::Interface for RcsEndUserMessage {
     type Vtable = IRcsEndUserMessage_Vtbl;
@@ -2542,7 +2695,7 @@ impl RcsEndUserMessageAction {
     }
 }
 impl windows_core::RuntimeType for RcsEndUserMessageAction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsEndUserMessageAction>();
 }
 unsafe impl windows_core::Interface for RcsEndUserMessageAction {
     type Vtable = IRcsEndUserMessageAction_Vtbl;
@@ -2574,7 +2727,7 @@ impl RcsEndUserMessageAvailableEventArgs {
     }
 }
 impl windows_core::RuntimeType for RcsEndUserMessageAvailableEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsEndUserMessageAvailableEventArgs>();
 }
 unsafe impl windows_core::Interface for RcsEndUserMessageAvailableEventArgs {
     type Vtable = IRcsEndUserMessageAvailableEventArgs_Vtbl;
@@ -2606,7 +2759,7 @@ impl RcsEndUserMessageAvailableTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for RcsEndUserMessageAvailableTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsEndUserMessageAvailableTriggerDetails>();
 }
 unsafe impl windows_core::Interface for RcsEndUserMessageAvailableTriggerDetails {
     type Vtable = IRcsEndUserMessageAvailableTriggerDetails_Vtbl;
@@ -2638,7 +2791,7 @@ impl RcsEndUserMessageManager {
     }
 }
 impl windows_core::RuntimeType for RcsEndUserMessageManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsEndUserMessageManager>();
 }
 unsafe impl windows_core::Interface for RcsEndUserMessageManager {
     type Vtable = IRcsEndUserMessageManager_Vtbl;
@@ -2719,7 +2872,7 @@ impl RcsServiceKindSupportedChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RcsServiceKindSupportedChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsServiceKindSupportedChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for RcsServiceKindSupportedChangedEventArgs {
     type Vtable = IRcsServiceKindSupportedChangedEventArgs_Vtbl;
@@ -2801,7 +2954,7 @@ impl RcsTransport {
     }
 }
 impl windows_core::RuntimeType for RcsTransport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsTransport>();
 }
 unsafe impl windows_core::Interface for RcsTransport {
     type Vtable = IRcsTransport_Vtbl;
@@ -2861,7 +3014,7 @@ impl RcsTransportConfiguration {
     }
 }
 impl windows_core::RuntimeType for RcsTransportConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRcsTransportConfiguration>();
 }
 unsafe impl windows_core::Interface for RcsTransportConfiguration {
     type Vtable = IRcsTransportConfiguration_Vtbl;
@@ -2900,7 +3053,7 @@ impl RemoteParticipantComposingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteParticipantComposingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteParticipantComposingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteParticipantComposingChangedEventArgs {
     type Vtable = IRemoteParticipantComposingChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/CommunicationBlocking/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/CommunicationBlocking/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICommunicationBlockingAccessManagerStatics, ICommunicationBlockingAccessManagerStatics_Vtbl, 0x1c969998_9d2a_5db7_edd5_0ce407fc2595);
+impl windows_core::RuntimeType for ICommunicationBlockingAccessManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICommunicationBlockingAccessManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +19,9 @@ pub struct ICommunicationBlockingAccessManagerStatics_Vtbl {
     pub ShowBlockedMessagesUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICommunicationBlockingAppManagerStatics, ICommunicationBlockingAppManagerStatics_Vtbl, 0x77db58ec_14a6_4baa_942a_6a673d999bf2);
+impl windows_core::RuntimeType for ICommunicationBlockingAppManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICommunicationBlockingAppManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +29,9 @@ pub struct ICommunicationBlockingAppManagerStatics_Vtbl {
     pub ShowCommunicationBlockingSettingsUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICommunicationBlockingAppManagerStatics2, ICommunicationBlockingAppManagerStatics2_Vtbl, 0x14a68edd_ed88_457a_a364_a3634d6f166d);
+impl windows_core::RuntimeType for ICommunicationBlockingAppManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICommunicationBlockingAppManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/DataProvider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IContactDataProviderConnection, IContactDataProviderConnection_Vtbl, 0x1a398a52_8c9d_4d6f_a4e0_111e9a125a30);
+impl windows_core::RuntimeType for IContactDataProviderConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactDataProviderConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IContactDataProviderConnection_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactDataProviderConnection2, IContactDataProviderConnection2_Vtbl, 0xa1d327b0_196c_4bfd_8f0f_c68d67f249d3);
+impl windows_core::RuntimeType for IContactDataProviderConnection2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactDataProviderConnection2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,12 +24,18 @@ pub struct IContactDataProviderConnection2_Vtbl {
     pub RemoveDeleteContactRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactDataProviderTriggerDetails, IContactDataProviderTriggerDetails_Vtbl, 0x527104be_3c62_43c8_9ae7_db531685cd99);
+impl windows_core::RuntimeType for IContactDataProviderTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactDataProviderTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListCreateOrUpdateContactRequest, IContactListCreateOrUpdateContactRequest_Vtbl, 0xb4af411f_c849_47d0_b119_91cf605b2f2a);
+impl windows_core::RuntimeType for IContactListCreateOrUpdateContactRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListCreateOrUpdateContactRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +45,9 @@ pub struct IContactListCreateOrUpdateContactRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListCreateOrUpdateContactRequestEventArgs, IContactListCreateOrUpdateContactRequestEventArgs_Vtbl, 0x851c1690_1a51_4b0c_aeef_1240ac5bed75);
+impl windows_core::RuntimeType for IContactListCreateOrUpdateContactRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListCreateOrUpdateContactRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +55,9 @@ pub struct IContactListCreateOrUpdateContactRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListDeleteContactRequest, IContactListDeleteContactRequest_Vtbl, 0x5e114687_ce03_4de5_8557_9ccf552d472a);
+impl windows_core::RuntimeType for IContactListDeleteContactRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListDeleteContactRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,6 +67,9 @@ pub struct IContactListDeleteContactRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListDeleteContactRequestEventArgs, IContactListDeleteContactRequestEventArgs_Vtbl, 0xb22054a1_e8fa_4db5_9389_2d12ee7d15ee);
+impl windows_core::RuntimeType for IContactListDeleteContactRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListDeleteContactRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +77,9 @@ pub struct IContactListDeleteContactRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListServerSearchReadBatchRequest, IContactListServerSearchReadBatchRequest_Vtbl, 0xba776a97_4030_4925_9fb4_143b295e653b);
+impl windows_core::RuntimeType for IContactListServerSearchReadBatchRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListServerSearchReadBatchRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,6 +92,9 @@ pub struct IContactListServerSearchReadBatchRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::ContactBatchStatus, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListServerSearchReadBatchRequestEventArgs, IContactListServerSearchReadBatchRequestEventArgs_Vtbl, 0x1a27e87b_69d7_4e4e_8042_861cba61471e);
+impl windows_core::RuntimeType for IContactListServerSearchReadBatchRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListServerSearchReadBatchRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +102,9 @@ pub struct IContactListServerSearchReadBatchRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListSyncManagerSyncRequest, IContactListSyncManagerSyncRequest_Vtbl, 0x3c0e57a4_c4e7_4970_9a8f_9a66a2bb6c1a);
+impl windows_core::RuntimeType for IContactListSyncManagerSyncRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListSyncManagerSyncRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,6 +113,9 @@ pub struct IContactListSyncManagerSyncRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListSyncManagerSyncRequestEventArgs, IContactListSyncManagerSyncRequestEventArgs_Vtbl, 0x158e4dac_446d_4f10_afc2_02683ec533a6);
+impl windows_core::RuntimeType for IContactListSyncManagerSyncRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListSyncManagerSyncRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,7 +189,7 @@ impl ContactDataProviderConnection {
     }
 }
 impl windows_core::RuntimeType for ContactDataProviderConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactDataProviderConnection>();
 }
 unsafe impl windows_core::Interface for ContactDataProviderConnection {
     type Vtable = IContactDataProviderConnection_Vtbl;
@@ -181,7 +214,7 @@ impl ContactDataProviderTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for ContactDataProviderTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactDataProviderTriggerDetails>();
 }
 unsafe impl windows_core::Interface for ContactDataProviderTriggerDetails {
     type Vtable = IContactDataProviderTriggerDetails_Vtbl;
@@ -230,7 +263,7 @@ impl ContactListCreateOrUpdateContactRequest {
     }
 }
 impl windows_core::RuntimeType for ContactListCreateOrUpdateContactRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListCreateOrUpdateContactRequest>();
 }
 unsafe impl windows_core::Interface for ContactListCreateOrUpdateContactRequest {
     type Vtable = IContactListCreateOrUpdateContactRequest_Vtbl;
@@ -262,7 +295,7 @@ impl ContactListCreateOrUpdateContactRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactListCreateOrUpdateContactRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListCreateOrUpdateContactRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactListCreateOrUpdateContactRequestEventArgs {
     type Vtable = IContactListCreateOrUpdateContactRequestEventArgs_Vtbl;
@@ -308,7 +341,7 @@ impl ContactListDeleteContactRequest {
     }
 }
 impl windows_core::RuntimeType for ContactListDeleteContactRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListDeleteContactRequest>();
 }
 unsafe impl windows_core::Interface for ContactListDeleteContactRequest {
     type Vtable = IContactListDeleteContactRequest_Vtbl;
@@ -340,7 +373,7 @@ impl ContactListDeleteContactRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactListDeleteContactRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListDeleteContactRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactListDeleteContactRequestEventArgs {
     type Vtable = IContactListDeleteContactRequestEventArgs_Vtbl;
@@ -410,7 +443,7 @@ impl ContactListServerSearchReadBatchRequest {
     }
 }
 impl windows_core::RuntimeType for ContactListServerSearchReadBatchRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListServerSearchReadBatchRequest>();
 }
 unsafe impl windows_core::Interface for ContactListServerSearchReadBatchRequest {
     type Vtable = IContactListServerSearchReadBatchRequest_Vtbl;
@@ -442,7 +475,7 @@ impl ContactListServerSearchReadBatchRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactListServerSearchReadBatchRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListServerSearchReadBatchRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactListServerSearchReadBatchRequestEventArgs {
     type Vtable = IContactListServerSearchReadBatchRequestEventArgs_Vtbl;
@@ -481,7 +514,7 @@ impl ContactListSyncManagerSyncRequest {
     }
 }
 impl windows_core::RuntimeType for ContactListSyncManagerSyncRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListSyncManagerSyncRequest>();
 }
 unsafe impl windows_core::Interface for ContactListSyncManagerSyncRequest {
     type Vtable = IContactListSyncManagerSyncRequest_Vtbl;
@@ -513,7 +546,7 @@ impl ContactListSyncManagerSyncRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactListSyncManagerSyncRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListSyncManagerSyncRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactListSyncManagerSyncRequestEventArgs {
     type Vtable = IContactListSyncManagerSyncRequestEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IContactPickerUI, IContactPickerUI_Vtbl, 0xe2cc1366_cf66_43c4_a96a_a5a112db4746);
+impl windows_core::RuntimeType for IContactPickerUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPickerUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +20,9 @@ pub struct IContactPickerUI_Vtbl {
     pub RemoveContactRemoved: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactPickerUI2, IContactPickerUI2_Vtbl, 0x6e449e28_7b25_4999_9b0b_875400a1e8c8);
+impl windows_core::RuntimeType for IContactPickerUI2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPickerUI2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +33,9 @@ pub struct IContactPickerUI2_Vtbl {
     DesiredFieldsWithContactFieldType: usize,
 }
 windows_core::imp::define_interface!(IContactRemovedEventArgs, IContactRemovedEventArgs_Vtbl, 0x6f354338_3302_4d13_ad8d_adcc0ff9e47c);
+impl windows_core::RuntimeType for IContactRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,7 +117,7 @@ impl ContactPickerUI {
     }
 }
 impl windows_core::RuntimeType for ContactPickerUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPickerUI>();
 }
 unsafe impl windows_core::Interface for ContactPickerUI {
     type Vtable = IContactPickerUI_Vtbl;
@@ -131,7 +140,7 @@ impl ContactRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactRemovedEventArgs {
     type Vtable = IContactRemovedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
@@ -3,6 +3,9 @@ pub mod DataProvider;
 #[cfg(feature = "ApplicationModel_Contacts_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IAggregateContactManager, IAggregateContactManager_Vtbl, 0x0379d5dd_db5a_4fd3_b54e_4df17917a212);
+impl windows_core::RuntimeType for IAggregateContactManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAggregateContactManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,12 +18,18 @@ pub struct IAggregateContactManager_Vtbl {
     pub TrySetPreferredSourceForPictureAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAggregateContactManager2, IAggregateContactManager2_Vtbl, 0x5e8cc2d8_a9cd_4430_9c4b_01348db2ca50);
+impl windows_core::RuntimeType for IAggregateContactManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAggregateContactManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetRemoteIdentificationInformationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContact, IContact_Vtbl, 0xec0072f3_2118_4049_9ebc_17f0ab692b64);
+impl windows_core::RuntimeType for IContact {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContact_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +49,9 @@ pub struct IContact_Vtbl {
     Fields: usize,
 }
 windows_core::imp::define_interface!(IContact2, IContact2_Vtbl, 0xf312f365_bb77_4c94_802d_8328cee40c08);
+impl windows_core::RuntimeType for IContact2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContact2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +101,9 @@ pub struct IContact2_Vtbl {
     ProviderProperties: usize,
 }
 windows_core::imp::define_interface!(IContact3, IContact3_Vtbl, 0x48201e67_e08e_42a4_b561_41d08ca9575d);
+impl windows_core::RuntimeType for IContact3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContact3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,6 +144,9 @@ pub struct IContact3_Vtbl {
     pub SortName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactAddress, IContactAddress_Vtbl, 0x9739d39a_42ce_4872_8d70_3063aa584b70);
+impl windows_core::RuntimeType for IContactAddress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactAddress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,6 +166,9 @@ pub struct IContactAddress_Vtbl {
     pub SetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactAnnotation, IContactAnnotation_Vtbl, 0x821fc2ef_7d41_44a2_84c3_60a281dd7b86);
+impl windows_core::RuntimeType for IContactAnnotation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactAnnotation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -166,6 +187,9 @@ pub struct IContactAnnotation_Vtbl {
     ProviderProperties: usize,
 }
 windows_core::imp::define_interface!(IContactAnnotation2, IContactAnnotation2_Vtbl, 0xb691ecf3_4ab7_4a1f_9941_0c9cf3171b75);
+impl windows_core::RuntimeType for IContactAnnotation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactAnnotation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,6 +197,9 @@ pub struct IContactAnnotation2_Vtbl {
     pub SetContactListId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactAnnotationList, IContactAnnotationList_Vtbl, 0x92a486aa_5c88_45b9_aad0_461888e68d8a);
+impl windows_core::RuntimeType for IContactAnnotationList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactAnnotationList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -193,6 +220,9 @@ pub struct IContactAnnotationList_Vtbl {
     pub DeleteAnnotationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactAnnotationStore, IContactAnnotationStore_Vtbl, 0x23acf4aa_7a77_457d_8203_987f4b31af09);
+impl windows_core::RuntimeType for IContactAnnotationStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactAnnotationStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -218,6 +248,9 @@ pub struct IContactAnnotationStore_Vtbl {
     FindAnnotationListsAsync: usize,
 }
 windows_core::imp::define_interface!(IContactAnnotationStore2, IContactAnnotationStore2_Vtbl, 0x7ede23fd_61e7_4967_8ec5_bdf280a24063);
+impl windows_core::RuntimeType for IContactAnnotationStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactAnnotationStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -227,6 +260,9 @@ pub struct IContactAnnotationStore2_Vtbl {
     FindAnnotationsForContactListAsync: usize,
 }
 windows_core::imp::define_interface!(IContactBatch, IContactBatch_Vtbl, 0x35d1972d_bfce_46bb_93f8_a5b06ec5e201);
+impl windows_core::RuntimeType for IContactBatch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactBatch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -237,12 +273,18 @@ pub struct IContactBatch_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ContactBatchStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactCardDelayedDataLoader, IContactCardDelayedDataLoader_Vtbl, 0xb60af902_1546_434d_869c_6e3520760ef3);
+impl windows_core::RuntimeType for IContactCardDelayedDataLoader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactCardDelayedDataLoader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactCardOptions, IContactCardOptions_Vtbl, 0x8c0a4f7e_6ab6_4f3f_be72_817236eeea5b);
+impl windows_core::RuntimeType for IContactCardOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactCardOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -252,6 +294,9 @@ pub struct IContactCardOptions_Vtbl {
     pub SetInitialTabKind: unsafe extern "system" fn(*mut core::ffi::c_void, ContactCardTabKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactCardOptions2, IContactCardOptions2_Vtbl, 0x8f271ba0_d74b_4cc6_9f53_1b0eb5d1273c);
+impl windows_core::RuntimeType for IContactCardOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactCardOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -261,6 +306,9 @@ pub struct IContactCardOptions2_Vtbl {
     ServerSearchContactListIds: usize,
 }
 windows_core::imp::define_interface!(IContactChange, IContactChange_Vtbl, 0x951d4b10_6a59_4720_a4e1_363d98c135d5);
+impl windows_core::RuntimeType for IContactChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -268,6 +316,9 @@ pub struct IContactChange_Vtbl {
     pub Contact: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactChangeReader, IContactChangeReader_Vtbl, 0x217319fa_2d0c_42e0_a9da_3ecd56a78a47);
+impl windows_core::RuntimeType for IContactChangeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactChangeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -279,6 +330,9 @@ pub struct IContactChangeReader_Vtbl {
     ReadBatchAsync: usize,
 }
 windows_core::imp::define_interface!(IContactChangeTracker, IContactChangeTracker_Vtbl, 0x6e992952_309b_404d_9712_b37bd30278aa);
+impl windows_core::RuntimeType for IContactChangeTracker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactChangeTracker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -287,24 +341,36 @@ pub struct IContactChangeTracker_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactChangeTracker2, IContactChangeTracker2_Vtbl, 0x7f8ad0fc_9321_4d18_9c09_d708c63fcd31);
+impl windows_core::RuntimeType for IContactChangeTracker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactChangeTracker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsTracking: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactChangedDeferral, IContactChangedDeferral_Vtbl, 0xc5143ae8_1b03_46f8_b694_a523e83cfcb6);
+impl windows_core::RuntimeType for IContactChangedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactChangedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactChangedEventArgs, IContactChangedEventArgs_Vtbl, 0x525e7fd1_73f3_4b7d_a918_580be4366121);
+impl windows_core::RuntimeType for IContactChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactConnectedServiceAccount, IContactConnectedServiceAccount_Vtbl, 0xf6f83553_aa27_4731_8e4a_3dec5ce9eec9);
+impl windows_core::RuntimeType for IContactConnectedServiceAccount {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactConnectedServiceAccount_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +380,9 @@ pub struct IContactConnectedServiceAccount_Vtbl {
     pub SetServiceName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactDate, IContactDate_Vtbl, 0xfe98ae66_b205_4934_9174_0ff2b0565707);
+impl windows_core::RuntimeType for IContactDate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactDate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -329,6 +398,9 @@ pub struct IContactDate_Vtbl {
     pub SetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactEmail, IContactEmail_Vtbl, 0x90a219a9_e3d3_4d63_993b_05b9a5393abf);
+impl windows_core::RuntimeType for IContactEmail {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactEmail_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -418,11 +490,17 @@ pub struct IContactFieldFactory_Vtbl {
     pub CreateField_Custom: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, ContactFieldType, ContactFieldCategory, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactGroup, IContactGroup_Vtbl, 0x59bdeb01_9e9a_475d_bfe5_a37b806d852c);
+impl windows_core::RuntimeType for IContactGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IContactInformation, IContactInformation_Vtbl, 0x275eb6d4_6a2e_4278_a914_e460d5f088f6);
+impl windows_core::RuntimeType for IContactInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -457,6 +535,9 @@ pub struct IContactInformation_Vtbl {
     QueryCustomFields: usize,
 }
 windows_core::imp::define_interface!(IContactInstantMessageField, IContactInstantMessageField_Vtbl, 0xcce33b37_0d85_41fa_b43d_da599c3eb009);
+impl windows_core::RuntimeType for IContactInstantMessageField {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactInstantMessageField_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -504,6 +585,9 @@ pub struct IContactInstantMessageFieldFactory_Vtbl {
     pub CreateInstantMessage_All: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, ContactFieldCategory, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactJobInfo, IContactJobInfo_Vtbl, 0x6d117b4c_ce50_4b43_9e69_b18258ea5315);
+impl windows_core::RuntimeType for IContactJobInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactJobInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -525,6 +609,9 @@ pub struct IContactJobInfo_Vtbl {
     pub SetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactLaunchActionVerbsStatics, IContactLaunchActionVerbsStatics_Vtbl, 0xfb1232d6_ee73_46e7_8761_11cd0157728f);
+impl windows_core::RuntimeType for IContactLaunchActionVerbsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactLaunchActionVerbsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -535,6 +622,9 @@ pub struct IContactLaunchActionVerbsStatics_Vtbl {
     pub VideoCall: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactList, IContactList_Vtbl, 0x16ddec75_392c_4845_9dfb_51a3e7ef3e42);
+impl windows_core::RuntimeType for IContactList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -565,6 +655,9 @@ pub struct IContactList_Vtbl {
     pub GetContactAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactList2, IContactList2_Vtbl, 0xcb3943b4_4550_4dcb_9229_40ff91fb0203);
+impl windows_core::RuntimeType for IContactList2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactList2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -573,6 +666,9 @@ pub struct IContactList2_Vtbl {
     pub SyncConstraints: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactList3, IContactList3_Vtbl, 0x1578ee57_26fc_41e8_a850_5aa32514aca9);
+impl windows_core::RuntimeType for IContactList3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactList3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -580,6 +676,9 @@ pub struct IContactList3_Vtbl {
     pub GetChangeTracker: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListLimitedWriteOperations, IContactListLimitedWriteOperations_Vtbl, 0xe19813da_4a0b_44b8_9a1f_a0f3d218175f);
+impl windows_core::RuntimeType for IContactListLimitedWriteOperations {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListLimitedWriteOperations_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -587,6 +686,9 @@ pub struct IContactListLimitedWriteOperations_Vtbl {
     pub TryDeleteContactAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListSyncConstraints, IContactListSyncConstraints_Vtbl, 0xb2b0bf01_3062_4e2e_969d_018d1987f314);
+impl windows_core::RuntimeType for IContactListSyncConstraints {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListSyncConstraints_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -648,6 +750,9 @@ pub struct IContactListSyncConstraints_Vtbl {
     pub SetMaxWebsites: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListSyncManager, IContactListSyncManager_Vtbl, 0x146e83be_7925_4acc_9de5_21ddd06f8674);
+impl windows_core::RuntimeType for IContactListSyncManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListSyncManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -659,6 +764,9 @@ pub struct IContactListSyncManager_Vtbl {
     pub RemoveSyncStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactListSyncManager2, IContactListSyncManager2_Vtbl, 0xa9591247_bb55_4e23_8128_370134a85d0d);
+impl windows_core::RuntimeType for IContactListSyncManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactListSyncManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -667,6 +775,9 @@ pub struct IContactListSyncManager2_Vtbl {
     pub SetLastAttemptedSyncTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactLocationField, IContactLocationField_Vtbl, 0x9ec00f82_ab6e_4b36_89e3_b23bc0a1dacc);
+impl windows_core::RuntimeType for IContactLocationField {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactLocationField_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -713,6 +824,9 @@ pub struct IContactLocationFieldFactory_Vtbl {
     pub CreateLocation_All: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, ContactFieldCategory, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactManagerForUser, IContactManagerForUser_Vtbl, 0xb74bba57_1076_4bef_aef3_54686d18387d);
+impl windows_core::RuntimeType for IContactManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -740,12 +854,18 @@ pub struct IContactManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IContactManagerForUser2, IContactManagerForUser2_Vtbl, 0x4d469c2e_3b75_4a73_bb30_736645472256);
+impl windows_core::RuntimeType for IContactManagerForUser2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactManagerForUser2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShowFullContactCard: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactManagerStatics, IContactManagerStatics_Vtbl, 0x81f21ac0_f661_4708_ba4f_d386bd0d622e);
+impl windows_core::RuntimeType for IContactManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -760,12 +880,18 @@ pub struct IContactManagerStatics_Vtbl {
     ShowDelayLoadedContactCard: usize,
 }
 windows_core::imp::define_interface!(IContactManagerStatics2, IContactManagerStatics2_Vtbl, 0xa178e620_47d8_48cc_963c_9592b6e510c6);
+impl windows_core::RuntimeType for IContactManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestStoreAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactManagerStatics3, IContactManagerStatics3_Vtbl, 0xc4cc3d42_7586_492a_930b_7bc138fc2139);
+impl windows_core::RuntimeType for IContactManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -800,6 +926,9 @@ pub struct IContactManagerStatics3_Vtbl {
     pub SetSystemSortOrder: unsafe extern "system" fn(*mut core::ffi::c_void, ContactNameOrder) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactManagerStatics4, IContactManagerStatics4_Vtbl, 0x24982272_347b_46dc_8d95_51bd41e15aaf);
+impl windows_core::RuntimeType for IContactManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -809,6 +938,9 @@ pub struct IContactManagerStatics4_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IContactManagerStatics5, IContactManagerStatics5_Vtbl, 0xf7591a87_acb7_4fad_90f2_a8ab64cdbba4);
+impl windows_core::RuntimeType for IContactManagerStatics5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactManagerStatics5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -817,6 +949,9 @@ pub struct IContactManagerStatics5_Vtbl {
     pub SetIncludeMiddleNameInSystemDisplayAndSort: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactMatchReason, IContactMatchReason_Vtbl, 0xbc922504_e7d8_413e_95f4_b75c54c74077);
+impl windows_core::RuntimeType for IContactMatchReason {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactMatchReason_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -828,6 +963,9 @@ pub struct IContactMatchReason_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactName, IContactName_Vtbl, 0xf404e97b_9034_453c_8ebf_140a38c86f1d);
+impl windows_core::RuntimeType for IContactName {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactName_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -849,6 +987,9 @@ pub struct IContactName_Vtbl {
     pub YomiDisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactPanel, IContactPanel_Vtbl, 0x41bf1265_d2ee_4b97_a80a_7d8d64cca6f5);
+impl windows_core::RuntimeType for IContactPanel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPanel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -867,12 +1008,18 @@ pub struct IContactPanel_Vtbl {
     pub RemoveClosing: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactPanelClosingEventArgs, IContactPanelClosingEventArgs_Vtbl, 0x222174d3_cf4b_46d7_b739_6edc16110bfb);
+impl windows_core::RuntimeType for IContactPanelClosingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPanelClosingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactPanelLaunchFullAppRequestedEventArgs, IContactPanelLaunchFullAppRequestedEventArgs_Vtbl, 0x88d61c0e_23b4_4be8_8afc_072c25a4190d);
+impl windows_core::RuntimeType for IContactPanelLaunchFullAppRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPanelLaunchFullAppRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -880,6 +1027,9 @@ pub struct IContactPanelLaunchFullAppRequestedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactPhone, IContactPhone_Vtbl, 0x467dab65_2712_4f52_b783_9ea8111c63cd);
+impl windows_core::RuntimeType for IContactPhone {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPhone_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -891,6 +1041,9 @@ pub struct IContactPhone_Vtbl {
     pub SetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactPicker, IContactPicker_Vtbl, 0x0e09fd91_42f8_4055_90a0_896f96738936);
+impl windows_core::RuntimeType for IContactPicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -909,6 +1062,9 @@ pub struct IContactPicker_Vtbl {
     PickMultipleContactsAsync: usize,
 }
 windows_core::imp::define_interface!(IContactPicker2, IContactPicker2_Vtbl, 0xb35011cf_5cef_4d24_aa0c_340c5208725d);
+impl windows_core::RuntimeType for IContactPicker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPicker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -923,6 +1079,9 @@ pub struct IContactPicker2_Vtbl {
     PickContactsAsync: usize,
 }
 windows_core::imp::define_interface!(IContactPicker3, IContactPicker3_Vtbl, 0x0e723315_b243_4bed_8516_22b1a7ac0ace);
+impl windows_core::RuntimeType for IContactPicker3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPicker3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -932,6 +1091,9 @@ pub struct IContactPicker3_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IContactPickerStatics, IContactPickerStatics_Vtbl, 0x7488c029_6a53_4258_a3e9_62dff6784b6c);
+impl windows_core::RuntimeType for IContactPickerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPickerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -942,6 +1104,9 @@ pub struct IContactPickerStatics_Vtbl {
     pub IsSupportedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactQueryOptions, IContactQueryOptions_Vtbl, 0x4408cc9e_7d7c_42f0_8ac7_f50733ecdbc1);
+impl windows_core::RuntimeType for IContactQueryOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactQueryOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -962,6 +1127,9 @@ pub struct IContactQueryOptions_Vtbl {
     AnnotationListIds: usize,
 }
 windows_core::imp::define_interface!(IContactQueryOptionsFactory, IContactQueryOptionsFactory_Vtbl, 0x543fba47_8ce7_46cb_9dac_9aa42a1bc8e2);
+impl windows_core::RuntimeType for IContactQueryOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactQueryOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -969,6 +1137,9 @@ pub struct IContactQueryOptionsFactory_Vtbl {
     pub CreateWithTextAndFields: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, ContactQuerySearchFields, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactQueryTextSearch, IContactQueryTextSearch_Vtbl, 0xf7e3f9cb_a957_439b_a0b7_1c02a1963ff0);
+impl windows_core::RuntimeType for IContactQueryTextSearch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactQueryTextSearch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -980,6 +1151,9 @@ pub struct IContactQueryTextSearch_Vtbl {
     pub SetSearchScope: unsafe extern "system" fn(*mut core::ffi::c_void, ContactQuerySearchScope) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactReader, IContactReader_Vtbl, 0xd397e42e_1488_42f2_bf64_253f4884bfed);
+impl windows_core::RuntimeType for IContactReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -990,6 +1164,9 @@ pub struct IContactReader_Vtbl {
     GetMatchingPropertiesWithMatchReason: usize,
 }
 windows_core::imp::define_interface!(IContactSignificantOther, IContactSignificantOther_Vtbl, 0x8873b5ab_c5fb_46d8_93fe_da3ff1934054);
+impl windows_core::RuntimeType for IContactSignificantOther {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactSignificantOther_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -999,6 +1176,9 @@ pub struct IContactSignificantOther_Vtbl {
     pub SetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactSignificantOther2, IContactSignificantOther2_Vtbl, 0x8d7bd474_3f03_45f8_ba0f_c4ed37d64219);
+impl windows_core::RuntimeType for IContactSignificantOther2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactSignificantOther2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1006,6 +1186,9 @@ pub struct IContactSignificantOther2_Vtbl {
     pub SetRelationship: unsafe extern "system" fn(*mut core::ffi::c_void, ContactRelationship) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactStore, IContactStore_Vtbl, 0x2c220b10_3a6c_4293_b9bc_fe987f6e0d52);
+impl windows_core::RuntimeType for IContactStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1020,6 +1203,9 @@ pub struct IContactStore_Vtbl {
     pub GetContactAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactStore2, IContactStore2_Vtbl, 0x18ce1c22_ebd5_4bfb_b690_5f4f27c4f0e8);
+impl windows_core::RuntimeType for IContactStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1039,17 +1225,26 @@ pub struct IContactStore2_Vtbl {
     pub CreateContactListInAccountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactStore3, IContactStore3_Vtbl, 0xcb882c6c_004e_4050_87f0_840407ee6818);
+impl windows_core::RuntimeType for IContactStore3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStore3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetChangeTracker: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactStoreNotificationTriggerDetails, IContactStoreNotificationTriggerDetails_Vtbl, 0xabb298d6_878a_4f8b_a9ce_46bb7d1c84ce);
+impl windows_core::RuntimeType for IContactStoreNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStoreNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IContactWebsite, IContactWebsite_Vtbl, 0x9f130176_dc1b_4055_ad66_652f39d990e8);
+impl windows_core::RuntimeType for IContactWebsite {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactWebsite_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1059,6 +1254,9 @@ pub struct IContactWebsite_Vtbl {
     pub SetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactWebsite2, IContactWebsite2_Vtbl, 0xf87ee91e_5647_4068_bb5e_4b6f437ce308);
+impl windows_core::RuntimeType for IContactWebsite2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactWebsite2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1066,6 +1264,9 @@ pub struct IContactWebsite2_Vtbl {
     pub SetRawValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFullContactCardOptions, IFullContactCardOptions_Vtbl, 0x8744436c_5cf9_4683_bdca_a1fdebf8dbce);
+impl windows_core::RuntimeType for IFullContactCardOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFullContactCardOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1080,6 +1281,10 @@ pub struct IFullContactCardOptions_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IKnownContactFieldStatics, IKnownContactFieldStatics_Vtbl, 0x2e0e1b12_d627_4fca_bad4_1faf168c7d14);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IKnownContactFieldStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IKnownContactFieldStatics_Vtbl {
@@ -1110,6 +1315,9 @@ pub struct IKnownContactFieldStatics_Vtbl {
     ConvertTypeToName: usize,
 }
 windows_core::imp::define_interface!(IPinnedContactIdsQueryResult, IPinnedContactIdsQueryResult_Vtbl, 0x7d9b2552_1579_4ddc_871f_a30a3aea9ba1);
+impl windows_core::RuntimeType for IPinnedContactIdsQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPinnedContactIdsQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1119,6 +1327,9 @@ pub struct IPinnedContactIdsQueryResult_Vtbl {
     ContactIds: usize,
 }
 windows_core::imp::define_interface!(IPinnedContactManager, IPinnedContactManager_Vtbl, 0xfcbc740c_e1d6_45c3_b8b6_a35604e167a0);
+impl windows_core::RuntimeType for IPinnedContactManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPinnedContactManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1138,6 +1349,9 @@ pub struct IPinnedContactManager_Vtbl {
     pub GetPinnedContactIdsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPinnedContactManagerStatics, IPinnedContactManagerStatics_Vtbl, 0xf65ccc7e_fdf9_486a_ace9_bc311d0ae7f0);
+impl windows_core::RuntimeType for IPinnedContactManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPinnedContactManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1205,7 +1419,7 @@ impl AggregateContactManager {
     }
 }
 impl windows_core::RuntimeType for AggregateContactManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAggregateContactManager>();
 }
 unsafe impl windows_core::Interface for AggregateContactManager {
     type Vtable = IAggregateContactManager_Vtbl;
@@ -1605,7 +1819,7 @@ impl Contact {
     }
 }
 impl windows_core::RuntimeType for Contact {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContact>();
 }
 unsafe impl windows_core::Interface for Contact {
     type Vtable = IContact_Vtbl;
@@ -1707,7 +1921,7 @@ impl ContactAddress {
     }
 }
 impl windows_core::RuntimeType for ContactAddress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactAddress>();
 }
 unsafe impl windows_core::Interface for ContactAddress {
     type Vtable = IContactAddress_Vtbl;
@@ -1805,7 +2019,7 @@ impl ContactAnnotation {
     }
 }
 impl windows_core::RuntimeType for ContactAnnotation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactAnnotation>();
 }
 unsafe impl windows_core::Interface for ContactAnnotation {
     type Vtable = IContactAnnotation_Vtbl;
@@ -1894,7 +2108,7 @@ impl ContactAnnotationList {
     }
 }
 impl windows_core::RuntimeType for ContactAnnotationList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactAnnotationList>();
 }
 unsafe impl windows_core::Interface for ContactAnnotationList {
     type Vtable = IContactAnnotationList_Vtbl;
@@ -1986,7 +2200,7 @@ impl ContactAnnotationStore {
     }
 }
 impl windows_core::RuntimeType for ContactAnnotationStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactAnnotationStore>();
 }
 unsafe impl windows_core::Interface for ContactAnnotationStore {
     type Vtable = IContactAnnotationStore_Vtbl;
@@ -2019,7 +2233,7 @@ impl ContactBatch {
     }
 }
 impl windows_core::RuntimeType for ContactBatch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactBatch>();
 }
 unsafe impl windows_core::Interface for ContactBatch {
     type Vtable = IContactBatch_Vtbl;
@@ -2049,7 +2263,7 @@ impl ContactCardDelayedDataLoader {
     }
 }
 impl windows_core::RuntimeType for ContactCardDelayedDataLoader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactCardDelayedDataLoader>();
 }
 unsafe impl windows_core::Interface for ContactCardDelayedDataLoader {
     type Vtable = IContactCardDelayedDataLoader_Vtbl;
@@ -2104,7 +2318,7 @@ impl ContactCardOptions {
     }
 }
 impl windows_core::RuntimeType for ContactCardOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactCardOptions>();
 }
 unsafe impl windows_core::Interface for ContactCardOptions {
     type Vtable = IContactCardOptions_Vtbl;
@@ -2136,7 +2350,7 @@ impl ContactChange {
     }
 }
 impl windows_core::RuntimeType for ContactChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactChange>();
 }
 unsafe impl windows_core::Interface for ContactChange {
     type Vtable = IContactChange_Vtbl;
@@ -2173,7 +2387,7 @@ impl ContactChangeReader {
     }
 }
 impl windows_core::RuntimeType for ContactChangeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactChangeReader>();
 }
 unsafe impl windows_core::Interface for ContactChangeReader {
     type Vtable = IContactChangeReader_Vtbl;
@@ -2213,7 +2427,7 @@ impl ContactChangeTracker {
     }
 }
 impl windows_core::RuntimeType for ContactChangeTracker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactChangeTracker>();
 }
 unsafe impl windows_core::Interface for ContactChangeTracker {
     type Vtable = IContactChangeTracker_Vtbl;
@@ -2235,7 +2449,7 @@ impl ContactChangedDeferral {
     }
 }
 impl windows_core::RuntimeType for ContactChangedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactChangedDeferral>();
 }
 unsafe impl windows_core::Interface for ContactChangedDeferral {
     type Vtable = IContactChangedDeferral_Vtbl;
@@ -2260,7 +2474,7 @@ impl ContactChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactChangedEventArgs {
     type Vtable = IContactChangedEventArgs_Vtbl;
@@ -2307,7 +2521,7 @@ impl ContactConnectedServiceAccount {
     }
 }
 impl windows_core::RuntimeType for ContactConnectedServiceAccount {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactConnectedServiceAccount>();
 }
 unsafe impl windows_core::Interface for ContactConnectedServiceAccount {
     type Vtable = IContactConnectedServiceAccount_Vtbl;
@@ -2396,7 +2610,7 @@ impl ContactDate {
     }
 }
 impl windows_core::RuntimeType for ContactDate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactDate>();
 }
 unsafe impl windows_core::Interface for ContactDate {
     type Vtable = IContactDate_Vtbl;
@@ -2454,7 +2668,7 @@ impl ContactEmail {
     }
 }
 impl windows_core::RuntimeType for ContactEmail {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactEmail>();
 }
 unsafe impl windows_core::Interface for ContactEmail {
     type Vtable = IContactEmail_Vtbl;
@@ -2524,7 +2738,7 @@ impl ContactField {
     }
 }
 impl windows_core::RuntimeType for ContactField {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactField>();
 }
 unsafe impl windows_core::Interface for ContactField {
     type Vtable = IContactField_Vtbl;
@@ -2616,7 +2830,7 @@ impl ContactFieldFactory {
     }
 }
 impl windows_core::RuntimeType for ContactFieldFactory {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactFieldFactory>();
 }
 unsafe impl windows_core::Interface for ContactFieldFactory {
     type Vtable = IContactFieldFactory_Vtbl;
@@ -2633,7 +2847,7 @@ pub struct ContactGroup(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactGroup, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactGroup {}
 impl windows_core::RuntimeType for ContactGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactGroup>();
 }
 unsafe impl windows_core::Interface for ContactGroup {
     type Vtable = IContactGroup_Vtbl;
@@ -2714,7 +2928,7 @@ impl ContactInformation {
     }
 }
 impl windows_core::RuntimeType for ContactInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactInformation>();
 }
 unsafe impl windows_core::Interface for ContactInformation {
     type Vtable = IContactInformation_Vtbl;
@@ -2813,7 +3027,7 @@ impl ContactInstantMessageField {
     }
 }
 impl windows_core::RuntimeType for ContactInstantMessageField {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactInstantMessageField>();
 }
 unsafe impl windows_core::Interface for ContactInstantMessageField {
     type Vtable = IContactInstantMessageField_Vtbl;
@@ -2926,7 +3140,7 @@ impl ContactJobInfo {
     }
 }
 impl windows_core::RuntimeType for ContactJobInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactJobInfo>();
 }
 unsafe impl windows_core::Interface for ContactJobInfo {
     type Vtable = IContactJobInfo_Vtbl;
@@ -3189,7 +3403,7 @@ impl ContactList {
     }
 }
 impl windows_core::RuntimeType for ContactList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactList>();
 }
 unsafe impl windows_core::Interface for ContactList {
     type Vtable = IContactList_Vtbl;
@@ -3224,7 +3438,7 @@ impl ContactListLimitedWriteOperations {
     }
 }
 impl windows_core::RuntimeType for ContactListLimitedWriteOperations {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListLimitedWriteOperations>();
 }
 unsafe impl windows_core::Interface for ContactListLimitedWriteOperations {
     type Vtable = IContactListLimitedWriteOperations_Vtbl;
@@ -3631,7 +3845,7 @@ impl ContactListSyncConstraints {
     }
 }
 impl windows_core::RuntimeType for ContactListSyncConstraints {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListSyncConstraints>();
 }
 unsafe impl windows_core::Interface for ContactListSyncConstraints {
     type Vtable = IContactListSyncConstraints_Vtbl;
@@ -3703,7 +3917,7 @@ impl ContactListSyncManager {
     }
 }
 impl windows_core::RuntimeType for ContactListSyncManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactListSyncManager>();
 }
 unsafe impl windows_core::Interface for ContactListSyncManager {
     type Vtable = IContactListSyncManager_Vtbl;
@@ -3815,7 +4029,7 @@ impl ContactLocationField {
     }
 }
 impl windows_core::RuntimeType for ContactLocationField {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactLocationField>();
 }
 unsafe impl windows_core::Interface for ContactLocationField {
     type Vtable = IContactLocationField_Vtbl;
@@ -4101,7 +4315,7 @@ impl ContactManagerForUser {
     }
 }
 impl windows_core::RuntimeType for ContactManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactManagerForUser>();
 }
 unsafe impl windows_core::Interface for ContactManagerForUser {
     type Vtable = IContactManagerForUser_Vtbl;
@@ -4141,7 +4355,7 @@ impl ContactMatchReason {
     }
 }
 impl windows_core::RuntimeType for ContactMatchReason {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactMatchReason>();
 }
 unsafe impl windows_core::Interface for ContactMatchReason {
     type Vtable = IContactMatchReason_Vtbl;
@@ -4207,7 +4421,7 @@ impl ContactPanel {
     }
 }
 impl windows_core::RuntimeType for ContactPanel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPanel>();
 }
 unsafe impl windows_core::Interface for ContactPanel {
     type Vtable = IContactPanel_Vtbl;
@@ -4232,7 +4446,7 @@ impl ContactPanelClosingEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactPanelClosingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPanelClosingEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactPanelClosingEventArgs {
     type Vtable = IContactPanelClosingEventArgs_Vtbl;
@@ -4261,7 +4475,7 @@ impl ContactPanelLaunchFullAppRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ContactPanelLaunchFullAppRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPanelLaunchFullAppRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for ContactPanelLaunchFullAppRequestedEventArgs {
     type Vtable = IContactPanelLaunchFullAppRequestedEventArgs_Vtbl;
@@ -4319,7 +4533,7 @@ impl ContactPhone {
     }
 }
 impl windows_core::RuntimeType for ContactPhone {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPhone>();
 }
 unsafe impl windows_core::Interface for ContactPhone {
     type Vtable = IContactPhone_Vtbl;
@@ -4441,7 +4655,7 @@ impl ContactPicker {
     }
 }
 impl windows_core::RuntimeType for ContactPicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactPicker>();
 }
 unsafe impl windows_core::Interface for ContactPicker {
     type Vtable = IContactPicker_Vtbl;
@@ -4537,7 +4751,7 @@ impl ContactQueryOptions {
     }
 }
 impl windows_core::RuntimeType for ContactQueryOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactQueryOptions>();
 }
 unsafe impl windows_core::Interface for ContactQueryOptions {
     type Vtable = IContactQueryOptions_Vtbl;
@@ -4588,7 +4802,7 @@ impl ContactQueryTextSearch {
     }
 }
 impl windows_core::RuntimeType for ContactQueryTextSearch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactQueryTextSearch>();
 }
 unsafe impl windows_core::Interface for ContactQueryTextSearch {
     type Vtable = IContactQueryTextSearch_Vtbl;
@@ -4624,7 +4838,7 @@ impl ContactReader {
     }
 }
 impl windows_core::RuntimeType for ContactReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactReader>();
 }
 unsafe impl windows_core::Interface for ContactReader {
     type Vtable = IContactReader_Vtbl;
@@ -4682,7 +4896,7 @@ impl ContactSignificantOther {
     }
 }
 impl windows_core::RuntimeType for ContactSignificantOther {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactSignificantOther>();
 }
 unsafe impl windows_core::Interface for ContactSignificantOther {
     type Vtable = IContactSignificantOther_Vtbl;
@@ -4811,7 +5025,7 @@ impl ContactStore {
     }
 }
 impl windows_core::RuntimeType for ContactStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactStore>();
 }
 unsafe impl windows_core::Interface for ContactStore {
     type Vtable = IContactStore_Vtbl;
@@ -4828,7 +5042,7 @@ pub struct ContactStoreNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ContactStoreNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl ContactStoreNotificationTriggerDetails {}
 impl windows_core::RuntimeType for ContactStoreNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactStoreNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for ContactStoreNotificationTriggerDetails {
     type Vtable = IContactStoreNotificationTriggerDetails_Vtbl;
@@ -4889,7 +5103,7 @@ impl ContactWebsite {
     }
 }
 impl windows_core::RuntimeType for ContactWebsite {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactWebsite>();
 }
 unsafe impl windows_core::Interface for ContactWebsite {
     type Vtable = IContactWebsite_Vtbl;
@@ -4927,7 +5141,7 @@ impl FullContactCardOptions {
     }
 }
 impl windows_core::RuntimeType for FullContactCardOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFullContactCardOptions>();
 }
 unsafe impl windows_core::Interface for FullContactCardOptions {
     type Vtable = IFullContactCardOptions_Vtbl;
@@ -5010,7 +5224,7 @@ impl PinnedContactIdsQueryResult {
     }
 }
 impl windows_core::RuntimeType for PinnedContactIdsQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPinnedContactIdsQueryResult>();
 }
 unsafe impl windows_core::Interface for PinnedContactIdsQueryResult {
     type Vtable = IPinnedContactIdsQueryResult_Vtbl;
@@ -5125,7 +5339,7 @@ impl PinnedContactManager {
     }
 }
 impl windows_core::RuntimeType for PinnedContactManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPinnedContactManager>();
 }
 unsafe impl windows_core::Interface for PinnedContactManager {
     type Vtable = IPinnedContactManager_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IActivationSignalDetectionConfiguration, IActivationSignalDetectionConfiguration_Vtbl, 0x40d8be16_5217_581c_9ab2_ce9b2f2e8e00);
+impl windows_core::RuntimeType for IActivationSignalDetectionConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivationSignalDetectionConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +49,9 @@ pub struct IActivationSignalDetectionConfiguration_Vtbl {
     pub ClearTrainingDataAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivationSignalDetectionConfiguration2, IActivationSignalDetectionConfiguration2_Vtbl, 0x71d9b022_562c_57ce_a78b_8b4ff0145bab);
+impl windows_core::RuntimeType for IActivationSignalDetectionConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivationSignalDetectionConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +68,9 @@ pub struct IActivationSignalDetectionConfiguration2_Vtbl {
     pub TrainingStepCompletionMaxAllowedTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivationSignalDetectionConfigurationCreationResult, IActivationSignalDetectionConfigurationCreationResult_Vtbl, 0x4c89bc1b_8d12_5e48_a71c_7f6bc1cd66e0);
+impl windows_core::RuntimeType for IActivationSignalDetectionConfigurationCreationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivationSignalDetectionConfigurationCreationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +78,9 @@ pub struct IActivationSignalDetectionConfigurationCreationResult_Vtbl {
     pub Configuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivationSignalDetector, IActivationSignalDetector_Vtbl, 0xb5bf345f_a4d0_5b2b_8e65_b3c55ee756ff);
+impl windows_core::RuntimeType for IActivationSignalDetector {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivationSignalDetector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -111,6 +123,9 @@ pub struct IActivationSignalDetector_Vtbl {
     pub RemoveConfigurationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivationSignalDetector2, IActivationSignalDetector2_Vtbl, 0xc7e2490a_baa5_59d2_85d1_ba42f7cf78c9);
+impl windows_core::RuntimeType for IActivationSignalDetector2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivationSignalDetector2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,6 +144,9 @@ pub struct IActivationSignalDetector2_Vtbl {
     pub DetectorId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConversationalAgentDetectorManager, IConversationalAgentDetectorManager_Vtbl, 0xde94fbb0_597a_5df8_8cfb_9dbb583ba3ff);
+impl windows_core::RuntimeType for IConversationalAgentDetectorManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentDetectorManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -150,6 +168,9 @@ pub struct IConversationalAgentDetectorManager_Vtbl {
     GetActivationSignalDetectorsAsync: usize,
 }
 windows_core::imp::define_interface!(IConversationalAgentDetectorManager2, IConversationalAgentDetectorManager2_Vtbl, 0x84610f31_d7f3_52fe_9311_c9eb4e3eb30a);
+impl windows_core::RuntimeType for IConversationalAgentDetectorManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentDetectorManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -157,12 +178,18 @@ pub struct IConversationalAgentDetectorManager2_Vtbl {
     pub GetActivationSignalDetectorFromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConversationalAgentDetectorManagerStatics, IConversationalAgentDetectorManagerStatics_Vtbl, 0x36a8d283_fa0e_5693_8489_0fb2f0ab40d3);
+impl windows_core::RuntimeType for IConversationalAgentDetectorManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentDetectorManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Default: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConversationalAgentSession, IConversationalAgentSession_Vtbl, 0xdaaae09a_b7ba_57e5_ad13_df520f9b6fa7);
+impl windows_core::RuntimeType for IConversationalAgentSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,6 +241,9 @@ pub struct IConversationalAgentSession_Vtbl {
     GetSupportedSignalModelIds: usize,
 }
 windows_core::imp::define_interface!(IConversationalAgentSession2, IConversationalAgentSession2_Vtbl, 0xa7a9fbf9_ac78_57ff_9596_acc7a1c9a607);
+impl windows_core::RuntimeType for IConversationalAgentSession2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSession2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -231,11 +261,17 @@ pub struct IConversationalAgentSession2_Vtbl {
     GetMissingPrerequisitesAsync: usize,
 }
 windows_core::imp::define_interface!(IConversationalAgentSessionInterruptedEventArgs, IConversationalAgentSessionInterruptedEventArgs_Vtbl, 0x9766591f_f63d_5d3e_9bf2_bd0760552686);
+impl windows_core::RuntimeType for IConversationalAgentSessionInterruptedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSessionInterruptedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IConversationalAgentSessionStatics, IConversationalAgentSessionStatics_Vtbl, 0xa005166e_e954_576e_be04_11b8ed10f37b);
+impl windows_core::RuntimeType for IConversationalAgentSessionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSessionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -243,6 +279,9 @@ pub struct IConversationalAgentSessionStatics_Vtbl {
     pub GetCurrentSessionSync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConversationalAgentSignal, IConversationalAgentSignal_Vtbl, 0x20ed25f7_b120_51f2_8603_265d6a47f232);
+impl windows_core::RuntimeType for IConversationalAgentSignal {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSignal_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -260,6 +299,9 @@ pub struct IConversationalAgentSignal_Vtbl {
     pub SetSignalEnd: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConversationalAgentSignal2, IConversationalAgentSignal2_Vtbl, 0xd0cc7ba9_9a7b_5c34_880e_b6146c904ecb);
+impl windows_core::RuntimeType for IConversationalAgentSignal2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSignal2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -267,23 +309,35 @@ pub struct IConversationalAgentSignal2_Vtbl {
     pub DetectorKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ActivationSignalDetectorKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConversationalAgentSignalDetectedEventArgs, IConversationalAgentSignalDetectedEventArgs_Vtbl, 0x4d57eb8f_f88a_599b_91d3_d604876708bc);
+impl windows_core::RuntimeType for IConversationalAgentSignalDetectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSignalDetectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IConversationalAgentSystemStateChangedEventArgs, IConversationalAgentSystemStateChangedEventArgs_Vtbl, 0x1c2c6e3e_2785_59a7_8e71_38adeef79928);
+impl windows_core::RuntimeType for IConversationalAgentSystemStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConversationalAgentSystemStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SystemStateChangeType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ConversationalAgentSystemStateChangeType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDetectionConfigurationAvailabilityChangedEventArgs, IDetectionConfigurationAvailabilityChangedEventArgs_Vtbl, 0x5129c9fb_4be8_5f14_af2b_88d62b1b4462);
+impl windows_core::RuntimeType for IDetectionConfigurationAvailabilityChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDetectionConfigurationAvailabilityChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DetectionConfigurationAvailabilityChangeKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDetectionConfigurationAvailabilityInfo, IDetectionConfigurationAvailabilityInfo_Vtbl, 0xb5affeb0_40f0_5398_b838_91979c2c6208);
+impl windows_core::RuntimeType for IDetectionConfigurationAvailabilityInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDetectionConfigurationAvailabilityInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -293,6 +347,9 @@ pub struct IDetectionConfigurationAvailabilityInfo_Vtbl {
     pub HasLockScreenPermission: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDetectionConfigurationAvailabilityInfo2, IDetectionConfigurationAvailabilityInfo2_Vtbl, 0x30e06433_38b3_5c4b_84c3_62b6e685b2ff);
+impl windows_core::RuntimeType for IDetectionConfigurationAvailabilityInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDetectionConfigurationAvailabilityInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -530,7 +587,7 @@ impl ActivationSignalDetectionConfiguration {
     }
 }
 impl windows_core::RuntimeType for ActivationSignalDetectionConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivationSignalDetectionConfiguration>();
 }
 unsafe impl windows_core::Interface for ActivationSignalDetectionConfiguration {
     type Vtable = IActivationSignalDetectionConfiguration_Vtbl;
@@ -562,7 +619,7 @@ impl ActivationSignalDetectionConfigurationCreationResult {
     }
 }
 impl windows_core::RuntimeType for ActivationSignalDetectionConfigurationCreationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivationSignalDetectionConfigurationCreationResult>();
 }
 unsafe impl windows_core::Interface for ActivationSignalDetectionConfigurationCreationResult {
     type Vtable = IActivationSignalDetectionConfigurationCreationResult_Vtbl;
@@ -744,7 +801,7 @@ impl ActivationSignalDetector {
     }
 }
 impl windows_core::RuntimeType for ActivationSignalDetector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivationSignalDetector>();
 }
 unsafe impl windows_core::Interface for ActivationSignalDetector {
     type Vtable = IActivationSignalDetector_Vtbl;
@@ -819,7 +876,7 @@ impl ConversationalAgentDetectorManager {
     }
 }
 impl windows_core::RuntimeType for ConversationalAgentDetectorManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConversationalAgentDetectorManager>();
 }
 unsafe impl windows_core::Interface for ConversationalAgentDetectorManager {
     type Vtable = IConversationalAgentDetectorManager_Vtbl;
@@ -1148,7 +1205,7 @@ impl ConversationalAgentSession {
     }
 }
 impl windows_core::RuntimeType for ConversationalAgentSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConversationalAgentSession>();
 }
 unsafe impl windows_core::Interface for ConversationalAgentSession {
     type Vtable = IConversationalAgentSession_Vtbl;
@@ -1165,7 +1222,7 @@ pub struct ConversationalAgentSessionInterruptedEventArgs(windows_core::IUnknown
 windows_core::imp::interface_hierarchy!(ConversationalAgentSessionInterruptedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ConversationalAgentSessionInterruptedEventArgs {}
 impl windows_core::RuntimeType for ConversationalAgentSessionInterruptedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConversationalAgentSessionInterruptedEventArgs>();
 }
 unsafe impl windows_core::Interface for ConversationalAgentSessionInterruptedEventArgs {
     type Vtable = IConversationalAgentSessionInterruptedEventArgs_Vtbl;
@@ -1266,7 +1323,7 @@ impl ConversationalAgentSignal {
     }
 }
 impl windows_core::RuntimeType for ConversationalAgentSignal {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConversationalAgentSignal>();
 }
 unsafe impl windows_core::Interface for ConversationalAgentSignal {
     type Vtable = IConversationalAgentSignal_Vtbl;
@@ -1283,7 +1340,7 @@ pub struct ConversationalAgentSignalDetectedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ConversationalAgentSignalDetectedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ConversationalAgentSignalDetectedEventArgs {}
 impl windows_core::RuntimeType for ConversationalAgentSignalDetectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConversationalAgentSignalDetectedEventArgs>();
 }
 unsafe impl windows_core::Interface for ConversationalAgentSignalDetectedEventArgs {
     type Vtable = IConversationalAgentSignalDetectedEventArgs_Vtbl;
@@ -1308,7 +1365,7 @@ impl ConversationalAgentSystemStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ConversationalAgentSystemStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConversationalAgentSystemStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ConversationalAgentSystemStateChangedEventArgs {
     type Vtable = IConversationalAgentSystemStateChangedEventArgs_Vtbl;
@@ -1333,7 +1390,7 @@ impl DetectionConfigurationAvailabilityChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DetectionConfigurationAvailabilityChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDetectionConfigurationAvailabilityChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for DetectionConfigurationAvailabilityChangedEventArgs {
     type Vtable = IDetectionConfigurationAvailabilityChangedEventArgs_Vtbl;
@@ -1387,7 +1444,7 @@ impl DetectionConfigurationAvailabilityInfo {
     }
 }
 impl windows_core::RuntimeType for DetectionConfigurationAvailabilityInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDetectionConfigurationAvailabilityInfo>();
 }
 unsafe impl windows_core::Interface for DetectionConfigurationAvailabilityInfo {
     type Vtable = IDetectionConfigurationAvailabilityInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppListEntry, IAppListEntry_Vtbl, 0xef00f07f_2108_490a_877a_8a9f17c25fad);
+impl windows_core::RuntimeType for IAppListEntry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppListEntry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,12 +9,18 @@ pub struct IAppListEntry_Vtbl {
     pub LaunchAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppListEntry2, IAppListEntry2_Vtbl, 0xd0a618ad_bf35_42ac_ac06_86eeeb41d04b);
+impl windows_core::RuntimeType for IAppListEntry2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppListEntry2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AppUserModelId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppListEntry3, IAppListEntry3_Vtbl, 0x6099f28d_fc32_470a_bc69_4b061a76ef2e);
+impl windows_core::RuntimeType for IAppListEntry3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppListEntry3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,12 +30,18 @@ pub struct IAppListEntry3_Vtbl {
     LaunchForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IAppListEntry4, IAppListEntry4_Vtbl, 0x2a131ed2_56f5_487c_8697_5166f3b33da0);
+impl windows_core::RuntimeType for IAppListEntry4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppListEntry4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AppInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreApplication, ICoreApplication_Vtbl, 0x0aacf7a4_5e1d_49df_8034_fb6a68bc5ed1);
+impl windows_core::RuntimeType for ICoreApplication {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplication_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +59,9 @@ pub struct ICoreApplication_Vtbl {
     pub RunWithActivationFactories: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreApplication2, ICoreApplication2_Vtbl, 0x998681fb_1ab6_4b7f_be4a_9a0645224c04);
+impl windows_core::RuntimeType for ICoreApplication2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplication2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +77,9 @@ pub struct ICoreApplication2_Vtbl {
     pub EnablePrelaunch: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreApplication3, ICoreApplication3_Vtbl, 0xfeec0d39_598b_4507_8a67_772632580a57);
+impl windows_core::RuntimeType for ICoreApplication3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplication3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +90,9 @@ pub struct ICoreApplication3_Vtbl {
     RequestRestartForUserAsync: usize,
 }
 windows_core::imp::define_interface!(ICoreApplicationExit, ICoreApplicationExit_Vtbl, 0xcf86461d_261e_4b72_9acd_44ed2ace6a29);
+impl windows_core::RuntimeType for ICoreApplicationExit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationExit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -104,6 +128,9 @@ pub struct ICoreApplicationUnhandledError_Vtbl {
     pub RemoveUnhandledErrorDetected: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreApplicationUseCount, ICoreApplicationUseCount_Vtbl, 0x518dc408_c077_475b_809e_0bc0c57e4b74);
+impl windows_core::RuntimeType for ICoreApplicationUseCount {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationUseCount_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -111,6 +138,9 @@ pub struct ICoreApplicationUseCount_Vtbl {
     pub DecrementApplicationUseCount: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreApplicationView, ICoreApplicationView_Vtbl, 0x638bb2db_451d_4661_b099_414f34ffb9f1);
+impl windows_core::RuntimeType for ICoreApplicationView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,6 +157,9 @@ pub struct ICoreApplicationView_Vtbl {
     pub IsHosted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreApplicationView2, ICoreApplicationView2_Vtbl, 0x68eb7adf_917f_48eb_9aeb_7de53e086ab1);
+impl windows_core::RuntimeType for ICoreApplicationView2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationView2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -136,6 +169,9 @@ pub struct ICoreApplicationView2_Vtbl {
     Dispatcher: usize,
 }
 windows_core::imp::define_interface!(ICoreApplicationView3, ICoreApplicationView3_Vtbl, 0x07ebe1b3_a4cf_4550_ab70_b07e85330bc8);
+impl windows_core::RuntimeType for ICoreApplicationView3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationView3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +181,9 @@ pub struct ICoreApplicationView3_Vtbl {
     pub RemoveHostedViewClosing: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreApplicationView5, ICoreApplicationView5_Vtbl, 0x2bc095a8_8ef0_446d_9e60_3a3e0428c671);
+impl windows_core::RuntimeType for ICoreApplicationView5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationView5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,6 +193,9 @@ pub struct ICoreApplicationView5_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(ICoreApplicationView6, ICoreApplicationView6_Vtbl, 0xc119d49a_0679_49ba_803f_b79c5cf34cca);
+impl windows_core::RuntimeType for ICoreApplicationView6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationView6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -163,6 +205,9 @@ pub struct ICoreApplicationView6_Vtbl {
     DispatcherQueue: usize,
 }
 windows_core::imp::define_interface!(ICoreApplicationViewTitleBar, ICoreApplicationViewTitleBar_Vtbl, 0x006d35e3_e1f1_431b_9508_29b96926ac53);
+impl windows_core::RuntimeType for ICoreApplicationViewTitleBar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreApplicationViewTitleBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +223,9 @@ pub struct ICoreApplicationViewTitleBar_Vtbl {
     pub RemoveIsVisibleChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreImmersiveApplication, ICoreImmersiveApplication_Vtbl, 0x1ada0e3e_e4a2_4123_b451_dc96bf800419);
+impl windows_core::RuntimeType for ICoreImmersiveApplication {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreImmersiveApplication_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,12 +237,18 @@ pub struct ICoreImmersiveApplication_Vtbl {
     pub MainView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreImmersiveApplication2, ICoreImmersiveApplication2_Vtbl, 0x828e1e36_e9e3_4cfc_9b66_48b78ea9bb2c);
+impl windows_core::RuntimeType for ICoreImmersiveApplication2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreImmersiveApplication2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateNewViewFromMainView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreImmersiveApplication3, ICoreImmersiveApplication3_Vtbl, 0x34a05b2f_ee0d_41e5_8314_cf10c91bf0af);
+impl windows_core::RuntimeType for ICoreImmersiveApplication3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreImmersiveApplication3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -266,12 +320,18 @@ pub struct IFrameworkViewSource_Vtbl {
     pub CreateView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHostedViewClosingEventArgs, IHostedViewClosingEventArgs_Vtbl, 0xd238943c_b24e_4790_acb5_3e4243c4ff87);
+impl windows_core::RuntimeType for IHostedViewClosingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHostedViewClosingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUnhandledError, IUnhandledError_Vtbl, 0x9459b726_53b5_4686_9eaf_fa8162dc3980);
+impl windows_core::RuntimeType for IUnhandledError {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUnhandledError_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -279,6 +339,9 @@ pub struct IUnhandledError_Vtbl {
     pub Propagate: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUnhandledErrorDetectedEventArgs, IUnhandledErrorDetectedEventArgs_Vtbl, 0x679ab78b_b336_4822_ac40_0d750f0b7a2b);
+impl windows_core::RuntimeType for IUnhandledErrorDetectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUnhandledErrorDetectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -330,7 +393,7 @@ impl AppListEntry {
     }
 }
 impl windows_core::RuntimeType for AppListEntry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppListEntry>();
 }
 unsafe impl windows_core::Interface for AppListEntry {
     type Vtable = IAppListEntry_Vtbl;
@@ -666,7 +729,7 @@ impl CoreApplicationView {
     }
 }
 impl windows_core::RuntimeType for CoreApplicationView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreApplicationView>();
 }
 unsafe impl windows_core::Interface for CoreApplicationView {
     type Vtable = ICoreApplicationView_Vtbl;
@@ -749,7 +812,7 @@ impl CoreApplicationViewTitleBar {
     }
 }
 impl windows_core::RuntimeType for CoreApplicationViewTitleBar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreApplicationViewTitleBar>();
 }
 unsafe impl windows_core::Interface for CoreApplicationViewTitleBar {
     type Vtable = ICoreApplicationViewTitleBar_Vtbl;
@@ -772,7 +835,7 @@ impl HostedViewClosingEventArgs {
     }
 }
 impl windows_core::RuntimeType for HostedViewClosingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHostedViewClosingEventArgs>();
 }
 unsafe impl windows_core::Interface for HostedViewClosingEventArgs {
     type Vtable = IHostedViewClosingEventArgs_Vtbl;
@@ -801,7 +864,7 @@ impl UnhandledError {
     }
 }
 impl windows_core::RuntimeType for UnhandledError {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUnhandledError>();
 }
 unsafe impl windows_core::Interface for UnhandledError {
     type Vtable = IUnhandledError_Vtbl;
@@ -826,7 +889,7 @@ impl UnhandledErrorDetectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UnhandledErrorDetectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUnhandledErrorDetectedEventArgs>();
 }
 unsafe impl windows_core::Interface for UnhandledErrorDetectedEventArgs {
     type Vtable = IUnhandledErrorDetectedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICoreDragDropManager, ICoreDragDropManager_Vtbl, 0x7d56d344_8464_4faf_aa49_37ea6e2d7bd1);
+impl windows_core::RuntimeType for ICoreDragDropManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDragDropManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct ICoreDragDropManager_Vtbl {
     pub SetAreConcurrentOperationsEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDragDropManagerStatics, ICoreDragDropManagerStatics_Vtbl, 0x9542fdca_da12_4c1c_8d06_041db29733c3);
+impl windows_core::RuntimeType for ICoreDragDropManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDragDropManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDragInfo, ICoreDragInfo_Vtbl, 0x48353a8b_cb50_464e_9575_cd4e3a7ab028);
+impl windows_core::RuntimeType for ICoreDragInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDragInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,12 +31,18 @@ pub struct ICoreDragInfo_Vtbl {
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDragInfo2, ICoreDragInfo2_Vtbl, 0xc54691e5_e6fb_4d74_b4b1_8a3c17f25e9e);
+impl windows_core::RuntimeType for ICoreDragInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDragInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AllowedOperations: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::DataPackageOperation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDragOperation, ICoreDragOperation_Vtbl, 0xcc06de4f_6db0_4e62_ab1b_a74a02dc6d85);
+impl windows_core::RuntimeType for ICoreDragOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDragOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +61,9 @@ pub struct ICoreDragOperation_Vtbl {
     pub StartAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDragOperation2, ICoreDragOperation2_Vtbl, 0x824b1e2c_d99a_4fc3_8507_6c182f33b46a);
+impl windows_core::RuntimeType for ICoreDragOperation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDragOperation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +71,9 @@ pub struct ICoreDragOperation2_Vtbl {
     pub SetAllowedOperations: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::DataPackageOperation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDragUIOverride, ICoreDragUIOverride_Vtbl, 0x89a85064_3389_4f4f_8897_7e8a3ffb3c93);
+impl windows_core::RuntimeType for ICoreDragUIOverride {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDragUIOverride_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -132,6 +153,9 @@ pub struct ICoreDropOperationTarget_Vtbl {
     pub DropAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDropOperationTargetRequestedEventArgs, ICoreDropOperationTargetRequestedEventArgs_Vtbl, 0x2aca929a_5e28_4ea6_829e_29134e665d6d);
+impl windows_core::RuntimeType for ICoreDropOperationTargetRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDropOperationTargetRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -180,7 +204,7 @@ impl CoreDragDropManager {
     }
 }
 impl windows_core::RuntimeType for CoreDragDropManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreDragDropManager>();
 }
 unsafe impl windows_core::Interface for CoreDragDropManager {
     type Vtable = ICoreDragDropManager_Vtbl;
@@ -226,7 +250,7 @@ impl CoreDragInfo {
     }
 }
 impl windows_core::RuntimeType for CoreDragInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreDragInfo>();
 }
 unsafe impl windows_core::Interface for CoreDragInfo {
     type Vtable = ICoreDragInfo_Vtbl;
@@ -307,7 +331,7 @@ impl CoreDragOperation {
     }
 }
 impl windows_core::RuntimeType for CoreDragOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreDragOperation>();
 }
 unsafe impl windows_core::Interface for CoreDragOperation {
     type Vtable = ICoreDragOperation_Vtbl;
@@ -389,7 +413,7 @@ impl CoreDragUIOverride {
     }
 }
 impl windows_core::RuntimeType for CoreDragUIOverride {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreDragUIOverride>();
 }
 unsafe impl windows_core::Interface for CoreDragUIOverride {
     type Vtable = ICoreDragUIOverride_Vtbl;
@@ -414,7 +438,7 @@ impl CoreDropOperationTargetRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreDropOperationTargetRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreDropOperationTargetRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreDropOperationTargetRequestedEventArgs {
     type Vtable = ICoreDropOperationTargetRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/ShareTarget/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/ShareTarget/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IQuickLink, IQuickLink_Vtbl, 0x603e4308_f0be_4adc_acc9_8b27ab9cf556);
+impl windows_core::RuntimeType for IQuickLink {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IQuickLink_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +27,9 @@ pub struct IQuickLink_Vtbl {
     SupportedFileTypes: usize,
 }
 windows_core::imp::define_interface!(IShareOperation, IShareOperation_Vtbl, 0x2246bab8_d0f8_41c1_a82a_4137db6504fb);
+impl windows_core::RuntimeType for IShareOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,12 +44,18 @@ pub struct IShareOperation_Vtbl {
     pub ReportError: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareOperation2, IShareOperation2_Vtbl, 0x0ffb97c1_9778_4a09_8e5b_cb5e482d0555);
+impl windows_core::RuntimeType for IShareOperation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareOperation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DismissUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareOperation3, IShareOperation3_Vtbl, 0x5ef6b382_b7a7_4571_a2a6_994a034988b2);
+impl windows_core::RuntimeType for IShareOperation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareOperation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,7 +132,7 @@ impl QuickLink {
     }
 }
 impl windows_core::RuntimeType for QuickLink {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IQuickLink>();
 }
 unsafe impl windows_core::Interface for QuickLink {
     type Vtable = IQuickLink_Vtbl;
@@ -193,7 +205,7 @@ impl ShareOperation {
     }
 }
 impl windows_core::RuntimeType for ShareOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareOperation>();
 }
 unsafe impl windows_core::Interface for ShareOperation {
     type Vtable = IShareOperation_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -3,6 +3,9 @@ pub mod DragDrop;
 #[cfg(feature = "ApplicationModel_DataTransfer_ShareTarget")]
 pub mod ShareTarget;
 windows_core::imp::define_interface!(IClipboardContentOptions, IClipboardContentOptions_Vtbl, 0xe888a98c_ad4b_5447_a056_ab3556276d2b);
+impl windows_core::RuntimeType for IClipboardContentOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClipboardContentOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,11 +23,17 @@ pub struct IClipboardContentOptions_Vtbl {
     HistoryFormats: usize,
 }
 windows_core::imp::define_interface!(IClipboardHistoryChangedEventArgs, IClipboardHistoryChangedEventArgs_Vtbl, 0xc0be453f_8ea2_53ce_9aba_8d2212573452);
+impl windows_core::RuntimeType for IClipboardHistoryChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClipboardHistoryChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IClipboardHistoryItem, IClipboardHistoryItem_Vtbl, 0x0173bd8a_afff_5c50_ab92_3d19f481ec58);
+impl windows_core::RuntimeType for IClipboardHistoryItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClipboardHistoryItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +42,9 @@ pub struct IClipboardHistoryItem_Vtbl {
     pub Content: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClipboardHistoryItemsResult, IClipboardHistoryItemsResult_Vtbl, 0xe6dfdee6_0ee2_52e3_852b_f295db65939a);
+impl windows_core::RuntimeType for IClipboardHistoryItemsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClipboardHistoryItemsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,6 +55,9 @@ pub struct IClipboardHistoryItemsResult_Vtbl {
     Items: usize,
 }
 windows_core::imp::define_interface!(IClipboardStatics, IClipboardStatics_Vtbl, 0xc627e291_34e2_4963_8eed_93cbb0ea3d70);
+impl windows_core::RuntimeType for IClipboardStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClipboardStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +69,9 @@ pub struct IClipboardStatics_Vtbl {
     pub RemoveContentChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClipboardStatics2, IClipboardStatics2_Vtbl, 0xd2ac1b6a_d29f_554b_b303_f0452345fe02);
+impl windows_core::RuntimeType for IClipboardStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClipboardStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,6 +90,9 @@ pub struct IClipboardStatics2_Vtbl {
     pub RemoveHistoryEnabledChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackage, IDataPackage_Vtbl, 0x61ebf5c7_efea_4346_9554_981d7e198ffe);
+impl windows_core::RuntimeType for IDataPackage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -110,6 +131,9 @@ pub struct IDataPackage_Vtbl {
     SetStorageItems: usize,
 }
 windows_core::imp::define_interface!(IDataPackage2, IDataPackage2_Vtbl, 0x041c1fe9_2409_45e1_a538_4c53eeee04a7);
+impl windows_core::RuntimeType for IDataPackage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +141,9 @@ pub struct IDataPackage2_Vtbl {
     pub SetWebLink: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackage3, IDataPackage3_Vtbl, 0x88f31f5d_787b_4d32_965a_a9838105a056);
+impl windows_core::RuntimeType for IDataPackage3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackage3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +151,9 @@ pub struct IDataPackage3_Vtbl {
     pub RemoveShareCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackage4, IDataPackage4_Vtbl, 0x13a24ec8_9382_536f_852a_3045e1b29a3b);
+impl windows_core::RuntimeType for IDataPackage4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackage4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -131,6 +161,9 @@ pub struct IDataPackage4_Vtbl {
     pub RemoveShareCanceled: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySet, IDataPackagePropertySet_Vtbl, 0xcd1c93eb_4c4c_443a_a8d3_f5c241e91689);
+impl windows_core::RuntimeType for IDataPackagePropertySet {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySet_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +189,9 @@ pub struct IDataPackagePropertySet_Vtbl {
     pub SetApplicationListingUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySet2, IDataPackagePropertySet2_Vtbl, 0xeb505d4a_9800_46aa_b181_7b6f0f2b919a);
+impl windows_core::RuntimeType for IDataPackagePropertySet2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySet2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +219,9 @@ pub struct IDataPackagePropertySet2_Vtbl {
     SetLogoBackgroundColor: usize,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySet3, IDataPackagePropertySet3_Vtbl, 0x9e87fd9b_5205_401b_874a_455653bd39e8);
+impl windows_core::RuntimeType for IDataPackagePropertySet3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySet3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -190,6 +229,9 @@ pub struct IDataPackagePropertySet3_Vtbl {
     pub SetEnterpriseId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySet4, IDataPackagePropertySet4_Vtbl, 0x6390ebf5_1739_4c74_b22f_865fab5e8545);
+impl windows_core::RuntimeType for IDataPackagePropertySet4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySet4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,6 +239,9 @@ pub struct IDataPackagePropertySet4_Vtbl {
     pub SetContentSourceUserActivityJson: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySetView, IDataPackagePropertySetView_Vtbl, 0xb94cec01_0c1a_4c57_be55_75d01289735d);
+impl windows_core::RuntimeType for IDataPackagePropertySetView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySetView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,6 +259,9 @@ pub struct IDataPackagePropertySetView_Vtbl {
     pub ApplicationListingUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySetView2, IDataPackagePropertySetView2_Vtbl, 0x6054509b_8ebe_4feb_9c1e_75e69de54b84);
+impl windows_core::RuntimeType for IDataPackagePropertySetView2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySetView2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -230,24 +278,36 @@ pub struct IDataPackagePropertySetView2_Vtbl {
     LogoBackgroundColor: usize,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySetView3, IDataPackagePropertySetView3_Vtbl, 0xdb764ce5_d174_495c_84fc_1a51f6ab45d7);
+impl windows_core::RuntimeType for IDataPackagePropertySetView3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySetView3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub EnterpriseId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySetView4, IDataPackagePropertySetView4_Vtbl, 0x4474c80d_d16f_40ae_9580_6f8562b94235);
+impl windows_core::RuntimeType for IDataPackagePropertySetView4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySetView4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ContentSourceUserActivityJson: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackagePropertySetView5, IDataPackagePropertySetView5_Vtbl, 0x6f0a9445_3760_50bb_8523_c4202ded7d78);
+impl windows_core::RuntimeType for IDataPackagePropertySetView5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackagePropertySetView5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsFromRoamingClipboard: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackageView, IDataPackageView_Vtbl, 0x7b840471_5900_4d85_a90b_10cb85fe3552);
+impl windows_core::RuntimeType for IDataPackageView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackageView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -282,6 +342,9 @@ pub struct IDataPackageView_Vtbl {
     GetStorageItemsAsync: usize,
 }
 windows_core::imp::define_interface!(IDataPackageView2, IDataPackageView2_Vtbl, 0x40ecba95_2450_4c1d_b6b4_ed45463dee9c);
+impl windows_core::RuntimeType for IDataPackageView2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackageView2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -289,6 +352,9 @@ pub struct IDataPackageView2_Vtbl {
     pub GetWebLinkAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPackageView3, IDataPackageView3_Vtbl, 0xd37771a8_ddad_4288_8428_d1cae394128b);
+impl windows_core::RuntimeType for IDataPackageView3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackageView3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -306,18 +372,27 @@ pub struct IDataPackageView3_Vtbl {
     UnlockAndAssumeEnterpriseIdentity: usize,
 }
 windows_core::imp::define_interface!(IDataPackageView4, IDataPackageView4_Vtbl, 0xdfe96f1f_e042_4433_a09f_26d6ffda8b85);
+impl windows_core::RuntimeType for IDataPackageView4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPackageView4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetAcceptedFormatId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataProviderDeferral, IDataProviderDeferral_Vtbl, 0xc2cf2373_2d26_43d9_b69d_dcb86d03f6da);
+impl windows_core::RuntimeType for IDataProviderDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataProviderDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataProviderRequest, IDataProviderRequest_Vtbl, 0xebbc7157_d3c8_47da_acde_f82388d5f716);
+impl windows_core::RuntimeType for IDataProviderRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataProviderRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -327,6 +402,9 @@ pub struct IDataProviderRequest_Vtbl {
     pub SetData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataRequest, IDataRequest_Vtbl, 0x4341ae3b_fc12_4e53_8c02_ac714c415a27);
+impl windows_core::RuntimeType for IDataRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -337,18 +415,27 @@ pub struct IDataRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataRequestDeferral, IDataRequestDeferral_Vtbl, 0x6dc4b89f_0386_4263_87c1_ed7dce30890e);
+impl windows_core::RuntimeType for IDataRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataRequestedEventArgs, IDataRequestedEventArgs_Vtbl, 0xcb8ba807_6ac5_43c9_8ac5_9ba232163182);
+impl windows_core::RuntimeType for IDataRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataTransferManager, IDataTransferManager_Vtbl, 0xa5caee9b_8708_49d1_8d36_67d25a8da00c);
+impl windows_core::RuntimeType for IDataTransferManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataTransferManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -358,6 +445,9 @@ pub struct IDataTransferManager_Vtbl {
     pub RemoveTargetApplicationChosen: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataTransferManager2, IDataTransferManager2_Vtbl, 0x30ae7d71_8ba8_4c02_8e3f_ddb23b388715);
+impl windows_core::RuntimeType for IDataTransferManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataTransferManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -365,6 +455,9 @@ pub struct IDataTransferManager2_Vtbl {
     pub RemoveShareProvidersRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataTransferManagerStatics, IDataTransferManagerStatics_Vtbl, 0xa9da01aa_e00e_4cfe_aa44_2dd932dca3d8);
+impl windows_core::RuntimeType for IDataTransferManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataTransferManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -372,18 +465,27 @@ pub struct IDataTransferManagerStatics_Vtbl {
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataTransferManagerStatics2, IDataTransferManagerStatics2_Vtbl, 0xc54ec2ec_9f97_4d63_9868_395e271ad8f5);
+impl windows_core::RuntimeType for IDataTransferManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataTransferManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataTransferManagerStatics3, IDataTransferManagerStatics3_Vtbl, 0x05845473_6c82_4f5c_ac23_62e458361fac);
+impl windows_core::RuntimeType for IDataTransferManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataTransferManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShowShareUIWithOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHtmlFormatHelperStatics, IHtmlFormatHelperStatics_Vtbl, 0xe22e7749_dd70_446f_aefc_61cee59f655e);
+impl windows_core::RuntimeType for IHtmlFormatHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHtmlFormatHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -391,24 +493,36 @@ pub struct IHtmlFormatHelperStatics_Vtbl {
     pub CreateHtmlFormat: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOperationCompletedEventArgs, IOperationCompletedEventArgs_Vtbl, 0xe7af329d_051d_4fab_b1a9_47fd77f70a41);
+impl windows_core::RuntimeType for IOperationCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOperationCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Operation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DataPackageOperation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOperationCompletedEventArgs2, IOperationCompletedEventArgs2_Vtbl, 0x858fa073_1e19_4105_b2f7_c8478808d562);
+impl windows_core::RuntimeType for IOperationCompletedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOperationCompletedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AcceptedFormatId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareCompletedEventArgs, IShareCompletedEventArgs_Vtbl, 0x4574c442_f913_4f60_9df7_cc4060ab1916);
+impl windows_core::RuntimeType for IShareCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShareTarget: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareProvider, IShareProvider_Vtbl, 0x2fabe026_443e_4cda_af25_8d81070efd80);
+impl windows_core::RuntimeType for IShareProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -425,6 +539,9 @@ pub struct IShareProvider_Vtbl {
     pub SetTag: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareProviderFactory, IShareProviderFactory_Vtbl, 0x172a174c_e79e_4f6d_b07d_128f469e0296);
+impl windows_core::RuntimeType for IShareProviderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareProviderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -434,6 +551,9 @@ pub struct IShareProviderFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IShareProviderOperation, IShareProviderOperation_Vtbl, 0x19cef937_d435_4179_b6af_14e0492b69f6);
+impl windows_core::RuntimeType for IShareProviderOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareProviderOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -442,6 +562,9 @@ pub struct IShareProviderOperation_Vtbl {
     pub ReportCompleted: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareProvidersRequestedEventArgs, IShareProvidersRequestedEventArgs_Vtbl, 0xf888f356_a3f8_4fce_85e4_8826e63be799);
+impl windows_core::RuntimeType for IShareProvidersRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareProvidersRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -453,6 +576,9 @@ pub struct IShareProvidersRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareTargetInfo, IShareTargetInfo_Vtbl, 0x385be607_c6e8_4114_b294_28f3bb6f9904);
+impl windows_core::RuntimeType for IShareTargetInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareTargetInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -460,6 +586,9 @@ pub struct IShareTargetInfo_Vtbl {
     pub ShareProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareUIOptions, IShareUIOptions_Vtbl, 0x72fa8a80_342f_4d90_9551_2ae04e37680c);
+impl windows_core::RuntimeType for IShareUIOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareUIOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -469,6 +598,9 @@ pub struct IShareUIOptions_Vtbl {
     pub SetSelectionRect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISharedStorageAccessManagerStatics, ISharedStorageAccessManagerStatics_Vtbl, 0xc6132ada_34b1_4849_bd5f_d09fee3158c5);
+impl windows_core::RuntimeType for ISharedStorageAccessManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedStorageAccessManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -483,6 +615,9 @@ pub struct ISharedStorageAccessManagerStatics_Vtbl {
     pub RemoveFile: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStandardDataFormatsStatics, IStandardDataFormatsStatics_Vtbl, 0x7ed681a1_a880_40c9_b4ed_0bee1e15f549);
+impl windows_core::RuntimeType for IStandardDataFormatsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStandardDataFormatsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -497,6 +632,9 @@ pub struct IStandardDataFormatsStatics_Vtbl {
     pub StorageItems: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStandardDataFormatsStatics2, IStandardDataFormatsStatics2_Vtbl, 0x42a254f4_9d76_42e8_861b_47c25dd0cf71);
+impl windows_core::RuntimeType for IStandardDataFormatsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStandardDataFormatsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -504,12 +642,18 @@ pub struct IStandardDataFormatsStatics2_Vtbl {
     pub ApplicationLink: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStandardDataFormatsStatics3, IStandardDataFormatsStatics3_Vtbl, 0x3b57b069_01d4_474c_8b5f_bc8e27f38b21);
+impl windows_core::RuntimeType for IStandardDataFormatsStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStandardDataFormatsStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub UserActivityJsonArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetApplicationChosenEventArgs, ITargetApplicationChosenEventArgs_Vtbl, 0xca6fb8ac_2987_4ee3_9c54_d8afbcb86c1d);
+impl windows_core::RuntimeType for ITargetApplicationChosenEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetApplicationChosenEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -701,7 +845,7 @@ impl ClipboardContentOptions {
     }
 }
 impl windows_core::RuntimeType for ClipboardContentOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClipboardContentOptions>();
 }
 unsafe impl windows_core::Interface for ClipboardContentOptions {
     type Vtable = IClipboardContentOptions_Vtbl;
@@ -718,7 +862,7 @@ pub struct ClipboardHistoryChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClipboardHistoryChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClipboardHistoryChangedEventArgs {}
 impl windows_core::RuntimeType for ClipboardHistoryChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClipboardHistoryChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ClipboardHistoryChangedEventArgs {
     type Vtable = IClipboardHistoryChangedEventArgs_Vtbl;
@@ -757,7 +901,7 @@ impl ClipboardHistoryItem {
     }
 }
 impl windows_core::RuntimeType for ClipboardHistoryItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClipboardHistoryItem>();
 }
 unsafe impl windows_core::Interface for ClipboardHistoryItem {
     type Vtable = IClipboardHistoryItem_Vtbl;
@@ -790,7 +934,7 @@ impl ClipboardHistoryItemsResult {
     }
 }
 impl windows_core::RuntimeType for ClipboardHistoryItemsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClipboardHistoryItemsResult>();
 }
 unsafe impl windows_core::Interface for ClipboardHistoryItemsResult {
     type Vtable = IClipboardHistoryItemsResult_Vtbl;
@@ -976,7 +1120,7 @@ impl DataPackage {
     }
 }
 impl windows_core::RuntimeType for DataPackage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataPackage>();
 }
 unsafe impl windows_core::Interface for DataPackage {
     type Vtable = IDataPackage_Vtbl;
@@ -1218,7 +1362,7 @@ impl DataPackagePropertySet {
     }
 }
 impl windows_core::RuntimeType for DataPackagePropertySet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataPackagePropertySet>();
 }
 unsafe impl windows_core::Interface for DataPackagePropertySet {
     type Vtable = IDataPackagePropertySet_Vtbl;
@@ -1393,7 +1537,7 @@ impl DataPackagePropertySetView {
     }
 }
 impl windows_core::RuntimeType for DataPackagePropertySetView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataPackagePropertySetView>();
 }
 unsafe impl windows_core::Interface for DataPackagePropertySetView {
     type Vtable = IDataPackagePropertySetView_Vtbl;
@@ -1569,7 +1713,7 @@ impl DataPackageView {
     }
 }
 impl windows_core::RuntimeType for DataPackageView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataPackageView>();
 }
 unsafe impl windows_core::Interface for DataPackageView {
     type Vtable = IDataPackageView_Vtbl;
@@ -1591,7 +1735,7 @@ impl DataProviderDeferral {
     }
 }
 impl windows_core::RuntimeType for DataProviderDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataProviderDeferral>();
 }
 unsafe impl windows_core::Interface for DataProviderDeferral {
     type Vtable = IDataProviderDeferral_Vtbl;
@@ -1637,7 +1781,7 @@ impl DataProviderRequest {
     }
 }
 impl windows_core::RuntimeType for DataProviderRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataProviderRequest>();
 }
 unsafe impl windows_core::Interface for DataProviderRequest {
     type Vtable = IDataProviderRequest_Vtbl;
@@ -1687,7 +1831,7 @@ impl DataRequest {
     }
 }
 impl windows_core::RuntimeType for DataRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataRequest>();
 }
 unsafe impl windows_core::Interface for DataRequest {
     type Vtable = IDataRequest_Vtbl;
@@ -1709,7 +1853,7 @@ impl DataRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for DataRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataRequestDeferral>();
 }
 unsafe impl windows_core::Interface for DataRequestDeferral {
     type Vtable = IDataRequestDeferral_Vtbl;
@@ -1734,7 +1878,7 @@ impl DataRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DataRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for DataRequestedEventArgs {
     type Vtable = IDataRequestedEventArgs_Vtbl;
@@ -1830,7 +1974,7 @@ impl DataTransferManager {
     }
 }
 impl windows_core::RuntimeType for DataTransferManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataTransferManager>();
 }
 unsafe impl windows_core::Interface for DataTransferManager {
     type Vtable = IDataTransferManager_Vtbl;
@@ -1883,7 +2027,7 @@ impl OperationCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for OperationCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOperationCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for OperationCompletedEventArgs {
     type Vtable = IOperationCompletedEventArgs_Vtbl;
@@ -1908,7 +2052,7 @@ impl ShareCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ShareCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for ShareCompletedEventArgs {
     type Vtable = IShareCompletedEventArgs_Vtbl;
@@ -1979,7 +2123,7 @@ impl ShareProvider {
     }
 }
 impl windows_core::RuntimeType for ShareProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareProvider>();
 }
 unsafe impl windows_core::Interface for ShareProvider {
     type Vtable = IShareProvider_Vtbl;
@@ -2015,7 +2159,7 @@ impl ShareProviderOperation {
     }
 }
 impl windows_core::RuntimeType for ShareProviderOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareProviderOperation>();
 }
 unsafe impl windows_core::Interface for ShareProviderOperation {
     type Vtable = IShareProviderOperation_Vtbl;
@@ -2055,7 +2199,7 @@ impl ShareProvidersRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ShareProvidersRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareProvidersRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for ShareProvidersRequestedEventArgs {
     type Vtable = IShareProvidersRequestedEventArgs_Vtbl;
@@ -2087,7 +2231,7 @@ impl ShareTargetInfo {
     }
 }
 impl windows_core::RuntimeType for ShareTargetInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareTargetInfo>();
 }
 unsafe impl windows_core::Interface for ShareTargetInfo {
     type Vtable = IShareTargetInfo_Vtbl;
@@ -2137,7 +2281,7 @@ impl ShareUIOptions {
     }
 }
 impl windows_core::RuntimeType for ShareUIOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareUIOptions>();
 }
 unsafe impl windows_core::Interface for ShareUIOptions {
     type Vtable = IShareUIOptions_Vtbl;
@@ -2269,7 +2413,7 @@ impl TargetApplicationChosenEventArgs {
     }
 }
 impl windows_core::RuntimeType for TargetApplicationChosenEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetApplicationChosenEventArgs>();
 }
 unsafe impl windows_core::Interface for TargetApplicationChosenEventArgs {
     type Vtable = ITargetApplicationChosenEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/DataProvider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IEmailDataProviderConnection, IEmailDataProviderConnection_Vtbl, 0x3b9c9dc7_37b2_4bf0_ae30_7b644a1c96e1);
+impl windows_core::RuntimeType for IEmailDataProviderConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailDataProviderConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,12 +38,18 @@ pub struct IEmailDataProviderConnection_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailDataProviderTriggerDetails, IEmailDataProviderTriggerDetails_Vtbl, 0x8f3e4e50_341e_45f3_bba0_84a005e1319a);
+impl windows_core::RuntimeType for IEmailDataProviderTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailDataProviderTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxCreateFolderRequest, IEmailMailboxCreateFolderRequest_Vtbl, 0x184d3775_c921_4c39_a309_e16c9f22b04b);
+impl windows_core::RuntimeType for IEmailMailboxCreateFolderRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxCreateFolderRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,6 +60,9 @@ pub struct IEmailMailboxCreateFolderRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::EmailMailboxCreateFolderStatus, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxCreateFolderRequestEventArgs, IEmailMailboxCreateFolderRequestEventArgs_Vtbl, 0x03e4c02c_241c_4ea9_a68f_ff20bc5afc85);
+impl windows_core::RuntimeType for IEmailMailboxCreateFolderRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxCreateFolderRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +70,9 @@ pub struct IEmailMailboxCreateFolderRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxDeleteFolderRequest, IEmailMailboxDeleteFolderRequest_Vtbl, 0x9469e88a_a931_4779_923d_09a3ea292e29);
+impl windows_core::RuntimeType for IEmailMailboxDeleteFolderRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxDeleteFolderRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +82,9 @@ pub struct IEmailMailboxDeleteFolderRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::EmailMailboxDeleteFolderStatus, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxDeleteFolderRequestEventArgs, IEmailMailboxDeleteFolderRequestEventArgs_Vtbl, 0xb4d32d06_2332_4678_8378_28b579336846);
+impl windows_core::RuntimeType for IEmailMailboxDeleteFolderRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxDeleteFolderRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -74,6 +92,9 @@ pub struct IEmailMailboxDeleteFolderRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxDownloadAttachmentRequest, IEmailMailboxDownloadAttachmentRequest_Vtbl, 0x0b1dbbb4_750c_48e1_bce4_8d589684ffbc);
+impl windows_core::RuntimeType for IEmailMailboxDownloadAttachmentRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxDownloadAttachmentRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +105,9 @@ pub struct IEmailMailboxDownloadAttachmentRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxDownloadAttachmentRequestEventArgs, IEmailMailboxDownloadAttachmentRequestEventArgs_Vtbl, 0xccddc46d_ffa8_4877_9f9d_fed7bcaf4104);
+impl windows_core::RuntimeType for IEmailMailboxDownloadAttachmentRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxDownloadAttachmentRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,6 +115,9 @@ pub struct IEmailMailboxDownloadAttachmentRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxDownloadMessageRequest, IEmailMailboxDownloadMessageRequest_Vtbl, 0x497b4187_5b4d_4b23_816c_f3842beb753e);
+impl windows_core::RuntimeType for IEmailMailboxDownloadMessageRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxDownloadMessageRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,6 +127,9 @@ pub struct IEmailMailboxDownloadMessageRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxDownloadMessageRequestEventArgs, IEmailMailboxDownloadMessageRequestEventArgs_Vtbl, 0x470409ad_d0a0_4a5b_bb2a_37621039c53e);
+impl windows_core::RuntimeType for IEmailMailboxDownloadMessageRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxDownloadMessageRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -107,6 +137,9 @@ pub struct IEmailMailboxDownloadMessageRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxEmptyFolderRequest, IEmailMailboxEmptyFolderRequest_Vtbl, 0xfe4b03ab_f86d_46d9_b4ce_bc8a6d9e9268);
+impl windows_core::RuntimeType for IEmailMailboxEmptyFolderRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxEmptyFolderRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +149,9 @@ pub struct IEmailMailboxEmptyFolderRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::EmailMailboxEmptyFolderStatus, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxEmptyFolderRequestEventArgs, IEmailMailboxEmptyFolderRequestEventArgs_Vtbl, 0x7183f484_985a_4ac0_b33f_ee0e2627a3c0);
+impl windows_core::RuntimeType for IEmailMailboxEmptyFolderRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxEmptyFolderRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -123,6 +159,9 @@ pub struct IEmailMailboxEmptyFolderRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxForwardMeetingRequest, IEmailMailboxForwardMeetingRequest_Vtbl, 0x616d6af1_70d4_4832_b869_b80542ae9be8);
+impl windows_core::RuntimeType for IEmailMailboxForwardMeetingRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxForwardMeetingRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +179,9 @@ pub struct IEmailMailboxForwardMeetingRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxForwardMeetingRequestEventArgs, IEmailMailboxForwardMeetingRequestEventArgs_Vtbl, 0x2bd8f33a_2974_4759_a5a5_58f44d3c0275);
+impl windows_core::RuntimeType for IEmailMailboxForwardMeetingRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxForwardMeetingRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,6 +189,9 @@ pub struct IEmailMailboxForwardMeetingRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxGetAutoReplySettingsRequest, IEmailMailboxGetAutoReplySettingsRequest_Vtbl, 0x9b380789_1e88_4e01_84cc_1386ad9a2c2f);
+impl windows_core::RuntimeType for IEmailMailboxGetAutoReplySettingsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxGetAutoReplySettingsRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +201,9 @@ pub struct IEmailMailboxGetAutoReplySettingsRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxGetAutoReplySettingsRequestEventArgs, IEmailMailboxGetAutoReplySettingsRequestEventArgs_Vtbl, 0xd79f55c2_fd45_4004_8a91_9bacf38b7022);
+impl windows_core::RuntimeType for IEmailMailboxGetAutoReplySettingsRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxGetAutoReplySettingsRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -163,6 +211,9 @@ pub struct IEmailMailboxGetAutoReplySettingsRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxMoveFolderRequest, IEmailMailboxMoveFolderRequest_Vtbl, 0x10ba2856_4a95_4068_91cc_67cc7acf454f);
+impl windows_core::RuntimeType for IEmailMailboxMoveFolderRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxMoveFolderRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -174,6 +225,9 @@ pub struct IEmailMailboxMoveFolderRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxMoveFolderRequestEventArgs, IEmailMailboxMoveFolderRequestEventArgs_Vtbl, 0x38623020_14ba_4c88_8698_7239e3c8aaa7);
+impl windows_core::RuntimeType for IEmailMailboxMoveFolderRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxMoveFolderRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,6 +235,9 @@ pub struct IEmailMailboxMoveFolderRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxProposeNewTimeForMeetingRequest, IEmailMailboxProposeNewTimeForMeetingRequest_Vtbl, 0x5aeff152_9799_4f9f_a399_ff07f3eef04e);
+impl windows_core::RuntimeType for IEmailMailboxProposeNewTimeForMeetingRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxProposeNewTimeForMeetingRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -194,6 +251,9 @@ pub struct IEmailMailboxProposeNewTimeForMeetingRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxProposeNewTimeForMeetingRequestEventArgs, IEmailMailboxProposeNewTimeForMeetingRequestEventArgs_Vtbl, 0xfb480b98_33ad_4a67_8251_0f9c249b6a20);
+impl windows_core::RuntimeType for IEmailMailboxProposeNewTimeForMeetingRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxProposeNewTimeForMeetingRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -201,6 +261,9 @@ pub struct IEmailMailboxProposeNewTimeForMeetingRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxResolveRecipientsRequest, IEmailMailboxResolveRecipientsRequest_Vtbl, 0xefa4cf70_7b39_4c9b_811e_41eaf43a332d);
+impl windows_core::RuntimeType for IEmailMailboxResolveRecipientsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxResolveRecipientsRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -216,6 +279,9 @@ pub struct IEmailMailboxResolveRecipientsRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxResolveRecipientsRequestEventArgs, IEmailMailboxResolveRecipientsRequestEventArgs_Vtbl, 0x260f9e02_b2cf_40f8_8c28_e3ed43b1e89a);
+impl windows_core::RuntimeType for IEmailMailboxResolveRecipientsRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxResolveRecipientsRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -223,6 +289,9 @@ pub struct IEmailMailboxResolveRecipientsRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxServerSearchReadBatchRequest, IEmailMailboxServerSearchReadBatchRequest_Vtbl, 0x090eebdf_5a96_41d3_8ad8_34912f9aa60e);
+impl windows_core::RuntimeType for IEmailMailboxServerSearchReadBatchRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxServerSearchReadBatchRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -236,6 +305,9 @@ pub struct IEmailMailboxServerSearchReadBatchRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::EmailBatchStatus, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxServerSearchReadBatchRequestEventArgs, IEmailMailboxServerSearchReadBatchRequestEventArgs_Vtbl, 0x14101b4e_ed9e_45d1_ad7a_cc9b7f643ae2);
+impl windows_core::RuntimeType for IEmailMailboxServerSearchReadBatchRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxServerSearchReadBatchRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -243,6 +315,9 @@ pub struct IEmailMailboxServerSearchReadBatchRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxSetAutoReplySettingsRequest, IEmailMailboxSetAutoReplySettingsRequest_Vtbl, 0x75a422d0_a88e_4e54_8dc7_c243186b774e);
+impl windows_core::RuntimeType for IEmailMailboxSetAutoReplySettingsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxSetAutoReplySettingsRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -252,6 +327,9 @@ pub struct IEmailMailboxSetAutoReplySettingsRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxSetAutoReplySettingsRequestEventArgs, IEmailMailboxSetAutoReplySettingsRequestEventArgs_Vtbl, 0x09da11ad_d7ca_4087_ac86_53fa67f76246);
+impl windows_core::RuntimeType for IEmailMailboxSetAutoReplySettingsRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxSetAutoReplySettingsRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -259,6 +337,9 @@ pub struct IEmailMailboxSetAutoReplySettingsRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxSyncManagerSyncRequest, IEmailMailboxSyncManagerSyncRequest_Vtbl, 0x4e10e8e4_7e67_405a_b673_dc60c91090fc);
+impl windows_core::RuntimeType for IEmailMailboxSyncManagerSyncRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxSyncManagerSyncRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -267,6 +348,9 @@ pub struct IEmailMailboxSyncManagerSyncRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxSyncManagerSyncRequestEventArgs, IEmailMailboxSyncManagerSyncRequestEventArgs_Vtbl, 0x439a031a_8fcc_4ae5_b9b5_d434e0a65aa8);
+impl windows_core::RuntimeType for IEmailMailboxSyncManagerSyncRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxSyncManagerSyncRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +358,9 @@ pub struct IEmailMailboxSyncManagerSyncRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxUpdateMeetingResponseRequest, IEmailMailboxUpdateMeetingResponseRequest_Vtbl, 0x5b99ac93_b2cf_4888_ba4f_306b6b66df30);
+impl windows_core::RuntimeType for IEmailMailboxUpdateMeetingResponseRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxUpdateMeetingResponseRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -287,6 +374,9 @@ pub struct IEmailMailboxUpdateMeetingResponseRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxUpdateMeetingResponseRequestEventArgs, IEmailMailboxUpdateMeetingResponseRequestEventArgs_Vtbl, 0x6898d761_56c9_4f17_be31_66fda94ba159);
+impl windows_core::RuntimeType for IEmailMailboxUpdateMeetingResponseRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxUpdateMeetingResponseRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,6 +384,9 @@ pub struct IEmailMailboxUpdateMeetingResponseRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxValidateCertificatesRequest, IEmailMailboxValidateCertificatesRequest_Vtbl, 0xa94d3931_e11a_4f97_b81a_187a70a8f41a);
+impl windows_core::RuntimeType for IEmailMailboxValidateCertificatesRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxValidateCertificatesRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -309,6 +402,9 @@ pub struct IEmailMailboxValidateCertificatesRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxValidateCertificatesRequestEventArgs, IEmailMailboxValidateCertificatesRequestEventArgs_Vtbl, 0x2583bf17_02ff_49fe_a73c_03f37566c691);
+impl windows_core::RuntimeType for IEmailMailboxValidateCertificatesRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxValidateCertificatesRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -536,7 +632,7 @@ impl EmailDataProviderConnection {
     }
 }
 impl windows_core::RuntimeType for EmailDataProviderConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailDataProviderConnection>();
 }
 unsafe impl windows_core::Interface for EmailDataProviderConnection {
     type Vtable = IEmailDataProviderConnection_Vtbl;
@@ -561,7 +657,7 @@ impl EmailDataProviderTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for EmailDataProviderTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailDataProviderTriggerDetails>();
 }
 unsafe impl windows_core::Interface for EmailDataProviderTriggerDetails {
     type Vtable = IEmailDataProviderTriggerDetails_Vtbl;
@@ -617,7 +713,7 @@ impl EmailMailboxCreateFolderRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxCreateFolderRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxCreateFolderRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxCreateFolderRequest {
     type Vtable = IEmailMailboxCreateFolderRequest_Vtbl;
@@ -649,7 +745,7 @@ impl EmailMailboxCreateFolderRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxCreateFolderRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxCreateFolderRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxCreateFolderRequestEventArgs {
     type Vtable = IEmailMailboxCreateFolderRequestEventArgs_Vtbl;
@@ -695,7 +791,7 @@ impl EmailMailboxDeleteFolderRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxDeleteFolderRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxDeleteFolderRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxDeleteFolderRequest {
     type Vtable = IEmailMailboxDeleteFolderRequest_Vtbl;
@@ -727,7 +823,7 @@ impl EmailMailboxDeleteFolderRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxDeleteFolderRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxDeleteFolderRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxDeleteFolderRequestEventArgs {
     type Vtable = IEmailMailboxDeleteFolderRequestEventArgs_Vtbl;
@@ -780,7 +876,7 @@ impl EmailMailboxDownloadAttachmentRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxDownloadAttachmentRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxDownloadAttachmentRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxDownloadAttachmentRequest {
     type Vtable = IEmailMailboxDownloadAttachmentRequest_Vtbl;
@@ -812,7 +908,7 @@ impl EmailMailboxDownloadAttachmentRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxDownloadAttachmentRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxDownloadAttachmentRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxDownloadAttachmentRequestEventArgs {
     type Vtable = IEmailMailboxDownloadAttachmentRequestEventArgs_Vtbl;
@@ -858,7 +954,7 @@ impl EmailMailboxDownloadMessageRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxDownloadMessageRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxDownloadMessageRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxDownloadMessageRequest {
     type Vtable = IEmailMailboxDownloadMessageRequest_Vtbl;
@@ -890,7 +986,7 @@ impl EmailMailboxDownloadMessageRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxDownloadMessageRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxDownloadMessageRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxDownloadMessageRequestEventArgs {
     type Vtable = IEmailMailboxDownloadMessageRequestEventArgs_Vtbl;
@@ -936,7 +1032,7 @@ impl EmailMailboxEmptyFolderRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxEmptyFolderRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxEmptyFolderRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxEmptyFolderRequest {
     type Vtable = IEmailMailboxEmptyFolderRequest_Vtbl;
@@ -968,7 +1064,7 @@ impl EmailMailboxEmptyFolderRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxEmptyFolderRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxEmptyFolderRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxEmptyFolderRequestEventArgs {
     type Vtable = IEmailMailboxEmptyFolderRequestEventArgs_Vtbl;
@@ -1050,7 +1146,7 @@ impl EmailMailboxForwardMeetingRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxForwardMeetingRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxForwardMeetingRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxForwardMeetingRequest {
     type Vtable = IEmailMailboxForwardMeetingRequest_Vtbl;
@@ -1082,7 +1178,7 @@ impl EmailMailboxForwardMeetingRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxForwardMeetingRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxForwardMeetingRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxForwardMeetingRequestEventArgs {
     type Vtable = IEmailMailboxForwardMeetingRequestEventArgs_Vtbl;
@@ -1131,7 +1227,7 @@ impl EmailMailboxGetAutoReplySettingsRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxGetAutoReplySettingsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxGetAutoReplySettingsRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxGetAutoReplySettingsRequest {
     type Vtable = IEmailMailboxGetAutoReplySettingsRequest_Vtbl;
@@ -1163,7 +1259,7 @@ impl EmailMailboxGetAutoReplySettingsRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxGetAutoReplySettingsRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxGetAutoReplySettingsRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxGetAutoReplySettingsRequestEventArgs {
     type Vtable = IEmailMailboxGetAutoReplySettingsRequestEventArgs_Vtbl;
@@ -1223,7 +1319,7 @@ impl EmailMailboxMoveFolderRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxMoveFolderRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxMoveFolderRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxMoveFolderRequest {
     type Vtable = IEmailMailboxMoveFolderRequest_Vtbl;
@@ -1255,7 +1351,7 @@ impl EmailMailboxMoveFolderRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxMoveFolderRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxMoveFolderRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxMoveFolderRequestEventArgs {
     type Vtable = IEmailMailboxMoveFolderRequestEventArgs_Vtbl;
@@ -1329,7 +1425,7 @@ impl EmailMailboxProposeNewTimeForMeetingRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxProposeNewTimeForMeetingRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxProposeNewTimeForMeetingRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxProposeNewTimeForMeetingRequest {
     type Vtable = IEmailMailboxProposeNewTimeForMeetingRequest_Vtbl;
@@ -1361,7 +1457,7 @@ impl EmailMailboxProposeNewTimeForMeetingRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxProposeNewTimeForMeetingRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxProposeNewTimeForMeetingRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxProposeNewTimeForMeetingRequestEventArgs {
     type Vtable = IEmailMailboxProposeNewTimeForMeetingRequestEventArgs_Vtbl;
@@ -1412,7 +1508,7 @@ impl EmailMailboxResolveRecipientsRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxResolveRecipientsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxResolveRecipientsRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxResolveRecipientsRequest {
     type Vtable = IEmailMailboxResolveRecipientsRequest_Vtbl;
@@ -1444,7 +1540,7 @@ impl EmailMailboxResolveRecipientsRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxResolveRecipientsRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxResolveRecipientsRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxResolveRecipientsRequestEventArgs {
     type Vtable = IEmailMailboxResolveRecipientsRequestEventArgs_Vtbl;
@@ -1521,7 +1617,7 @@ impl EmailMailboxServerSearchReadBatchRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxServerSearchReadBatchRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxServerSearchReadBatchRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxServerSearchReadBatchRequest {
     type Vtable = IEmailMailboxServerSearchReadBatchRequest_Vtbl;
@@ -1553,7 +1649,7 @@ impl EmailMailboxServerSearchReadBatchRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxServerSearchReadBatchRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxServerSearchReadBatchRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxServerSearchReadBatchRequestEventArgs {
     type Vtable = IEmailMailboxServerSearchReadBatchRequestEventArgs_Vtbl;
@@ -1599,7 +1695,7 @@ impl EmailMailboxSetAutoReplySettingsRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxSetAutoReplySettingsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxSetAutoReplySettingsRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxSetAutoReplySettingsRequest {
     type Vtable = IEmailMailboxSetAutoReplySettingsRequest_Vtbl;
@@ -1631,7 +1727,7 @@ impl EmailMailboxSetAutoReplySettingsRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxSetAutoReplySettingsRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxSetAutoReplySettingsRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxSetAutoReplySettingsRequestEventArgs {
     type Vtable = IEmailMailboxSetAutoReplySettingsRequestEventArgs_Vtbl;
@@ -1670,7 +1766,7 @@ impl EmailMailboxSyncManagerSyncRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxSyncManagerSyncRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxSyncManagerSyncRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxSyncManagerSyncRequest {
     type Vtable = IEmailMailboxSyncManagerSyncRequest_Vtbl;
@@ -1702,7 +1798,7 @@ impl EmailMailboxSyncManagerSyncRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxSyncManagerSyncRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxSyncManagerSyncRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxSyncManagerSyncRequestEventArgs {
     type Vtable = IEmailMailboxSyncManagerSyncRequestEventArgs_Vtbl;
@@ -1776,7 +1872,7 @@ impl EmailMailboxUpdateMeetingResponseRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxUpdateMeetingResponseRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxUpdateMeetingResponseRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxUpdateMeetingResponseRequest {
     type Vtable = IEmailMailboxUpdateMeetingResponseRequest_Vtbl;
@@ -1808,7 +1904,7 @@ impl EmailMailboxUpdateMeetingResponseRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxUpdateMeetingResponseRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxUpdateMeetingResponseRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxUpdateMeetingResponseRequestEventArgs {
     type Vtable = IEmailMailboxUpdateMeetingResponseRequestEventArgs_Vtbl;
@@ -1859,7 +1955,7 @@ impl EmailMailboxValidateCertificatesRequest {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxValidateCertificatesRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxValidateCertificatesRequest>();
 }
 unsafe impl windows_core::Interface for EmailMailboxValidateCertificatesRequest {
     type Vtable = IEmailMailboxValidateCertificatesRequest_Vtbl;
@@ -1891,7 +1987,7 @@ impl EmailMailboxValidateCertificatesRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxValidateCertificatesRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxValidateCertificatesRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxValidateCertificatesRequestEventArgs {
     type Vtable = IEmailMailboxValidateCertificatesRequestEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "ApplicationModel_Email_DataProvider")]
 pub mod DataProvider;
 windows_core::imp::define_interface!(IEmailAttachment, IEmailAttachment_Vtbl, 0xf353caf9_57c8_4adb_b992_60fceb584f54);
+impl windows_core::RuntimeType for IEmailAttachment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailAttachment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +19,9 @@ pub struct IEmailAttachment_Vtbl {
     SetData: usize,
 }
 windows_core::imp::define_interface!(IEmailAttachment2, IEmailAttachment2_Vtbl, 0x225f1070_b0ff_4571_9d54_a706c48d55c6);
+impl windows_core::RuntimeType for IEmailAttachment2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailAttachment2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,6 +41,9 @@ pub struct IEmailAttachment2_Vtbl {
     pub SetMimeType: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailAttachmentFactory, IEmailAttachmentFactory_Vtbl, 0x796eac46_ed56_4979_8708_abb8bc854b7d);
+impl windows_core::RuntimeType for IEmailAttachmentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailAttachmentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +53,9 @@ pub struct IEmailAttachmentFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IEmailAttachmentFactory2, IEmailAttachmentFactory2_Vtbl, 0x23259435_51f9_427d_adcd_241023c8cfb7);
+impl windows_core::RuntimeType for IEmailAttachmentFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailAttachmentFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +65,9 @@ pub struct IEmailAttachmentFactory2_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IEmailConversation, IEmailConversation_Vtbl, 0xda18c248_a0bc_4349_902d_90f66389f51b);
+impl windows_core::RuntimeType for IEmailConversation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailConversation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +94,9 @@ pub struct IEmailConversation_Vtbl {
     FindMessagesWithCountAsync: usize,
 }
 windows_core::imp::define_interface!(IEmailConversationBatch, IEmailConversationBatch_Vtbl, 0xb8c1ab81_01c5_432a_9df1_fe85d98a279a);
+impl windows_core::RuntimeType for IEmailConversationBatch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailConversationBatch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,12 +107,18 @@ pub struct IEmailConversationBatch_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut EmailBatchStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailConversationReader, IEmailConversationReader_Vtbl, 0xb4630f82_2875_44c8_9b8c_85beb3a3c653);
+impl windows_core::RuntimeType for IEmailConversationReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailConversationReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReadBatchAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailFolder, IEmailFolder_Vtbl, 0xa24f7771_996c_4864_b1ba_ed1240e57d11);
+impl windows_core::RuntimeType for IEmailFolder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailFolder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -128,6 +152,9 @@ pub struct IEmailFolder_Vtbl {
     pub SaveMessageAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailIrmInfo, IEmailIrmInfo_Vtbl, 0x90f52193_b1a0_4ebd_a6b6_ddca55606e0e);
+impl windows_core::RuntimeType for IEmailIrmInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailIrmInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -157,12 +184,18 @@ pub struct IEmailIrmInfo_Vtbl {
     pub SetTemplate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailIrmInfoFactory, IEmailIrmInfoFactory_Vtbl, 0x314bb18c_e3e6_4d7b_be8d_91a96311b01b);
+impl windows_core::RuntimeType for IEmailIrmInfoFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailIrmInfoFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailIrmTemplate, IEmailIrmTemplate_Vtbl, 0xf327758d_546d_4bea_a963_54a38b2cc016);
+impl windows_core::RuntimeType for IEmailIrmTemplate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailIrmTemplate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -174,12 +207,18 @@ pub struct IEmailIrmTemplate_Vtbl {
     pub SetName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailIrmTemplateFactory, IEmailIrmTemplateFactory_Vtbl, 0x3da31876_8738_4418_b9cb_471b936fe71e);
+impl windows_core::RuntimeType for IEmailIrmTemplateFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailIrmTemplateFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailItemCounts, IEmailItemCounts_Vtbl, 0x5bd13321_fec8_4bab_83ba_0baf3c1f6cbd);
+impl windows_core::RuntimeType for IEmailItemCounts {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailItemCounts_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +228,9 @@ pub struct IEmailItemCounts_Vtbl {
     pub Unread: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailbox, IEmailMailbox_Vtbl, 0xa8790649_cf5b_411b_80b1_4a6a1484ce25);
+impl windows_core::RuntimeType for IEmailMailbox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailbox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -250,6 +292,9 @@ pub struct IEmailMailbox_Vtbl {
     pub TryGetAutoReplySettingsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, EmailMailboxAutoReplyMessageResponseKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailbox2, IEmailMailbox2_Vtbl, 0x14f8e404_6ca2_4ab2_9241_79cd7bf46346);
+impl windows_core::RuntimeType for IEmailMailbox2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailbox2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -258,6 +303,9 @@ pub struct IEmailMailbox2_Vtbl {
     pub NetworkId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailbox3, IEmailMailbox3_Vtbl, 0x3da5897b_458b_408a_8e37_ac8b05d8af56);
+impl windows_core::RuntimeType for IEmailMailbox3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailbox3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,18 +322,27 @@ pub struct IEmailMailbox3_Vtbl {
     pub TryDeleteFolderAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailbox4, IEmailMailbox4_Vtbl, 0x5d1f301b_f222_48a7_b7b6_716356cd26a1);
+impl windows_core::RuntimeType for IEmailMailbox4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailbox4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RegisterSyncManagerAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailbox5, IEmailMailbox5_Vtbl, 0x39967087_0092_49be_bd0e_5d4dc9d96d90);
+impl windows_core::RuntimeType for IEmailMailbox5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailbox5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetChangeTracker: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxAction, IEmailMailboxAction_Vtbl, 0xac9889fa_21fa_4927_9210_d410582fdf3e);
+impl windows_core::RuntimeType for IEmailMailboxAction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxAction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -293,6 +350,9 @@ pub struct IEmailMailboxAction_Vtbl {
     pub ChangeNumber: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxAutoReply, IEmailMailboxAutoReply_Vtbl, 0xe223254c_8ab4_485b_b31f_04d15476bd59);
+impl windows_core::RuntimeType for IEmailMailboxAutoReply {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxAutoReply_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -302,6 +362,9 @@ pub struct IEmailMailboxAutoReply_Vtbl {
     pub SetResponse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxAutoReplySettings, IEmailMailboxAutoReplySettings_Vtbl, 0xa87a9fa8_0ac6_4b77_ba77_a6b99e9a27b8);
+impl windows_core::RuntimeType for IEmailMailboxAutoReplySettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxAutoReplySettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -318,6 +381,9 @@ pub struct IEmailMailboxAutoReplySettings_Vtbl {
     pub UnknownExternalReply: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxCapabilities, IEmailMailboxCapabilities_Vtbl, 0xeedec3a6_89db_4305_82c4_439e0a33da11);
+impl windows_core::RuntimeType for IEmailMailboxCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -331,6 +397,9 @@ pub struct IEmailMailboxCapabilities_Vtbl {
     pub CanSmartSend: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxCapabilities2, IEmailMailboxCapabilities2_Vtbl, 0x69723ee4_2f21_4cbc_88ab_2e7602a4806b);
+impl windows_core::RuntimeType for IEmailMailboxCapabilities2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxCapabilities2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -342,6 +411,9 @@ pub struct IEmailMailboxCapabilities2_Vtbl {
     pub CanMoveFolder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxCapabilities3, IEmailMailboxCapabilities3_Vtbl, 0xf690e944_56f2_45aa_872c_0ce9f3db0b5c);
+impl windows_core::RuntimeType for IEmailMailboxCapabilities3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxCapabilities3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -361,6 +433,9 @@ pub struct IEmailMailboxCapabilities3_Vtbl {
     pub SetCanMoveFolder: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxChange, IEmailMailboxChange_Vtbl, 0x61edf54b_11ef_400c_adde_8cde65c85e66);
+impl windows_core::RuntimeType for IEmailMailboxChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -373,6 +448,9 @@ pub struct IEmailMailboxChange_Vtbl {
     pub Folder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxChangeReader, IEmailMailboxChangeReader_Vtbl, 0xbdbd0ebb_c53d_4331_97be_be75a2146a75);
+impl windows_core::RuntimeType for IEmailMailboxChangeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxChangeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -384,6 +462,9 @@ pub struct IEmailMailboxChangeReader_Vtbl {
     ReadBatchAsync: usize,
 }
 windows_core::imp::define_interface!(IEmailMailboxChangeTracker, IEmailMailboxChangeTracker_Vtbl, 0x7ae48638_5166_42b7_8882_fd21c92bdd4b);
+impl windows_core::RuntimeType for IEmailMailboxChangeTracker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxChangeTracker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -393,18 +474,27 @@ pub struct IEmailMailboxChangeTracker_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxChangedDeferral, IEmailMailboxChangedDeferral_Vtbl, 0x779a74c1_97c5_4b54_b30d_306232623e6d);
+impl windows_core::RuntimeType for IEmailMailboxChangedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxChangedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxChangedEventArgs, IEmailMailboxChangedEventArgs_Vtbl, 0x3cfd5f6e_01d4_4e4a_a44c_b22dd42ec207);
+impl windows_core::RuntimeType for IEmailMailboxChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxCreateFolderResult, IEmailMailboxCreateFolderResult_Vtbl, 0xb228557f_2885_4998_b595_8a2d374ce950);
+impl windows_core::RuntimeType for IEmailMailboxCreateFolderResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxCreateFolderResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -412,6 +502,9 @@ pub struct IEmailMailboxCreateFolderResult_Vtbl {
     pub Folder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxPolicies, IEmailMailboxPolicies_Vtbl, 0x1f3345c5_1c3b_4dc7_b410_6373783e545d);
+impl windows_core::RuntimeType for IEmailMailboxPolicies {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxPolicies_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -421,6 +514,9 @@ pub struct IEmailMailboxPolicies_Vtbl {
     pub RequiredSmimeSigningAlgorithm: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxPolicies2, IEmailMailboxPolicies2_Vtbl, 0xbab58afb_a14b_497c_a8e2_55eac29cc4b5);
+impl windows_core::RuntimeType for IEmailMailboxPolicies2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxPolicies2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -428,6 +524,9 @@ pub struct IEmailMailboxPolicies2_Vtbl {
     pub MustSignSmimeMessages: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxPolicies3, IEmailMailboxPolicies3_Vtbl, 0xbdd4a01f_4867_414a_81a2_803919c44191);
+impl windows_core::RuntimeType for IEmailMailboxPolicies3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxPolicies3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -439,6 +538,9 @@ pub struct IEmailMailboxPolicies3_Vtbl {
     pub SetMustSignSmimeMessages: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxSyncManager, IEmailMailboxSyncManager_Vtbl, 0x517ac55a_3591_4b5d_85bc_c71dde862263);
+impl windows_core::RuntimeType for IEmailMailboxSyncManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxSyncManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -450,6 +552,9 @@ pub struct IEmailMailboxSyncManager_Vtbl {
     pub RemoveSyncStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMailboxSyncManager2, IEmailMailboxSyncManager2_Vtbl, 0xcd8dc97e_95c1_4f89_81b7_e6aecb6695fc);
+impl windows_core::RuntimeType for IEmailMailboxSyncManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMailboxSyncManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -458,6 +563,9 @@ pub struct IEmailMailboxSyncManager2_Vtbl {
     pub SetLastAttemptedSyncTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailManagerForUser, IEmailManagerForUser_Vtbl, 0xf773de9f_3ca5_4b0f_90c1_156e40174ce5);
+impl windows_core::RuntimeType for IEmailManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -469,18 +577,27 @@ pub struct IEmailManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IEmailManagerStatics, IEmailManagerStatics_Vtbl, 0xf5128654_55c5_4890_a824_216c2618ce7f);
+impl windows_core::RuntimeType for IEmailManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShowComposeNewEmailAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailManagerStatics2, IEmailManagerStatics2_Vtbl, 0xac052da3_b194_425d_b6d9_d0f04135eda2);
+impl windows_core::RuntimeType for IEmailManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestStoreAsync: unsafe extern "system" fn(*mut core::ffi::c_void, EmailStoreAccessType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailManagerStatics3, IEmailManagerStatics3_Vtbl, 0x4a722395_843e_4945_b3aa_349e07a362c5);
+impl windows_core::RuntimeType for IEmailManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -490,6 +607,9 @@ pub struct IEmailManagerStatics3_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IEmailMeetingInfo, IEmailMeetingInfo_Vtbl, 0x31c03fa9_7933_415f_a275_d165ba07026b);
+impl windows_core::RuntimeType for IEmailMeetingInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMeetingInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -527,12 +647,18 @@ pub struct IEmailMeetingInfo_Vtbl {
     pub SetStartTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMeetingInfo2, IEmailMeetingInfo2_Vtbl, 0x7e59386d_b0d9_4fe5_867c_e31ed2b588b8);
+impl windows_core::RuntimeType for IEmailMeetingInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMeetingInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsReportedOutOfDateByServer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMessage, IEmailMessage_Vtbl, 0x6c6d948d_80b5_48f8_b0b1_e04e430f44e5);
+impl windows_core::RuntimeType for IEmailMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -558,6 +684,9 @@ pub struct IEmailMessage_Vtbl {
     Attachments: usize,
 }
 windows_core::imp::define_interface!(IEmailMessage2, IEmailMessage2_Vtbl, 0xfdc8248b_9f1a_44db_bd3c_65c384770f86);
+impl windows_core::RuntimeType for IEmailMessage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMessage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -614,6 +743,9 @@ pub struct IEmailMessage2_Vtbl {
     SetBodyStream: usize,
 }
 windows_core::imp::define_interface!(IEmailMessage3, IEmailMessage3_Vtbl, 0xa1ea675c_e598_4d29_a018_fc7b7eece0a1);
+impl windows_core::RuntimeType for IEmailMessage3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMessage3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -629,6 +761,9 @@ pub struct IEmailMessage3_Vtbl {
     pub SetSmimeKind: unsafe extern "system" fn(*mut core::ffi::c_void, EmailMessageSmimeKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMessage4, IEmailMessage4_Vtbl, 0x317cf181_3e7f_4a05_8394_3e10336dd435);
+impl windows_core::RuntimeType for IEmailMessage4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMessage4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -640,6 +775,9 @@ pub struct IEmailMessage4_Vtbl {
     pub SetSentRepresenting: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMessageBatch, IEmailMessageBatch_Vtbl, 0x605cd08f_25d9_4f1b_9e51_0514c0149653);
+impl windows_core::RuntimeType for IEmailMessageBatch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMessageBatch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -650,12 +788,18 @@ pub struct IEmailMessageBatch_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut EmailBatchStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailMessageReader, IEmailMessageReader_Vtbl, 0x2f4abe9f_6213_4a85_a3b0_f92d1a839d19);
+impl windows_core::RuntimeType for IEmailMessageReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailMessageReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReadBatchAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailQueryOptions, IEmailQueryOptions_Vtbl, 0x45504b9b_3e7f_4d52_b6dd_d6fd4e1fbd9a);
+impl windows_core::RuntimeType for IEmailQueryOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailQueryOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -672,6 +816,9 @@ pub struct IEmailQueryOptions_Vtbl {
     FolderIds: usize,
 }
 windows_core::imp::define_interface!(IEmailQueryOptionsFactory, IEmailQueryOptionsFactory_Vtbl, 0x88f1a1b8_78ab_4ee8_b4e3_046d6e2fe5e2);
+impl windows_core::RuntimeType for IEmailQueryOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailQueryOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -679,6 +826,9 @@ pub struct IEmailQueryOptionsFactory_Vtbl {
     pub CreateWithTextAndFields: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, EmailQuerySearchFields, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailQueryTextSearch, IEmailQueryTextSearch_Vtbl, 0x9fa0a288_3c5d_46a5_a6e2_31d6fd17e540);
+impl windows_core::RuntimeType for IEmailQueryTextSearch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailQueryTextSearch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -690,6 +840,9 @@ pub struct IEmailQueryTextSearch_Vtbl {
     pub SetText: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailRecipient, IEmailRecipient_Vtbl, 0xcae825b3_4478_4814_b900_c902b5e19b53);
+impl windows_core::RuntimeType for IEmailRecipient {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailRecipient_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -699,6 +852,9 @@ pub struct IEmailRecipient_Vtbl {
     pub SetAddress: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailRecipientFactory, IEmailRecipientFactory_Vtbl, 0x5500b84d_c79a_4ef8_b909_722e18e3935d);
+impl windows_core::RuntimeType for IEmailRecipientFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailRecipientFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -706,6 +862,9 @@ pub struct IEmailRecipientFactory_Vtbl {
     pub CreateWithName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailRecipientResolutionResult, IEmailRecipientResolutionResult_Vtbl, 0x918338fa_8d8d_4573_80d1_07172a34b98d);
+impl windows_core::RuntimeType for IEmailRecipientResolutionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailRecipientResolutionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -716,6 +875,9 @@ pub struct IEmailRecipientResolutionResult_Vtbl {
     PublicKeys: usize,
 }
 windows_core::imp::define_interface!(IEmailRecipientResolutionResult2, IEmailRecipientResolutionResult2_Vtbl, 0x5e420bb6_ce5b_4bde_b9d4_e16da0b09fca);
+impl windows_core::RuntimeType for IEmailRecipientResolutionResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailRecipientResolutionResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -726,6 +888,9 @@ pub struct IEmailRecipientResolutionResult2_Vtbl {
     SetPublicKeys: usize,
 }
 windows_core::imp::define_interface!(IEmailStore, IEmailStore_Vtbl, 0xf803226e_9137_4f8b_a470_279ac3058eb6);
+impl windows_core::RuntimeType for IEmailStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -745,6 +910,9 @@ pub struct IEmailStore_Vtbl {
     pub CreateMailboxInAccountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailStoreNotificationTriggerDetails, IEmailStoreNotificationTriggerDetails_Vtbl, 0xce17563c_46e6_43c9_96f7_facf7dd710cb);
+impl windows_core::RuntimeType for IEmailStoreNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailStoreNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -900,7 +1068,7 @@ impl EmailAttachment {
     }
 }
 impl windows_core::RuntimeType for EmailAttachment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailAttachment>();
 }
 unsafe impl windows_core::Interface for EmailAttachment {
     type Vtable = IEmailAttachment_Vtbl;
@@ -1025,7 +1193,7 @@ impl EmailConversation {
     }
 }
 impl windows_core::RuntimeType for EmailConversation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailConversation>();
 }
 unsafe impl windows_core::Interface for EmailConversation {
     type Vtable = IEmailConversation_Vtbl;
@@ -1058,7 +1226,7 @@ impl EmailConversationBatch {
     }
 }
 impl windows_core::RuntimeType for EmailConversationBatch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailConversationBatch>();
 }
 unsafe impl windows_core::Interface for EmailConversationBatch {
     type Vtable = IEmailConversationBatch_Vtbl;
@@ -1083,7 +1251,7 @@ impl EmailConversationReader {
     }
 }
 impl windows_core::RuntimeType for EmailConversationReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailConversationReader>();
 }
 unsafe impl windows_core::Interface for EmailConversationReader {
     type Vtable = IEmailConversationReader_Vtbl;
@@ -1280,7 +1448,7 @@ impl EmailFolder {
     }
 }
 impl windows_core::RuntimeType for EmailFolder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailFolder>();
 }
 unsafe impl windows_core::Interface for EmailFolder {
     type Vtable = IEmailFolder_Vtbl;
@@ -1454,7 +1622,7 @@ impl EmailIrmInfo {
     }
 }
 impl windows_core::RuntimeType for EmailIrmInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailIrmInfo>();
 }
 unsafe impl windows_core::Interface for EmailIrmInfo {
     type Vtable = IEmailIrmInfo_Vtbl;
@@ -1523,7 +1691,7 @@ impl EmailIrmTemplate {
     }
 }
 impl windows_core::RuntimeType for EmailIrmTemplate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailIrmTemplate>();
 }
 unsafe impl windows_core::Interface for EmailIrmTemplate {
     type Vtable = IEmailIrmTemplate_Vtbl;
@@ -1569,7 +1737,7 @@ impl EmailItemCounts {
     }
 }
 impl windows_core::RuntimeType for EmailItemCounts {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailItemCounts>();
 }
 unsafe impl windows_core::Interface for EmailItemCounts {
     type Vtable = IEmailItemCounts_Vtbl;
@@ -2033,7 +2201,7 @@ impl EmailMailbox {
     }
 }
 impl windows_core::RuntimeType for EmailMailbox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailbox>();
 }
 unsafe impl windows_core::Interface for EmailMailbox {
     type Vtable = IEmailMailbox_Vtbl;
@@ -2065,7 +2233,7 @@ impl EmailMailboxAction {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxAction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxAction>();
 }
 unsafe impl windows_core::Interface for EmailMailboxAction {
     type Vtable = IEmailMailboxAction_Vtbl;
@@ -2105,7 +2273,7 @@ impl EmailMailboxAutoReply {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxAutoReply {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxAutoReply>();
 }
 unsafe impl windows_core::Interface for EmailMailboxAutoReply {
     type Vtable = IEmailMailboxAutoReply_Vtbl;
@@ -2201,7 +2369,7 @@ impl EmailMailboxAutoReplySettings {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxAutoReplySettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxAutoReplySettings>();
 }
 unsafe impl windows_core::Interface for EmailMailboxAutoReplySettings {
     type Vtable = IEmailMailboxAutoReplySettings_Vtbl;
@@ -2373,7 +2541,7 @@ impl EmailMailboxCapabilities {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxCapabilities>();
 }
 unsafe impl windows_core::Interface for EmailMailboxCapabilities {
     type Vtable = IEmailMailboxCapabilities_Vtbl;
@@ -2420,7 +2588,7 @@ impl EmailMailboxChange {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxChange>();
 }
 unsafe impl windows_core::Interface for EmailMailboxChange {
     type Vtable = IEmailMailboxChange_Vtbl;
@@ -2457,7 +2625,7 @@ impl EmailMailboxChangeReader {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxChangeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxChangeReader>();
 }
 unsafe impl windows_core::Interface for EmailMailboxChangeReader {
     type Vtable = IEmailMailboxChangeReader_Vtbl;
@@ -2497,7 +2665,7 @@ impl EmailMailboxChangeTracker {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxChangeTracker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxChangeTracker>();
 }
 unsafe impl windows_core::Interface for EmailMailboxChangeTracker {
     type Vtable = IEmailMailboxChangeTracker_Vtbl;
@@ -2519,7 +2687,7 @@ impl EmailMailboxChangedDeferral {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxChangedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxChangedDeferral>();
 }
 unsafe impl windows_core::Interface for EmailMailboxChangedDeferral {
     type Vtable = IEmailMailboxChangedDeferral_Vtbl;
@@ -2544,7 +2712,7 @@ impl EmailMailboxChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for EmailMailboxChangedEventArgs {
     type Vtable = IEmailMailboxChangedEventArgs_Vtbl;
@@ -2576,7 +2744,7 @@ impl EmailMailboxCreateFolderResult {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxCreateFolderResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxCreateFolderResult>();
 }
 unsafe impl windows_core::Interface for EmailMailboxCreateFolderResult {
     type Vtable = IEmailMailboxCreateFolderResult_Vtbl;
@@ -2666,7 +2834,7 @@ impl EmailMailboxPolicies {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxPolicies {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxPolicies>();
 }
 unsafe impl windows_core::Interface for EmailMailboxPolicies {
     type Vtable = IEmailMailboxPolicies_Vtbl;
@@ -2738,7 +2906,7 @@ impl EmailMailboxSyncManager {
     }
 }
 impl windows_core::RuntimeType for EmailMailboxSyncManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMailboxSyncManager>();
 }
 unsafe impl windows_core::Interface for EmailMailboxSyncManager {
     type Vtable = IEmailMailboxSyncManager_Vtbl;
@@ -2827,7 +2995,7 @@ impl EmailManagerForUser {
     }
 }
 impl windows_core::RuntimeType for EmailManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailManagerForUser>();
 }
 unsafe impl windows_core::Interface for EmailManagerForUser {
     type Vtable = IEmailManagerForUser_Vtbl;
@@ -3019,7 +3187,7 @@ impl EmailMeetingInfo {
     }
 }
 impl windows_core::RuntimeType for EmailMeetingInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMeetingInfo>();
 }
 unsafe impl windows_core::Interface for EmailMeetingInfo {
     type Vtable = IEmailMeetingInfo_Vtbl;
@@ -3428,7 +3596,7 @@ impl EmailMessage {
     }
 }
 impl windows_core::RuntimeType for EmailMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMessage>();
 }
 unsafe impl windows_core::Interface for EmailMessage {
     type Vtable = IEmailMessage_Vtbl;
@@ -3461,7 +3629,7 @@ impl EmailMessageBatch {
     }
 }
 impl windows_core::RuntimeType for EmailMessageBatch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMessageBatch>();
 }
 unsafe impl windows_core::Interface for EmailMessageBatch {
     type Vtable = IEmailMessageBatch_Vtbl;
@@ -3486,7 +3654,7 @@ impl EmailMessageReader {
     }
 }
 impl windows_core::RuntimeType for EmailMessageReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailMessageReader>();
 }
 unsafe impl windows_core::Interface for EmailMessageReader {
     type Vtable = IEmailMessageReader_Vtbl;
@@ -3576,7 +3744,7 @@ impl EmailQueryOptions {
     }
 }
 impl windows_core::RuntimeType for EmailQueryOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailQueryOptions>();
 }
 unsafe impl windows_core::Interface for EmailQueryOptions {
     type Vtable = IEmailQueryOptions_Vtbl;
@@ -3627,7 +3795,7 @@ impl EmailQueryTextSearch {
     }
 }
 impl windows_core::RuntimeType for EmailQueryTextSearch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailQueryTextSearch>();
 }
 unsafe impl windows_core::Interface for EmailQueryTextSearch {
     type Vtable = IEmailQueryTextSearch_Vtbl;
@@ -3691,7 +3859,7 @@ impl EmailRecipient {
     }
 }
 impl windows_core::RuntimeType for EmailRecipient {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailRecipient>();
 }
 unsafe impl windows_core::Interface for EmailRecipient {
     type Vtable = IEmailRecipient_Vtbl;
@@ -3743,7 +3911,7 @@ impl EmailRecipientResolutionResult {
     }
 }
 impl windows_core::RuntimeType for EmailRecipientResolutionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailRecipientResolutionResult>();
 }
 unsafe impl windows_core::Interface for EmailRecipientResolutionResult {
     type Vtable = IEmailRecipientResolutionResult_Vtbl;
@@ -3845,7 +4013,7 @@ impl EmailStore {
     }
 }
 impl windows_core::RuntimeType for EmailStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailStore>();
 }
 unsafe impl windows_core::Interface for EmailStore {
     type Vtable = IEmailStore_Vtbl;
@@ -3862,7 +4030,7 @@ pub struct EmailStoreNotificationTriggerDetails(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(EmailStoreNotificationTriggerDetails, windows_core::IUnknown, windows_core::IInspectable);
 impl EmailStoreNotificationTriggerDetails {}
 impl windows_core::RuntimeType for EmailStoreNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailStoreNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for EmailStoreNotificationTriggerDetails {
     type Vtable = IEmailStoreNotificationTriggerDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IExtendedExecutionForegroundRevokedEventArgs, IExtendedExecutionForegroundRevokedEventArgs_Vtbl, 0xb07cd940_9557_aea4_2c99_bdd56d9be461);
+impl windows_core::RuntimeType for IExtendedExecutionForegroundRevokedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExtendedExecutionForegroundRevokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ExtendedExecutionForegroundRevokedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IExtendedExecutionForegroundSession, IExtendedExecutionForegroundSession_Vtbl, 0xfbf440e1_9d10_4201_b01e_c83275296f2e);
+impl windows_core::RuntimeType for IExtendedExecutionForegroundSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExtendedExecutionForegroundSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,7 +36,7 @@ impl ExtendedExecutionForegroundRevokedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ExtendedExecutionForegroundRevokedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExtendedExecutionForegroundRevokedEventArgs>();
 }
 unsafe impl windows_core::Interface for ExtendedExecutionForegroundRevokedEventArgs {
     type Vtable = IExtendedExecutionForegroundRevokedEventArgs_Vtbl;
@@ -103,7 +109,7 @@ impl ExtendedExecutionForegroundSession {
     }
 }
 impl windows_core::RuntimeType for ExtendedExecutionForegroundSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExtendedExecutionForegroundSession>();
 }
 unsafe impl windows_core::Interface for ExtendedExecutionForegroundSession {
     type Vtable = IExtendedExecutionForegroundSession_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
@@ -1,12 +1,18 @@
 #[cfg(feature = "ApplicationModel_ExtendedExecution_Foreground")]
 pub mod Foreground;
 windows_core::imp::define_interface!(IExtendedExecutionRevokedEventArgs, IExtendedExecutionRevokedEventArgs_Vtbl, 0xbfbc9f16_63b5_4c0b_aad6_828af5373ec3);
+impl windows_core::RuntimeType for IExtendedExecutionRevokedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExtendedExecutionRevokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ExtendedExecutionRevokedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IExtendedExecutionSession, IExtendedExecutionSession_Vtbl, 0xaf908a2d_118b_48f1_9308_0c4fc41e200f);
+impl windows_core::RuntimeType for IExtendedExecutionSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExtendedExecutionSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,7 +40,7 @@ impl ExtendedExecutionRevokedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ExtendedExecutionRevokedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExtendedExecutionRevokedEventArgs>();
 }
 unsafe impl windows_core::Interface for ExtendedExecutionRevokedEventArgs {
     type Vtable = IExtendedExecutionRevokedEventArgs_Vtbl;
@@ -118,7 +124,7 @@ impl ExtendedExecutionSession {
     }
 }
 impl windows_core::RuntimeType for ExtendedExecutionSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExtendedExecutionSession>();
 }
 unsafe impl windows_core::Interface for ExtendedExecutionSession {
     type Vtable = IExtendedExecutionSession_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Holographic/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHolographicKeyboard, IHolographicKeyboard_Vtbl, 0x07dd0893_aa21_5e6f_a91b_11b2b3fd7be3);
+impl windows_core::RuntimeType for IHolographicKeyboard {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicKeyboard_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +16,9 @@ pub struct IHolographicKeyboard_Vtbl {
     pub ResetPlacementOverride: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicKeyboardStatics, IHolographicKeyboardStatics_Vtbl, 0xb676c624_63d7_58cf_b06b_08baa032a23f);
+impl windows_core::RuntimeType for IHolographicKeyboardStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicKeyboardStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,7 +62,7 @@ impl HolographicKeyboard {
     }
 }
 impl windows_core::RuntimeType for HolographicKeyboard {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicKeyboard>();
 }
 unsafe impl windows_core::Interface for HolographicKeyboard {
     type Vtable = IHolographicKeyboard_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/LockScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/LockScreen/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ILockApplicationHost, ILockApplicationHost_Vtbl, 0x38ee31ad_d94f_4e7c_81fa_4f4436506281);
+impl windows_core::RuntimeType for ILockApplicationHost {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockApplicationHost_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,12 +10,18 @@ pub struct ILockApplicationHost_Vtbl {
     pub RemoveUnlocking: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockApplicationHostStatics, ILockApplicationHostStatics_Vtbl, 0xf48fab8e_23d7_4e63_96a1_666ff52d3b2c);
+impl windows_core::RuntimeType for ILockApplicationHostStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockApplicationHostStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenBadge, ILockScreenBadge_Vtbl, 0xe95105d9_2bff_4db0_9b4f_3824778b9c9a);
+impl windows_core::RuntimeType for ILockScreenBadge {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenBadge_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +38,9 @@ pub struct ILockScreenBadge_Vtbl {
     pub LaunchApp: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenInfo, ILockScreenInfo_Vtbl, 0xf59aa65c_9711_4dc9_a630_95b6cb8cdad0);
+impl windows_core::RuntimeType for ILockScreenInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,12 +70,18 @@ pub struct ILockScreenInfo_Vtbl {
     AlarmIcon: usize,
 }
 windows_core::imp::define_interface!(ILockScreenUnlockingDeferral, ILockScreenUnlockingDeferral_Vtbl, 0x7e7d1ad6_5203_43e7_9bd6_7c3947d1e3fe);
+impl windows_core::RuntimeType for ILockScreenUnlockingDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenUnlockingDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenUnlockingEventArgs, ILockScreenUnlockingEventArgs_Vtbl, 0x44e6c007_75fb_4abb_9f8b_824748900c71);
+impl windows_core::RuntimeType for ILockScreenUnlockingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenUnlockingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,7 +124,7 @@ impl LockApplicationHost {
     }
 }
 impl windows_core::RuntimeType for LockApplicationHost {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockApplicationHost>();
 }
 unsafe impl windows_core::Interface for LockApplicationHost {
     type Vtable = ILockApplicationHost_Vtbl;
@@ -158,7 +176,7 @@ impl LockScreenBadge {
     }
 }
 impl windows_core::RuntimeType for LockScreenBadge {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenBadge>();
 }
 unsafe impl windows_core::Interface for LockScreenBadge {
     type Vtable = ILockScreenBadge_Vtbl;
@@ -264,7 +282,7 @@ impl LockScreenInfo {
     }
 }
 impl windows_core::RuntimeType for LockScreenInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenInfo>();
 }
 unsafe impl windows_core::Interface for LockScreenInfo {
     type Vtable = ILockScreenInfo_Vtbl;
@@ -286,7 +304,7 @@ impl LockScreenUnlockingDeferral {
     }
 }
 impl windows_core::RuntimeType for LockScreenUnlockingDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenUnlockingDeferral>();
 }
 unsafe impl windows_core::Interface for LockScreenUnlockingDeferral {
     type Vtable = ILockScreenUnlockingDeferral_Vtbl;
@@ -318,7 +336,7 @@ impl LockScreenUnlockingEventArgs {
     }
 }
 impl windows_core::RuntimeType for LockScreenUnlockingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockScreenUnlockingEventArgs>();
 }
 unsafe impl windows_core::Interface for LockScreenUnlockingEventArgs {
     type Vtable = ILockScreenUnlockingEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPaymentAppCanMakePaymentTriggerDetails, IPaymentAppCanMakePaymentTriggerDetails_Vtbl, 0x0ce201f0_8b93_4eb6_8c46_2e4a6c6a26f6);
+impl windows_core::RuntimeType for IPaymentAppCanMakePaymentTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentAppCanMakePaymentTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IPaymentAppCanMakePaymentTriggerDetails_Vtbl {
     pub ReportCanMakePaymentResult: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentAppManager, IPaymentAppManager_Vtbl, 0x0e47aa53_8521_4969_a957_df2538a3a98f);
+impl windows_core::RuntimeType for IPaymentAppManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentAppManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,12 +22,18 @@ pub struct IPaymentAppManager_Vtbl {
     pub UnregisterAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentAppManagerStatics, IPaymentAppManagerStatics_Vtbl, 0xa341ac28_fc89_4406_b4d9_34e7fe79dfb6);
+impl windows_core::RuntimeType for IPaymentAppManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentAppManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentTransaction, IPaymentTransaction_Vtbl, 0x62581da0_26a5_4e9b_a6eb_66606cf001d3);
+impl windows_core::RuntimeType for IPaymentTransaction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentTransaction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,12 +50,18 @@ pub struct IPaymentTransaction_Vtbl {
     pub Reject: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentTransactionAcceptResult, IPaymentTransactionAcceptResult_Vtbl, 0x060e3276_d30c_4817_95a2_df7ae9273b56);
+impl windows_core::RuntimeType for IPaymentTransactionAcceptResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentTransactionAcceptResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::PaymentRequestCompletionStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentTransactionStatics, IPaymentTransactionStatics_Vtbl, 0x8d639750_ee0a_4df5_9b1e_1c0f9ec59881);
+impl windows_core::RuntimeType for IPaymentTransactionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentTransactionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -70,7 +88,7 @@ impl PaymentAppCanMakePaymentTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PaymentAppCanMakePaymentTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentAppCanMakePaymentTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PaymentAppCanMakePaymentTriggerDetails {
     type Vtable = IPaymentAppCanMakePaymentTriggerDetails_Vtbl;
@@ -117,7 +135,7 @@ impl PaymentAppManager {
     }
 }
 impl windows_core::RuntimeType for PaymentAppManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentAppManager>();
 }
 unsafe impl windows_core::Interface for PaymentAppManager {
     type Vtable = IPaymentAppManager_Vtbl;
@@ -220,7 +238,7 @@ impl PaymentTransaction {
     }
 }
 impl windows_core::RuntimeType for PaymentTransaction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentTransaction>();
 }
 unsafe impl windows_core::Interface for PaymentTransaction {
     type Vtable = IPaymentTransaction_Vtbl;
@@ -245,7 +263,7 @@ impl PaymentTransactionAcceptResult {
     }
 }
 impl windows_core::RuntimeType for PaymentTransactionAcceptResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentTransactionAcceptResult>();
 }
 unsafe impl windows_core::Interface for PaymentTransactionAcceptResult {
     type Vtable = IPaymentTransactionAcceptResult_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "ApplicationModel_Payments_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IPaymentAddress, IPaymentAddress_Vtbl, 0x5f2264e9_6f3a_4166_a018_0a0b06bb32b5);
+impl windows_core::RuntimeType for IPaymentAddress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentAddress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,18 +41,27 @@ pub struct IPaymentAddress_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IPaymentCanMakePaymentResult, IPaymentCanMakePaymentResult_Vtbl, 0x7696fe55_d5d3_4d3d_b345_45591759c510);
+impl windows_core::RuntimeType for IPaymentCanMakePaymentResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentCanMakePaymentResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PaymentCanMakePaymentResultStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentCanMakePaymentResultFactory, IPaymentCanMakePaymentResultFactory_Vtbl, 0xbbdcaa3e_7d49_4f69_aa53_2a0f8164b7c9);
+impl windows_core::RuntimeType for IPaymentCanMakePaymentResultFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentCanMakePaymentResultFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, PaymentCanMakePaymentResultStatus, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentCurrencyAmount, IPaymentCurrencyAmount_Vtbl, 0xe3a3e9e0_b41f_4987_bdcb_071331f2daa4);
+impl windows_core::RuntimeType for IPaymentCurrencyAmount {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentCurrencyAmount_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +73,9 @@ pub struct IPaymentCurrencyAmount_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentCurrencyAmountFactory, IPaymentCurrencyAmountFactory_Vtbl, 0x3257d338_140c_4575_8535_f773178c09a7);
+impl windows_core::RuntimeType for IPaymentCurrencyAmountFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentCurrencyAmountFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,6 +83,9 @@ pub struct IPaymentCurrencyAmountFactory_Vtbl {
     pub CreateWithCurrencySystem: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentDetails, IPaymentDetails_Vtbl, 0x53bb2d7d_e0eb_4053_8eae_ce7c48e02945);
+impl windows_core::RuntimeType for IPaymentDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +117,9 @@ pub struct IPaymentDetails_Vtbl {
     SetModifiers: usize,
 }
 windows_core::imp::define_interface!(IPaymentDetailsFactory, IPaymentDetailsFactory_Vtbl, 0xcfe8afee_c0ea_4ca1_8bc7_6de67b1f3763);
+impl windows_core::RuntimeType for IPaymentDetailsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentDetailsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,6 +130,9 @@ pub struct IPaymentDetailsFactory_Vtbl {
     CreateWithDisplayItems: usize,
 }
 windows_core::imp::define_interface!(IPaymentDetailsModifier, IPaymentDetailsModifier_Vtbl, 0xbe1c7d65_4323_41d7_b305_dfcb765f69de);
+impl windows_core::RuntimeType for IPaymentDetailsModifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentDetailsModifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +148,9 @@ pub struct IPaymentDetailsModifier_Vtbl {
     AdditionalDisplayItems: usize,
 }
 windows_core::imp::define_interface!(IPaymentDetailsModifierFactory, IPaymentDetailsModifierFactory_Vtbl, 0x79005286_54de_429c_9e4f_5dce6e10ebce);
+impl windows_core::RuntimeType for IPaymentDetailsModifierFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentDetailsModifierFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,6 +168,9 @@ pub struct IPaymentDetailsModifierFactory_Vtbl {
     CreateWithAdditionalDisplayItemsAndJsonData: usize,
 }
 windows_core::imp::define_interface!(IPaymentItem, IPaymentItem_Vtbl, 0x685ac88b_79b2_4b76_9e03_a876223dfe72);
+impl windows_core::RuntimeType for IPaymentItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,12 +182,18 @@ pub struct IPaymentItem_Vtbl {
     pub SetPending: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentItemFactory, IPaymentItemFactory_Vtbl, 0xc6ab7ad8_2503_4d1d_a778_02b2e5927b2c);
+impl windows_core::RuntimeType for IPaymentItemFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentItemFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentMediator, IPaymentMediator_Vtbl, 0xfb0ee829_ec0c_449a_83da_7ae3073365a2);
+impl windows_core::RuntimeType for IPaymentMediator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentMediator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,12 +205,18 @@ pub struct IPaymentMediator_Vtbl {
     pub SubmitPaymentRequestWithChangeHandlerAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentMediator2, IPaymentMediator2_Vtbl, 0xceef98f1_e407_4128_8e73_d93d5f822786);
+impl windows_core::RuntimeType for IPaymentMediator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentMediator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CanMakePaymentAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentMerchantInfo, IPaymentMerchantInfo_Vtbl, 0x63445050_0e94_4ed6_aacb_e6012bd327a7);
+impl windows_core::RuntimeType for IPaymentMerchantInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentMerchantInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -182,12 +224,18 @@ pub struct IPaymentMerchantInfo_Vtbl {
     pub Uri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentMerchantInfoFactory, IPaymentMerchantInfoFactory_Vtbl, 0x9e89ced3_ccb7_4167_a8ec_e10ae96dbcd1);
+impl windows_core::RuntimeType for IPaymentMerchantInfoFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentMerchantInfoFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentMethodData, IPaymentMethodData_Vtbl, 0xd1d3caf4_de98_4129_b1b7_c3ad86237bf4);
+impl windows_core::RuntimeType for IPaymentMethodData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentMethodData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,6 +246,9 @@ pub struct IPaymentMethodData_Vtbl {
     pub JsonData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentMethodDataFactory, IPaymentMethodDataFactory_Vtbl, 0x8addd27f_9baa_4a82_8342_a8210992a36b);
+impl windows_core::RuntimeType for IPaymentMethodDataFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentMethodDataFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -211,6 +262,9 @@ pub struct IPaymentMethodDataFactory_Vtbl {
     CreateWithJsonData: usize,
 }
 windows_core::imp::define_interface!(IPaymentOptions, IPaymentOptions_Vtbl, 0xaaa30854_1f2b_4365_8251_01b58915a5bc);
+impl windows_core::RuntimeType for IPaymentOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -226,6 +280,9 @@ pub struct IPaymentOptions_Vtbl {
     pub SetShippingType: unsafe extern "system" fn(*mut core::ffi::c_void, PaymentShippingType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentRequest, IPaymentRequest_Vtbl, 0xb74942e1_ed7b_47eb_bc08_78cc5d6896b6);
+impl windows_core::RuntimeType for IPaymentRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -238,12 +295,18 @@ pub struct IPaymentRequest_Vtbl {
     pub Options: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentRequest2, IPaymentRequest2_Vtbl, 0xb63ccfb5_5998_493e_a04c_67048a50f141);
+impl windows_core::RuntimeType for IPaymentRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentRequestChangedArgs, IPaymentRequestChangedArgs_Vtbl, 0xc6145e44_cd8b_4be4_b555_27c99194c0c5);
+impl windows_core::RuntimeType for IPaymentRequestChangedArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequestChangedArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -253,6 +316,9 @@ pub struct IPaymentRequestChangedArgs_Vtbl {
     pub Acknowledge: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentRequestChangedResult, IPaymentRequestChangedResult_Vtbl, 0xdf699e5c_16c4_47ad_9401_8440ec0757db);
+impl windows_core::RuntimeType for IPaymentRequestChangedResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequestChangedResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -264,6 +330,9 @@ pub struct IPaymentRequestChangedResult_Vtbl {
     pub SetUpdatedPaymentDetails: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentRequestChangedResultFactory, IPaymentRequestChangedResultFactory_Vtbl, 0x08740f56_1d33_4431_814b_67ea24bf21db);
+impl windows_core::RuntimeType for IPaymentRequestChangedResultFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequestChangedResultFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -271,6 +340,9 @@ pub struct IPaymentRequestChangedResultFactory_Vtbl {
     pub CreateWithPaymentDetails: unsafe extern "system" fn(*mut core::ffi::c_void, bool, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentRequestFactory, IPaymentRequestFactory_Vtbl, 0x3e8a79dc_6b74_42d3_b103_f0de35fb1848);
+impl windows_core::RuntimeType for IPaymentRequestFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequestFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -288,6 +360,9 @@ pub struct IPaymentRequestFactory_Vtbl {
     CreateWithMerchantInfoAndOptions: usize,
 }
 windows_core::imp::define_interface!(IPaymentRequestFactory2, IPaymentRequestFactory2_Vtbl, 0xe6ce1325_a506_4372_b7ef_1a031d5662d1);
+impl windows_core::RuntimeType for IPaymentRequestFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequestFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -297,6 +372,9 @@ pub struct IPaymentRequestFactory2_Vtbl {
     CreateWithMerchantInfoOptionsAndId: usize,
 }
 windows_core::imp::define_interface!(IPaymentRequestSubmitResult, IPaymentRequestSubmitResult_Vtbl, 0x7b9c3912_30f2_4e90_b249_8ce7d78ffe56);
+impl windows_core::RuntimeType for IPaymentRequestSubmitResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentRequestSubmitResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -304,6 +382,9 @@ pub struct IPaymentRequestSubmitResult_Vtbl {
     pub Response: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentResponse, IPaymentResponse_Vtbl, 0xe1389457_8bd2_4888_9fa8_97985545108e);
+impl windows_core::RuntimeType for IPaymentResponse {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentResponse_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -316,6 +397,9 @@ pub struct IPaymentResponse_Vtbl {
     pub CompleteAsync: unsafe extern "system" fn(*mut core::ffi::c_void, PaymentRequestCompletionStatus, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentShippingOption, IPaymentShippingOption_Vtbl, 0x13372ada_9753_4574_8966_93145a76c7f9);
+impl windows_core::RuntimeType for IPaymentShippingOption {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentShippingOption_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -329,6 +413,9 @@ pub struct IPaymentShippingOption_Vtbl {
     pub SetIsSelected: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentShippingOptionFactory, IPaymentShippingOptionFactory_Vtbl, 0x5de5f917_b2d7_446b_9d73_6123fbca3bc6);
+impl windows_core::RuntimeType for IPaymentShippingOptionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentShippingOptionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -337,6 +424,9 @@ pub struct IPaymentShippingOptionFactory_Vtbl {
     pub CreateWithSelectedAndTag: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, bool, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentToken, IPaymentToken_Vtbl, 0xbbcac013_ccd0_41f2_b2a1_0a2e4b5dce25);
+impl windows_core::RuntimeType for IPaymentToken {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentToken_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -344,6 +434,9 @@ pub struct IPaymentToken_Vtbl {
     pub JsonDetails: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPaymentTokenFactory, IPaymentTokenFactory_Vtbl, 0x988cd7aa_4753_4904_8373_dd7b08b995c1);
+impl windows_core::RuntimeType for IPaymentTokenFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPaymentTokenFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -498,7 +591,7 @@ impl PaymentAddress {
     }
 }
 impl windows_core::RuntimeType for PaymentAddress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentAddress>();
 }
 unsafe impl windows_core::Interface for PaymentAddress {
     type Vtable = IPaymentAddress_Vtbl;
@@ -534,7 +627,7 @@ impl PaymentCanMakePaymentResult {
     }
 }
 impl windows_core::RuntimeType for PaymentCanMakePaymentResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentCanMakePaymentResult>();
 }
 unsafe impl windows_core::Interface for PaymentCanMakePaymentResult {
     type Vtable = IPaymentCanMakePaymentResult_Vtbl;
@@ -602,7 +695,7 @@ impl PaymentCurrencyAmount {
     }
 }
 impl windows_core::RuntimeType for PaymentCurrencyAmount {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentCurrencyAmount>();
 }
 unsafe impl windows_core::Interface for PaymentCurrencyAmount {
     type Vtable = IPaymentCurrencyAmount_Vtbl;
@@ -714,7 +807,7 @@ impl PaymentDetails {
     }
 }
 impl windows_core::RuntimeType for PaymentDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentDetails>();
 }
 unsafe impl windows_core::Interface for PaymentDetails {
     type Vtable = IPaymentDetails_Vtbl;
@@ -802,7 +895,7 @@ impl PaymentDetailsModifier {
     }
 }
 impl windows_core::RuntimeType for PaymentDetailsModifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentDetailsModifier>();
 }
 unsafe impl windows_core::Interface for PaymentDetailsModifier {
     type Vtable = IPaymentDetailsModifier_Vtbl;
@@ -870,7 +963,7 @@ impl PaymentItem {
     }
 }
 impl windows_core::RuntimeType for PaymentItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentItem>();
 }
 unsafe impl windows_core::Interface for PaymentItem {
     type Vtable = IPaymentItem_Vtbl;
@@ -934,7 +1027,7 @@ impl PaymentMediator {
     }
 }
 impl windows_core::RuntimeType for PaymentMediator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentMediator>();
 }
 unsafe impl windows_core::Interface for PaymentMediator {
     type Vtable = IPaymentMediator_Vtbl;
@@ -987,7 +1080,7 @@ impl PaymentMerchantInfo {
     }
 }
 impl windows_core::RuntimeType for PaymentMerchantInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentMerchantInfo>();
 }
 unsafe impl windows_core::Interface for PaymentMerchantInfo {
     type Vtable = IPaymentMerchantInfo_Vtbl;
@@ -1045,7 +1138,7 @@ impl PaymentMethodData {
     }
 }
 impl windows_core::RuntimeType for PaymentMethodData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentMethodData>();
 }
 unsafe impl windows_core::Interface for PaymentMethodData {
     type Vtable = IPaymentMethodData_Vtbl;
@@ -1125,7 +1218,7 @@ impl PaymentOptions {
     }
 }
 impl windows_core::RuntimeType for PaymentOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentOptions>();
 }
 unsafe impl windows_core::Interface for PaymentOptions {
     type Vtable = IPaymentOptions_Vtbl;
@@ -1238,7 +1331,7 @@ impl PaymentRequest {
     }
 }
 impl windows_core::RuntimeType for PaymentRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentRequest>();
 }
 unsafe impl windows_core::Interface for PaymentRequest {
     type Vtable = IPaymentRequest_Vtbl;
@@ -1284,7 +1377,7 @@ impl PaymentRequestChangedArgs {
     }
 }
 impl windows_core::RuntimeType for PaymentRequestChangedArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentRequestChangedArgs>();
 }
 unsafe impl windows_core::Interface for PaymentRequestChangedArgs {
     type Vtable = IPaymentRequestChangedArgs_Vtbl;
@@ -1358,7 +1451,7 @@ impl PaymentRequestChangedResult {
     }
 }
 impl windows_core::RuntimeType for PaymentRequestChangedResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentRequestChangedResult>();
 }
 unsafe impl windows_core::Interface for PaymentRequestChangedResult {
     type Vtable = IPaymentRequestChangedResult_Vtbl;
@@ -1390,7 +1483,7 @@ impl PaymentRequestSubmitResult {
     }
 }
 impl windows_core::RuntimeType for PaymentRequestSubmitResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentRequestSubmitResult>();
 }
 unsafe impl windows_core::Interface for PaymentRequestSubmitResult {
     type Vtable = IPaymentRequestSubmitResult_Vtbl;
@@ -1457,7 +1550,7 @@ impl PaymentResponse {
     }
 }
 impl windows_core::RuntimeType for PaymentResponse {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentResponse>();
 }
 unsafe impl windows_core::Interface for PaymentResponse {
     type Vtable = IPaymentResponse_Vtbl;
@@ -1554,7 +1647,7 @@ impl PaymentShippingOption {
     }
 }
 impl windows_core::RuntimeType for PaymentShippingOption {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentShippingOption>();
 }
 unsafe impl windows_core::Interface for PaymentShippingOption {
     type Vtable = IPaymentShippingOption_Vtbl;
@@ -1603,7 +1696,7 @@ impl PaymentToken {
     }
 }
 impl windows_core::RuntimeType for PaymentToken {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPaymentToken>();
 }
 unsafe impl windows_core::Interface for PaymentToken {
     type Vtable = IPaymentToken_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/Holographic/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHolographicApplicationPreviewStatics, IHolographicApplicationPreviewStatics_Vtbl, 0xfe038691_2a3a_45a9_a208_7bed691919f3);
+impl windows_core::RuntimeType for IHolographicApplicationPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicApplicationPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,10 @@ pub struct IHolographicApplicationPreviewStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IHolographicKeyboardPlacementOverridePreview, IHolographicKeyboardPlacementOverridePreview_Vtbl, 0xc8a8ce3a_dfde_5a14_8d5f_182c526dd9c4);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IHolographicKeyboardPlacementOverridePreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IHolographicKeyboardPlacementOverridePreview_Vtbl {
@@ -29,6 +36,10 @@ pub struct IHolographicKeyboardPlacementOverridePreview_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IHolographicKeyboardPlacementOverridePreviewStatics, IHolographicKeyboardPlacementOverridePreviewStatics_Vtbl, 0x202e6039_1ff6_5a06_aac4_a5e24fa3ec4b);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IHolographicKeyboardPlacementOverridePreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IHolographicKeyboardPlacementOverridePreviewStatics_Vtbl {
@@ -110,7 +121,7 @@ impl HolographicKeyboardPlacementOverridePreview {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for HolographicKeyboardPlacementOverridePreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicKeyboardPlacementOverridePreview>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for HolographicKeyboardPlacementOverridePreview {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/InkWorkspace/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/InkWorkspace/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IInkWorkspaceHostedAppManager, IInkWorkspaceHostedAppManager_Vtbl, 0xfe0a7990_5e59_4bb7_8a63_7d218cd96300);
+impl windows_core::RuntimeType for IInkWorkspaceHostedAppManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkWorkspaceHostedAppManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IInkWorkspaceHostedAppManager_Vtbl {
     SetThumbnailAsync: usize,
 }
 windows_core::imp::define_interface!(IInkWorkspaceHostedAppManagerStatics, IInkWorkspaceHostedAppManagerStatics_Vtbl, 0xcbfd8cc5_a162_4bc4_84ee_e8716d5233c5);
+impl windows_core::RuntimeType for IInkWorkspaceHostedAppManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkWorkspaceHostedAppManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,7 +48,7 @@ impl InkWorkspaceHostedAppManager {
     }
 }
 impl windows_core::RuntimeType for InkWorkspaceHostedAppManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkWorkspaceHostedAppManager>();
 }
 unsafe impl windows_core::Interface for InkWorkspaceHostedAppManager {
     type Vtable = IInkWorkspaceHostedAppManager_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Preview/Notes/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Preview/Notes/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(INotePlacementChangedPreviewEventArgs, INotePlacementChangedPreviewEventArgs_Vtbl, 0x491d57b7_f780_4e7f_a939_9a4caf965214);
+impl windows_core::RuntimeType for INotePlacementChangedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotePlacementChangedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ViewId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INoteVisibilityChangedPreviewEventArgs, INoteVisibilityChangedPreviewEventArgs_Vtbl, 0x0e34649e_3815_4ff6_83b3_a14d17120e24);
+impl windows_core::RuntimeType for INoteVisibilityChangedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INoteVisibilityChangedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +18,9 @@ pub struct INoteVisibilityChangedPreviewEventArgs_Vtbl {
     pub IsVisible: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INotesWindowManagerPreview, INotesWindowManagerPreview_Vtbl, 0xdc2ac23e_4850_4f13_9cc7_ff487efdfcde);
+impl windows_core::RuntimeType for INotesWindowManagerPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotesWindowManagerPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +50,9 @@ pub struct INotesWindowManagerPreview_Vtbl {
     pub RemoveNoteVisibilityChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INotesWindowManagerPreview2, INotesWindowManagerPreview2_Vtbl, 0xedfe864a_1f54_4b09_9823_ff477f6fa3bc);
+impl windows_core::RuntimeType for INotesWindowManagerPreview2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotesWindowManagerPreview2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +68,9 @@ pub struct INotesWindowManagerPreview2_Vtbl {
     SetThumbnailImageForTaskSwitcherAsync: usize,
 }
 windows_core::imp::define_interface!(INotesWindowManagerPreviewShowNoteOptions, INotesWindowManagerPreviewShowNoteOptions_Vtbl, 0x886b09d6_a6ae_4007_a56d_1ca70c84c0d2);
+impl windows_core::RuntimeType for INotesWindowManagerPreviewShowNoteOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotesWindowManagerPreviewShowNoteOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +78,9 @@ pub struct INotesWindowManagerPreviewShowNoteOptions_Vtbl {
     pub SetShowWithFocus: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INotesWindowManagerPreviewStatics, INotesWindowManagerPreviewStatics_Vtbl, 0x6668cc88_0a8e_4127_a38e_995445868a78);
+impl windows_core::RuntimeType for INotesWindowManagerPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotesWindowManagerPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -82,7 +100,7 @@ impl NotePlacementChangedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for NotePlacementChangedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INotePlacementChangedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for NotePlacementChangedPreviewEventArgs {
     type Vtable = INotePlacementChangedPreviewEventArgs_Vtbl;
@@ -114,7 +132,7 @@ impl NoteVisibilityChangedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for NoteVisibilityChangedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INoteVisibilityChangedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for NoteVisibilityChangedPreviewEventArgs {
     type Vtable = INoteVisibilityChangedPreviewEventArgs_Vtbl;
@@ -273,7 +291,7 @@ impl NotesWindowManagerPreview {
     }
 }
 impl windows_core::RuntimeType for NotesWindowManagerPreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INotesWindowManagerPreview>();
 }
 unsafe impl windows_core::Interface for NotesWindowManagerPreview {
     type Vtable = INotesWindowManagerPreview_Vtbl;
@@ -309,7 +327,7 @@ impl NotesWindowManagerPreviewShowNoteOptions {
     }
 }
 impl windows_core::RuntimeType for NotesWindowManagerPreviewShowNoteOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INotesWindowManagerPreviewShowNoteOptions>();
 }
 unsafe impl windows_core::Interface for NotesWindowManagerPreviewShowNoteOptions {
     type Vtable = INotesWindowManagerPreviewShowNoteOptions_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(INamedResource, INamedResource_Vtbl, 0x1c98c219_0b13_4240_89a5_d495dc189a00);
+impl windows_core::RuntimeType for INamedResource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INamedResource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +22,9 @@ pub struct INamedResource_Vtbl {
     ResolveAllForContext: usize,
 }
 windows_core::imp::define_interface!(IResourceCandidate, IResourceCandidate_Vtbl, 0xaf5207d9_c433_4764_b3fd_8fa6bfbcbadc);
+impl windows_core::RuntimeType for IResourceCandidate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceCandidate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +43,9 @@ pub struct IResourceCandidate_Vtbl {
     pub GetQualifierValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceCandidate2, IResourceCandidate2_Vtbl, 0x69e5b468_f6fc_4013_aaa2_d53f1757d3b5);
+impl windows_core::RuntimeType for IResourceCandidate2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceCandidate2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,12 +55,18 @@ pub struct IResourceCandidate2_Vtbl {
     GetValueAsStreamAsync: usize,
 }
 windows_core::imp::define_interface!(IResourceCandidate3, IResourceCandidate3_Vtbl, 0x08ae97f8_517a_4674_958c_4a3c7cd2cc6b);
+impl windows_core::RuntimeType for IResourceCandidate3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceCandidate3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ResourceCandidateKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceContext, IResourceContext_Vtbl, 0x2fa22f4b_707e_4b27_ad0d_d0d8cd468fd2);
+impl windows_core::RuntimeType for IResourceContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +94,9 @@ pub struct IResourceContext_Vtbl {
     SetLanguages: usize,
 }
 windows_core::imp::define_interface!(IResourceContextStatics, IResourceContextStatics_Vtbl, 0x98be9d6c_6338_4b31_99df_b2b442f17149);
+impl windows_core::RuntimeType for IResourceContextStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceContextStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -88,6 +106,9 @@ pub struct IResourceContextStatics_Vtbl {
     CreateMatchingContext: usize,
 }
 windows_core::imp::define_interface!(IResourceContextStatics2, IResourceContextStatics2_Vtbl, 0x41f752ef_12af_41b9_ab36_b1eb4b512460);
+impl windows_core::RuntimeType for IResourceContextStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceContextStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,12 +122,18 @@ pub struct IResourceContextStatics2_Vtbl {
     pub GetForViewIndependentUse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceContextStatics3, IResourceContextStatics3_Vtbl, 0x20cf492c_af0f_450b_9da6_106dd0c29a39);
+impl windows_core::RuntimeType for IResourceContextStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceContextStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetGlobalQualifierValueWithPersistence: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, ResourceQualifierPersistence) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceContextStatics4, IResourceContextStatics4_Vtbl, 0x22eb9ccd_fb31_4bfa_b86b_df9d9d7bdc39);
+impl windows_core::RuntimeType for IResourceContextStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceContextStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +143,9 @@ pub struct IResourceContextStatics4_Vtbl {
     GetForUIContext: usize,
 }
 windows_core::imp::define_interface!(IResourceManager, IResourceManager_Vtbl, 0xf744d97b_9988_44fb_abd6_5378844cfa8b);
+impl windows_core::RuntimeType for IResourceManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,6 +165,9 @@ pub struct IResourceManager_Vtbl {
     UnloadPriFiles: usize,
 }
 windows_core::imp::define_interface!(IResourceManager2, IResourceManager2_Vtbl, 0x9d66fe6c_a4d7_4c23_9e85_675f304c252d);
+impl windows_core::RuntimeType for IResourceManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,6 +181,9 @@ pub struct IResourceManager2_Vtbl {
     GetAllSubtreesForPackage: usize,
 }
 windows_core::imp::define_interface!(IResourceManagerStatics, IResourceManagerStatics_Vtbl, 0x1cc0fdfc_69ee_4e43_9901_47f12687baf7);
+impl windows_core::RuntimeType for IResourceManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -155,6 +191,9 @@ pub struct IResourceManagerStatics_Vtbl {
     pub IsResourceReference: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceMap, IResourceMap_Vtbl, 0x72284824_db8c_42f8_b08c_53ff357dad82);
+impl windows_core::RuntimeType for IResourceMap {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceMap_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -164,6 +203,9 @@ pub struct IResourceMap_Vtbl {
     pub GetSubtree: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceQualifier, IResourceQualifier_Vtbl, 0x785da5b2_4afd_4376_a888_c5f9a6b7a05c);
+impl windows_core::RuntimeType for IResourceQualifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceQualifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -231,7 +273,7 @@ impl NamedResource {
     }
 }
 impl windows_core::RuntimeType for NamedResource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INamedResource>();
 }
 unsafe impl windows_core::Interface for NamedResource {
     type Vtable = INamedResource_Vtbl;
@@ -315,7 +357,7 @@ impl ResourceCandidate {
     }
 }
 impl windows_core::RuntimeType for ResourceCandidate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceCandidate>();
 }
 unsafe impl windows_core::Interface for ResourceCandidate {
     type Vtable = IResourceCandidate_Vtbl;
@@ -382,7 +424,7 @@ impl ResourceCandidateVectorView {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceCandidateVectorView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IVectorView<ResourceCandidate>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceCandidateVectorView {
@@ -546,7 +588,7 @@ impl ResourceContext {
     }
 }
 impl windows_core::RuntimeType for ResourceContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceContext>();
 }
 unsafe impl windows_core::Interface for ResourceContext {
     type Vtable = IResourceContext_Vtbl;
@@ -610,7 +652,7 @@ impl ResourceContextLanguagesVectorView {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceContextLanguagesVectorView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IVectorView<windows_core::HSTRING>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceContextLanguagesVectorView {
@@ -719,7 +761,7 @@ impl ResourceManager {
     }
 }
 impl windows_core::RuntimeType for ResourceManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceManager>();
 }
 unsafe impl windows_core::Interface for ResourceManager {
     type Vtable = IResourceManager_Vtbl;
@@ -807,7 +849,7 @@ impl ResourceMap {
     }
 }
 impl windows_core::RuntimeType for ResourceMap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceMap>();
 }
 unsafe impl windows_core::Interface for ResourceMap {
     type Vtable = IResourceMap_Vtbl;
@@ -879,7 +921,7 @@ impl ResourceMapIterator {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceMapIterator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterator<super::super::super::Foundation::Collections::IKeyValuePair<windows_core::HSTRING, NamedResource>>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceMapIterator {
@@ -944,7 +986,7 @@ impl ResourceMapMapView {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceMapMapView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IMapView<windows_core::HSTRING, ResourceMap>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceMapMapView {
@@ -1020,7 +1062,7 @@ impl ResourceMapMapViewIterator {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceMapMapViewIterator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterator<super::super::super::Foundation::Collections::IKeyValuePair<windows_core::HSTRING, ResourceMap>>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceMapMapViewIterator {
@@ -1077,7 +1119,7 @@ impl ResourceQualifier {
     }
 }
 impl windows_core::RuntimeType for ResourceQualifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceQualifier>();
 }
 unsafe impl windows_core::Interface for ResourceQualifier {
     type Vtable = IResourceQualifier_Vtbl;
@@ -1138,7 +1180,7 @@ impl ResourceQualifierMapView {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceQualifierMapView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IMapView<windows_core::HSTRING, windows_core::HSTRING>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceQualifierMapView {
@@ -1256,7 +1298,7 @@ impl ResourceQualifierObservableMap {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceQualifierObservableMap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IObservableMap<windows_core::HSTRING, windows_core::HSTRING>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceQualifierObservableMap {
@@ -1343,7 +1385,7 @@ impl ResourceQualifierVectorView {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ResourceQualifierVectorView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IVectorView<ResourceQualifier>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ResourceQualifierVectorView {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IIndexedResourceCandidate, IIndexedResourceCandidate_Vtbl, 0x0e619ef3_faec_4414_a9d7_54acd5953f29);
+impl windows_core::RuntimeType for IIndexedResourceCandidate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIndexedResourceCandidate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +19,9 @@ pub struct IIndexedResourceCandidate_Vtbl {
     pub GetQualifierValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIndexedResourceQualifier, IIndexedResourceQualifier_Vtbl, 0xdae3bb9b_d304_497f_a168_a340042c8adb);
+impl windows_core::RuntimeType for IIndexedResourceQualifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIndexedResourceQualifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,10 @@ pub struct IIndexedResourceQualifier_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IResourceIndexer, IResourceIndexer_Vtbl, 0x2d4cf9a5_e32f_4ab2_8748_96350a016da3);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IResourceIndexer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IResourceIndexer_Vtbl {
@@ -40,6 +50,10 @@ pub struct IResourceIndexer_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IResourceIndexerFactory, IResourceIndexerFactory_Vtbl, 0xb8de3f09_31cd_4d97_bd30_8d39f742bc61);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IResourceIndexerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IResourceIndexerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +64,10 @@ pub struct IResourceIndexerFactory_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IResourceIndexerFactory2, IResourceIndexerFactory2_Vtbl, 0x6040f18d_d5e5_4b60_9201_cd279cbcfed9);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IResourceIndexerFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IResourceIndexerFactory2_Vtbl {
@@ -110,7 +128,7 @@ impl IndexedResourceCandidate {
     }
 }
 impl windows_core::RuntimeType for IndexedResourceCandidate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIndexedResourceCandidate>();
 }
 unsafe impl windows_core::Interface for IndexedResourceCandidate {
     type Vtable = IIndexedResourceCandidate_Vtbl;
@@ -142,7 +160,7 @@ impl IndexedResourceQualifier {
     }
 }
 impl windows_core::RuntimeType for IndexedResourceQualifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIndexedResourceQualifier>();
 }
 unsafe impl windows_core::Interface for IndexedResourceQualifier {
     type Vtable = IIndexedResourceQualifier_Vtbl;
@@ -219,7 +237,7 @@ impl ResourceIndexer {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for ResourceIndexer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceIndexer>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for ResourceIndexer {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/mod.rs
@@ -3,30 +3,45 @@ pub mod Core;
 #[cfg(feature = "ApplicationModel_Resources_Management")]
 pub mod Management;
 windows_core::imp::define_interface!(IResourceLoader, IResourceLoader_Vtbl, 0x08524908_16ef_45ad_a602_293637d7e61a);
+impl windows_core::RuntimeType for IResourceLoader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceLoader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetString: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceLoader2, IResourceLoader2_Vtbl, 0x10eb6ec6_8138_48c1_bc65_e1f14207367c);
+impl windows_core::RuntimeType for IResourceLoader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceLoader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetStringForUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceLoaderFactory, IResourceLoaderFactory_Vtbl, 0xc33a3603_69dc_4285_a077_d5c0e47ccbe8);
+impl windows_core::RuntimeType for IResourceLoaderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceLoaderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateResourceLoaderByName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceLoaderStatics, IResourceLoaderStatics_Vtbl, 0xbf777ce1_19c8_49c2_953c_47e9227b334e);
+impl windows_core::RuntimeType for IResourceLoaderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceLoaderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetStringForReference: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceLoaderStatics2, IResourceLoaderStatics2_Vtbl, 0x0cc04141_6466_4989_9494_0b82dfc53f1f);
+impl windows_core::RuntimeType for IResourceLoaderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceLoaderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +51,9 @@ pub struct IResourceLoaderStatics2_Vtbl {
     pub GetForViewIndependentUseWithName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResourceLoaderStatics3, IResourceLoaderStatics3_Vtbl, 0x64609dfb_64ac_491b_8100_0e558d61c1d0);
+impl windows_core::RuntimeType for IResourceLoaderStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceLoaderStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +63,9 @@ pub struct IResourceLoaderStatics3_Vtbl {
     GetForUIContext: usize,
 }
 windows_core::imp::define_interface!(IResourceLoaderStatics4, IResourceLoaderStatics4_Vtbl, 0x9fb36c32_6c8c_4316_962e_909539b5c259);
+impl windows_core::RuntimeType for IResourceLoaderStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceLoaderStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,7 +182,7 @@ impl ResourceLoader {
     }
 }
 impl windows_core::RuntimeType for ResourceLoader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceLoader>();
 }
 unsafe impl windows_core::Interface for ResourceLoader {
     type Vtable = IResourceLoader_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
@@ -1,9 +1,15 @@
 windows_core::imp::define_interface!(IRequestingFocusOnKeyboardInputEventArgs, IRequestingFocusOnKeyboardInputEventArgs_Vtbl, 0xa1195f27_b1a7_41a2_879d_6a68687e5985);
+impl windows_core::RuntimeType for IRequestingFocusOnKeyboardInputEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRequestingFocusOnKeyboardInputEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISearchSuggestion, ISearchSuggestion_Vtbl, 0x5b5554b0_1527_437b_95c5_8d18d2b8af55);
+impl windows_core::RuntimeType for ISearchSuggestion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchSuggestion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +24,9 @@ pub struct ISearchSuggestion_Vtbl {
     pub ImageAlternateText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISearchSuggestionManager, ISearchSuggestionManager_Vtbl, 0x3f0c50a1_cb9d_497b_b500_3c04ac959ad2);
+impl windows_core::RuntimeType for ISearchSuggestionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchSuggestionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +51,9 @@ pub struct ISearchSuggestionManager_Vtbl {
     pub RemoveRequestingFocusOnKeyboardInput: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISearchSuggestionsRequestedEventArgs, ISearchSuggestionsRequestedEventArgs_Vtbl, 0x6fd519e5_9e7e_4ab4_8be3_c76b1bd4344a);
+impl windows_core::RuntimeType for ISearchSuggestionsRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchSuggestionsRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,7 +68,7 @@ pub struct RequestingFocusOnKeyboardInputEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RequestingFocusOnKeyboardInputEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RequestingFocusOnKeyboardInputEventArgs {}
 impl windows_core::RuntimeType for RequestingFocusOnKeyboardInputEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRequestingFocusOnKeyboardInputEventArgs>();
 }
 unsafe impl windows_core::Interface for RequestingFocusOnKeyboardInputEventArgs {
     type Vtable = IRequestingFocusOnKeyboardInputEventArgs_Vtbl;
@@ -117,7 +129,7 @@ impl SearchSuggestion {
     }
 }
 impl windows_core::RuntimeType for SearchSuggestion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchSuggestion>();
 }
 unsafe impl windows_core::Interface for SearchSuggestion {
     type Vtable = ISearchSuggestion_Vtbl;
@@ -232,7 +244,7 @@ impl SearchSuggestionManager {
     }
 }
 impl windows_core::RuntimeType for SearchSuggestionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchSuggestionManager>();
 }
 unsafe impl windows_core::Interface for SearchSuggestionManager {
     type Vtable = ISearchSuggestionManager_Vtbl;
@@ -276,7 +288,7 @@ impl SearchSuggestionsRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SearchSuggestionsRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchSuggestionsRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for SearchSuggestionsRequestedEventArgs {
     type Vtable = ISearchSuggestionsRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "ApplicationModel_Search_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(ILocalContentSuggestionSettings, ILocalContentSuggestionSettings_Vtbl, 0xeeaeb062_743d_456e_84a3_23f06f2d15d7);
+impl windows_core::RuntimeType for ILocalContentSuggestionSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalContentSuggestionSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +22,10 @@ pub struct ILocalContentSuggestionSettings_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPane, ISearchPane_Vtbl, 0xfdacec38_3700_4d73_91a1_2f998674238a);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPane {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPane_Vtbl {
@@ -177,6 +184,9 @@ pub struct ISearchPaneQueryChangedEventArgs_Vtbl {
     LinguisticDetails: usize,
 }
 windows_core::imp::define_interface!(ISearchPaneQueryLinguisticDetails, ISearchPaneQueryLinguisticDetails_Vtbl, 0x82fb460e_0940_4b6d_b8d0_642b30989e15);
+impl windows_core::RuntimeType for ISearchPaneQueryLinguisticDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchPaneQueryLinguisticDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +199,10 @@ pub struct ISearchPaneQueryLinguisticDetails_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneQuerySubmittedEventArgs, ISearchPaneQuerySubmittedEventArgs_Vtbl, 0x143ba4fc_e9c5_4736_91b2_e8eb9cb88356);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneQuerySubmittedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneQuerySubmittedEventArgs_Vtbl {
@@ -205,6 +219,10 @@ pub struct ISearchPaneQuerySubmittedEventArgs_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails, ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails_Vtbl, 0x460c92e5_4c32_4538_a4d4_b6b4400d140f);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,6 +233,10 @@ pub struct ISearchPaneQuerySubmittedEventArgsWithLinguisticDetails_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneResultSuggestionChosenEventArgs, ISearchPaneResultSuggestionChosenEventArgs_Vtbl, 0xc8316cc0_aed2_41e0_bce0_c26ca74f85ec);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneResultSuggestionChosenEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneResultSuggestionChosenEventArgs_Vtbl {
@@ -227,6 +249,10 @@ pub struct ISearchPaneResultSuggestionChosenEventArgs_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneStatics, ISearchPaneStatics_Vtbl, 0x9572adf1_8f1d_481f_a15b_c61655f16a0e);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -238,6 +264,10 @@ pub struct ISearchPaneStatics_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneStaticsWithHideThisApplication, ISearchPaneStaticsWithHideThisApplication_Vtbl, 0x00732830_50f1_4d03_99ac_c6644c8ed8b5);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneStaticsWithHideThisApplication {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneStaticsWithHideThisApplication_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +278,10 @@ pub struct ISearchPaneStaticsWithHideThisApplication_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneSuggestionsRequest, ISearchPaneSuggestionsRequest_Vtbl, 0x81b10b1c_e561_4093_9b4d_2ad482794a53);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneSuggestionsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneSuggestionsRequest_Vtbl {
@@ -268,6 +302,10 @@ pub struct ISearchPaneSuggestionsRequest_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneSuggestionsRequestDeferral, ISearchPaneSuggestionsRequestDeferral_Vtbl, 0xa0d009f7_8748_4ee2_ad44_afa6be997c51);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneSuggestionsRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneSuggestionsRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -278,6 +316,10 @@ pub struct ISearchPaneSuggestionsRequestDeferral_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneSuggestionsRequestedEventArgs, ISearchPaneSuggestionsRequestedEventArgs_Vtbl, 0xc89b8a2f_ac56_4460_8d2f_80023bec4fc5);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneSuggestionsRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneSuggestionsRequestedEventArgs_Vtbl {
@@ -290,6 +332,10 @@ pub struct ISearchPaneSuggestionsRequestedEventArgs_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISearchPaneVisibilityChangedEventArgs, ISearchPaneVisibilityChangedEventArgs_Vtbl, 0x3c4d3046_ac4b_49f2_97d6_020e6182cb9c);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISearchPaneVisibilityChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISearchPaneVisibilityChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -299,6 +345,9 @@ pub struct ISearchPaneVisibilityChangedEventArgs_Vtbl {
     Visible: usize,
 }
 windows_core::imp::define_interface!(ISearchQueryLinguisticDetails, ISearchQueryLinguisticDetails_Vtbl, 0x46a1205b_69c9_4745_b72f_a8a4fc8f24ae);
+impl windows_core::RuntimeType for ISearchQueryLinguisticDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchQueryLinguisticDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -310,6 +359,9 @@ pub struct ISearchQueryLinguisticDetails_Vtbl {
     pub QueryTextCompositionLength: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISearchQueryLinguisticDetailsFactory, ISearchQueryLinguisticDetailsFactory_Vtbl, 0xcac6c3b8_3c64_4dfd_ad9f_479e4d4065a4);
+impl windows_core::RuntimeType for ISearchQueryLinguisticDetailsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchQueryLinguisticDetailsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -319,6 +371,9 @@ pub struct ISearchQueryLinguisticDetailsFactory_Vtbl {
     CreateInstance: usize,
 }
 windows_core::imp::define_interface!(ISearchSuggestionCollection, ISearchSuggestionCollection_Vtbl, 0x323a8a4b_fbea_4446_abbc_3da7915fdd3a);
+impl windows_core::RuntimeType for ISearchSuggestionCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchSuggestionCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -335,6 +390,9 @@ pub struct ISearchSuggestionCollection_Vtbl {
     pub AppendSearchSeparator: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISearchSuggestionsRequest, ISearchSuggestionsRequest_Vtbl, 0x4e4e26a7_44e5_4039_9099_6000ead1f0c6);
+impl windows_core::RuntimeType for ISearchSuggestionsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchSuggestionsRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -343,6 +401,9 @@ pub struct ISearchSuggestionsRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISearchSuggestionsRequestDeferral, ISearchSuggestionsRequestDeferral_Vtbl, 0xb71598a9_c065_456d_a845_1eccec5dc28b);
+impl windows_core::RuntimeType for ISearchSuggestionsRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISearchSuggestionsRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -400,7 +461,7 @@ impl LocalContentSuggestionSettings {
     }
 }
 impl windows_core::RuntimeType for LocalContentSuggestionSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILocalContentSuggestionSettings>();
 }
 unsafe impl windows_core::Interface for LocalContentSuggestionSettings {
     type Vtable = ILocalContentSuggestionSettings_Vtbl;
@@ -625,7 +686,7 @@ impl SearchPane {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPane {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPane>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPane {
@@ -673,7 +734,7 @@ impl SearchPaneQueryChangedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPaneQueryChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneQueryChangedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPaneQueryChangedEventArgs {
@@ -717,7 +778,7 @@ impl SearchPaneQueryLinguisticDetails {
     }
 }
 impl windows_core::RuntimeType for SearchPaneQueryLinguisticDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneQueryLinguisticDetails>();
 }
 unsafe impl windows_core::Interface for SearchPaneQueryLinguisticDetails {
     type Vtable = ISearchPaneQueryLinguisticDetails_Vtbl;
@@ -763,7 +824,7 @@ impl SearchPaneQuerySubmittedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPaneQuerySubmittedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneQuerySubmittedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPaneQuerySubmittedEventArgs {
@@ -797,7 +858,7 @@ impl SearchPaneResultSuggestionChosenEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPaneResultSuggestionChosenEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneResultSuggestionChosenEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPaneResultSuggestionChosenEventArgs {
@@ -847,7 +908,7 @@ impl SearchPaneSuggestionsRequest {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPaneSuggestionsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneSuggestionsRequest>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPaneSuggestionsRequest {
@@ -878,7 +939,7 @@ impl SearchPaneSuggestionsRequestDeferral {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPaneSuggestionsRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneSuggestionsRequestDeferral>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPaneSuggestionsRequestDeferral {
@@ -938,7 +999,7 @@ impl SearchPaneSuggestionsRequestedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPaneSuggestionsRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneSuggestionsRequestedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPaneSuggestionsRequestedEventArgs {
@@ -972,7 +1033,7 @@ impl SearchPaneVisibilityChangedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SearchPaneVisibilityChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchPaneVisibilityChangedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SearchPaneVisibilityChangedEventArgs {
@@ -1031,7 +1092,7 @@ impl SearchQueryLinguisticDetails {
     }
 }
 impl windows_core::RuntimeType for SearchQueryLinguisticDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchQueryLinguisticDetails>();
 }
 unsafe impl windows_core::Interface for SearchQueryLinguisticDetails {
     type Vtable = ISearchQueryLinguisticDetails_Vtbl;
@@ -1080,7 +1141,7 @@ impl SearchSuggestionCollection {
     }
 }
 impl windows_core::RuntimeType for SearchSuggestionCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchSuggestionCollection>();
 }
 unsafe impl windows_core::Interface for SearchSuggestionCollection {
     type Vtable = ISearchSuggestionCollection_Vtbl;
@@ -1119,7 +1180,7 @@ impl SearchSuggestionsRequest {
     }
 }
 impl windows_core::RuntimeType for SearchSuggestionsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchSuggestionsRequest>();
 }
 unsafe impl windows_core::Interface for SearchSuggestionsRequest {
     type Vtable = ISearchSuggestionsRequest_Vtbl;
@@ -1141,7 +1202,7 @@ impl SearchSuggestionsRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for SearchSuggestionsRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISearchSuggestionsRequestDeferral>();
 }
 unsafe impl windows_core::Interface for SearchSuggestionsRequestDeferral {
     type Vtable = ISearchSuggestionsRequestDeferral_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/LicenseManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/LicenseManagement/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ILicenseManagerStatics, ILicenseManagerStatics_Vtbl, 0xb5ac3ae0_da47_4f20_9a23_09182c9476ff);
+impl windows_core::RuntimeType for ILicenseManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILicenseManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,12 +15,18 @@ pub struct ILicenseManagerStatics_Vtbl {
     GetSatisfactionInfosAsync: usize,
 }
 windows_core::imp::define_interface!(ILicenseManagerStatics2, ILicenseManagerStatics2_Vtbl, 0xab2ec47b_1f79_4480_b87e_2c499e601ba3);
+impl windows_core::RuntimeType for ILicenseManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILicenseManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RefreshLicensesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, LicenseRefreshOption, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILicenseSatisfactionInfo, ILicenseSatisfactionInfo_Vtbl, 0x3ccbb08f_db31_48d5_8384_fa17c81474e2);
+impl windows_core::RuntimeType for ILicenseSatisfactionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILicenseSatisfactionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +39,9 @@ pub struct ILicenseSatisfactionInfo_Vtbl {
     pub IsSatisfied: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILicenseSatisfactionResult, ILicenseSatisfactionResult_Vtbl, 0x3c674f73_3c87_4ee1_8201_f428359bd3af);
+impl windows_core::RuntimeType for ILicenseSatisfactionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILicenseSatisfactionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -138,7 +150,7 @@ impl LicenseSatisfactionInfo {
     }
 }
 impl windows_core::RuntimeType for LicenseSatisfactionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILicenseSatisfactionInfo>();
 }
 unsafe impl windows_core::Interface for LicenseSatisfactionInfo {
     type Vtable = ILicenseSatisfactionInfo_Vtbl;
@@ -171,7 +183,7 @@ impl LicenseSatisfactionResult {
     }
 }
 impl windows_core::RuntimeType for LicenseSatisfactionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILicenseSatisfactionResult>();
 }
 unsafe impl windows_core::Interface for LicenseSatisfactionResult {
     type Vtable = ILicenseSatisfactionResult_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/InstallControl/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/InstallControl/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppInstallItem, IAppInstallItem_Vtbl, 0x49d3dfab_168a_4cbf_a93a_9e448c82737d);
+impl windows_core::RuntimeType for IAppInstallItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +19,9 @@ pub struct IAppInstallItem_Vtbl {
     pub RemoveStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallItem2, IAppInstallItem2_Vtbl, 0xd3972af8_40c0_4fd7_aa6c_0aa13ca6188c);
+impl windows_core::RuntimeType for IAppInstallItem2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallItem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,9 @@ pub struct IAppInstallItem2_Vtbl {
     pub RestartWithTelemetry: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallItem3, IAppInstallItem3_Vtbl, 0x6f3dc998_dd47_433c_9234_560172d67a45);
+impl windows_core::RuntimeType for IAppInstallItem3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallItem3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +43,9 @@ pub struct IAppInstallItem3_Vtbl {
     pub ItemOperationsMightAffectOtherItems: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallItem4, IAppInstallItem4_Vtbl, 0xc2d1ce12_71ff_4fc8_b540_453d4b37e1d1);
+impl windows_core::RuntimeType for IAppInstallItem4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallItem4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +53,9 @@ pub struct IAppInstallItem4_Vtbl {
     pub SetLaunchAfterInstall: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallItem5, IAppInstallItem5_Vtbl, 0x5510e7cc_4076_4a0b_9472_c21d9d380e55);
+impl windows_core::RuntimeType for IAppInstallItem5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallItem5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +71,9 @@ pub struct IAppInstallItem5_Vtbl {
     pub SetInstallInProgressToastNotificationMode: unsafe extern "system" fn(*mut core::ffi::c_void, AppInstallationToastNotificationMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallManager, IAppInstallManager_Vtbl, 0x9353e170_8441_4b45_bd72_7c2fa925beee);
+impl windows_core::RuntimeType for IAppInstallManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +104,9 @@ pub struct IAppInstallManager_Vtbl {
     pub GetIsAppAllowedToInstallAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallManager2, IAppInstallManager2_Vtbl, 0x16937851_ed37_480d_8314_52e27c03f04a);
+impl windows_core::RuntimeType for IAppInstallManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,6 +123,9 @@ pub struct IAppInstallManager2_Vtbl {
     pub RestartWithTelemetry: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallManager3, IAppInstallManager3_Vtbl, 0x95b24b17_e96a_4d0e_84e1_c8cb417a0178);
+impl windows_core::RuntimeType for IAppInstallManager3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManager3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -136,6 +160,9 @@ pub struct IAppInstallManager3_Vtbl {
     pub MoveToFrontOfDownloadQueue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallManager4, IAppInstallManager4_Vtbl, 0x260a2a16_5a9e_4ebd_b944_f2ba75c31159);
+impl windows_core::RuntimeType for IAppInstallManager4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManager4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,6 +174,9 @@ pub struct IAppInstallManager4_Vtbl {
     pub GetFreeDeviceEntitlementAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallManager5, IAppInstallManager5_Vtbl, 0x3cd7be4c_1be9_4f7f_b675_aa1d64a529b2);
+impl windows_core::RuntimeType for IAppInstallManager5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManager5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +186,9 @@ pub struct IAppInstallManager5_Vtbl {
     AppInstallItemsWithGroupSupport: usize,
 }
 windows_core::imp::define_interface!(IAppInstallManager6, IAppInstallManager6_Vtbl, 0xc9e7d408_f27a_4471_b2f4_e76efcbebcca);
+impl windows_core::RuntimeType for IAppInstallManager6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManager6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -187,18 +220,27 @@ pub struct IAppInstallManager6_Vtbl {
     GetIsPackageIdentityAllowedToInstallForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IAppInstallManager7, IAppInstallManager7_Vtbl, 0xa5ee7b30_d5e4_49a3_9853_3db03203321d);
+impl windows_core::RuntimeType for IAppInstallManager7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManager7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CanInstallForAllUsers: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallManagerItemEventArgs, IAppInstallManagerItemEventArgs_Vtbl, 0xbc505743_4674_4dd1_957e_c25682086a14);
+impl windows_core::RuntimeType for IAppInstallManagerItemEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallManagerItemEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Item: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallOptions, IAppInstallOptions_Vtbl, 0xc9808300_1cb8_4eb6_8c9f_6a30c64a5b51);
+impl windows_core::RuntimeType for IAppInstallOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,6 +264,9 @@ pub struct IAppInstallOptions_Vtbl {
     pub SetLaunchAfterInstall: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallOptions2, IAppInstallOptions2_Vtbl, 0x8a04c0d7_c94b_425e_95b4_bf27faeaee89);
+impl windows_core::RuntimeType for IAppInstallOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -245,6 +290,9 @@ pub struct IAppInstallOptions2_Vtbl {
     pub SetExtendedCampaignId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallStatus, IAppInstallStatus_Vtbl, 0x936dccfa_2450_4126_88b1_6127a644dd5c);
+impl windows_core::RuntimeType for IAppInstallStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -255,6 +303,9 @@ pub struct IAppInstallStatus_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallStatus2, IAppInstallStatus2_Vtbl, 0x96e7818a_5e92_4aa9_8edc_58fed4b87e00);
+impl windows_core::RuntimeType for IAppInstallStatus2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallStatus2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -265,12 +316,18 @@ pub struct IAppInstallStatus2_Vtbl {
     pub ReadyForLaunch: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallStatus3, IAppInstallStatus3_Vtbl, 0xcb880c56_837b_4b4c_9ebb_6d44a0a96307);
+impl windows_core::RuntimeType for IAppInstallStatus3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallStatus3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsStaged: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUpdateOptions, IAppUpdateOptions_Vtbl, 0x26f0b02f_c2f3_4aea_af8c_6308dd9db85f);
+impl windows_core::RuntimeType for IAppUpdateOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUpdateOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -280,6 +337,9 @@ pub struct IAppUpdateOptions_Vtbl {
     pub SetAllowForcedAppRestart: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUpdateOptions2, IAppUpdateOptions2_Vtbl, 0xf4646e08_ed26_4bf9_9679_48f628e53df8);
+impl windows_core::RuntimeType for IAppUpdateOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUpdateOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -287,6 +347,9 @@ pub struct IAppUpdateOptions2_Vtbl {
     pub SetAutomaticallyDownloadAndInstallUpdateIfFound: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGetEntitlementResult, IGetEntitlementResult_Vtbl, 0x74fc843f_1a9e_4609_8e4d_819086d08a3d);
+impl windows_core::RuntimeType for IGetEntitlementResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGetEntitlementResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -467,7 +530,7 @@ impl AppInstallItem {
     }
 }
 impl windows_core::RuntimeType for AppInstallItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstallItem>();
 }
 unsafe impl windows_core::Interface for AppInstallItem {
     type Vtable = IAppInstallItem_Vtbl;
@@ -868,7 +931,7 @@ impl AppInstallManager {
     }
 }
 impl windows_core::RuntimeType for AppInstallManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstallManager>();
 }
 unsafe impl windows_core::Interface for AppInstallManager {
     type Vtable = IAppInstallManager_Vtbl;
@@ -893,7 +956,7 @@ impl AppInstallManagerItemEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppInstallManagerItemEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstallManagerItemEventArgs>();
 }
 unsafe impl windows_core::Interface for AppInstallManagerItemEventArgs {
     type Vtable = IAppInstallManagerItemEventArgs_Vtbl;
@@ -1088,7 +1151,7 @@ impl AppInstallOptions {
     }
 }
 impl windows_core::RuntimeType for AppInstallOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstallOptions>();
 }
 unsafe impl windows_core::Interface for AppInstallOptions {
     type Vtable = IAppInstallOptions_Vtbl;
@@ -1163,7 +1226,7 @@ impl AppInstallStatus {
     }
 }
 impl windows_core::RuntimeType for AppInstallStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstallStatus>();
 }
 unsafe impl windows_core::Interface for AppInstallStatus {
     type Vtable = IAppInstallStatus_Vtbl;
@@ -1221,7 +1284,7 @@ impl AppUpdateOptions {
     }
 }
 impl windows_core::RuntimeType for AppUpdateOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppUpdateOptions>();
 }
 unsafe impl windows_core::Interface for AppUpdateOptions {
     type Vtable = IAppUpdateOptions_Vtbl;
@@ -1246,7 +1309,7 @@ impl GetEntitlementResult {
     }
 }
 impl windows_core::RuntimeType for GetEntitlementResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGetEntitlementResult>();
 }
 unsafe impl windows_core::Interface for GetEntitlementResult {
     type Vtable = IGetEntitlementResult_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "ApplicationModel_Store_Preview_InstallControl")]
 pub mod InstallControl;
 windows_core::imp::define_interface!(IDeliveryOptimizationSettings, IDeliveryOptimizationSettings_Vtbl, 0x1810fda0_e853_565e_b874_7a8a7b9a0e0f);
+impl windows_core::RuntimeType for IDeliveryOptimizationSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeliveryOptimizationSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct IDeliveryOptimizationSettings_Vtbl {
     pub DownloadModeSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DeliveryOptimizationDownloadModeSource) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeliveryOptimizationSettingsStatics, IDeliveryOptimizationSettingsStatics_Vtbl, 0x5c817caf_aed5_5999_b4c9_8c60898bc4f3);
+impl windows_core::RuntimeType for IDeliveryOptimizationSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeliveryOptimizationSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetCurrentSettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreConfigurationStatics, IStoreConfigurationStatics_Vtbl, 0x728f7fc0_8628_42ec_84a2_07780eb44d8b);
+impl windows_core::RuntimeType for IStoreConfigurationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreConfigurationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +37,9 @@ pub struct IStoreConfigurationStatics_Vtbl {
     FilterUnsupportedSystemFeaturesAsync: usize,
 }
 windows_core::imp::define_interface!(IStoreConfigurationStatics2, IStoreConfigurationStatics2_Vtbl, 0x657c4595_c8b7_4fe9_9f4c_4d71027d347e);
+impl windows_core::RuntimeType for IStoreConfigurationStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreConfigurationStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,6 +47,9 @@ pub struct IStoreConfigurationStatics2_Vtbl {
     pub SetPurchasePromptingPolicy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreConfigurationStatics3, IStoreConfigurationStatics3_Vtbl, 0x6d45f57c_f144_4cb5_9d3f_4eb05e30b6d3);
+impl windows_core::RuntimeType for IStoreConfigurationStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreConfigurationStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -65,6 +80,9 @@ pub struct IStoreConfigurationStatics3_Vtbl {
     SetPurchasePromptingPolicyForUser: usize,
 }
 windows_core::imp::define_interface!(IStoreConfigurationStatics4, IStoreConfigurationStatics4_Vtbl, 0x20ff56d2_4ee3_4cf0_9b12_552c03310f75);
+impl windows_core::RuntimeType for IStoreConfigurationStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreConfigurationStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +108,9 @@ pub struct IStoreConfigurationStatics4_Vtbl {
     ShouldRestrictToEnterpriseStoreOnlyForUser: usize,
 }
 windows_core::imp::define_interface!(IStoreConfigurationStatics5, IStoreConfigurationStatics5_Vtbl, 0xf7613191_8fa9_49db_822b_0160e7e4e5c5);
+impl windows_core::RuntimeType for IStoreConfigurationStatics5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreConfigurationStatics5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,6 +124,9 @@ pub struct IStoreConfigurationStatics5_Vtbl {
     PinToDesktopForUser: usize,
 }
 windows_core::imp::define_interface!(IStoreHardwareManufacturerInfo, IStoreHardwareManufacturerInfo_Vtbl, 0xf292dc08_c654_43ac_a21f_34801c9d3388);
+impl windows_core::RuntimeType for IStoreHardwareManufacturerInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreHardwareManufacturerInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -112,6 +136,9 @@ pub struct IStoreHardwareManufacturerInfo_Vtbl {
     pub ManufacturerName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePreview, IStorePreview_Vtbl, 0x8a157241_840e_49a9_bc01_5d5b01fbc8e9);
+impl windows_core::RuntimeType for IStorePreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,6 +149,9 @@ pub struct IStorePreview_Vtbl {
     LoadAddOnProductInfosAsync: usize,
 }
 windows_core::imp::define_interface!(IStorePreviewProductInfo, IStorePreviewProductInfo_Vtbl, 0x1937dbb3_6c01_4c9d_85cd_5babaac2b351);
+impl windows_core::RuntimeType for IStorePreviewProductInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePreviewProductInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,12 +165,18 @@ pub struct IStorePreviewProductInfo_Vtbl {
     SkuInfoList: usize,
 }
 windows_core::imp::define_interface!(IStorePreviewPurchaseResults, IStorePreviewPurchaseResults_Vtbl, 0xb0daaed1_d6c5_4e53_a043_fba0d8e61231);
+impl windows_core::RuntimeType for IStorePreviewPurchaseResults {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePreviewPurchaseResults_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ProductPurchaseStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut StorePreviewProductPurchaseStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePreviewSkuInfo, IStorePreviewSkuInfo_Vtbl, 0x81fd76e2_0b26_48d9_98ce_27461c669d6c);
+impl windows_core::RuntimeType for IStorePreviewSkuInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePreviewSkuInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -155,6 +191,9 @@ pub struct IStorePreviewSkuInfo_Vtbl {
     pub ExtendedData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAuthenticationCoreManagerHelper, IWebAuthenticationCoreManagerHelper_Vtbl, 0x06a50525_e715_4123_9276_9d6f865ba55f);
+impl windows_core::RuntimeType for IWebAuthenticationCoreManagerHelper {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationCoreManagerHelper_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,7 +238,7 @@ impl DeliveryOptimizationSettings {
     }
 }
 impl windows_core::RuntimeType for DeliveryOptimizationSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeliveryOptimizationSettings>();
 }
 unsafe impl windows_core::Interface for DeliveryOptimizationSettings {
     type Vtable = IDeliveryOptimizationSettings_Vtbl;
@@ -463,7 +502,7 @@ impl StoreHardwareManufacturerInfo {
     }
 }
 impl windows_core::RuntimeType for StoreHardwareManufacturerInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreHardwareManufacturerInfo>();
 }
 unsafe impl windows_core::Interface for StoreHardwareManufacturerInfo {
     type Vtable = IStoreHardwareManufacturerInfo_Vtbl;
@@ -541,7 +580,7 @@ impl StorePreviewProductInfo {
     }
 }
 impl windows_core::RuntimeType for StorePreviewProductInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePreviewProductInfo>();
 }
 unsafe impl windows_core::Interface for StorePreviewProductInfo {
     type Vtable = IStorePreviewProductInfo_Vtbl;
@@ -566,7 +605,7 @@ impl StorePreviewPurchaseResults {
     }
 }
 impl windows_core::RuntimeType for StorePreviewPurchaseResults {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePreviewPurchaseResults>();
 }
 unsafe impl windows_core::Interface for StorePreviewPurchaseResults {
     type Vtable = IStorePreviewPurchaseResults_Vtbl;
@@ -647,7 +686,7 @@ impl StorePreviewSkuInfo {
     }
 }
 impl windows_core::RuntimeType for StorePreviewSkuInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePreviewSkuInfo>();
 }
 unsafe impl windows_core::Interface for StorePreviewSkuInfo {
     type Vtable = IStorePreviewSkuInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
@@ -3,6 +3,9 @@ pub mod LicenseManagement;
 #[cfg(feature = "ApplicationModel_Store_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(ICurrentApp, ICurrentApp_Vtbl, 0xd52dc065_da3f_4685_995e_9b482eb5e603);
+impl windows_core::RuntimeType for ICurrentApp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentApp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +22,9 @@ pub struct ICurrentApp_Vtbl {
     pub GetProductReceiptAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrentApp2Statics, ICurrentApp2Statics_Vtbl, 0xdf4e6e2d_3171_4ad3_8614_2c61244373cb);
+impl windows_core::RuntimeType for ICurrentApp2Statics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentApp2Statics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +32,9 @@ pub struct ICurrentApp2Statics_Vtbl {
     pub GetCustomerCollectionsIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrentAppSimulator, ICurrentAppSimulator_Vtbl, 0xf17f9db1_74cd_4787_9787_19866e9a5559);
+impl windows_core::RuntimeType for ICurrentAppSimulator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentAppSimulator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +55,9 @@ pub struct ICurrentAppSimulator_Vtbl {
     ReloadSimulatorAsync: usize,
 }
 windows_core::imp::define_interface!(ICurrentAppSimulatorStaticsWithFiltering, ICurrentAppSimulatorStaticsWithFiltering_Vtbl, 0x617e70e2_f86f_4b54_9666_dde285092c68);
+impl windows_core::RuntimeType for ICurrentAppSimulatorStaticsWithFiltering {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentAppSimulatorStaticsWithFiltering_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,12 +71,18 @@ pub struct ICurrentAppSimulatorStaticsWithFiltering_Vtbl {
     LoadListingInformationByKeywordsAsync: usize,
 }
 windows_core::imp::define_interface!(ICurrentAppSimulatorWithCampaignId, ICurrentAppSimulatorWithCampaignId_Vtbl, 0x84678a43_df00_4672_a43f_b25b1441cfcf);
+impl windows_core::RuntimeType for ICurrentAppSimulatorWithCampaignId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentAppSimulatorWithCampaignId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetAppPurchaseCampaignIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrentAppSimulatorWithConsumables, ICurrentAppSimulatorWithConsumables_Vtbl, 0x4e51f0ab_20e7_4412_9b85_59bb78388667);
+impl windows_core::RuntimeType for ICurrentAppSimulatorWithConsumables {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentAppSimulatorWithConsumables_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +95,9 @@ pub struct ICurrentAppSimulatorWithConsumables_Vtbl {
     GetUnfulfilledConsumablesAsync: usize,
 }
 windows_core::imp::define_interface!(ICurrentAppStaticsWithFiltering, ICurrentAppStaticsWithFiltering_Vtbl, 0xd36d6542_9085_438e_97ba_a25c976be2fd);
+impl windows_core::RuntimeType for ICurrentAppStaticsWithFiltering {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentAppStaticsWithFiltering_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,12 +112,18 @@ pub struct ICurrentAppStaticsWithFiltering_Vtbl {
     pub ReportProductFulfillment: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrentAppWithCampaignId, ICurrentAppWithCampaignId_Vtbl, 0x312f4cd0_36c1_44a6_b32b_432d608e4dd6);
+impl windows_core::RuntimeType for ICurrentAppWithCampaignId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentAppWithCampaignId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetAppPurchaseCampaignIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrentAppWithConsumables, ICurrentAppWithConsumables_Vtbl, 0x844e0071_9e4f_4f79_995a_5f91172e6cef);
+impl windows_core::RuntimeType for ICurrentAppWithConsumables {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentAppWithConsumables_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,6 +136,9 @@ pub struct ICurrentAppWithConsumables_Vtbl {
     GetUnfulfilledConsumablesAsync: usize,
 }
 windows_core::imp::define_interface!(ILicenseInformation, ILicenseInformation_Vtbl, 0x8eb7dc30_f170_4ed5_8e21_1516da3fd367);
+impl windows_core::RuntimeType for ILicenseInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILicenseInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -123,6 +153,9 @@ pub struct ILicenseInformation_Vtbl {
     pub RemoveLicenseChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IListingInformation, IListingInformation_Vtbl, 0x588b4abf_bc74_4383_b78c_99606323dece);
+impl windows_core::RuntimeType for IListingInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IListingInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -137,6 +170,9 @@ pub struct IListingInformation_Vtbl {
     pub AgeRating: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IListingInformation2, IListingInformation2_Vtbl, 0xc0fd2c1d_b30e_4384_84ea_72fefa82223e);
+impl windows_core::RuntimeType for IListingInformation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IListingInformation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -146,6 +182,9 @@ pub struct IListingInformation2_Vtbl {
     pub CurrencyCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductLicense, IProductLicense_Vtbl, 0x363308c7_2bcf_4c0e_8f2f_e808aaa8f99d);
+impl windows_core::RuntimeType for IProductLicense {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductLicense_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,12 +193,18 @@ pub struct IProductLicense_Vtbl {
     pub ExpirationDate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductLicenseWithFulfillment, IProductLicenseWithFulfillment_Vtbl, 0xfc535c8a_f667_40f3_ba3c_045a63abb3ac);
+impl windows_core::RuntimeType for IProductLicenseWithFulfillment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductLicenseWithFulfillment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsConsumable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductListing, IProductListing_Vtbl, 0x45a7d6ad_c750_4d9c_947c_b00dcbf9e9c2);
+impl windows_core::RuntimeType for IProductListing {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductListing_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -168,6 +213,9 @@ pub struct IProductListing_Vtbl {
     pub Name: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductListing2, IProductListing2_Vtbl, 0xf89e290f_73fe_494d_a939_08a9b2495abe);
+impl windows_core::RuntimeType for IProductListing2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductListing2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -177,12 +225,18 @@ pub struct IProductListing2_Vtbl {
     pub CurrencyCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductListingWithConsumables, IProductListingWithConsumables_Vtbl, 0xeb9e9790_8f6b_481f_93a7_5c3a63068149);
+impl windows_core::RuntimeType for IProductListingWithConsumables {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductListingWithConsumables_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ProductType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ProductType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductListingWithMetadata, IProductListingWithMetadata_Vtbl, 0x124da567_23f8_423e_9532_189943c40ace);
+impl windows_core::RuntimeType for IProductListingWithMetadata {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductListingWithMetadata_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -196,6 +250,9 @@ pub struct IProductListingWithMetadata_Vtbl {
     pub ImageUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductPurchaseDisplayProperties, IProductPurchaseDisplayProperties_Vtbl, 0xd70b7420_bc92_401b_a809_c9b2e5dbbdaf);
+impl windows_core::RuntimeType for IProductPurchaseDisplayProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductPurchaseDisplayProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,12 +264,18 @@ pub struct IProductPurchaseDisplayProperties_Vtbl {
     pub SetImage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProductPurchaseDisplayPropertiesFactory, IProductPurchaseDisplayPropertiesFactory_Vtbl, 0x6f491df4_32d6_4b40_b474_b83038a4d9cf);
+impl windows_core::RuntimeType for IProductPurchaseDisplayPropertiesFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProductPurchaseDisplayPropertiesFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateProductPurchaseDisplayProperties: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPurchaseResults, IPurchaseResults_Vtbl, 0xed50b37e_8656_4f65_b8c8_ac7e0cb1a1c2);
+impl windows_core::RuntimeType for IPurchaseResults {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPurchaseResults_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,6 +285,9 @@ pub struct IPurchaseResults_Vtbl {
     pub OfferId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUnfulfilledConsumable, IUnfulfilledConsumable_Vtbl, 0x2df7fbbb_1cdd_4cb8_a014_7b9cf8986927);
+impl windows_core::RuntimeType for IUnfulfilledConsumable {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUnfulfilledConsumable_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -567,7 +633,7 @@ impl LicenseInformation {
     }
 }
 impl windows_core::RuntimeType for LicenseInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILicenseInformation>();
 }
 unsafe impl windows_core::Interface for LicenseInformation {
     type Vtable = ILicenseInformation_Vtbl;
@@ -656,7 +722,7 @@ impl ListingInformation {
     }
 }
 impl windows_core::RuntimeType for ListingInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IListingInformation>();
 }
 unsafe impl windows_core::Interface for ListingInformation {
     type Vtable = IListingInformation_Vtbl;
@@ -702,7 +768,7 @@ impl ProductLicense {
     }
 }
 impl windows_core::RuntimeType for ProductLicense {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProductLicense>();
 }
 unsafe impl windows_core::Interface for ProductLicense {
     type Vtable = IProductLicense_Vtbl;
@@ -805,7 +871,7 @@ impl ProductListing {
     }
 }
 impl windows_core::RuntimeType for ProductListing {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProductListing>();
 }
 unsafe impl windows_core::Interface for ProductListing {
     type Vtable = IProductListing_Vtbl;
@@ -877,7 +943,7 @@ impl ProductPurchaseDisplayProperties {
     }
 }
 impl windows_core::RuntimeType for ProductPurchaseDisplayProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProductPurchaseDisplayProperties>();
 }
 unsafe impl windows_core::Interface for ProductPurchaseDisplayProperties {
     type Vtable = IProductPurchaseDisplayProperties_Vtbl;
@@ -923,7 +989,7 @@ impl PurchaseResults {
     }
 }
 impl windows_core::RuntimeType for PurchaseResults {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPurchaseResults>();
 }
 unsafe impl windows_core::Interface for PurchaseResults {
     type Vtable = IPurchaseResults_Vtbl;
@@ -962,7 +1028,7 @@ impl UnfulfilledConsumable {
     }
 }
 impl windows_core::RuntimeType for UnfulfilledConsumable {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUnfulfilledConsumable>();
 }
 unsafe impl windows_core::Interface for UnfulfilledConsumable {
     type Vtable = IUnfulfilledConsumable_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICoreUserActivityManagerStatics, ICoreUserActivityManagerStatics_Vtbl, 0xca3adb02_a4be_4d4d_bfa8_6795f4264efb);
+impl windows_core::RuntimeType for ICoreUserActivityManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreUserActivityManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "ApplicationModel_UserActivities_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IUserActivity, IUserActivity_Vtbl, 0xfc103e9e_2cab_4d36_aea2_b4bb556cef0f);
+impl windows_core::RuntimeType for IUserActivity {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivity_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,12 +24,18 @@ pub struct IUserActivity_Vtbl {
     pub CreateSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivity2, IUserActivity2_Vtbl, 0x9dc40c62_08c4_47ac_aa9c_2bb2221c55fd);
+impl windows_core::RuntimeType for IUserActivity2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivity2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ToJson: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivity3, IUserActivity3_Vtbl, 0xe7697744_e1a2_5147_8e06_55f1eeef271c);
+impl windows_core::RuntimeType for IUserActivity3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivity3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +43,9 @@ pub struct IUserActivity3_Vtbl {
     pub SetIsRoamable: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityAttribution, IUserActivityAttribution_Vtbl, 0x34a5c8b5_86dd_4aec_a491_6a4faea5d22e);
+impl windows_core::RuntimeType for IUserActivityAttribution {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityAttribution_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,12 +57,18 @@ pub struct IUserActivityAttribution_Vtbl {
     pub SetAddImageQuery: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityAttributionFactory, IUserActivityAttributionFactory_Vtbl, 0xe62bd252_c566_4f42_9974_916c4d76377e);
+impl windows_core::RuntimeType for IUserActivityAttributionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityAttributionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityChannel, IUserActivityChannel_Vtbl, 0xbac0f8b8_a0e4_483b_b948_9cbabd06070c);
+impl windows_core::RuntimeType for IUserActivityChannel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityChannel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +77,9 @@ pub struct IUserActivityChannel_Vtbl {
     pub DeleteAllActivitiesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityChannel2, IUserActivityChannel2_Vtbl, 0x1698e35b_eb7e_4ea0_bf17_a459e8be706c);
+impl windows_core::RuntimeType for IUserActivityChannel2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityChannel2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,12 +93,18 @@ pub struct IUserActivityChannel2_Vtbl {
     GetSessionHistoryItemsForUserActivityAsync: usize,
 }
 windows_core::imp::define_interface!(IUserActivityChannelStatics, IUserActivityChannelStatics_Vtbl, 0xc8c005ab_198d_4d80_abb2_c9775ec4a729);
+impl windows_core::RuntimeType for IUserActivityChannelStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityChannelStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityChannelStatics2, IUserActivityChannelStatics2_Vtbl, 0x8e87de30_aa4f_4624_9ad0_d40f3ba0317c);
+impl windows_core::RuntimeType for IUserActivityChannelStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityChannelStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -88,6 +115,9 @@ pub struct IUserActivityChannelStatics2_Vtbl {
     TryGetForWebAccount: usize,
 }
 windows_core::imp::define_interface!(IUserActivityChannelStatics3, IUserActivityChannelStatics3_Vtbl, 0x53bc4ddb_bbdf_5984_802a_5305874e205c);
+impl windows_core::RuntimeType for IUserActivityChannelStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityChannelStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,24 +146,36 @@ pub struct IUserActivityContentInfo_Vtbl {
     pub ToJson: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityContentInfoStatics, IUserActivityContentInfoStatics_Vtbl, 0x9988c34b_0386_4bc9_968a_8200b004144f);
+impl windows_core::RuntimeType for IUserActivityContentInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityContentInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromJson: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityFactory, IUserActivityFactory_Vtbl, 0x7c385758_361d_4a67_8a3b_34ca2978f9a3);
+impl windows_core::RuntimeType for IUserActivityFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithActivityId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityRequest, IUserActivityRequest_Vtbl, 0xa0ef6355_cf35_4ff0_8833_50cb4b72e06d);
+impl windows_core::RuntimeType for IUserActivityRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetUserActivity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityRequestManager, IUserActivityRequestManager_Vtbl, 0x0c30be4e_903d_48d6_82d4_4043ed57791b);
+impl windows_core::RuntimeType for IUserActivityRequestManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityRequestManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,12 +183,18 @@ pub struct IUserActivityRequestManager_Vtbl {
     pub RemoveUserActivityRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityRequestManagerStatics, IUserActivityRequestManagerStatics_Vtbl, 0xc0392df1_224a_432c_81e5_0c76b4c4cefa);
+impl windows_core::RuntimeType for IUserActivityRequestManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityRequestManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityRequestedEventArgs, IUserActivityRequestedEventArgs_Vtbl, 0xa4cc7a4c_8229_4cfd_a3bc_c61d318575a4);
+impl windows_core::RuntimeType for IUserActivityRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,12 +202,18 @@ pub struct IUserActivityRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivitySession, IUserActivitySession_Vtbl, 0xae434d78_24fa_44a3_ad48_6eda61aa1924);
+impl windows_core::RuntimeType for IUserActivitySession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivitySession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ActivityId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivitySessionHistoryItem, IUserActivitySessionHistoryItem_Vtbl, 0xe8d59bd3_3e5d_49fd_98d7_6da97521e255);
+impl windows_core::RuntimeType for IUserActivitySessionHistoryItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivitySessionHistoryItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -168,6 +222,9 @@ pub struct IUserActivitySessionHistoryItem_Vtbl {
     pub EndTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserActivityStatics, IUserActivityStatics_Vtbl, 0x8c8fd333_0e09_47f6_9ac7_95cf5c39367b);
+impl windows_core::RuntimeType for IUserActivityStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -182,6 +239,9 @@ pub struct IUserActivityStatics_Vtbl {
     ToJsonArray: usize,
 }
 windows_core::imp::define_interface!(IUserActivityVisualElements, IUserActivityVisualElements_Vtbl, 0x94757513_262f_49ef_bbbf_9b75d2e85250);
+impl windows_core::RuntimeType for IUserActivityVisualElements {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityVisualElements_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -209,6 +269,9 @@ pub struct IUserActivityVisualElements_Vtbl {
     Content: usize,
 }
 windows_core::imp::define_interface!(IUserActivityVisualElements2, IUserActivityVisualElements2_Vtbl, 0xcaae7fc7_3eef_4359_825c_9d51b9220de3);
+impl windows_core::RuntimeType for IUserActivityVisualElements2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserActivityVisualElements2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -381,7 +444,7 @@ impl UserActivity {
     }
 }
 impl windows_core::RuntimeType for UserActivity {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivity>();
 }
 unsafe impl windows_core::Interface for UserActivity {
     type Vtable = IUserActivity_Vtbl;
@@ -456,7 +519,7 @@ impl UserActivityAttribution {
     }
 }
 impl windows_core::RuntimeType for UserActivityAttribution {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivityAttribution>();
 }
 unsafe impl windows_core::Interface for UserActivityAttribution {
     type Vtable = IUserActivityAttribution_Vtbl;
@@ -555,7 +618,7 @@ impl UserActivityChannel {
     }
 }
 impl windows_core::RuntimeType for UserActivityChannel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivityChannel>();
 }
 unsafe impl windows_core::Interface for UserActivityChannel {
     type Vtable = IUserActivityChannel_Vtbl;
@@ -592,7 +655,7 @@ impl UserActivityContentInfo {
     }
 }
 impl windows_core::RuntimeType for UserActivityContentInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivityContentInfo>();
 }
 unsafe impl windows_core::Interface for UserActivityContentInfo {
     type Vtable = IUserActivityContentInfo_Vtbl;
@@ -617,7 +680,7 @@ impl UserActivityRequest {
     }
 }
 impl windows_core::RuntimeType for UserActivityRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivityRequest>();
 }
 unsafe impl windows_core::Interface for UserActivityRequest {
     type Vtable = IUserActivityRequest_Vtbl;
@@ -660,7 +723,7 @@ impl UserActivityRequestManager {
     }
 }
 impl windows_core::RuntimeType for UserActivityRequestManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivityRequestManager>();
 }
 unsafe impl windows_core::Interface for UserActivityRequestManager {
     type Vtable = IUserActivityRequestManager_Vtbl;
@@ -690,7 +753,7 @@ impl UserActivityRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserActivityRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivityRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for UserActivityRequestedEventArgs {
     type Vtable = IUserActivityRequestedEventArgs_Vtbl;
@@ -720,7 +783,7 @@ impl UserActivitySession {
     }
 }
 impl windows_core::RuntimeType for UserActivitySession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivitySession>();
 }
 unsafe impl windows_core::Interface for UserActivitySession {
     type Vtable = IUserActivitySession_Vtbl;
@@ -759,7 +822,7 @@ impl UserActivitySessionHistoryItem {
     }
 }
 impl windows_core::RuntimeType for UserActivitySessionHistoryItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivitySessionHistoryItem>();
 }
 unsafe impl windows_core::Interface for UserActivitySessionHistoryItem {
     type Vtable = IUserActivitySessionHistoryItem_Vtbl;
@@ -853,7 +916,7 @@ impl UserActivityVisualElements {
     }
 }
 impl windows_core::RuntimeType for UserActivityVisualElements {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserActivityVisualElements>();
 }
 unsafe impl windows_core::Interface for UserActivityVisualElements {
     type Vtable = IUserActivityVisualElements_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IUserDataAccountPartnerAccountInfo, IUserDataAccountPartnerAccountInfo_Vtbl, 0x5f200037_f6ef_4ec3_8630_012c59c1149f);
+impl windows_core::RuntimeType for IUserDataAccountPartnerAccountInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountPartnerAccountInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IUserDataAccountPartnerAccountInfo_Vtbl {
     pub AccountKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UserDataAccountProviderPartnerAccountKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountProviderAddAccountOperation, IUserDataAccountProviderAddAccountOperation_Vtbl, 0xb9c72530_3f84_4b5d_8eaa_45e97aa842ed);
+impl windows_core::RuntimeType for IUserDataAccountProviderAddAccountOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountProviderAddAccountOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +43,9 @@ pub struct IUserDataAccountProviderOperation_Vtbl {
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UserDataAccountProviderOperationKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountProviderResolveErrorsOperation, IUserDataAccountProviderResolveErrorsOperation_Vtbl, 0x6235dc15_bfcb_41e1_9957_9759a28846cc);
+impl windows_core::RuntimeType for IUserDataAccountProviderResolveErrorsOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountProviderResolveErrorsOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +53,9 @@ pub struct IUserDataAccountProviderResolveErrorsOperation_Vtbl {
     pub ReportCompleted: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountProviderSettingsOperation, IUserDataAccountProviderSettingsOperation_Vtbl, 0x92034db7_8648_4f30_acfa_3002658ca80d);
+impl windows_core::RuntimeType for IUserDataAccountProviderSettingsOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountProviderSettingsOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,7 +90,7 @@ impl UserDataAccountPartnerAccountInfo {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountPartnerAccountInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountPartnerAccountInfo>();
 }
 unsafe impl windows_core::Interface for UserDataAccountPartnerAccountInfo {
     type Vtable = IUserDataAccountPartnerAccountInfo_Vtbl;
@@ -123,7 +135,7 @@ impl UserDataAccountProviderAddAccountOperation {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountProviderAddAccountOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountProviderAddAccountOperation>();
 }
 unsafe impl windows_core::Interface for UserDataAccountProviderAddAccountOperation {
     type Vtable = IUserDataAccountProviderAddAccountOperation_Vtbl;
@@ -160,7 +172,7 @@ impl UserDataAccountProviderResolveErrorsOperation {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountProviderResolveErrorsOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountProviderResolveErrorsOperation>();
 }
 unsafe impl windows_core::Interface for UserDataAccountProviderResolveErrorsOperation {
     type Vtable = IUserDataAccountProviderResolveErrorsOperation_Vtbl;
@@ -197,7 +209,7 @@ impl UserDataAccountProviderSettingsOperation {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountProviderSettingsOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountProviderSettingsOperation>();
 }
 unsafe impl windows_core::Interface for UserDataAccountProviderSettingsOperation {
     type Vtable = IUserDataAccountProviderSettingsOperation_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDeviceAccountConfiguration, IDeviceAccountConfiguration_Vtbl, 0xad0123a3_fbdc_4d1b_be43_5a27ea4a1b63);
+impl windows_core::RuntimeType for IDeviceAccountConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceAccountConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +39,9 @@ pub struct IDeviceAccountConfiguration_Vtbl {
     pub SetOutgoingServerUsername: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceAccountConfiguration2, IDeviceAccountConfiguration2_Vtbl, 0xf2b2e5a6_728d_4a4a_8945_2bf8580136de);
+impl windows_core::RuntimeType for IDeviceAccountConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceAccountConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,6 +115,9 @@ pub struct IDeviceAccountConfiguration2_Vtbl {
     pub SetIsSyncScheduleManagedBySystem: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountSystemAccessManagerStatics, IUserDataAccountSystemAccessManagerStatics_Vtbl, 0x9d6b11b9_cbe5_45f5_822b_c267b81dbdb6);
+impl windows_core::RuntimeType for IUserDataAccountSystemAccessManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountSystemAccessManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,6 +127,9 @@ pub struct IUserDataAccountSystemAccessManagerStatics_Vtbl {
     AddAndShowDeviceAccountsAsync: usize,
 }
 windows_core::imp::define_interface!(IUserDataAccountSystemAccessManagerStatics2, IUserDataAccountSystemAccessManagerStatics2_Vtbl, 0x943f854d_4b4e_439f_83d3_979b27c05ac7);
+impl windows_core::RuntimeType for IUserDataAccountSystemAccessManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountSystemAccessManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -643,7 +655,7 @@ impl DeviceAccountConfiguration {
     }
 }
 impl windows_core::RuntimeType for DeviceAccountConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceAccountConfiguration>();
 }
 unsafe impl windows_core::Interface for DeviceAccountConfiguration {
     type Vtable = IDeviceAccountConfiguration_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
@@ -3,6 +3,9 @@ pub mod Provider;
 #[cfg(feature = "ApplicationModel_UserDataAccounts_SystemAccess")]
 pub mod SystemAccess;
 windows_core::imp::define_interface!(IUserDataAccount, IUserDataAccount_Vtbl, 0xb9c4367e_b348_4910_be94_4ad4bba6dea7);
+impl windows_core::RuntimeType for IUserDataAccount {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccount_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +40,9 @@ pub struct IUserDataAccount_Vtbl {
     FindContactAnnotationListsAsync: usize,
 }
 windows_core::imp::define_interface!(IUserDataAccount2, IUserDataAccount2_Vtbl, 0x078cd89f_de82_404b_8195_c8a3ac198f60);
+impl windows_core::RuntimeType for IUserDataAccount2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccount2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +50,9 @@ pub struct IUserDataAccount2_Vtbl {
     pub IsProtectedUnderLock: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccount3, IUserDataAccount3_Vtbl, 0x01533845_6c43_4286_9d69_3e1709a1f266);
+impl windows_core::RuntimeType for IUserDataAccount3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccount3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,6 +64,9 @@ pub struct IUserDataAccount3_Vtbl {
     pub SetDisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccount4, IUserDataAccount4_Vtbl, 0xc4315210_eae5_4f0a_a8b2_1cca115e008f);
+impl windows_core::RuntimeType for IUserDataAccount4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccount4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +92,9 @@ pub struct IUserDataAccount4_Vtbl {
     SetIcon: usize,
 }
 windows_core::imp::define_interface!(IUserDataAccountManagerForUser, IUserDataAccountManagerForUser_Vtbl, 0x56a6e8db_db8f_41ab_a65f_8c5971aac982);
+impl windows_core::RuntimeType for IUserDataAccountManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +105,9 @@ pub struct IUserDataAccountManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IUserDataAccountManagerStatics, IUserDataAccountManagerStatics_Vtbl, 0x0d9b89ea_1928_4a20_86d5_3c737f7dc3b0);
+impl windows_core::RuntimeType for IUserDataAccountManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +117,9 @@ pub struct IUserDataAccountManagerStatics_Vtbl {
     pub ShowAccountErrorResolverAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountManagerStatics2, IUserDataAccountManagerStatics2_Vtbl, 0x6a3ded88_316b_435e_b534_f7d4b4b7dba6);
+impl windows_core::RuntimeType for IUserDataAccountManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +129,9 @@ pub struct IUserDataAccountManagerStatics2_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IUserDataAccountStore, IUserDataAccountStore_Vtbl, 0x2073b0ad_7d0a_4e76_bf45_2368f978a59a);
+impl windows_core::RuntimeType for IUserDataAccountStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -119,6 +143,9 @@ pub struct IUserDataAccountStore_Vtbl {
     pub CreateAccountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountStore2, IUserDataAccountStore2_Vtbl, 0xb1e0aef7_9560_4631_8af0_061d30161469);
+impl windows_core::RuntimeType for IUserDataAccountStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,12 +154,18 @@ pub struct IUserDataAccountStore2_Vtbl {
     pub RemoveStoreChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountStore3, IUserDataAccountStore3_Vtbl, 0x8142c094_f3c9_478b_b117_6585bebb6789);
+impl windows_core::RuntimeType for IUserDataAccountStore3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountStore3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateAccountWithPackageRelativeAppIdAndEnterpriseIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataAccountStoreChangedEventArgs, IUserDataAccountStoreChangedEventArgs_Vtbl, 0x84e3e2e5_8820_4512_b1f6_2e035be1072c);
+impl windows_core::RuntimeType for IUserDataAccountStoreChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAccountStoreChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -329,7 +362,7 @@ impl UserDataAccount {
     }
 }
 impl windows_core::RuntimeType for UserDataAccount {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccount>();
 }
 unsafe impl windows_core::Interface for UserDataAccount {
     type Vtable = IUserDataAccount_Vtbl;
@@ -412,7 +445,7 @@ impl UserDataAccountManagerForUser {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountManagerForUser>();
 }
 unsafe impl windows_core::Interface for UserDataAccountManagerForUser {
     type Vtable = IUserDataAccountManagerForUser_Vtbl;
@@ -480,7 +513,7 @@ impl UserDataAccountStore {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountStore>();
 }
 unsafe impl windows_core::Interface for UserDataAccountStore {
     type Vtable = IUserDataAccountStore_Vtbl;
@@ -505,7 +538,7 @@ impl UserDataAccountStoreChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataAccountStoreChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAccountStoreChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataAccountStoreChangedEventArgs {
     type Vtable = IUserDataAccountStoreChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/DataProvider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/DataProvider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IUserDataTaskDataProviderConnection, IUserDataTaskDataProviderConnection_Vtbl, 0x9ff39d1d_a447_428b_afe9_e5402bdeb041);
+impl windows_core::RuntimeType for IUserDataTaskDataProviderConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskDataProviderConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,12 +18,18 @@ pub struct IUserDataTaskDataProviderConnection_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskDataProviderTriggerDetails, IUserDataTaskDataProviderTriggerDetails_Vtbl, 0xae273202_b1c9_453e_afc5_b30af3bd217d);
+impl windows_core::RuntimeType for IUserDataTaskDataProviderTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskDataProviderTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListCompleteTaskRequest, IUserDataTaskListCompleteTaskRequest_Vtbl, 0xf65e14a3_1a42_49da_8552_2873e52c55eb);
+impl windows_core::RuntimeType for IUserDataTaskListCompleteTaskRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListCompleteTaskRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +39,9 @@ pub struct IUserDataTaskListCompleteTaskRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListCompleteTaskRequestEventArgs, IUserDataTaskListCompleteTaskRequestEventArgs_Vtbl, 0xd77c393d_4cf2_48ad_87fd_963f0eaa7a95);
+impl windows_core::RuntimeType for IUserDataTaskListCompleteTaskRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListCompleteTaskRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +49,9 @@ pub struct IUserDataTaskListCompleteTaskRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListCreateOrUpdateTaskRequest, IUserDataTaskListCreateOrUpdateTaskRequest_Vtbl, 0x2133772c_55c2_4300_8279_04326e07cce4);
+impl windows_core::RuntimeType for IUserDataTaskListCreateOrUpdateTaskRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListCreateOrUpdateTaskRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +61,9 @@ pub struct IUserDataTaskListCreateOrUpdateTaskRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListCreateOrUpdateTaskRequestEventArgs, IUserDataTaskListCreateOrUpdateTaskRequestEventArgs_Vtbl, 0x12c55a52_e378_419b_ae38_a5e9e604476e);
+impl windows_core::RuntimeType for IUserDataTaskListCreateOrUpdateTaskRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListCreateOrUpdateTaskRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +71,9 @@ pub struct IUserDataTaskListCreateOrUpdateTaskRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListDeleteTaskRequest, IUserDataTaskListDeleteTaskRequest_Vtbl, 0x4b863c68_7657_4f3d_b074_d47ec8df07e7);
+impl windows_core::RuntimeType for IUserDataTaskListDeleteTaskRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListDeleteTaskRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +83,9 @@ pub struct IUserDataTaskListDeleteTaskRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListDeleteTaskRequestEventArgs, IUserDataTaskListDeleteTaskRequestEventArgs_Vtbl, 0x6063dad9_f562_4145_8efe_d50078c92b7f);
+impl windows_core::RuntimeType for IUserDataTaskListDeleteTaskRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListDeleteTaskRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +93,9 @@ pub struct IUserDataTaskListDeleteTaskRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListSkipOccurrenceRequest, IUserDataTaskListSkipOccurrenceRequest_Vtbl, 0xab87e34d_1cd3_431c_9f58_089aa4338d85);
+impl windows_core::RuntimeType for IUserDataTaskListSkipOccurrenceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListSkipOccurrenceRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +105,9 @@ pub struct IUserDataTaskListSkipOccurrenceRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListSkipOccurrenceRequestEventArgs, IUserDataTaskListSkipOccurrenceRequestEventArgs_Vtbl, 0x7a3b924a_cc2f_4e7b_aacd_a5b9d29cfa4e);
+impl windows_core::RuntimeType for IUserDataTaskListSkipOccurrenceRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListSkipOccurrenceRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,6 +115,9 @@ pub struct IUserDataTaskListSkipOccurrenceRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListSyncManagerSyncRequest, IUserDataTaskListSyncManagerSyncRequest_Vtbl, 0x40a73807_7590_4149_ae19_b211431a9f48);
+impl windows_core::RuntimeType for IUserDataTaskListSyncManagerSyncRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListSyncManagerSyncRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,6 +126,9 @@ pub struct IUserDataTaskListSyncManagerSyncRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListSyncManagerSyncRequestEventArgs, IUserDataTaskListSyncManagerSyncRequestEventArgs_Vtbl, 0x8ead1c12_768e_43bd_8385_5cdc351ffdea);
+impl windows_core::RuntimeType for IUserDataTaskListSyncManagerSyncRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListSyncManagerSyncRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -180,7 +216,7 @@ impl UserDataTaskDataProviderConnection {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskDataProviderConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskDataProviderConnection>();
 }
 unsafe impl windows_core::Interface for UserDataTaskDataProviderConnection {
     type Vtable = IUserDataTaskDataProviderConnection_Vtbl;
@@ -205,7 +241,7 @@ impl UserDataTaskDataProviderTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskDataProviderTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskDataProviderTriggerDetails>();
 }
 unsafe impl windows_core::Interface for UserDataTaskDataProviderTriggerDetails {
     type Vtable = IUserDataTaskDataProviderTriggerDetails_Vtbl;
@@ -251,7 +287,7 @@ impl UserDataTaskListCompleteTaskRequest {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListCompleteTaskRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListCompleteTaskRequest>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListCompleteTaskRequest {
     type Vtable = IUserDataTaskListCompleteTaskRequest_Vtbl;
@@ -283,7 +319,7 @@ impl UserDataTaskListCompleteTaskRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListCompleteTaskRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListCompleteTaskRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListCompleteTaskRequestEventArgs {
     type Vtable = IUserDataTaskListCompleteTaskRequestEventArgs_Vtbl;
@@ -332,7 +368,7 @@ impl UserDataTaskListCreateOrUpdateTaskRequest {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListCreateOrUpdateTaskRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListCreateOrUpdateTaskRequest>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListCreateOrUpdateTaskRequest {
     type Vtable = IUserDataTaskListCreateOrUpdateTaskRequest_Vtbl;
@@ -364,7 +400,7 @@ impl UserDataTaskListCreateOrUpdateTaskRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListCreateOrUpdateTaskRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListCreateOrUpdateTaskRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListCreateOrUpdateTaskRequestEventArgs {
     type Vtable = IUserDataTaskListCreateOrUpdateTaskRequestEventArgs_Vtbl;
@@ -410,7 +446,7 @@ impl UserDataTaskListDeleteTaskRequest {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListDeleteTaskRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListDeleteTaskRequest>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListDeleteTaskRequest {
     type Vtable = IUserDataTaskListDeleteTaskRequest_Vtbl;
@@ -442,7 +478,7 @@ impl UserDataTaskListDeleteTaskRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListDeleteTaskRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListDeleteTaskRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListDeleteTaskRequestEventArgs {
     type Vtable = IUserDataTaskListDeleteTaskRequestEventArgs_Vtbl;
@@ -488,7 +524,7 @@ impl UserDataTaskListSkipOccurrenceRequest {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListSkipOccurrenceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListSkipOccurrenceRequest>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListSkipOccurrenceRequest {
     type Vtable = IUserDataTaskListSkipOccurrenceRequest_Vtbl;
@@ -520,7 +556,7 @@ impl UserDataTaskListSkipOccurrenceRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListSkipOccurrenceRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListSkipOccurrenceRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListSkipOccurrenceRequestEventArgs {
     type Vtable = IUserDataTaskListSkipOccurrenceRequestEventArgs_Vtbl;
@@ -559,7 +595,7 @@ impl UserDataTaskListSyncManagerSyncRequest {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListSyncManagerSyncRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListSyncManagerSyncRequest>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListSyncManagerSyncRequest {
     type Vtable = IUserDataTaskListSyncManagerSyncRequest_Vtbl;
@@ -591,7 +627,7 @@ impl UserDataTaskListSyncManagerSyncRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListSyncManagerSyncRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListSyncManagerSyncRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListSyncManagerSyncRequestEventArgs {
     type Vtable = IUserDataTaskListSyncManagerSyncRequestEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "ApplicationModel_UserDataTasks_DataProvider")]
 pub mod DataProvider;
 windows_core::imp::define_interface!(IUserDataTask, IUserDataTask_Vtbl, 0x7c6585d1_e0d4_4f99_aee2_bc2d5ddadf4c);
+impl windows_core::RuntimeType for IUserDataTask {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTask_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +36,9 @@ pub struct IUserDataTask_Vtbl {
     pub SetStartDate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskBatch, IUserDataTaskBatch_Vtbl, 0x382da5fe_20b5_431c_8f42_a5d292ec930c);
+impl windows_core::RuntimeType for IUserDataTaskBatch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskBatch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +48,9 @@ pub struct IUserDataTaskBatch_Vtbl {
     Tasks: usize,
 }
 windows_core::imp::define_interface!(IUserDataTaskList, IUserDataTaskList_Vtbl, 0x49412e39_7c1d_4df1_bed3_314b7cbf5e4e);
+impl windows_core::RuntimeType for IUserDataTaskList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +75,9 @@ pub struct IUserDataTaskList_Vtbl {
     pub SaveAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListLimitedWriteOperations, IUserDataTaskListLimitedWriteOperations_Vtbl, 0x7aa267f2_6078_4183_919e_4f29f19cfae9);
+impl windows_core::RuntimeType for IUserDataTaskListLimitedWriteOperations {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListLimitedWriteOperations_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +87,9 @@ pub struct IUserDataTaskListLimitedWriteOperations_Vtbl {
     pub TrySkipOccurrenceAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskListSyncManager, IUserDataTaskListSyncManager_Vtbl, 0x8e591a95_1dcf_469f_93ec_ba48bb553c6b);
+impl windows_core::RuntimeType for IUserDataTaskListSyncManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskListSyncManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +104,9 @@ pub struct IUserDataTaskListSyncManager_Vtbl {
     pub RemoveSyncStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskManager, IUserDataTaskManager_Vtbl, 0x8451c914_e60b_48a9_9211_7fb8a56cb84c);
+impl windows_core::RuntimeType for IUserDataTaskManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +117,9 @@ pub struct IUserDataTaskManager_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IUserDataTaskManagerStatics, IUserDataTaskManagerStatics_Vtbl, 0xb35539f8_c502_47fc_a81e_100883719d55);
+impl windows_core::RuntimeType for IUserDataTaskManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,6 +130,9 @@ pub struct IUserDataTaskManagerStatics_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IUserDataTaskQueryOptions, IUserDataTaskQueryOptions_Vtbl, 0x959f27ed_909a_4d30_8c1b_331d8fe667e2);
+impl windows_core::RuntimeType for IUserDataTaskQueryOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskQueryOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,12 +142,18 @@ pub struct IUserDataTaskQueryOptions_Vtbl {
     pub SetKind: unsafe extern "system" fn(*mut core::ffi::c_void, UserDataTaskQueryKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskReader, IUserDataTaskReader_Vtbl, 0x03e688b1_4ccf_4500_883b_e76290cfed63);
+impl windows_core::RuntimeType for IUserDataTaskReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReadBatchAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskRecurrenceProperties, IUserDataTaskRecurrenceProperties_Vtbl, 0x73df80b0_27c6_40ce_b149_9cd41485a69e);
+impl windows_core::RuntimeType for IUserDataTaskRecurrenceProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskRecurrenceProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +175,9 @@ pub struct IUserDataTaskRecurrenceProperties_Vtbl {
     pub SetDay: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskRegenerationProperties, IUserDataTaskRegenerationProperties_Vtbl, 0x92ab0007_090e_4704_bb5c_84fc0b0d9c31);
+impl windows_core::RuntimeType for IUserDataTaskRegenerationProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskRegenerationProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +191,9 @@ pub struct IUserDataTaskRegenerationProperties_Vtbl {
     pub SetInterval: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataTaskStore, IUserDataTaskStore_Vtbl, 0xf06a9cb0_f1db_45ba_8a62_086004c0213d);
+impl windows_core::RuntimeType for IUserDataTaskStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataTaskStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -354,7 +390,7 @@ impl UserDataTask {
     }
 }
 impl windows_core::RuntimeType for UserDataTask {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTask>();
 }
 unsafe impl windows_core::Interface for UserDataTask {
     type Vtable = IUserDataTask_Vtbl;
@@ -380,7 +416,7 @@ impl UserDataTaskBatch {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskBatch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskBatch>();
 }
 unsafe impl windows_core::Interface for UserDataTaskBatch {
     type Vtable = IUserDataTaskBatch_Vtbl;
@@ -528,7 +564,7 @@ impl UserDataTaskList {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskList>();
 }
 unsafe impl windows_core::Interface for UserDataTaskList {
     type Vtable = IUserDataTaskList_Vtbl;
@@ -577,7 +613,7 @@ impl UserDataTaskListLimitedWriteOperations {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListLimitedWriteOperations {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListLimitedWriteOperations>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListLimitedWriteOperations {
     type Vtable = IUserDataTaskListLimitedWriteOperations_Vtbl;
@@ -649,7 +685,7 @@ impl UserDataTaskListSyncManager {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskListSyncManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskListSyncManager>();
 }
 unsafe impl windows_core::Interface for UserDataTaskListSyncManager {
     type Vtable = IUserDataTaskListSyncManager_Vtbl;
@@ -703,7 +739,7 @@ impl UserDataTaskManager {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskManager>();
 }
 unsafe impl windows_core::Interface for UserDataTaskManager {
     type Vtable = IUserDataTaskManager_Vtbl;
@@ -750,7 +786,7 @@ impl UserDataTaskQueryOptions {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskQueryOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskQueryOptions>();
 }
 unsafe impl windows_core::Interface for UserDataTaskQueryOptions {
     type Vtable = IUserDataTaskQueryOptions_Vtbl;
@@ -775,7 +811,7 @@ impl UserDataTaskReader {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskReader>();
 }
 unsafe impl windows_core::Interface for UserDataTaskReader {
     type Vtable = IUserDataTaskReader_Vtbl;
@@ -906,7 +942,7 @@ impl UserDataTaskRecurrenceProperties {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskRecurrenceProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskRecurrenceProperties>();
 }
 unsafe impl windows_core::Interface for UserDataTaskRecurrenceProperties {
     type Vtable = IUserDataTaskRecurrenceProperties_Vtbl;
@@ -981,7 +1017,7 @@ impl UserDataTaskRegenerationProperties {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskRegenerationProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskRegenerationProperties>();
 }
 unsafe impl windows_core::Interface for UserDataTaskRegenerationProperties {
     type Vtable = IUserDataTaskRegenerationProperties_Vtbl;
@@ -1028,7 +1064,7 @@ impl UserDataTaskStore {
     }
 }
 impl windows_core::RuntimeType for UserDataTaskStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataTaskStore>();
 }
 unsafe impl windows_core::Interface for UserDataTaskStore {
     type Vtable = IUserDataTaskStore_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IVoiceCommand, IVoiceCommand_Vtbl, 0x936f5273_ec82_42a6_a55c_d2d79ec6f920);
+impl windows_core::RuntimeType for IVoiceCommand {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommand_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,18 +16,27 @@ pub struct IVoiceCommand_Vtbl {
     SpeechRecognitionResult: usize,
 }
 windows_core::imp::define_interface!(IVoiceCommandCompletedEventArgs, IVoiceCommandCompletedEventArgs_Vtbl, 0xc85e675d_fe42_432c_9907_09df9fcf64e8);
+impl windows_core::RuntimeType for IVoiceCommandCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VoiceCommandCompletionReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoiceCommandConfirmationResult, IVoiceCommandConfirmationResult_Vtbl, 0xa022593e_8221_4526_b083_840972262247);
+impl windows_core::RuntimeType for IVoiceCommandConfirmationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandConfirmationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Confirmed: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoiceCommandContentTile, IVoiceCommandContentTile_Vtbl, 0x3eefe9f0_b8c7_4c76_a0de_1607895ee327);
+impl windows_core::RuntimeType for IVoiceCommandContentTile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandContentTile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,6 +64,9 @@ pub struct IVoiceCommandContentTile_Vtbl {
     pub SetContentTileType: unsafe extern "system" fn(*mut core::ffi::c_void, VoiceCommandContentTileType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoiceCommandDefinition, IVoiceCommandDefinition_Vtbl, 0x7972aad0_0974_4979_984b_cb8959cd61ae);
+impl windows_core::RuntimeType for IVoiceCommandDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +78,9 @@ pub struct IVoiceCommandDefinition_Vtbl {
     SetPhraseListAsync: usize,
 }
 windows_core::imp::define_interface!(IVoiceCommandDefinitionManagerStatics, IVoiceCommandDefinitionManagerStatics_Vtbl, 0x8fe7a69e_067e_4f16_a18c_5b17e9499940);
+impl windows_core::RuntimeType for IVoiceCommandDefinitionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandDefinitionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,12 +94,18 @@ pub struct IVoiceCommandDefinitionManagerStatics_Vtbl {
     InstalledCommandDefinitions: usize,
 }
 windows_core::imp::define_interface!(IVoiceCommandDisambiguationResult, IVoiceCommandDisambiguationResult_Vtbl, 0xecc68cfe_c9ac_45df_a8ea_feea08ef9c5e);
+impl windows_core::RuntimeType for IVoiceCommandDisambiguationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandDisambiguationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SelectedItem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoiceCommandResponse, IVoiceCommandResponse_Vtbl, 0x0284b30e_8a3b_4cc4_a6a1_cad5be2716b5);
+impl windows_core::RuntimeType for IVoiceCommandResponse {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandResponse_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -97,6 +121,9 @@ pub struct IVoiceCommandResponse_Vtbl {
     VoiceCommandContentTiles: usize,
 }
 windows_core::imp::define_interface!(IVoiceCommandResponseStatics, IVoiceCommandResponseStatics_Vtbl, 0x2932f813_0d3b_49f2_96dd_625019bd3b5d);
+impl windows_core::RuntimeType for IVoiceCommandResponseStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandResponseStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -113,6 +140,9 @@ pub struct IVoiceCommandResponseStatics_Vtbl {
     CreateResponseForPromptWithTiles: usize,
 }
 windows_core::imp::define_interface!(IVoiceCommandServiceConnection, IVoiceCommandServiceConnection_Vtbl, 0xd894bb9f_21da_44a4_98a2_fb131920a9cc);
+impl windows_core::RuntimeType for IVoiceCommandServiceConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandServiceConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -131,6 +161,9 @@ pub struct IVoiceCommandServiceConnection_Vtbl {
     pub RemoveVoiceCommandCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoiceCommandServiceConnectionStatics, IVoiceCommandServiceConnectionStatics_Vtbl, 0x370ebffb_2d34_42df_8770_074d0f334697);
+impl windows_core::RuntimeType for IVoiceCommandServiceConnectionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandServiceConnectionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +173,9 @@ pub struct IVoiceCommandServiceConnectionStatics_Vtbl {
     FromAppServiceTriggerDetails: usize,
 }
 windows_core::imp::define_interface!(IVoiceCommandUserMessage, IVoiceCommandUserMessage_Vtbl, 0x674eb3c0_44f6_4f07_b979_4c723fc08597);
+impl windows_core::RuntimeType for IVoiceCommandUserMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandUserMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,7 +214,7 @@ impl VoiceCommand {
     }
 }
 impl windows_core::RuntimeType for VoiceCommand {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommand>();
 }
 unsafe impl windows_core::Interface for VoiceCommand {
     type Vtable = IVoiceCommand_Vtbl;
@@ -203,7 +239,7 @@ impl VoiceCommandCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for VoiceCommandCompletedEventArgs {
     type Vtable = IVoiceCommandCompletedEventArgs_Vtbl;
@@ -228,7 +264,7 @@ impl VoiceCommandConfirmationResult {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandConfirmationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandConfirmationResult>();
 }
 unsafe impl windows_core::Interface for VoiceCommandConfirmationResult {
     type Vtable = IVoiceCommandConfirmationResult_Vtbl;
@@ -349,7 +385,7 @@ impl VoiceCommandContentTile {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandContentTile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandContentTile>();
 }
 unsafe impl windows_core::Interface for VoiceCommandContentTile {
     type Vtable = IVoiceCommandContentTile_Vtbl;
@@ -392,7 +428,7 @@ impl VoiceCommandDefinition {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandDefinition>();
 }
 unsafe impl windows_core::Interface for VoiceCommandDefinition {
     type Vtable = IVoiceCommandDefinition_Vtbl;
@@ -445,7 +481,7 @@ impl VoiceCommandDisambiguationResult {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandDisambiguationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandDisambiguationResult>();
 }
 unsafe impl windows_core::Interface for VoiceCommandDisambiguationResult {
     type Vtable = IVoiceCommandDisambiguationResult_Vtbl;
@@ -563,7 +599,7 @@ impl VoiceCommandResponse {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandResponse {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandResponse>();
 }
 unsafe impl windows_core::Interface for VoiceCommandResponse {
     type Vtable = IVoiceCommandResponse_Vtbl;
@@ -685,7 +721,7 @@ impl VoiceCommandServiceConnection {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandServiceConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandServiceConnection>();
 }
 unsafe impl windows_core::Interface for VoiceCommandServiceConnection {
     type Vtable = IVoiceCommandServiceConnection_Vtbl;
@@ -732,7 +768,7 @@ impl VoiceCommandUserMessage {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandUserMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandUserMessage>();
 }
 unsafe impl windows_core::Interface for VoiceCommandUserMessage {
     type Vtable = IVoiceCommandUserMessage_Vtbl;

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItemSystemStore, IWalletItemSystemStore_Vtbl, 0x522e2bff_96a2_4a17_8d19_fe1d9f837561);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItemSystemStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItemSystemStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +32,10 @@ pub struct IWalletItemSystemStore_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItemSystemStore2, IWalletItemSystemStore2_Vtbl, 0xf98d3a4e_be00_4fdd_9734_6c113c1ac1cb);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItemSystemStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItemSystemStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +50,10 @@ pub struct IWalletItemSystemStore2_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletManagerSystemStatics, IWalletManagerSystemStatics_Vtbl, 0xbee8eb89_2634_4b9a_8b23_ee8903c91fe0);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletManagerSystemStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletManagerSystemStatics_Vtbl {
@@ -130,7 +142,7 @@ impl WalletItemSystemStore {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletItemSystemStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletItemSystemStore>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletItemSystemStore {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
@@ -3,6 +3,10 @@ pub mod System;
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletBarcode, IWalletBarcode_Vtbl, 0x4f857b29_de80_4ea4_a1cd_81cd084dac27);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletBarcode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletBarcode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +26,10 @@ pub struct IWalletBarcode_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletBarcodeFactory, IWalletBarcodeFactory_Vtbl, 0x30117161_ed9c_469e_bbfd_306c95ea7108);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletBarcodeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletBarcodeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +44,10 @@ pub struct IWalletBarcodeFactory_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItem, IWalletItem_Vtbl, 0x20b54be8_118d_4ec4_996c_b963e7bd3e74);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItem_Vtbl {
@@ -252,6 +264,10 @@ pub struct IWalletItem_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItemCustomProperty, IWalletItemCustomProperty_Vtbl, 0xb94b40f3_fa00_40fd_98dc_9de46697f1e7);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItemCustomProperty {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItemCustomProperty_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -299,6 +315,10 @@ pub struct IWalletItemCustomProperty_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItemCustomPropertyFactory, IWalletItemCustomPropertyFactory_Vtbl, 0xd0046a44_61a1_41aa_b259_a5610ab5d575);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItemCustomPropertyFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItemCustomPropertyFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -310,6 +330,10 @@ pub struct IWalletItemCustomPropertyFactory_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItemFactory, IWalletItemFactory_Vtbl, 0x53e27470_4f0b_4a3e_99e5_0bbb1eab38d4);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItemFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItemFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -320,6 +344,10 @@ pub struct IWalletItemFactory_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItemStore, IWalletItemStore_Vtbl, 0x7160484b_6d49_48f8_91a9_40a1d0f13ef4);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItemStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItemStore_Vtbl {
@@ -368,6 +396,10 @@ pub struct IWalletItemStore_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletItemStore2, IWalletItemStore2_Vtbl, 0x65e682f0_7009_4a15_bd54_4fff379bffe2);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletItemStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletItemStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -383,6 +415,10 @@ pub struct IWalletItemStore2_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletManagerStatics, IWalletManagerStatics_Vtbl, 0x5111d6b8_c9a4_4c64_b4dd_e1e548001c0d);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -393,6 +429,10 @@ pub struct IWalletManagerStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletRelevantLocation, IWalletRelevantLocation_Vtbl, 0x9fd8782a_e3f9_4de1_bab3_bb192e46b3f3);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletRelevantLocation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletRelevantLocation_Vtbl {
@@ -416,6 +456,10 @@ pub struct IWalletRelevantLocation_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletTransaction, IWalletTransaction_Vtbl, 0x40e1e940_2606_4519_81cb_bff1c60d1f79);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletTransaction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletTransaction_Vtbl {
@@ -472,6 +516,10 @@ pub struct IWalletTransaction_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletVerb, IWalletVerb_Vtbl, 0x17b826d6_e3c1_4c74_8a94_217aadbc4884);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletVerb {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletVerb_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -486,6 +534,10 @@ pub struct IWalletVerb_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IWalletVerbFactory, IWalletVerbFactory_Vtbl, 0x76012771_be58_4d5e_83ed_58b1669c7ad9);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IWalletVerbFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IWalletVerbFactory_Vtbl {
@@ -553,7 +605,7 @@ impl WalletBarcode {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletBarcode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletBarcode>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletBarcode {
@@ -972,7 +1024,7 @@ impl WalletItem {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletItem>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletItem {
@@ -1076,7 +1128,7 @@ impl WalletItemCustomProperty {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletItemCustomProperty {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletItemCustomProperty>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletItemCustomProperty {
@@ -1191,7 +1243,7 @@ impl WalletItemStore {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletItemStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletItemStore>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletItemStore {
@@ -1272,7 +1324,7 @@ impl WalletRelevantLocation {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletRelevantLocation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletRelevantLocation>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletRelevantLocation {
@@ -1386,7 +1438,7 @@ impl WalletTransaction {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletTransaction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletTransaction>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletTransaction {
@@ -1438,7 +1490,7 @@ impl WalletVerb {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for WalletVerb {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWalletVerb>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for WalletVerb {

--- a/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
@@ -51,6 +51,9 @@ pub mod VoiceCommands;
 #[cfg(feature = "ApplicationModel_Wallet")]
 pub mod Wallet;
 windows_core::imp::define_interface!(IAppDisplayInfo, IAppDisplayInfo_Vtbl, 0x1aeb1103_e4d4_41aa_a4f6_c4a276e79eac);
+impl windows_core::RuntimeType for IAppDisplayInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDisplayInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +65,9 @@ pub struct IAppDisplayInfo_Vtbl {
     GetLogo: usize,
 }
 windows_core::imp::define_interface!(IAppInfo, IAppInfo_Vtbl, 0xcf7f59b3_6a09_4de8_a6c0_5792d56880d1);
+impl windows_core::RuntimeType for IAppInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,24 +77,36 @@ pub struct IAppInfo_Vtbl {
     pub PackageFamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInfo2, IAppInfo2_Vtbl, 0xbe4b1f5a_2098_431b_bd25_b30878748d47);
+impl windows_core::RuntimeType for IAppInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Package: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInfo3, IAppInfo3_Vtbl, 0x09a78e46_93a4_46de_9397_0843b57115ea);
+impl windows_core::RuntimeType for IAppInfo3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInfo3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExecutionContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppExecutionContext) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInfo4, IAppInfo4_Vtbl, 0x2f34bdeb_1609_4554_9f33_12e1e803e0d4);
+impl windows_core::RuntimeType for IAppInfo4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInfo4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SupportedFileExtensions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInfoStatics, IAppInfoStatics_Vtbl, 0xcf1f782a_e48b_4f0c_9b0b_79c3f8957dd7);
+impl windows_core::RuntimeType for IAppInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,12 +118,18 @@ pub struct IAppInfoStatics_Vtbl {
     GetFromAppUserModelIdForUser: usize,
 }
 windows_core::imp::define_interface!(IAppInstallerInfo, IAppInstallerInfo_Vtbl, 0x29ab2ac0_d4f6_42a3_adcd_d6583c659508);
+impl windows_core::RuntimeType for IAppInstallerInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallerInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Uri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallerInfo2, IAppInstallerInfo2_Vtbl, 0xd20f1388_8256_597c_8511_c84ec50d5e2b);
+impl windows_core::RuntimeType for IAppInstallerInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallerInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -138,6 +162,9 @@ pub struct IAppInstallerInfo2_Vtbl {
     pub PolicySource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppInstallerPolicySource) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstance, IAppInstance_Vtbl, 0x675f2b47_f25f_4532_9fd6_3633e0634d01);
+impl windows_core::RuntimeType for IAppInstance {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstance_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -146,6 +173,9 @@ pub struct IAppInstance_Vtbl {
     pub RedirectActivationTo: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstanceStatics, IAppInstanceStatics_Vtbl, 0x9d11e77f_9ea6_47af_a6ec_46784c5ba254);
+impl windows_core::RuntimeType for IAppInstanceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstanceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -162,18 +192,27 @@ pub struct IAppInstanceStatics_Vtbl {
     GetInstances: usize,
 }
 windows_core::imp::define_interface!(ICameraApplicationManagerStatics, ICameraApplicationManagerStatics_Vtbl, 0x9599ddce_9bd3_435c_8054_c1add50028fe);
+impl windows_core::RuntimeType for ICameraApplicationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraApplicationManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShowInstalledApplicationsUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDesignModeStatics, IDesignModeStatics_Vtbl, 0x2c3893cc_f81a_4e7a_b857_76a80887e185);
+impl windows_core::RuntimeType for IDesignModeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDesignModeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DesignModeEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDesignModeStatics2, IDesignModeStatics2_Vtbl, 0x80cf8137_b064_4858_bec8_3eba22357535);
+impl windows_core::RuntimeType for IDesignModeStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDesignModeStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,6 +238,9 @@ pub struct IEnteredBackgroundEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFindRelatedPackagesOptions, IFindRelatedPackagesOptions_Vtbl, 0x41dd7eea_b335_521f_b96c_5ea07f5b7329);
+impl windows_core::RuntimeType for IFindRelatedPackagesOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFindRelatedPackagesOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,12 +256,18 @@ pub struct IFindRelatedPackagesOptions_Vtbl {
     pub SetIncludeResources: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFindRelatedPackagesOptionsFactory, IFindRelatedPackagesOptionsFactory_Vtbl, 0xd7d17254_a4fd_55c4_98cf_f2710b7d8be2);
+impl windows_core::RuntimeType for IFindRelatedPackagesOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFindRelatedPackagesOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, PackageRelationship, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFullTrustProcessLaunchResult, IFullTrustProcessLaunchResult_Vtbl, 0x8917d888_edfb_515f_8e22_5ebceb69dfd9);
+impl windows_core::RuntimeType for IFullTrustProcessLaunchResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFullTrustProcessLaunchResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -227,6 +275,9 @@ pub struct IFullTrustProcessLaunchResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFullTrustProcessLauncherStatics, IFullTrustProcessLauncherStatics_Vtbl, 0xd784837f_1100_3c6b_a455_f6262cc331b6);
+impl windows_core::RuntimeType for IFullTrustProcessLauncherStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFullTrustProcessLauncherStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -236,6 +287,9 @@ pub struct IFullTrustProcessLauncherStatics_Vtbl {
     pub LaunchFullTrustProcessForAppWithParametersAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFullTrustProcessLauncherStatics2, IFullTrustProcessLauncherStatics2_Vtbl, 0x8b8ed72f_b65c_56cf_a1a7_2bf77cbc6ea8);
+impl windows_core::RuntimeType for IFullTrustProcessLauncherStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFullTrustProcessLauncherStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -262,6 +316,9 @@ pub struct ILeavingBackgroundEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILimitedAccessFeatureRequestResult, ILimitedAccessFeatureRequestResult_Vtbl, 0xd45156a6_1e24_5ddd_abb4_6188aba4d5bf);
+impl windows_core::RuntimeType for ILimitedAccessFeatureRequestResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILimitedAccessFeatureRequestResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -270,12 +327,18 @@ pub struct ILimitedAccessFeatureRequestResult_Vtbl {
     pub EstimatedRemovalDate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILimitedAccessFeaturesStatics, ILimitedAccessFeaturesStatics_Vtbl, 0x8be612d4_302b_5fbf_a632_1a99e43e8925);
+impl windows_core::RuntimeType for ILimitedAccessFeaturesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILimitedAccessFeaturesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryUnlockFeature: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackage, IPackage_Vtbl, 0x163c792f_bd75_413c_bf23_b1fe7b95d825);
+impl windows_core::RuntimeType for IPackage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -291,6 +354,9 @@ pub struct IPackage_Vtbl {
     Dependencies: usize,
 }
 windows_core::imp::define_interface!(IPackage2, IPackage2_Vtbl, 0xa6612fb6_7688_4ace_95fb_359538e7aa01);
+impl windows_core::RuntimeType for IPackage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -303,6 +369,9 @@ pub struct IPackage2_Vtbl {
     pub IsDevelopmentMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackage3, IPackage3_Vtbl, 0x5f738b61_f86a_4917_93d1_f1ee9d3b35d9);
+impl windows_core::RuntimeType for IPackage3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +383,9 @@ pub struct IPackage3_Vtbl {
     GetAppListEntriesAsync: usize,
 }
 windows_core::imp::define_interface!(IPackage4, IPackage4_Vtbl, 0x65aed1ae_b95b_450c_882b_6255187f397e);
+impl windows_core::RuntimeType for IPackage4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -322,6 +394,9 @@ pub struct IPackage4_Vtbl {
     pub VerifyContentIntegrityAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackage5, IPackage5_Vtbl, 0x0e842dd4_d9ac_45ed_9a1e_74ce056b2635);
+impl windows_core::RuntimeType for IPackage5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -341,6 +416,9 @@ pub struct IPackage5_Vtbl {
     pub SetInUseAsync: unsafe extern "system" fn(*mut core::ffi::c_void, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackage6, IPackage6_Vtbl, 0x8b1ad942_12d7_4754_ae4e_638cbc0e3a2e);
+impl windows_core::RuntimeType for IPackage6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -348,6 +426,9 @@ pub struct IPackage6_Vtbl {
     pub CheckUpdateAvailabilityAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackage7, IPackage7_Vtbl, 0x86ff8d31_a2e4_45e0_9732_283a6d88fde1);
+impl windows_core::RuntimeType for IPackage7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -361,6 +442,9 @@ pub struct IPackage7_Vtbl {
     EffectiveLocation: usize,
 }
 windows_core::imp::define_interface!(IPackage8, IPackage8_Vtbl, 0x2c584f7b_ce2a_4be6_a093_77cfbb2a7ea1);
+impl windows_core::RuntimeType for IPackage8 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage8_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -393,6 +477,9 @@ pub struct IPackage8_Vtbl {
     pub IsStub: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackage9, IPackage9_Vtbl, 0xd5ab224f_d7e1_49ec_90ce_720cdbd02e9c);
+impl windows_core::RuntimeType for IPackage9 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackage9_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -403,6 +490,9 @@ pub struct IPackage9_Vtbl {
     pub SourceUriSchemeName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageCatalog, IPackageCatalog_Vtbl, 0x230a3751_9de3_4445_be74_91fb325abefe);
+impl windows_core::RuntimeType for IPackageCatalog {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalog_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -418,6 +508,9 @@ pub struct IPackageCatalog_Vtbl {
     pub RemovePackageStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageCatalog2, IPackageCatalog2_Vtbl, 0x96a60c36_8ff7_4344_b6bf_ee64c2207ed2);
+impl windows_core::RuntimeType for IPackageCatalog2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalog2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -426,6 +519,9 @@ pub struct IPackageCatalog2_Vtbl {
     pub AddOptionalPackageAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageCatalog3, IPackageCatalog3_Vtbl, 0x96dd5c88_8837_43f9_9015_033434ba14f3);
+impl windows_core::RuntimeType for IPackageCatalog3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalog3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -435,6 +531,9 @@ pub struct IPackageCatalog3_Vtbl {
     RemoveOptionalPackagesAsync: usize,
 }
 windows_core::imp::define_interface!(IPackageCatalog4, IPackageCatalog4_Vtbl, 0xc37c399b_44cc_4b7b_8baf_796c04ead3b9);
+impl windows_core::RuntimeType for IPackageCatalog4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalog4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -445,6 +544,9 @@ pub struct IPackageCatalog4_Vtbl {
     RemoveResourcePackagesAsync: usize,
 }
 windows_core::imp::define_interface!(IPackageCatalogAddOptionalPackageResult, IPackageCatalogAddOptionalPackageResult_Vtbl, 0x3bf10cd4_b4df_47b3_a963_e2fa832f7dd3);
+impl windows_core::RuntimeType for IPackageCatalogAddOptionalPackageResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalogAddOptionalPackageResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -452,6 +554,9 @@ pub struct IPackageCatalogAddOptionalPackageResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageCatalogAddResourcePackageResult, IPackageCatalogAddResourcePackageResult_Vtbl, 0x9636ce0d_3e17_493f_aa08_ccec6fdef699);
+impl windows_core::RuntimeType for IPackageCatalogAddResourcePackageResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalogAddResourcePackageResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -460,6 +565,9 @@ pub struct IPackageCatalogAddResourcePackageResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageCatalogRemoveOptionalPackagesResult, IPackageCatalogRemoveOptionalPackagesResult_Vtbl, 0x29d2f97b_d974_4e64_9359_22cadfd79828);
+impl windows_core::RuntimeType for IPackageCatalogRemoveOptionalPackagesResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalogRemoveOptionalPackagesResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -470,6 +578,9 @@ pub struct IPackageCatalogRemoveOptionalPackagesResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageCatalogRemoveResourcePackagesResult, IPackageCatalogRemoveResourcePackagesResult_Vtbl, 0xae719709_1a52_4321_87b3_e5a1a17981a7);
+impl windows_core::RuntimeType for IPackageCatalogRemoveResourcePackagesResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalogRemoveResourcePackagesResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -480,6 +591,9 @@ pub struct IPackageCatalogRemoveResourcePackagesResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageCatalogStatics, IPackageCatalogStatics_Vtbl, 0xa18c9696_e65b_4634_ba21_5e63eb7244a7);
+impl windows_core::RuntimeType for IPackageCatalogStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageCatalogStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -509,6 +623,9 @@ pub struct IPackageCatalogStatics2_Vtbl {
     pub OpenForPackage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageContentGroup, IPackageContentGroup_Vtbl, 0x8f62695d_120a_4798_b5e1_5800dda8f2e1);
+impl windows_core::RuntimeType for IPackageContentGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageContentGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -518,6 +635,9 @@ pub struct IPackageContentGroup_Vtbl {
     pub IsRequired: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageContentGroupStagingEventArgs, IPackageContentGroupStagingEventArgs_Vtbl, 0x3d7bc27e_6f27_446c_986e_d4733d4d9113);
+impl windows_core::RuntimeType for IPackageContentGroupStagingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageContentGroupStagingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -530,12 +650,18 @@ pub struct IPackageContentGroupStagingEventArgs_Vtbl {
     pub IsContentGroupRequired: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageContentGroupStatics, IPackageContentGroupStatics_Vtbl, 0x70ee7619_5f12_4b92_b9ea_6ccada13bc75);
+impl windows_core::RuntimeType for IPackageContentGroupStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageContentGroupStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequiredGroupName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageId, IPackageId_Vtbl, 0x1adb665e_37c7_4790_9980_dd7ae74e8bb2);
+impl windows_core::RuntimeType for IPackageId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -552,6 +678,9 @@ pub struct IPackageId_Vtbl {
     pub FamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageIdWithMetadata, IPackageIdWithMetadata_Vtbl, 0x40577a7c_0c9e_443d_9074_855f5ce0a08d);
+impl windows_core::RuntimeType for IPackageIdWithMetadata {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageIdWithMetadata_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -559,6 +688,9 @@ pub struct IPackageIdWithMetadata_Vtbl {
     pub Author: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageInstallingEventArgs, IPackageInstallingEventArgs_Vtbl, 0x97741eb7_ab7a_401a_8b61_eb0e7faff237);
+impl windows_core::RuntimeType for IPackageInstallingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageInstallingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -569,6 +701,9 @@ pub struct IPackageInstallingEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageStagingEventArgs, IPackageStagingEventArgs_Vtbl, 0x1041682d_54e2_4f51_b828_9ef7046c210f);
+impl windows_core::RuntimeType for IPackageStagingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageStagingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -579,12 +714,18 @@ pub struct IPackageStagingEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageStatics, IPackageStatics_Vtbl, 0x4e534bdf_2960_4878_97a4_9624deb72f2d);
+impl windows_core::RuntimeType for IPackageStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageStatus, IPackageStatus_Vtbl, 0x5fe74f71_a365_4c09_a02d_046d525ea1da);
+impl windows_core::RuntimeType for IPackageStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -602,18 +743,27 @@ pub struct IPackageStatus_Vtbl {
     pub DeploymentInProgress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageStatus2, IPackageStatus2_Vtbl, 0xf428fa93_7c56_4862_acfa_abaedcc0694d);
+impl windows_core::RuntimeType for IPackageStatus2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageStatus2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsPartiallyStaged: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageStatusChangedEventArgs, IPackageStatusChangedEventArgs_Vtbl, 0x437d714d_bd80_4a70_bc50_f6e796509575);
+impl windows_core::RuntimeType for IPackageStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Package: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageUninstallingEventArgs, IPackageUninstallingEventArgs_Vtbl, 0x4443aa52_ab22_44cd_82bb_4ec9b827367a);
+impl windows_core::RuntimeType for IPackageUninstallingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageUninstallingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -624,6 +774,9 @@ pub struct IPackageUninstallingEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageUpdateAvailabilityResult, IPackageUpdateAvailabilityResult_Vtbl, 0x114e5009_199a_48a1_a079_313c45634a71);
+impl windows_core::RuntimeType for IPackageUpdateAvailabilityResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageUpdateAvailabilityResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -631,6 +784,9 @@ pub struct IPackageUpdateAvailabilityResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageUpdatingEventArgs, IPackageUpdatingEventArgs_Vtbl, 0xcd7b4228_fd74_443e_b114_23e677b0e86f);
+impl windows_core::RuntimeType for IPackageUpdatingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageUpdatingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -642,6 +798,9 @@ pub struct IPackageUpdatingEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageWithMetadata, IPackageWithMetadata_Vtbl, 0x95949780_1de9_40f2_b452_0de9f1910012);
+impl windows_core::RuntimeType for IPackageWithMetadata {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageWithMetadata_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -653,6 +812,9 @@ pub struct IPackageWithMetadata_Vtbl {
     Launch: usize,
 }
 windows_core::imp::define_interface!(IStartupTask, IStartupTask_Vtbl, 0xf75c23c8_b5f2_4f6c_88dd_36cb1d599d17);
+impl windows_core::RuntimeType for IStartupTask {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStartupTask_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -662,6 +824,9 @@ pub struct IStartupTask_Vtbl {
     pub TaskId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStartupTaskStatics, IStartupTaskStatics_Vtbl, 0xee5b60bd_a148_41a7_b26e_e8b88a1e62f8);
+impl windows_core::RuntimeType for IStartupTaskStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStartupTaskStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -762,7 +927,7 @@ impl AppDisplayInfo {
     }
 }
 impl windows_core::RuntimeType for AppDisplayInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppDisplayInfo>();
 }
 unsafe impl windows_core::Interface for AppDisplayInfo {
     type Vtable = IAppDisplayInfo_Vtbl;
@@ -856,7 +1021,7 @@ impl AppInfo {
     }
 }
 impl windows_core::RuntimeType for AppInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInfo>();
 }
 unsafe impl windows_core::Interface for AppInfo {
     type Vtable = IAppInfo_Vtbl;
@@ -990,7 +1155,7 @@ impl AppInstallerInfo {
     }
 }
 impl windows_core::RuntimeType for AppInstallerInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstallerInfo>();
 }
 unsafe impl windows_core::Interface for AppInstallerInfo {
     type Vtable = IAppInstallerInfo_Vtbl;
@@ -1060,7 +1225,7 @@ impl AppInstance {
     }
 }
 impl windows_core::RuntimeType for AppInstance {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstance>();
 }
 unsafe impl windows_core::Interface for AppInstance {
     type Vtable = IAppInstance_Vtbl;
@@ -1128,7 +1293,7 @@ impl EnteredBackgroundEventArgs {
     }
 }
 impl windows_core::RuntimeType for EnteredBackgroundEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEnteredBackgroundEventArgs>();
 }
 unsafe impl windows_core::Interface for EnteredBackgroundEventArgs {
     type Vtable = IEnteredBackgroundEventArgs_Vtbl;
@@ -1212,7 +1377,7 @@ impl FindRelatedPackagesOptions {
     }
 }
 impl windows_core::RuntimeType for FindRelatedPackagesOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFindRelatedPackagesOptions>();
 }
 unsafe impl windows_core::Interface for FindRelatedPackagesOptions {
     type Vtable = IFindRelatedPackagesOptions_Vtbl;
@@ -1244,7 +1409,7 @@ impl FullTrustProcessLaunchResult {
     }
 }
 impl windows_core::RuntimeType for FullTrustProcessLaunchResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFullTrustProcessLaunchResult>();
 }
 unsafe impl windows_core::Interface for FullTrustProcessLaunchResult {
     type Vtable = IFullTrustProcessLaunchResult_Vtbl;
@@ -1322,7 +1487,7 @@ impl LeavingBackgroundEventArgs {
     }
 }
 impl windows_core::RuntimeType for LeavingBackgroundEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILeavingBackgroundEventArgs>();
 }
 unsafe impl windows_core::Interface for LeavingBackgroundEventArgs {
     type Vtable = ILeavingBackgroundEventArgs_Vtbl;
@@ -1361,7 +1526,7 @@ impl LimitedAccessFeatureRequestResult {
     }
 }
 impl windows_core::RuntimeType for LimitedAccessFeatureRequestResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILimitedAccessFeatureRequestResult>();
 }
 unsafe impl windows_core::Interface for LimitedAccessFeatureRequestResult {
     type Vtable = ILimitedAccessFeatureRequestResult_Vtbl;
@@ -1729,7 +1894,7 @@ impl Package {
     }
 }
 impl windows_core::RuntimeType for Package {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackage>();
 }
 unsafe impl windows_core::Interface for Package {
     type Vtable = IPackage_Vtbl;
@@ -1898,7 +2063,7 @@ impl PackageCatalog {
     }
 }
 impl windows_core::RuntimeType for PackageCatalog {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageCatalog>();
 }
 unsafe impl windows_core::Interface for PackageCatalog {
     type Vtable = IPackageCatalog_Vtbl;
@@ -1928,7 +2093,7 @@ impl PackageCatalogAddOptionalPackageResult {
     }
 }
 impl windows_core::RuntimeType for PackageCatalogAddOptionalPackageResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageCatalogAddOptionalPackageResult>();
 }
 unsafe impl windows_core::Interface for PackageCatalogAddOptionalPackageResult {
     type Vtable = IPackageCatalogAddOptionalPackageResult_Vtbl;
@@ -1965,7 +2130,7 @@ impl PackageCatalogAddResourcePackageResult {
     }
 }
 impl windows_core::RuntimeType for PackageCatalogAddResourcePackageResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageCatalogAddResourcePackageResult>();
 }
 unsafe impl windows_core::Interface for PackageCatalogAddResourcePackageResult {
     type Vtable = IPackageCatalogAddResourcePackageResult_Vtbl;
@@ -1998,7 +2163,7 @@ impl PackageCatalogRemoveOptionalPackagesResult {
     }
 }
 impl windows_core::RuntimeType for PackageCatalogRemoveOptionalPackagesResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageCatalogRemoveOptionalPackagesResult>();
 }
 unsafe impl windows_core::Interface for PackageCatalogRemoveOptionalPackagesResult {
     type Vtable = IPackageCatalogRemoveOptionalPackagesResult_Vtbl;
@@ -2029,7 +2194,7 @@ impl PackageCatalogRemoveResourcePackagesResult {
     }
 }
 impl windows_core::RuntimeType for PackageCatalogRemoveResourcePackagesResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageCatalogRemoveResourcePackagesResult>();
 }
 unsafe impl windows_core::Interface for PackageCatalogRemoveResourcePackagesResult {
     type Vtable = IPackageCatalogRemoveResourcePackagesResult_Vtbl;
@@ -2086,7 +2251,7 @@ impl PackageContentGroup {
     }
 }
 impl windows_core::RuntimeType for PackageContentGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageContentGroup>();
 }
 unsafe impl windows_core::Interface for PackageContentGroup {
     type Vtable = IPackageContentGroup_Vtbl;
@@ -2153,7 +2318,7 @@ impl PackageContentGroupStagingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PackageContentGroupStagingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageContentGroupStagingEventArgs>();
 }
 unsafe impl windows_core::Interface for PackageContentGroupStagingEventArgs {
     type Vtable = IPackageContentGroupStagingEventArgs_Vtbl;
@@ -2242,7 +2407,7 @@ impl PackageId {
     }
 }
 impl windows_core::RuntimeType for PackageId {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageId>();
 }
 unsafe impl windows_core::Interface for PackageId {
     type Vtable = IPackageId_Vtbl;
@@ -2295,7 +2460,7 @@ impl PackageInstallingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PackageInstallingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageInstallingEventArgs>();
 }
 unsafe impl windows_core::Interface for PackageInstallingEventArgs {
     type Vtable = IPackageInstallingEventArgs_Vtbl;
@@ -2348,7 +2513,7 @@ impl PackageStagingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PackageStagingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageStagingEventArgs>();
 }
 unsafe impl windows_core::Interface for PackageStagingEventArgs {
     type Vtable = IPackageStagingEventArgs_Vtbl;
@@ -2457,7 +2622,7 @@ impl PackageStatus {
     }
 }
 impl windows_core::RuntimeType for PackageStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageStatus>();
 }
 unsafe impl windows_core::Interface for PackageStatus {
     type Vtable = IPackageStatus_Vtbl;
@@ -2482,7 +2647,7 @@ impl PackageStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PackageStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PackageStatusChangedEventArgs {
     type Vtable = IPackageStatusChangedEventArgs_Vtbl;
@@ -2535,7 +2700,7 @@ impl PackageUninstallingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PackageUninstallingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageUninstallingEventArgs>();
 }
 unsafe impl windows_core::Interface for PackageUninstallingEventArgs {
     type Vtable = IPackageUninstallingEventArgs_Vtbl;
@@ -2567,7 +2732,7 @@ impl PackageUpdateAvailabilityResult {
     }
 }
 impl windows_core::RuntimeType for PackageUpdateAvailabilityResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageUpdateAvailabilityResult>();
 }
 unsafe impl windows_core::Interface for PackageUpdateAvailabilityResult {
     type Vtable = IPackageUpdateAvailabilityResult_Vtbl;
@@ -2627,7 +2792,7 @@ impl PackageUpdatingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PackageUpdatingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageUpdatingEventArgs>();
 }
 unsafe impl windows_core::Interface for PackageUpdatingEventArgs {
     type Vtable = IPackageUpdatingEventArgs_Vtbl;
@@ -2688,7 +2853,7 @@ impl StartupTask {
     }
 }
 impl windows_core::RuntimeType for StartupTask {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStartupTask>();
 }
 unsafe impl windows_core::Interface for StartupTask {
     type Vtable = IStartupTask_Vtbl;
@@ -2711,7 +2876,7 @@ impl SuspendingDeferral {
     }
 }
 impl windows_core::RuntimeType for SuspendingDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISuspendingDeferral>();
 }
 unsafe impl windows_core::Interface for SuspendingDeferral {
     type Vtable = ISuspendingDeferral_Vtbl;
@@ -2737,7 +2902,7 @@ impl SuspendingEventArgs {
     }
 }
 impl windows_core::RuntimeType for SuspendingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISuspendingEventArgs>();
 }
 unsafe impl windows_core::Interface for SuspendingEventArgs {
     type Vtable = ISuspendingEventArgs_Vtbl;
@@ -2770,7 +2935,7 @@ impl SuspendingOperation {
     }
 }
 impl windows_core::RuntimeType for SuspendingOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISuspendingOperation>();
 }
 unsafe impl windows_core::Interface for SuspendingOperation {
     type Vtable = ISuspendingOperation_Vtbl;

--- a/crates/libs/windows/src/Windows/Data/Html/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Html/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHtmlUtilities, IHtmlUtilities_Vtbl, 0xfec00add_2399_4fac_b5a7_05e9acd7181d);
+impl windows_core::RuntimeType for IHtmlUtilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHtmlUtilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Data/Json/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Json/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IJsonArray, IJsonArray_Vtbl, 0x08c1ddb6_0cbd_4a9a_b5d3_2f852dc37e81);
+impl windows_core::RuntimeType for IJsonArray {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonArray_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IJsonArray_Vtbl {
     pub GetBooleanAt: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJsonArrayStatics, IJsonArrayStatics_Vtbl, 0xdb1434a9_e164_499f_93e2_8a8f49bb90ba);
+impl windows_core::RuntimeType for IJsonArrayStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonArrayStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,12 +22,18 @@ pub struct IJsonArrayStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJsonErrorStatics2, IJsonErrorStatics2_Vtbl, 0x404030da_87d0_436c_83ab_fc7b12c0cc26);
+impl windows_core::RuntimeType for IJsonErrorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonErrorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetJsonStatus: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut JsonErrorStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJsonObject, IJsonObject_Vtbl, 0x064e24dd_29c2_4f83_9ac1_9ee11578beb3);
+impl windows_core::RuntimeType for IJsonObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +46,9 @@ pub struct IJsonObject_Vtbl {
     pub GetNamedBoolean: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJsonObjectStatics, IJsonObjectStatics_Vtbl, 0x2289f159_54de_45d8_abcc_22603fa066a0);
+impl windows_core::RuntimeType for IJsonObjectStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonObjectStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +56,9 @@ pub struct IJsonObjectStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJsonObjectWithDefaultValues, IJsonObjectWithDefaultValues_Vtbl, 0xd960d2a2_b7f0_4f00_8e44_d82cf415ea13);
+impl windows_core::RuntimeType for IJsonObjectWithDefaultValues {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonObjectWithDefaultValues_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -119,6 +137,9 @@ pub struct IJsonValue_Vtbl {
     pub GetObject: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJsonValueStatics, IJsonValueStatics_Vtbl, 0x5f6b544a_2f53_48e1_91a3_f78b50a6345c);
+impl windows_core::RuntimeType for IJsonValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,6 +150,9 @@ pub struct IJsonValueStatics_Vtbl {
     pub CreateStringValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJsonValueStatics2, IJsonValueStatics2_Vtbl, 0x1d9ecbe4_3fe8_4335_8392_93d8e36865f0);
+impl windows_core::RuntimeType for IJsonValueStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonValueStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -353,7 +377,7 @@ impl JsonArray {
     }
 }
 impl windows_core::RuntimeType for JsonArray {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IJsonArray>();
 }
 unsafe impl windows_core::Interface for JsonArray {
     type Vtable = IJsonArray_Vtbl;
@@ -647,7 +671,7 @@ impl JsonObject {
     }
 }
 impl windows_core::RuntimeType for JsonObject {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IJsonObject>();
 }
 unsafe impl windows_core::Interface for JsonObject {
     type Vtable = IJsonObject_Vtbl;
@@ -784,7 +808,7 @@ impl JsonValue {
     }
 }
 impl windows_core::RuntimeType for JsonValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IJsonValue>();
 }
 unsafe impl windows_core::Interface for JsonValue {
     type Vtable = IJsonValue_Vtbl;

--- a/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPdfDocument, IPdfDocument_Vtbl, 0xac7ebedd_80fa_4089_846e_81b77ff5a86c);
+impl windows_core::RuntimeType for IPdfDocument {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPdfDocument_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IPdfDocument_Vtbl {
     pub IsPasswordProtected: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPdfDocumentStatics, IPdfDocumentStatics_Vtbl, 0x433a0b5f_c007_4788_90f2_08143d922599);
+impl windows_core::RuntimeType for IPdfDocumentStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPdfDocumentStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +34,9 @@ pub struct IPdfDocumentStatics_Vtbl {
     LoadFromStreamWithPasswordAsync: usize,
 }
 windows_core::imp::define_interface!(IPdfPage, IPdfPage_Vtbl, 0x9db4b0c8_5320_4cfc_ad76_493fdad0e594);
+impl windows_core::RuntimeType for IPdfPage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPdfPage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +56,9 @@ pub struct IPdfPage_Vtbl {
     pub PreferredZoom: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPdfPageDimensions, IPdfPageDimensions_Vtbl, 0x22170471_313e_44e8_835d_63a3e7624a10);
+impl windows_core::RuntimeType for IPdfPageDimensions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPdfPageDimensions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +69,9 @@ pub struct IPdfPageDimensions_Vtbl {
     pub ArtBox: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPdfPageRenderOptions, IPdfPageRenderOptions_Vtbl, 0x3c98056f_b7cf_4c29_9a04_52d90267f425);
+impl windows_core::RuntimeType for IPdfPageRenderOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPdfPageRenderOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,7 +167,7 @@ impl PdfDocument {
     }
 }
 impl windows_core::RuntimeType for PdfDocument {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPdfDocument>();
 }
 unsafe impl windows_core::Interface for PdfDocument {
     type Vtable = IPdfDocument_Vtbl;
@@ -240,7 +255,7 @@ impl PdfPage {
     }
 }
 impl windows_core::RuntimeType for PdfPage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPdfPage>();
 }
 unsafe impl windows_core::Interface for PdfPage {
     type Vtable = IPdfPage_Vtbl;
@@ -293,7 +308,7 @@ impl PdfPageDimensions {
     }
 }
 impl windows_core::RuntimeType for PdfPageDimensions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPdfPageDimensions>();
 }
 unsafe impl windows_core::Interface for PdfPageDimensions {
     type Vtable = IPdfPageDimensions_Vtbl;
@@ -386,7 +401,7 @@ impl PdfPageRenderOptions {
     }
 }
 impl windows_core::RuntimeType for PdfPageRenderOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPdfPageRenderOptions>();
 }
 unsafe impl windows_core::Interface for PdfPageRenderOptions {
     type Vtable = IPdfPageRenderOptions_Vtbl;

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAlternateWordForm, IAlternateWordForm_Vtbl, 0x47396c1e_51b9_4207_9146_248e636a1d1d);
+impl windows_core::RuntimeType for IAlternateWordForm {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAlternateWordForm_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IAlternateWordForm_Vtbl {
     pub NormalizationFormat: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AlternateNormalizationFormat) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISelectableWordSegment, ISelectableWordSegment_Vtbl, 0x916a4cb7_8aa7_4c78_b374_5dedb752e60b);
+impl windows_core::RuntimeType for ISelectableWordSegment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISelectableWordSegment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +20,9 @@ pub struct ISelectableWordSegment_Vtbl {
     pub SourceTextSegment: unsafe extern "system" fn(*mut core::ffi::c_void, *mut TextSegment) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISelectableWordsSegmenter, ISelectableWordsSegmenter_Vtbl, 0xf6dc31e7_4b13_45c5_8897_7d71269e085d);
+impl windows_core::RuntimeType for ISelectableWordsSegmenter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISelectableWordsSegmenter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,12 +38,18 @@ pub struct ISelectableWordsSegmenter_Vtbl {
     Tokenize: usize,
 }
 windows_core::imp::define_interface!(ISelectableWordsSegmenterFactory, ISelectableWordsSegmenterFactory_Vtbl, 0x8c7a7648_6057_4339_bc70_f210010a4150);
+impl windows_core::RuntimeType for ISelectableWordsSegmenterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISelectableWordsSegmenterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISemanticTextQuery, ISemanticTextQuery_Vtbl, 0x6a1cab51_1fb2_4909_80b8_35731a2b3e7f);
+impl windows_core::RuntimeType for ISemanticTextQuery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISemanticTextQuery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +63,9 @@ pub struct ISemanticTextQuery_Vtbl {
     FindInProperty: usize,
 }
 windows_core::imp::define_interface!(ISemanticTextQueryFactory, ISemanticTextQueryFactory_Vtbl, 0x238c0503_f995_4587_8777_a2b7d80acfef);
+impl windows_core::RuntimeType for ISemanticTextQueryFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISemanticTextQueryFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,6 +73,9 @@ pub struct ISemanticTextQueryFactory_Vtbl {
     pub CreateWithLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextConversionGenerator, ITextConversionGenerator_Vtbl, 0x03606a5e_2aa9_4ab6_af8b_a562b63a8992);
+impl windows_core::RuntimeType for ITextConversionGenerator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextConversionGenerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -70,12 +91,18 @@ pub struct ITextConversionGenerator_Vtbl {
     GetCandidatesWithMaxCountAsync: usize,
 }
 windows_core::imp::define_interface!(ITextConversionGeneratorFactory, ITextConversionGeneratorFactory_Vtbl, 0xfcaa3781_3083_49ab_be15_56dfbbb74d6f);
+impl windows_core::RuntimeType for ITextConversionGeneratorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextConversionGeneratorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextPhoneme, ITextPhoneme_Vtbl, 0x9362a40a_9b7a_4569_94cf_d84f2f38cf9b);
+impl windows_core::RuntimeType for ITextPhoneme {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextPhoneme_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,6 +110,9 @@ pub struct ITextPhoneme_Vtbl {
     pub ReadingText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextPredictionGenerator, ITextPredictionGenerator_Vtbl, 0x5eacab07_abf1_4cb6_9d9e_326f2b468756);
+impl windows_core::RuntimeType for ITextPredictionGenerator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextPredictionGenerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,6 +128,9 @@ pub struct ITextPredictionGenerator_Vtbl {
     GetCandidatesWithMaxCountAsync: usize,
 }
 windows_core::imp::define_interface!(ITextPredictionGenerator2, ITextPredictionGenerator2_Vtbl, 0xb84723b8_2c77_486a_900a_a3453eedc15d);
+impl windows_core::RuntimeType for ITextPredictionGenerator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextPredictionGenerator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -119,12 +152,18 @@ pub struct ITextPredictionGenerator2_Vtbl {
     SetInputScope: usize,
 }
 windows_core::imp::define_interface!(ITextPredictionGeneratorFactory, ITextPredictionGeneratorFactory_Vtbl, 0x7257b416_8ba2_4751_9d30_9d85435653a2);
+impl windows_core::RuntimeType for ITextPredictionGeneratorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextPredictionGeneratorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextReverseConversionGenerator, ITextReverseConversionGenerator_Vtbl, 0x51e7f514_9c51_4d86_ae1b_b498fbad8313);
+impl windows_core::RuntimeType for ITextReverseConversionGenerator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextReverseConversionGenerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,6 +172,9 @@ pub struct ITextReverseConversionGenerator_Vtbl {
     pub ConvertBackAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextReverseConversionGenerator2, ITextReverseConversionGenerator2_Vtbl, 0x1aafd2ec_85d6_46fd_828a_3a4830fa6e18);
+impl windows_core::RuntimeType for ITextReverseConversionGenerator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextReverseConversionGenerator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -142,12 +184,18 @@ pub struct ITextReverseConversionGenerator2_Vtbl {
     GetPhonemesAsync: usize,
 }
 windows_core::imp::define_interface!(ITextReverseConversionGeneratorFactory, ITextReverseConversionGeneratorFactory_Vtbl, 0x63bed326_1fda_41f6_89d5_23ddea3c729a);
+impl windows_core::RuntimeType for ITextReverseConversionGeneratorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextReverseConversionGeneratorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUnicodeCharactersStatics, IUnicodeCharactersStatics_Vtbl, 0x97909e87_9291_4f91_b6c8_b6e359d7a7fb);
+impl windows_core::RuntimeType for IUnicodeCharactersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUnicodeCharactersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -170,6 +218,9 @@ pub struct IUnicodeCharactersStatics_Vtbl {
     pub GetGeneralCategory: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut UnicodeGeneralCategory) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWordSegment, IWordSegment_Vtbl, 0xd2d4ba6d_987c_4cc0_b6bd_d49a11b38f9a);
+impl windows_core::RuntimeType for IWordSegment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWordSegment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,6 +232,9 @@ pub struct IWordSegment_Vtbl {
     AlternateForms: usize,
 }
 windows_core::imp::define_interface!(IWordsSegmenter, IWordsSegmenter_Vtbl, 0x86b4d4d1_b2fe_4e34_a81d_66640300454f);
+impl windows_core::RuntimeType for IWordsSegmenter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWordsSegmenter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -196,6 +250,9 @@ pub struct IWordsSegmenter_Vtbl {
     Tokenize: usize,
 }
 windows_core::imp::define_interface!(IWordsSegmenterFactory, IWordsSegmenterFactory_Vtbl, 0xe6977274_fc35_455c_8bfb_6d7f4653ca97);
+impl windows_core::RuntimeType for IWordsSegmenterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWordsSegmenterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -229,7 +286,7 @@ impl AlternateWordForm {
     }
 }
 impl windows_core::RuntimeType for AlternateWordForm {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAlternateWordForm>();
 }
 unsafe impl windows_core::Interface for AlternateWordForm {
     type Vtable = IAlternateWordForm_Vtbl;
@@ -261,7 +318,7 @@ impl SelectableWordSegment {
     }
 }
 impl windows_core::RuntimeType for SelectableWordSegment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISelectableWordSegment>();
 }
 unsafe impl windows_core::Interface for SelectableWordSegment {
     type Vtable = ISelectableWordSegment_Vtbl;
@@ -320,7 +377,7 @@ impl SelectableWordsSegmenter {
     }
 }
 impl windows_core::RuntimeType for SelectableWordsSegmenter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISelectableWordsSegmenter>();
 }
 unsafe impl windows_core::Interface for SelectableWordsSegmenter {
     type Vtable = ISelectableWordsSegmenter_Vtbl;
@@ -371,7 +428,7 @@ impl SemanticTextQuery {
     }
 }
 impl windows_core::RuntimeType for SemanticTextQuery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISemanticTextQuery>();
 }
 unsafe impl windows_core::Interface for SemanticTextQuery {
     type Vtable = ISemanticTextQuery_Vtbl;
@@ -430,7 +487,7 @@ impl TextConversionGenerator {
     }
 }
 impl windows_core::RuntimeType for TextConversionGenerator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITextConversionGenerator>();
 }
 unsafe impl windows_core::Interface for TextConversionGenerator {
     type Vtable = ITextConversionGenerator_Vtbl;
@@ -462,7 +519,7 @@ impl TextPhoneme {
     }
 }
 impl windows_core::RuntimeType for TextPhoneme {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITextPhoneme>();
 }
 unsafe impl windows_core::Interface for TextPhoneme {
     type Vtable = ITextPhoneme_Vtbl;
@@ -556,7 +613,7 @@ impl TextPredictionGenerator {
     }
 }
 impl windows_core::RuntimeType for TextPredictionGenerator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITextPredictionGenerator>();
 }
 unsafe impl windows_core::Interface for TextPredictionGenerator {
     type Vtable = ITextPredictionGenerator_Vtbl;
@@ -614,7 +671,7 @@ impl TextReverseConversionGenerator {
     }
 }
 impl windows_core::RuntimeType for TextReverseConversionGenerator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITextReverseConversionGenerator>();
 }
 unsafe impl windows_core::Interface for TextReverseConversionGenerator {
     type Vtable = ITextReverseConversionGenerator_Vtbl;
@@ -764,7 +821,7 @@ impl WordSegment {
     }
 }
 impl windows_core::RuntimeType for WordSegment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWordSegment>();
 }
 unsafe impl windows_core::Interface for WordSegment {
     type Vtable = IWordSegment_Vtbl;
@@ -823,7 +880,7 @@ impl WordsSegmenter {
     }
 }
 impl windows_core::RuntimeType for WordsSegmenter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWordsSegmenter>();
 }
 unsafe impl windows_core::Interface for WordsSegmenter {
     type Vtable = IWordsSegmenter_Vtbl;

--- a/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDtdEntity, IDtdEntity_Vtbl, 0x6a0b5ffc_63b4_480f_9e6a_8a92816aade4);
+impl windows_core::RuntimeType for IDtdEntity {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDtdEntity_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IDtdEntity_Vtbl {
     pub NotationName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDtdNotation, IDtdNotation_Vtbl, 0x8cb4e04d_6d46_4edb_ab73_df83c51ad397);
+impl windows_core::RuntimeType for IDtdNotation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDtdNotation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +20,9 @@ pub struct IDtdNotation_Vtbl {
     pub SystemId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlAttribute, IXmlAttribute_Vtbl, 0xac144aa4_b4f1_4db6_b206_8a22c308db0a);
+impl windows_core::RuntimeType for IXmlAttribute {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlAttribute_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +32,9 @@ pub struct IXmlAttribute_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlCDataSection, IXmlCDataSection_Vtbl, 0x4d04b46f_c8bd_45b4_8899_0400d7c2c60f);
+impl windows_core::RuntimeType for IXmlCDataSection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlCDataSection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -313,11 +325,17 @@ pub struct IXmlCharacterData_Vtbl {
     pub ReplaceData: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlComment, IXmlComment_Vtbl, 0xbca474d5_b61f_4611_9cac_2e92e3476d47);
+impl windows_core::RuntimeType for IXmlComment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlComment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IXmlDocument, IXmlDocument_Vtbl, 0xf7f3a506_1e87_42d6_bcfb_b8c809fa5494);
+impl windows_core::RuntimeType for IXmlDocument {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlDocument_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -340,11 +358,17 @@ pub struct IXmlDocument_Vtbl {
     pub ImportNode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlDocumentFragment, IXmlDocumentFragment_Vtbl, 0xe2ea6a96_0c21_44a5_8bc9_9e4a262708ec);
+impl windows_core::RuntimeType for IXmlDocumentFragment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlDocumentFragment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IXmlDocumentIO, IXmlDocumentIO_Vtbl, 0x6cd0e74e_ee65_4489_9ebf_ca43e87ba637);
+impl windows_core::RuntimeType for IXmlDocumentIO {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlDocumentIO_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -356,6 +380,9 @@ pub struct IXmlDocumentIO_Vtbl {
     SaveToFileAsync: usize,
 }
 windows_core::imp::define_interface!(IXmlDocumentIO2, IXmlDocumentIO2_Vtbl, 0x5d034661_7bd8_4ad5_9ebf_81e6347263b1);
+impl windows_core::RuntimeType for IXmlDocumentIO2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlDocumentIO2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -369,6 +396,9 @@ pub struct IXmlDocumentIO2_Vtbl {
     LoadXmlFromBufferWithSettings: usize,
 }
 windows_core::imp::define_interface!(IXmlDocumentStatics, IXmlDocumentStatics_Vtbl, 0x5543d254_d757_4b79_9539_232b18f50bf1);
+impl windows_core::RuntimeType for IXmlDocumentStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlDocumentStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -384,6 +414,9 @@ pub struct IXmlDocumentStatics_Vtbl {
     LoadFromFileWithSettingsAsync: usize,
 }
 windows_core::imp::define_interface!(IXmlDocumentType, IXmlDocumentType_Vtbl, 0xf7342425_9781_4964_8e94_9b1c6dfc9bc7);
+impl windows_core::RuntimeType for IXmlDocumentType {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlDocumentType_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -392,12 +425,18 @@ pub struct IXmlDocumentType_Vtbl {
     pub Notations: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlDomImplementation, IXmlDomImplementation_Vtbl, 0x6de58132_f11d_4fbb_8cc6_583cba93112f);
+impl windows_core::RuntimeType for IXmlDomImplementation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlDomImplementation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub HasFeature: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlElement, IXmlElement_Vtbl, 0x2dfb8a1f_6b10_4ef8_9f83_efcce8faec37);
+impl windows_core::RuntimeType for IXmlElement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -416,11 +455,17 @@ pub struct IXmlElement_Vtbl {
     pub GetAttributeNodeNS: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlEntityReference, IXmlEntityReference_Vtbl, 0x2e2f47bc_c3d0_4ccf_bb86_0ab8c36a61cf);
+impl windows_core::RuntimeType for IXmlEntityReference {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlEntityReference_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IXmlLoadSettings, IXmlLoadSettings_Vtbl, 0x58aa07a8_fed6_46f7_b4c5_fb1ba72108d6);
+impl windows_core::RuntimeType for IXmlLoadSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlLoadSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -436,6 +481,9 @@ pub struct IXmlLoadSettings_Vtbl {
     pub SetElementContentWhiteSpace: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlNamedNodeMap, IXmlNamedNodeMap_Vtbl, 0xb3a69eb0_aab0_4b82_a6fa_b1453f7c021b);
+impl windows_core::RuntimeType for IXmlNamedNodeMap {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlNamedNodeMap_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -708,6 +756,9 @@ pub struct IXmlNode_Vtbl {
     pub SetPrefix: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlNodeList, IXmlNodeList_Vtbl, 0x8c60ad77_83a4_4ec1_9c54_7ba429e13da6);
+impl windows_core::RuntimeType for IXmlNodeList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlNodeList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -796,6 +847,9 @@ pub struct IXmlNodeSerializer_Vtbl {
     pub SetInnerText: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXmlProcessingInstruction, IXmlProcessingInstruction_Vtbl, 0x2707fd1e_1e92_4ece_b6f4_26f069078ddc);
+impl windows_core::RuntimeType for IXmlProcessingInstruction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXmlProcessingInstruction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1341,7 +1395,7 @@ impl DtdEntity {
     }
 }
 impl windows_core::RuntimeType for DtdEntity {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDtdEntity>();
 }
 unsafe impl windows_core::Interface for DtdEntity {
     type Vtable = IDtdEntity_Vtbl;
@@ -1598,7 +1652,7 @@ impl DtdNotation {
     }
 }
 impl windows_core::RuntimeType for DtdNotation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDtdNotation>();
 }
 unsafe impl windows_core::Interface for DtdNotation {
     type Vtable = IDtdNotation_Vtbl;
@@ -1866,7 +1920,7 @@ impl XmlAttribute {
     }
 }
 impl windows_core::RuntimeType for XmlAttribute {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlAttribute>();
 }
 unsafe impl windows_core::Interface for XmlAttribute {
     type Vtable = IXmlAttribute_Vtbl;
@@ -2157,7 +2211,7 @@ impl XmlCDataSection {
     }
 }
 impl windows_core::RuntimeType for XmlCDataSection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlCDataSection>();
 }
 unsafe impl windows_core::Interface for XmlCDataSection {
     type Vtable = IXmlCDataSection_Vtbl;
@@ -2441,7 +2495,7 @@ impl XmlComment {
     }
 }
 impl windows_core::RuntimeType for XmlComment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlComment>();
 }
 unsafe impl windows_core::Interface for XmlComment {
     type Vtable = IXmlComment_Vtbl;
@@ -2903,7 +2957,7 @@ impl XmlDocument {
     }
 }
 impl windows_core::RuntimeType for XmlDocument {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlDocument>();
 }
 unsafe impl windows_core::Interface for XmlDocument {
     type Vtable = IXmlDocument_Vtbl;
@@ -3146,7 +3200,7 @@ impl XmlDocumentFragment {
     }
 }
 impl windows_core::RuntimeType for XmlDocumentFragment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlDocumentFragment>();
 }
 unsafe impl windows_core::Interface for XmlDocumentFragment {
     type Vtable = IXmlDocumentFragment_Vtbl;
@@ -3410,7 +3464,7 @@ impl XmlDocumentType {
     }
 }
 impl windows_core::RuntimeType for XmlDocumentType {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlDocumentType>();
 }
 unsafe impl windows_core::Interface for XmlDocumentType {
     type Vtable = IXmlDocumentType_Vtbl;
@@ -3438,7 +3492,7 @@ impl XmlDomImplementation {
     }
 }
 impl windows_core::RuntimeType for XmlDomImplementation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlDomImplementation>();
 }
 unsafe impl windows_core::Interface for XmlDomImplementation {
     type Vtable = IXmlDomImplementation_Vtbl;
@@ -3781,7 +3835,7 @@ impl XmlElement {
     }
 }
 impl windows_core::RuntimeType for XmlElement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlElement>();
 }
 unsafe impl windows_core::Interface for XmlElement {
     type Vtable = IXmlElement_Vtbl;
@@ -4024,7 +4078,7 @@ impl XmlEntityReference {
     }
 }
 impl windows_core::RuntimeType for XmlEntityReference {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlEntityReference>();
 }
 unsafe impl windows_core::Interface for XmlEntityReference {
     type Vtable = IXmlEntityReference_Vtbl;
@@ -4104,7 +4158,7 @@ impl XmlLoadSettings {
     }
 }
 impl windows_core::RuntimeType for XmlLoadSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlLoadSettings>();
 }
 unsafe impl windows_core::Interface for XmlLoadSettings {
     type Vtable = IXmlLoadSettings_Vtbl;
@@ -4235,7 +4289,7 @@ impl XmlNamedNodeMap {
     }
 }
 impl windows_core::RuntimeType for XmlNamedNodeMap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlNamedNodeMap>();
 }
 unsafe impl windows_core::Interface for XmlNamedNodeMap {
     type Vtable = IXmlNamedNodeMap_Vtbl;
@@ -4328,7 +4382,7 @@ impl XmlNodeList {
     }
 }
 impl windows_core::RuntimeType for XmlNodeList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlNodeList>();
 }
 unsafe impl windows_core::Interface for XmlNodeList {
     type Vtable = IXmlNodeList_Vtbl;
@@ -4605,7 +4659,7 @@ impl XmlProcessingInstruction {
     }
 }
 impl windows_core::RuntimeType for XmlProcessingInstruction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlProcessingInstruction>();
 }
 unsafe impl windows_core::Interface for XmlProcessingInstruction {
     type Vtable = IXmlProcessingInstruction_Vtbl;
@@ -4896,7 +4950,7 @@ impl XmlText {
     }
 }
 impl windows_core::RuntimeType for XmlText {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXmlText>();
 }
 unsafe impl windows_core::Interface for XmlText {
     type Vtable = IXmlText_Vtbl;

--- a/crates/libs/windows/src/Windows/Data/Xml/Xsl/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Xsl/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IXsltProcessor, IXsltProcessor_Vtbl, 0x7b64703f_550c_48c6_a90f_93a5b964518f);
+impl windows_core::RuntimeType for IXsltProcessor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXsltProcessor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IXsltProcessor_Vtbl {
     TransformToString: usize,
 }
 windows_core::imp::define_interface!(IXsltProcessor2, IXsltProcessor2_Vtbl, 0x8da45c56_97a5_44cb_a8be_27d86280c70a);
+impl windows_core::RuntimeType for IXsltProcessor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXsltProcessor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IXsltProcessor2_Vtbl {
     TransformToDocument: usize,
 }
 windows_core::imp::define_interface!(IXsltProcessorFactory, IXsltProcessorFactory_Vtbl, 0x274146c0_9a51_4663_bf30_0ef742146f20);
+impl windows_core::RuntimeType for IXsltProcessorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXsltProcessorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,7 +78,7 @@ impl XsltProcessor {
     }
 }
 impl windows_core::RuntimeType for XsltProcessor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXsltProcessor>();
 }
 unsafe impl windows_core::Interface for XsltProcessor {
     type Vtable = IXsltProcessor_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Adc_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IAdcChannel, IAdcChannel_Vtbl, 0x040bf414_2588_4a56_abef_73a260acc60a);
+impl windows_core::RuntimeType for IAdcChannel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdcChannel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IAdcChannel_Vtbl {
     pub ReadRatio: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdcController, IAdcController_Vtbl, 0x2a76e4b0_a896_4219_86b6_ea8cdce98f56);
+impl windows_core::RuntimeType for IAdcController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdcController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +28,9 @@ pub struct IAdcController_Vtbl {
     pub OpenChannel: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdcControllerStatics, IAdcControllerStatics_Vtbl, 0xcce98e0c_01f8_4891_bc3b_be53ef279ca4);
+impl windows_core::RuntimeType for IAdcControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdcControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +40,9 @@ pub struct IAdcControllerStatics_Vtbl {
     GetControllersAsync: usize,
 }
 windows_core::imp::define_interface!(IAdcControllerStatics2, IAdcControllerStatics2_Vtbl, 0xa2b93b1d_977b_4f5a_a5fe_a6abaffe6484);
+impl windows_core::RuntimeType for IAdcControllerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdcControllerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,7 +81,7 @@ impl AdcChannel {
     }
 }
 impl windows_core::RuntimeType for AdcChannel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdcChannel>();
 }
 unsafe impl windows_core::Interface for AdcChannel {
     type Vtable = IAdcChannel_Vtbl;
@@ -166,7 +178,7 @@ impl AdcController {
     }
 }
 impl windows_core::RuntimeType for AdcController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdcController>();
 }
 unsafe impl windows_core::Interface for AdcController {
     type Vtable = IAdcController_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Background/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDeviceServicingDetails, IDeviceServicingDetails_Vtbl, 0x4aabee29_2344_4ac4_8527_4a8ef6905645);
+impl windows_core::RuntimeType for IDeviceServicingDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceServicingDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IDeviceServicingDetails_Vtbl {
     pub ExpectedDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceUseDetails, IDeviceUseDetails_Vtbl, 0x7d565141_557e_4154_b994_e4f7a11fb323);
+impl windows_core::RuntimeType for IDeviceUseDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceUseDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,7 +47,7 @@ impl DeviceServicingDetails {
     }
 }
 impl windows_core::RuntimeType for DeviceServicingDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceServicingDetails>();
 }
 unsafe impl windows_core::Interface for DeviceServicingDetails {
     type Vtable = IDeviceServicingDetails_Vtbl;
@@ -73,7 +79,7 @@ impl DeviceUseDetails {
     }
 }
 impl windows_core::RuntimeType for DeviceUseDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceUseDetails>();
 }
 unsafe impl windows_core::Interface for DeviceUseDetails {
     type Vtable = IDeviceUseDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBluetoothLEAdvertisement, IBluetoothLEAdvertisement_Vtbl, 0x066fb2b7_33d1_4e7d_8367_cf81d0f79653);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +31,9 @@ pub struct IBluetoothLEAdvertisement_Vtbl {
     GetSectionsByType: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementBytePattern, IBluetoothLEAdvertisementBytePattern_Vtbl, 0xfbfad7f2_b9c5_4a08_bc51_502f8ef68a79);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementBytePattern {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementBytePattern_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +51,9 @@ pub struct IBluetoothLEAdvertisementBytePattern_Vtbl {
     SetData: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementBytePatternFactory, IBluetoothLEAdvertisementBytePatternFactory_Vtbl, 0xc2e24d73_fd5c_4ec3_be2a_9ca6fa11b7bd);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementBytePatternFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementBytePatternFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +63,9 @@ pub struct IBluetoothLEAdvertisementBytePatternFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementDataSection, IBluetoothLEAdvertisementDataSection_Vtbl, 0xd7213314_3a43_40f9_b6f0_92bfefc34ae3);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementDataSection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementDataSection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +81,9 @@ pub struct IBluetoothLEAdvertisementDataSection_Vtbl {
     SetData: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementDataSectionFactory, IBluetoothLEAdvertisementDataSectionFactory_Vtbl, 0xe7a40942_a845_4045_bf7e_3e9971db8a6b);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementDataSectionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementDataSectionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +93,9 @@ pub struct IBluetoothLEAdvertisementDataSectionFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementDataTypesStatics, IBluetoothLEAdvertisementDataTypesStatics_Vtbl, 0x3bb6472f_0606_434b_a76e_74159f0684d3);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementDataTypesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementDataTypesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,6 +123,9 @@ pub struct IBluetoothLEAdvertisementDataTypesStatics_Vtbl {
     pub ManufacturerSpecificData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementFilter, IBluetoothLEAdvertisementFilter_Vtbl, 0x131eb0d3_d04e_47b1_837e_49405bf6f80f);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +137,9 @@ pub struct IBluetoothLEAdvertisementFilter_Vtbl {
     BytePatterns: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisher, IBluetoothLEAdvertisementPublisher_Vtbl, 0xcde820f9_d9fa_43d6_a264_ddd8b7da8b78);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,6 +151,9 @@ pub struct IBluetoothLEAdvertisementPublisher_Vtbl {
     pub RemoveStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisher2, IBluetoothLEAdvertisementPublisher2_Vtbl, 0xfbdb545e_56f1_510f_a434_217fbd9e7bd2);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisher2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisher2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,12 +167,18 @@ pub struct IBluetoothLEAdvertisementPublisher2_Vtbl {
     pub SetIncludeTransmitPowerLevel: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisherFactory, IBluetoothLEAdvertisementPublisherFactory_Vtbl, 0x5c5f065e_b863_4981_a1af_1c544d8b0c0d);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisherFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisherFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisherStatusChangedEventArgs, IBluetoothLEAdvertisementPublisherStatusChangedEventArgs_Vtbl, 0x09c2bd9f_2dff_4b23_86ee_0d14fb94aeae);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisherStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisherStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -153,12 +186,18 @@ pub struct IBluetoothLEAdvertisementPublisherStatusChangedEventArgs_Vtbl {
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::BluetoothError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisherStatusChangedEventArgs2, IBluetoothLEAdvertisementPublisherStatusChangedEventArgs2_Vtbl, 0x8f62790e_dc88_5c8b_b34e_10b321850f88);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisherStatusChangedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisherStatusChangedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SelectedTransmitPowerLevelInDBm: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementReceivedEventArgs, IBluetoothLEAdvertisementReceivedEventArgs_Vtbl, 0x27987ddf_e596_41be_8d43_9e6731d4a913);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +208,9 @@ pub struct IBluetoothLEAdvertisementReceivedEventArgs_Vtbl {
     pub Advertisement: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementReceivedEventArgs2, IBluetoothLEAdvertisementReceivedEventArgs2_Vtbl, 0x12d9c87b_0399_5f0e_a348_53b02b6b162e);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementReceivedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementReceivedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,6 +223,9 @@ pub struct IBluetoothLEAdvertisementReceivedEventArgs2_Vtbl {
     pub IsScanResponse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementWatcher, IBluetoothLEAdvertisementWatcher_Vtbl, 0xa6ac336f_f3d3_4297_8d6c_c81ea6623f40);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,6 +248,9 @@ pub struct IBluetoothLEAdvertisementWatcher_Vtbl {
     pub RemoveStopped: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementWatcher2, IBluetoothLEAdvertisementWatcher2_Vtbl, 0x01bf26bc_b164_5805_90a3_e8a7997ff225);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementWatcher2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementWatcher2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -210,18 +258,27 @@ pub struct IBluetoothLEAdvertisementWatcher2_Vtbl {
     pub SetAllowExtendedAdvertisements: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementWatcherFactory, IBluetoothLEAdvertisementWatcherFactory_Vtbl, 0x9aaf2d56_39ac_453e_b32a_85c657e017f1);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementWatcherFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementWatcherFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementWatcherStoppedEventArgs, IBluetoothLEAdvertisementWatcherStoppedEventArgs_Vtbl, 0xdd40f84d_e7b9_43e3_9c04_0685d085fd8c);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementWatcherStoppedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementWatcherStoppedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::BluetoothError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEManufacturerData, IBluetoothLEManufacturerData_Vtbl, 0x912dba18_6963_4533_b061_4694dafb34e5);
+impl windows_core::RuntimeType for IBluetoothLEManufacturerData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEManufacturerData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -237,6 +294,9 @@ pub struct IBluetoothLEManufacturerData_Vtbl {
     SetData: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEManufacturerDataFactory, IBluetoothLEManufacturerDataFactory_Vtbl, 0xc09b39f8_319a_441e_8de5_66a81e877a6c);
+impl windows_core::RuntimeType for IBluetoothLEManufacturerDataFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEManufacturerDataFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -324,7 +384,7 @@ impl BluetoothLEAdvertisement {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisement>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisement {
     type Vtable = IBluetoothLEAdvertisement_Vtbl;
@@ -402,7 +462,7 @@ impl BluetoothLEAdvertisementBytePattern {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementBytePattern {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementBytePattern>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementBytePattern {
     type Vtable = IBluetoothLEAdvertisementBytePattern_Vtbl;
@@ -469,7 +529,7 @@ impl BluetoothLEAdvertisementDataSection {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementDataSection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementDataSection>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementDataSection {
     type Vtable = IBluetoothLEAdvertisementDataSection_Vtbl;
@@ -659,7 +719,7 @@ impl BluetoothLEAdvertisementFilter {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementFilter>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementFilter {
     type Vtable = IBluetoothLEAdvertisementFilter_Vtbl;
@@ -781,7 +841,7 @@ impl BluetoothLEAdvertisementPublisher {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementPublisher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementPublisher>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementPublisher {
     type Vtable = IBluetoothLEAdvertisementPublisher_Vtbl;
@@ -820,7 +880,7 @@ impl BluetoothLEAdvertisementPublisherStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementPublisherStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementPublisherStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementPublisherStatusChangedEventArgs {
     type Vtable = IBluetoothLEAdvertisementPublisherStatusChangedEventArgs_Vtbl;
@@ -922,7 +982,7 @@ impl BluetoothLEAdvertisementReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementReceivedEventArgs {
     type Vtable = IBluetoothLEAdvertisementReceivedEventArgs_Vtbl;
@@ -1082,7 +1142,7 @@ impl BluetoothLEAdvertisementWatcher {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementWatcher>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementWatcher {
     type Vtable = IBluetoothLEAdvertisementWatcher_Vtbl;
@@ -1107,7 +1167,7 @@ impl BluetoothLEAdvertisementWatcherStoppedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementWatcherStoppedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementWatcherStoppedEventArgs>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementWatcherStoppedEventArgs {
     type Vtable = IBluetoothLEAdvertisementWatcherStoppedEventArgs_Vtbl;
@@ -1174,7 +1234,7 @@ impl BluetoothLEManufacturerData {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEManufacturerData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEManufacturerData>();
 }
 unsafe impl windows_core::Interface for BluetoothLEManufacturerData {
     type Vtable = IBluetoothLEManufacturerData_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisherTriggerDetails, IBluetoothLEAdvertisementPublisherTriggerDetails_Vtbl, 0x610eca86_3480_41c9_a918_7ddadf207e00);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisherTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisherTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,12 +12,18 @@ pub struct IBluetoothLEAdvertisementPublisherTriggerDetails_Vtbl {
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::BluetoothError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementPublisherTriggerDetails2, IBluetoothLEAdvertisementPublisherTriggerDetails2_Vtbl, 0xd4a3d025_c601_42d6_9829_4ccb3f5cd77f);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementPublisherTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementPublisherTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SelectedTransmitPowerLevelInDBm: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAdvertisementWatcherTriggerDetails, IBluetoothLEAdvertisementWatcherTriggerDetails_Vtbl, 0xa7db5ad7_2257_4e69_9784_fee645c1dce0);
+impl windows_core::RuntimeType for IBluetoothLEAdvertisementWatcherTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAdvertisementWatcherTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +35,9 @@ pub struct IBluetoothLEAdvertisementWatcherTriggerDetails_Vtbl {
     pub SignalStrengthFilter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattCharacteristicNotificationTriggerDetails, IGattCharacteristicNotificationTriggerDetails_Vtbl, 0x9ba03b18_0fec_436a_93b1_f46c697532a2);
+impl windows_core::RuntimeType for IGattCharacteristicNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +51,9 @@ pub struct IGattCharacteristicNotificationTriggerDetails_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(IGattCharacteristicNotificationTriggerDetails2, IGattCharacteristicNotificationTriggerDetails2_Vtbl, 0x727a50dc_949d_454a_b192_983467e3d50f);
+impl windows_core::RuntimeType for IGattCharacteristicNotificationTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicNotificationTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +65,9 @@ pub struct IGattCharacteristicNotificationTriggerDetails2_Vtbl {
     ValueChangedEvents: usize,
 }
 windows_core::imp::define_interface!(IGattServiceProviderConnection, IGattServiceProviderConnection_Vtbl, 0x7fa1b9b9_2f13_40b5_9582_8eb78e98ef13);
+impl windows_core::RuntimeType for IGattServiceProviderConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +79,9 @@ pub struct IGattServiceProviderConnection_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceProviderConnectionStatics, IGattServiceProviderConnectionStatics_Vtbl, 0x3d509f4b_0b0e_4466_b8cd_6ebdda1fa17d);
+impl windows_core::RuntimeType for IGattServiceProviderConnectionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderConnectionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -70,12 +91,18 @@ pub struct IGattServiceProviderConnectionStatics_Vtbl {
     AllServices: usize,
 }
 windows_core::imp::define_interface!(IGattServiceProviderTriggerDetails, IGattServiceProviderTriggerDetails_Vtbl, 0xae8c0625_05ff_4afb_b16a_de95f3cf0158);
+impl windows_core::RuntimeType for IGattServiceProviderTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommConnectionTriggerDetails, IRfcommConnectionTriggerDetails_Vtbl, 0xf922734d_2e3c_4efc_ab59_fc5cf96f97e3);
+impl windows_core::RuntimeType for IRfcommConnectionTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommConnectionTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -87,6 +114,9 @@ pub struct IRfcommConnectionTriggerDetails_Vtbl {
     pub RemoteDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommInboundConnectionInformation, IRfcommInboundConnectionInformation_Vtbl, 0x6d3e75a8_5429_4059_92e3_1e8b65528707);
+impl windows_core::RuntimeType for IRfcommInboundConnectionInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommInboundConnectionInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -110,6 +140,9 @@ pub struct IRfcommInboundConnectionInformation_Vtbl {
     pub SetServiceCapabilities: unsafe extern "system" fn(*mut core::ffi::c_void, super::BluetoothServiceCapabilities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommOutboundConnectionInformation, IRfcommOutboundConnectionInformation_Vtbl, 0xb091227b_f434_4cb0_99b1_4ab8cedaedd7);
+impl windows_core::RuntimeType for IRfcommOutboundConnectionInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommOutboundConnectionInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,7 +184,7 @@ impl BluetoothLEAdvertisementPublisherTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementPublisherTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementPublisherTriggerDetails>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementPublisherTriggerDetails {
     type Vtable = IBluetoothLEAdvertisementPublisherTriggerDetails_Vtbl;
@@ -191,7 +224,7 @@ impl BluetoothLEAdvertisementWatcherTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAdvertisementWatcherTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAdvertisementWatcherTriggerDetails>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAdvertisementWatcherTriggerDetails {
     type Vtable = IBluetoothLEAdvertisementWatcherTriggerDetails_Vtbl;
@@ -247,7 +280,7 @@ impl GattCharacteristicNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for GattCharacteristicNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattCharacteristicNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for GattCharacteristicNotificationTriggerDetails {
     type Vtable = IGattCharacteristicNotificationTriggerDetails_Vtbl;
@@ -296,7 +329,7 @@ impl GattServiceProviderConnection {
     }
 }
 impl windows_core::RuntimeType for GattServiceProviderConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProviderConnection>();
 }
 unsafe impl windows_core::Interface for GattServiceProviderConnection {
     type Vtable = IGattServiceProviderConnection_Vtbl;
@@ -321,7 +354,7 @@ impl GattServiceProviderTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for GattServiceProviderTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProviderTriggerDetails>();
 }
 unsafe impl windows_core::Interface for GattServiceProviderTriggerDetails {
     type Vtable = IGattServiceProviderTriggerDetails_Vtbl;
@@ -361,7 +394,7 @@ impl RfcommConnectionTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for RfcommConnectionTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommConnectionTriggerDetails>();
 }
 unsafe impl windows_core::Interface for RfcommConnectionTriggerDetails {
     type Vtable = IRfcommConnectionTriggerDetails_Vtbl;
@@ -422,7 +455,7 @@ impl RfcommInboundConnectionInformation {
     }
 }
 impl windows_core::RuntimeType for RfcommInboundConnectionInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommInboundConnectionInformation>();
 }
 unsafe impl windows_core::Interface for RfcommInboundConnectionInformation {
     type Vtable = IRfcommInboundConnectionInformation_Vtbl;
@@ -456,7 +489,7 @@ impl RfcommOutboundConnectionInformation {
     }
 }
 impl windows_core::RuntimeType for RfcommOutboundConnectionInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommOutboundConnectionInformation>();
 }
 unsafe impl windows_core::Interface for RfcommOutboundConnectionInformation {
     type Vtable = IRfcommOutboundConnectionInformation_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGattCharacteristic, IGattCharacteristic_Vtbl, 0x59cb50c1_5934_4f68_a198_eb864fa44e6b);
+impl windows_core::RuntimeType for IGattCharacteristic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +35,9 @@ pub struct IGattCharacteristic_Vtbl {
     pub RemoveValueChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattCharacteristic2, IGattCharacteristic2_Vtbl, 0xae1ab578_ec06_4764_b780_9835a1d35d6e);
+impl windows_core::RuntimeType for IGattCharacteristic2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristic2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +48,9 @@ pub struct IGattCharacteristic2_Vtbl {
     GetAllDescriptors: usize,
 }
 windows_core::imp::define_interface!(IGattCharacteristic3, IGattCharacteristic3_Vtbl, 0x3f3c663e_93d4_406b_b817_db81f8ed53b3);
+impl windows_core::RuntimeType for IGattCharacteristic3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristic3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +69,9 @@ pub struct IGattCharacteristic3_Vtbl {
     pub WriteClientCharacteristicConfigurationDescriptorWithResultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, GattClientCharacteristicConfigurationDescriptorValue, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattCharacteristicStatics, IGattCharacteristicStatics_Vtbl, 0x59cb50c3_5934_4f68_a198_eb864fa44e6b);
+impl windows_core::RuntimeType for IGattCharacteristicStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +81,9 @@ pub struct IGattCharacteristicStatics_Vtbl {
     ConvertShortIdToUuid: usize,
 }
 windows_core::imp::define_interface!(IGattCharacteristicUuidsStatics, IGattCharacteristicUuidsStatics_Vtbl, 0x58fa4586_b1de_470c_b7de_0d11ff44f4b7);
+impl windows_core::RuntimeType for IGattCharacteristicUuidsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicUuidsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,6 +110,9 @@ pub struct IGattCharacteristicUuidsStatics_Vtbl {
     pub TemperatureType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattCharacteristicUuidsStatics2, IGattCharacteristicUuidsStatics2_Vtbl, 0x1855b425_d46e_4a2c_9c3f_ed6dea29e7be);
+impl windows_core::RuntimeType for IGattCharacteristicUuidsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicUuidsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -160,6 +178,9 @@ pub struct IGattCharacteristicUuidsStatics2_Vtbl {
     pub UnreadAlertStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattCharacteristicsResult, IGattCharacteristicsResult_Vtbl, 0x1194945c_b257_4f3e_9db7_f68bc9a9aef2);
+impl windows_core::RuntimeType for IGattCharacteristicsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattCharacteristicsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -171,6 +192,9 @@ pub struct IGattCharacteristicsResult_Vtbl {
     Characteristics: usize,
 }
 windows_core::imp::define_interface!(IGattClientNotificationResult, IGattClientNotificationResult_Vtbl, 0x506d5599_0112_419a_8e3b_ae21afabd2c2);
+impl windows_core::RuntimeType for IGattClientNotificationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattClientNotificationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,12 +203,18 @@ pub struct IGattClientNotificationResult_Vtbl {
     pub ProtocolError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattClientNotificationResult2, IGattClientNotificationResult2_Vtbl, 0x8faec497_45e0_497e_9582_29a1fe281ad5);
+impl windows_core::RuntimeType for IGattClientNotificationResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattClientNotificationResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BytesSent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattDescriptor, IGattDescriptor_Vtbl, 0x92055f2b_8084_4344_b4c2_284de19a8506);
+impl windows_core::RuntimeType for IGattDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -200,6 +230,9 @@ pub struct IGattDescriptor_Vtbl {
     WriteValueAsync: usize,
 }
 windows_core::imp::define_interface!(IGattDescriptor2, IGattDescriptor2_Vtbl, 0x8f563d39_d630_406c_ba11_10cdd16b0e5e);
+impl windows_core::RuntimeType for IGattDescriptor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDescriptor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -209,6 +242,9 @@ pub struct IGattDescriptor2_Vtbl {
     WriteValueWithResultAsync: usize,
 }
 windows_core::imp::define_interface!(IGattDescriptorStatics, IGattDescriptorStatics_Vtbl, 0x92055f2d_8084_4344_b4c2_284de19a8506);
+impl windows_core::RuntimeType for IGattDescriptorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDescriptorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -218,6 +254,9 @@ pub struct IGattDescriptorStatics_Vtbl {
     ConvertShortIdToUuid: usize,
 }
 windows_core::imp::define_interface!(IGattDescriptorUuidsStatics, IGattDescriptorUuidsStatics_Vtbl, 0xa6f862ce_9cfc_42f1_9185_ff37b75181d3);
+impl windows_core::RuntimeType for IGattDescriptorUuidsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDescriptorUuidsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -229,6 +268,9 @@ pub struct IGattDescriptorUuidsStatics_Vtbl {
     pub ServerCharacteristicConfiguration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattDescriptorsResult, IGattDescriptorsResult_Vtbl, 0x9bc091f3_95e7_4489_8d25_ff81955a57b9);
+impl windows_core::RuntimeType for IGattDescriptorsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDescriptorsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,6 +282,9 @@ pub struct IGattDescriptorsResult_Vtbl {
     Descriptors: usize,
 }
 windows_core::imp::define_interface!(IGattDeviceService, IGattDeviceService_Vtbl, 0xac7b7c05_b33c_47cf_990f_6b8f5577df71);
+impl windows_core::RuntimeType for IGattDeviceService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDeviceService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -256,6 +301,9 @@ pub struct IGattDeviceService_Vtbl {
     pub AttributeHandle: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattDeviceService2, IGattDeviceService2_Vtbl, 0xfc54520b_0b0d_4708_bae0_9ffd9489bc59);
+impl windows_core::RuntimeType for IGattDeviceService2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDeviceService2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -277,6 +325,9 @@ pub struct IGattDeviceService2_Vtbl {
     GetAllIncludedServices: usize,
 }
 windows_core::imp::define_interface!(IGattDeviceService3, IGattDeviceService3_Vtbl, 0xb293a950_0c53_437c_a9b3_5c3210c6e569);
+impl windows_core::RuntimeType for IGattDeviceService3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDeviceService3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -301,6 +352,9 @@ pub struct IGattDeviceService3_Vtbl {
     pub GetIncludedServicesForUuidWithCacheModeAsync: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, super::BluetoothCacheMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattDeviceServiceStatics, IGattDeviceServiceStatics_Vtbl, 0x196d0022_faad_45dc_ae5b_2ac3184e84db);
+impl windows_core::RuntimeType for IGattDeviceServiceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDeviceServiceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -316,6 +370,9 @@ pub struct IGattDeviceServiceStatics_Vtbl {
     ConvertShortIdToUuid: usize,
 }
 windows_core::imp::define_interface!(IGattDeviceServiceStatics2, IGattDeviceServiceStatics2_Vtbl, 0x0604186e_24a6_4b0d_a2f2_30cc01545d25);
+impl windows_core::RuntimeType for IGattDeviceServiceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDeviceServiceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -326,6 +383,9 @@ pub struct IGattDeviceServiceStatics2_Vtbl {
     pub GetDeviceSelectorForBluetoothDeviceIdAndUuidWithCacheMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, windows_core::GUID, super::BluetoothCacheMode, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattDeviceServicesResult, IGattDeviceServicesResult_Vtbl, 0x171dd3ee_016d_419d_838a_576cf475a3d8);
+impl windows_core::RuntimeType for IGattDeviceServicesResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattDeviceServicesResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -337,6 +397,9 @@ pub struct IGattDeviceServicesResult_Vtbl {
     Services: usize,
 }
 windows_core::imp::define_interface!(IGattLocalCharacteristic, IGattLocalCharacteristic_Vtbl, 0xaede376d_5412_4d74_92a8_8deb8526829c);
+impl windows_core::RuntimeType for IGattLocalCharacteristic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattLocalCharacteristic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -378,6 +441,9 @@ pub struct IGattLocalCharacteristic_Vtbl {
     NotifyValueForSubscribedClientAsync: usize,
 }
 windows_core::imp::define_interface!(IGattLocalCharacteristicParameters, IGattLocalCharacteristicParameters_Vtbl, 0xfaf73db4_4cff_44c7_8445_040e6ead0063);
+impl windows_core::RuntimeType for IGattLocalCharacteristicParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattLocalCharacteristicParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -403,6 +469,9 @@ pub struct IGattLocalCharacteristicParameters_Vtbl {
     PresentationFormats: usize,
 }
 windows_core::imp::define_interface!(IGattLocalCharacteristicResult, IGattLocalCharacteristicResult_Vtbl, 0x7975de9b_0170_4397_9666_92f863f12ee6);
+impl windows_core::RuntimeType for IGattLocalCharacteristicResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattLocalCharacteristicResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -410,6 +479,9 @@ pub struct IGattLocalCharacteristicResult_Vtbl {
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::BluetoothError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattLocalDescriptor, IGattLocalDescriptor_Vtbl, 0xf48ebe06_789d_4a4b_8652_bd017b5d2fc6);
+impl windows_core::RuntimeType for IGattLocalDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattLocalDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -426,6 +498,9 @@ pub struct IGattLocalDescriptor_Vtbl {
     pub RemoveWriteRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattLocalDescriptorParameters, IGattLocalDescriptorParameters_Vtbl, 0x5fdede6a_f3c1_4b66_8c4b_e3d2293b40e9);
+impl windows_core::RuntimeType for IGattLocalDescriptorParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattLocalDescriptorParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -443,6 +518,9 @@ pub struct IGattLocalDescriptorParameters_Vtbl {
     pub WriteProtectionLevel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GattProtectionLevel) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattLocalDescriptorResult, IGattLocalDescriptorResult_Vtbl, 0x375791be_321f_4366_bfc1_3bc6b82c79f8);
+impl windows_core::RuntimeType for IGattLocalDescriptorResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattLocalDescriptorResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -450,6 +528,9 @@ pub struct IGattLocalDescriptorResult_Vtbl {
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::BluetoothError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattLocalService, IGattLocalService_Vtbl, 0xf513e258_f7f7_4902_b803_57fcc7d6fe83);
+impl windows_core::RuntimeType for IGattLocalService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattLocalService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -461,6 +542,9 @@ pub struct IGattLocalService_Vtbl {
     Characteristics: usize,
 }
 windows_core::imp::define_interface!(IGattPresentationFormat, IGattPresentationFormat_Vtbl, 0x196d0021_faad_45dc_ae5b_2ac3184e84db);
+impl windows_core::RuntimeType for IGattPresentationFormat {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattPresentationFormat_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -471,18 +555,27 @@ pub struct IGattPresentationFormat_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattPresentationFormatStatics, IGattPresentationFormatStatics_Vtbl, 0x196d0020_faad_45dc_ae5b_2ac3184e84db);
+impl windows_core::RuntimeType for IGattPresentationFormatStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattPresentationFormatStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BluetoothSigAssignedNumbers: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattPresentationFormatStatics2, IGattPresentationFormatStatics2_Vtbl, 0xa9c21713_b82f_435e_b634_21fd85a43c07);
+impl windows_core::RuntimeType for IGattPresentationFormatStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattPresentationFormatStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromParts: unsafe extern "system" fn(*mut core::ffi::c_void, u8, i32, u16, u8, u16, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattPresentationFormatTypesStatics, IGattPresentationFormatTypesStatics_Vtbl, 0xfaf1ba0a_30ba_409c_bef7_cffb6d03b8fb);
+impl windows_core::RuntimeType for IGattPresentationFormatTypesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattPresentationFormatTypesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -515,6 +608,9 @@ pub struct IGattPresentationFormatTypesStatics_Vtbl {
     pub Struct: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattProtocolErrorStatics, IGattProtocolErrorStatics_Vtbl, 0xca46c5c5_0ecc_4809_bea3_cf79bc991e37);
+impl windows_core::RuntimeType for IGattProtocolErrorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattProtocolErrorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -537,6 +633,9 @@ pub struct IGattProtocolErrorStatics_Vtbl {
     pub InsufficientResources: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattReadClientCharacteristicConfigurationDescriptorResult, IGattReadClientCharacteristicConfigurationDescriptorResult_Vtbl, 0x63a66f09_1aea_4c4c_a50f_97bae474b348);
+impl windows_core::RuntimeType for IGattReadClientCharacteristicConfigurationDescriptorResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReadClientCharacteristicConfigurationDescriptorResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -544,12 +643,18 @@ pub struct IGattReadClientCharacteristicConfigurationDescriptorResult_Vtbl {
     pub ClientCharacteristicConfigurationDescriptor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GattClientCharacteristicConfigurationDescriptorValue) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattReadClientCharacteristicConfigurationDescriptorResult2, IGattReadClientCharacteristicConfigurationDescriptorResult2_Vtbl, 0x1bf1a59d_ba4d_4622_8651_f4ee150d0a5d);
+impl windows_core::RuntimeType for IGattReadClientCharacteristicConfigurationDescriptorResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReadClientCharacteristicConfigurationDescriptorResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ProtocolError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattReadRequest, IGattReadRequest_Vtbl, 0xf1dd6535_6acd_42a6_a4bb_d789dae0043e);
+impl windows_core::RuntimeType for IGattReadRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReadRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -565,6 +670,9 @@ pub struct IGattReadRequest_Vtbl {
     pub RespondWithProtocolError: unsafe extern "system" fn(*mut core::ffi::c_void, u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattReadRequestedEventArgs, IGattReadRequestedEventArgs_Vtbl, 0x93497243_f39c_484b_8ab6_996ba486cfa3);
+impl windows_core::RuntimeType for IGattReadRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReadRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -573,6 +681,9 @@ pub struct IGattReadRequestedEventArgs_Vtbl {
     pub GetRequestAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattReadResult, IGattReadResult_Vtbl, 0x63a66f08_1aea_4c4c_a50f_97bae474b348);
+impl windows_core::RuntimeType for IGattReadResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReadResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -583,12 +694,18 @@ pub struct IGattReadResult_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(IGattReadResult2, IGattReadResult2_Vtbl, 0xa10f50a0_fb43_48af_baaa_638a5c6329fe);
+impl windows_core::RuntimeType for IGattReadResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReadResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ProtocolError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattReliableWriteTransaction, IGattReliableWriteTransaction_Vtbl, 0x63a66f07_1aea_4c4c_a50f_97bae474b348);
+impl windows_core::RuntimeType for IGattReliableWriteTransaction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReliableWriteTransaction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -599,12 +716,18 @@ pub struct IGattReliableWriteTransaction_Vtbl {
     pub CommitAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattReliableWriteTransaction2, IGattReliableWriteTransaction2_Vtbl, 0x51113987_ef12_462f_9fb2_a1a43a679416);
+impl windows_core::RuntimeType for IGattReliableWriteTransaction2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattReliableWriteTransaction2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CommitWithResultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattRequestStateChangedEventArgs, IGattRequestStateChangedEventArgs_Vtbl, 0xe834d92c_27be_44b3_9d0d_4fc6e808dd3f);
+impl windows_core::RuntimeType for IGattRequestStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattRequestStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -612,6 +735,9 @@ pub struct IGattRequestStateChangedEventArgs_Vtbl {
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::BluetoothError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceProvider, IGattServiceProvider_Vtbl, 0x7822b3cd_2889_4f86_a051_3f0aed1c2760);
+impl windows_core::RuntimeType for IGattServiceProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -624,6 +750,9 @@ pub struct IGattServiceProvider_Vtbl {
     pub StopAdvertising: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceProviderAdvertisementStatusChangedEventArgs, IGattServiceProviderAdvertisementStatusChangedEventArgs_Vtbl, 0x59a5aa65_fa21_4ffc_b155_04d928012686);
+impl windows_core::RuntimeType for IGattServiceProviderAdvertisementStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderAdvertisementStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -631,6 +760,9 @@ pub struct IGattServiceProviderAdvertisementStatusChangedEventArgs_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GattServiceProviderAdvertisementStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceProviderAdvertisingParameters, IGattServiceProviderAdvertisingParameters_Vtbl, 0xe2ce31ab_6315_4c22_9bd7_781dbc3d8d82);
+impl windows_core::RuntimeType for IGattServiceProviderAdvertisingParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderAdvertisingParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -640,6 +772,9 @@ pub struct IGattServiceProviderAdvertisingParameters_Vtbl {
     pub IsDiscoverable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceProviderAdvertisingParameters2, IGattServiceProviderAdvertisingParameters2_Vtbl, 0xff68468d_ca92_4434_9743_0e90988ad879);
+impl windows_core::RuntimeType for IGattServiceProviderAdvertisingParameters2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderAdvertisingParameters2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -653,6 +788,9 @@ pub struct IGattServiceProviderAdvertisingParameters2_Vtbl {
     ServiceData: usize,
 }
 windows_core::imp::define_interface!(IGattServiceProviderResult, IGattServiceProviderResult_Vtbl, 0x764696d8_c53e_428c_8a48_67afe02c3ae6);
+impl windows_core::RuntimeType for IGattServiceProviderResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -660,12 +798,18 @@ pub struct IGattServiceProviderResult_Vtbl {
     pub ServiceProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceProviderStatics, IGattServiceProviderStatics_Vtbl, 0x31794063_5256_4054_a4f4_7bbe7755a57e);
+impl windows_core::RuntimeType for IGattServiceProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceUuidsStatics, IGattServiceUuidsStatics_Vtbl, 0x6dc57058_9aba_4417_b8f2_dce016d34ee2);
+impl windows_core::RuntimeType for IGattServiceUuidsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceUuidsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -680,6 +824,9 @@ pub struct IGattServiceUuidsStatics_Vtbl {
     pub RunningSpeedAndCadence: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattServiceUuidsStatics2, IGattServiceUuidsStatics2_Vtbl, 0xd2ae94f5_3d15_4f79_9c0c_eaafa675155c);
+impl windows_core::RuntimeType for IGattServiceUuidsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattServiceUuidsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -698,6 +845,9 @@ pub struct IGattServiceUuidsStatics2_Vtbl {
     pub TxPower: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattSession, IGattSession_Vtbl, 0xd23b5143_e04e_4c24_999c_9c256f9856b1);
+impl windows_core::RuntimeType for IGattSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -713,12 +863,18 @@ pub struct IGattSession_Vtbl {
     pub RemoveSessionStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattSessionStatics, IGattSessionStatics_Vtbl, 0x2e65b95c_539f_4db7_82a8_73bdbbf73ebf);
+impl windows_core::RuntimeType for IGattSessionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattSessionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromDeviceIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattSessionStatusChangedEventArgs, IGattSessionStatusChangedEventArgs_Vtbl, 0x7605b72e_837f_404c_ab34_3163f39ddf32);
+impl windows_core::RuntimeType for IGattSessionStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattSessionStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -726,6 +882,9 @@ pub struct IGattSessionStatusChangedEventArgs_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GattSessionStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattSubscribedClient, IGattSubscribedClient_Vtbl, 0x736e9001_15a4_4ec2_9248_e3f20d463be9);
+impl windows_core::RuntimeType for IGattSubscribedClient {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattSubscribedClient_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -735,6 +894,9 @@ pub struct IGattSubscribedClient_Vtbl {
     pub RemoveMaxNotificationSizeChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattValueChangedEventArgs, IGattValueChangedEventArgs_Vtbl, 0xd21bdb54_06e3_4ed8_a263_acfac8ba7313);
+impl windows_core::RuntimeType for IGattValueChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -745,6 +907,9 @@ pub struct IGattValueChangedEventArgs_Vtbl {
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattWriteRequest, IGattWriteRequest_Vtbl, 0xaeb6a9ed_de2f_4fc2_a9a8_94ea7844f13d);
+impl windows_core::RuntimeType for IGattWriteRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattWriteRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -761,6 +926,9 @@ pub struct IGattWriteRequest_Vtbl {
     pub RespondWithProtocolError: unsafe extern "system" fn(*mut core::ffi::c_void, u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattWriteRequestedEventArgs, IGattWriteRequestedEventArgs_Vtbl, 0x2dec8bbe_a73a_471a_94d5_037deadd0806);
+impl windows_core::RuntimeType for IGattWriteRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattWriteRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -769,6 +937,9 @@ pub struct IGattWriteRequestedEventArgs_Vtbl {
     pub GetRequestAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGattWriteResult, IGattWriteResult_Vtbl, 0x4991ddb1_cb2b_44f7_99fc_d29a2871dc9b);
+impl windows_core::RuntimeType for IGattWriteResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGattWriteResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -985,7 +1156,7 @@ impl GattCharacteristic {
     }
 }
 impl windows_core::RuntimeType for GattCharacteristic {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattCharacteristic>();
 }
 unsafe impl windows_core::Interface for GattCharacteristic {
     type Vtable = IGattCharacteristic_Vtbl;
@@ -1527,7 +1698,7 @@ impl GattCharacteristicsResult {
     }
 }
 impl windows_core::RuntimeType for GattCharacteristicsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattCharacteristicsResult>();
 }
 unsafe impl windows_core::Interface for GattCharacteristicsResult {
     type Vtable = IGattCharacteristicsResult_Vtbl;
@@ -1573,7 +1744,7 @@ impl GattClientNotificationResult {
     }
 }
 impl windows_core::RuntimeType for GattClientNotificationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattClientNotificationResult>();
 }
 unsafe impl windows_core::Interface for GattClientNotificationResult {
     type Vtable = IGattClientNotificationResult_Vtbl;
@@ -1664,7 +1835,7 @@ impl GattDescriptor {
     }
 }
 impl windows_core::RuntimeType for GattDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattDescriptor>();
 }
 unsafe impl windows_core::Interface for GattDescriptor {
     type Vtable = IGattDescriptor_Vtbl;
@@ -1751,7 +1922,7 @@ impl GattDescriptorsResult {
     }
 }
 impl windows_core::RuntimeType for GattDescriptorsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattDescriptorsResult>();
 }
 unsafe impl windows_core::Interface for GattDescriptorsResult {
     type Vtable = IGattDescriptorsResult_Vtbl;
@@ -2014,7 +2185,7 @@ impl GattDeviceService {
     }
 }
 impl windows_core::RuntimeType for GattDeviceService {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattDeviceService>();
 }
 unsafe impl windows_core::Interface for GattDeviceService {
     type Vtable = IGattDeviceService_Vtbl;
@@ -2054,7 +2225,7 @@ impl GattDeviceServicesResult {
     }
 }
 impl windows_core::RuntimeType for GattDeviceServicesResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattDeviceServicesResult>();
 }
 unsafe impl windows_core::Interface for GattDeviceServicesResult {
     type Vtable = IGattDeviceServicesResult_Vtbl;
@@ -2214,7 +2385,7 @@ impl GattLocalCharacteristic {
     }
 }
 impl windows_core::RuntimeType for GattLocalCharacteristic {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattLocalCharacteristic>();
 }
 unsafe impl windows_core::Interface for GattLocalCharacteristic {
     type Vtable = IGattLocalCharacteristic_Vtbl;
@@ -2307,7 +2478,7 @@ impl GattLocalCharacteristicParameters {
     }
 }
 impl windows_core::RuntimeType for GattLocalCharacteristicParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattLocalCharacteristicParameters>();
 }
 unsafe impl windows_core::Interface for GattLocalCharacteristicParameters {
     type Vtable = IGattLocalCharacteristicParameters_Vtbl;
@@ -2339,7 +2510,7 @@ impl GattLocalCharacteristicResult {
     }
 }
 impl windows_core::RuntimeType for GattLocalCharacteristicResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattLocalCharacteristicResult>();
 }
 unsafe impl windows_core::Interface for GattLocalCharacteristicResult {
     type Vtable = IGattLocalCharacteristicResult_Vtbl;
@@ -2414,7 +2585,7 @@ impl GattLocalDescriptor {
     }
 }
 impl windows_core::RuntimeType for GattLocalDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattLocalDescriptor>();
 }
 unsafe impl windows_core::Interface for GattLocalDescriptor {
     type Vtable = IGattLocalDescriptor_Vtbl;
@@ -2477,7 +2648,7 @@ impl GattLocalDescriptorParameters {
     }
 }
 impl windows_core::RuntimeType for GattLocalDescriptorParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattLocalDescriptorParameters>();
 }
 unsafe impl windows_core::Interface for GattLocalDescriptorParameters {
     type Vtable = IGattLocalDescriptorParameters_Vtbl;
@@ -2509,7 +2680,7 @@ impl GattLocalDescriptorResult {
     }
 }
 impl windows_core::RuntimeType for GattLocalDescriptorResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattLocalDescriptorResult>();
 }
 unsafe impl windows_core::Interface for GattLocalDescriptorResult {
     type Vtable = IGattLocalDescriptorResult_Vtbl;
@@ -2552,7 +2723,7 @@ impl GattLocalService {
     }
 }
 impl windows_core::RuntimeType for GattLocalService {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattLocalService>();
 }
 unsafe impl windows_core::Interface for GattLocalService {
     type Vtable = IGattLocalService_Vtbl;
@@ -2627,7 +2798,7 @@ impl GattPresentationFormat {
     }
 }
 impl windows_core::RuntimeType for GattPresentationFormat {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattPresentationFormat>();
 }
 unsafe impl windows_core::Interface for GattPresentationFormat {
     type Vtable = IGattPresentationFormat_Vtbl;
@@ -2952,7 +3123,7 @@ impl GattReadClientCharacteristicConfigurationDescriptorResult {
     }
 }
 impl windows_core::RuntimeType for GattReadClientCharacteristicConfigurationDescriptorResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattReadClientCharacteristicConfigurationDescriptorResult>();
 }
 unsafe impl windows_core::Interface for GattReadClientCharacteristicConfigurationDescriptorResult {
     type Vtable = IGattReadClientCharacteristicConfigurationDescriptorResult_Vtbl;
@@ -3017,7 +3188,7 @@ impl GattReadRequest {
     }
 }
 impl windows_core::RuntimeType for GattReadRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattReadRequest>();
 }
 unsafe impl windows_core::Interface for GattReadRequest {
     type Vtable = IGattReadRequest_Vtbl;
@@ -3056,7 +3227,7 @@ impl GattReadRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GattReadRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattReadRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for GattReadRequestedEventArgs {
     type Vtable = IGattReadRequestedEventArgs_Vtbl;
@@ -3096,7 +3267,7 @@ impl GattReadResult {
     }
 }
 impl windows_core::RuntimeType for GattReadResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattReadResult>();
 }
 unsafe impl windows_core::Interface for GattReadResult {
     type Vtable = IGattReadResult_Vtbl;
@@ -3144,7 +3315,7 @@ impl GattReliableWriteTransaction {
     }
 }
 impl windows_core::RuntimeType for GattReliableWriteTransaction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattReliableWriteTransaction>();
 }
 unsafe impl windows_core::Interface for GattReliableWriteTransaction {
     type Vtable = IGattReliableWriteTransaction_Vtbl;
@@ -3176,7 +3347,7 @@ impl GattRequestStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GattRequestStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattRequestStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GattRequestStateChangedEventArgs {
     type Vtable = IGattRequestStateChangedEventArgs_Vtbl;
@@ -3248,7 +3419,7 @@ impl GattServiceProvider {
     }
 }
 impl windows_core::RuntimeType for GattServiceProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProvider>();
 }
 unsafe impl windows_core::Interface for GattServiceProvider {
     type Vtable = IGattServiceProvider_Vtbl;
@@ -3280,7 +3451,7 @@ impl GattServiceProviderAdvertisementStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GattServiceProviderAdvertisementStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProviderAdvertisementStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GattServiceProviderAdvertisementStatusChangedEventArgs {
     type Vtable = IGattServiceProviderAdvertisementStatusChangedEventArgs_Vtbl;
@@ -3343,7 +3514,7 @@ impl GattServiceProviderAdvertisingParameters {
     }
 }
 impl windows_core::RuntimeType for GattServiceProviderAdvertisingParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProviderAdvertisingParameters>();
 }
 unsafe impl windows_core::Interface for GattServiceProviderAdvertisingParameters {
     type Vtable = IGattServiceProviderAdvertisingParameters_Vtbl;
@@ -3375,7 +3546,7 @@ impl GattServiceProviderResult {
     }
 }
 impl windows_core::RuntimeType for GattServiceProviderResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattServiceProviderResult>();
 }
 unsafe impl windows_core::Interface for GattServiceProviderResult {
     type Vtable = IGattServiceProviderResult_Vtbl;
@@ -3627,7 +3798,7 @@ impl GattSession {
     }
 }
 impl windows_core::RuntimeType for GattSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattSession>();
 }
 unsafe impl windows_core::Interface for GattSession {
     type Vtable = IGattSession_Vtbl;
@@ -3659,7 +3830,7 @@ impl GattSessionStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GattSessionStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattSessionStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GattSessionStatusChangedEventArgs {
     type Vtable = IGattSessionStatusChangedEventArgs_Vtbl;
@@ -3705,7 +3876,7 @@ impl GattSubscribedClient {
     }
 }
 impl windows_core::RuntimeType for GattSubscribedClient {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattSubscribedClient>();
 }
 unsafe impl windows_core::Interface for GattSubscribedClient {
     type Vtable = IGattSubscribedClient_Vtbl;
@@ -3738,7 +3909,7 @@ impl GattValueChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GattValueChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattValueChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GattValueChangedEventArgs {
     type Vtable = IGattValueChangedEventArgs_Vtbl;
@@ -3807,7 +3978,7 @@ impl GattWriteRequest {
     }
 }
 impl windows_core::RuntimeType for GattWriteRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattWriteRequest>();
 }
 unsafe impl windows_core::Interface for GattWriteRequest {
     type Vtable = IGattWriteRequest_Vtbl;
@@ -3846,7 +4017,7 @@ impl GattWriteRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GattWriteRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattWriteRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for GattWriteRequestedEventArgs {
     type Vtable = IGattWriteRequestedEventArgs_Vtbl;
@@ -3878,7 +4049,7 @@ impl GattWriteResult {
     }
 }
 impl windows_core::RuntimeType for GattWriteResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGattWriteResult>();
 }
 unsafe impl windows_core::Interface for GattWriteResult {
     type Vtable = IGattWriteResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Rfcomm/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Rfcomm/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IRfcommDeviceService, IRfcommDeviceService_Vtbl, 0xae81ff1f_c5a1_4c40_8c28_f3efd69062f3);
+impl windows_core::RuntimeType for IRfcommDeviceService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommDeviceService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,12 +29,18 @@ pub struct IRfcommDeviceService_Vtbl {
     GetSdpRawAttributesWithCacheModeAsync: usize,
 }
 windows_core::imp::define_interface!(IRfcommDeviceService2, IRfcommDeviceService2_Vtbl, 0x536ced14_ebcd_49fe_bf9f_40efc689b20d);
+impl windows_core::RuntimeType for IRfcommDeviceService2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommDeviceService2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Device: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommDeviceService3, IRfcommDeviceService3_Vtbl, 0x1c22ace6_dd44_4d23_866d_8f3486ee6490);
+impl windows_core::RuntimeType for IRfcommDeviceService3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommDeviceService3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +54,9 @@ pub struct IRfcommDeviceService3_Vtbl {
     RequestAccessAsync: usize,
 }
 windows_core::imp::define_interface!(IRfcommDeviceServiceStatics, IRfcommDeviceServiceStatics_Vtbl, 0xa4a149ef_626d_41ac_b253_87ac5c27e28a);
+impl windows_core::RuntimeType for IRfcommDeviceServiceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommDeviceServiceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,6 +64,9 @@ pub struct IRfcommDeviceServiceStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommDeviceServiceStatics2, IRfcommDeviceServiceStatics2_Vtbl, 0xaa8cb1c9_e78d_4be4_8076_0a3d87a0a05f);
+impl windows_core::RuntimeType for IRfcommDeviceServiceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommDeviceServiceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +76,9 @@ pub struct IRfcommDeviceServiceStatics2_Vtbl {
     pub GetDeviceSelectorForBluetoothDeviceAndServiceIdWithCacheMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, super::BluetoothCacheMode, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommDeviceServicesResult, IRfcommDeviceServicesResult_Vtbl, 0x3b48388c_7ccf_488e_9625_d259a5732d55);
+impl windows_core::RuntimeType for IRfcommDeviceServicesResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommDeviceServicesResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +89,9 @@ pub struct IRfcommDeviceServicesResult_Vtbl {
     Services: usize,
 }
 windows_core::imp::define_interface!(IRfcommServiceId, IRfcommServiceId_Vtbl, 0x22629204_7e02_4017_8136_da1b6a1b9bbf);
+impl windows_core::RuntimeType for IRfcommServiceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommServiceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +100,9 @@ pub struct IRfcommServiceId_Vtbl {
     pub AsString: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommServiceIdStatics, IRfcommServiceIdStatics_Vtbl, 0x2a179eba_a975_46e3_b56b_08ffd783a5fe);
+impl windows_core::RuntimeType for IRfcommServiceIdStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommServiceIdStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +116,9 @@ pub struct IRfcommServiceIdStatics_Vtbl {
     pub GenericFileTransfer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommServiceProvider, IRfcommServiceProvider_Vtbl, 0xeadbfdc4_b1f6_44ff_9f7c_e7a82ab86821);
+impl windows_core::RuntimeType for IRfcommServiceProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommServiceProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -107,6 +134,9 @@ pub struct IRfcommServiceProvider_Vtbl {
     pub StopAdvertising: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRfcommServiceProvider2, IRfcommServiceProvider2_Vtbl, 0x736bdfc6_3c81_4d1e_baf2_ddbb81284512);
+impl windows_core::RuntimeType for IRfcommServiceProvider2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommServiceProvider2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +146,9 @@ pub struct IRfcommServiceProvider2_Vtbl {
     StartAdvertisingWithRadioDiscoverability: usize,
 }
 windows_core::imp::define_interface!(IRfcommServiceProviderStatics, IRfcommServiceProviderStatics_Vtbl, 0x98888303_69ca_413a_84f7_4344c7292997);
+impl windows_core::RuntimeType for IRfcommServiceProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRfcommServiceProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -273,7 +306,7 @@ impl RfcommDeviceService {
     }
 }
 impl windows_core::RuntimeType for RfcommDeviceService {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommDeviceService>();
 }
 unsafe impl windows_core::Interface for RfcommDeviceService {
     type Vtable = IRfcommDeviceService_Vtbl;
@@ -306,7 +339,7 @@ impl RfcommDeviceServicesResult {
     }
 }
 impl windows_core::RuntimeType for RfcommDeviceServicesResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommDeviceServicesResult>();
 }
 unsafe impl windows_core::Interface for RfcommDeviceServicesResult {
     type Vtable = IRfcommDeviceServicesResult_Vtbl;
@@ -398,7 +431,7 @@ impl RfcommServiceId {
     }
 }
 impl windows_core::RuntimeType for RfcommServiceId {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommServiceId>();
 }
 unsafe impl windows_core::Interface for RfcommServiceId {
     type Vtable = IRfcommServiceId_Vtbl;
@@ -465,7 +498,7 @@ impl RfcommServiceProvider {
     }
 }
 impl windows_core::RuntimeType for RfcommServiceProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRfcommServiceProvider>();
 }
 unsafe impl windows_core::Interface for RfcommServiceProvider {
     type Vtable = IRfcommServiceProvider_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
@@ -7,6 +7,9 @@ pub mod GenericAttributeProfile;
 #[cfg(feature = "Devices_Bluetooth_Rfcomm")]
 pub mod Rfcomm;
 windows_core::imp::define_interface!(IBluetoothAdapter, IBluetoothAdapter_Vtbl, 0x7974f04c_5f7a_4a34_9225_a855f84b1a8b);
+impl windows_core::RuntimeType for IBluetoothAdapter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothAdapter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +26,9 @@ pub struct IBluetoothAdapter_Vtbl {
     GetRadioAsync: usize,
 }
 windows_core::imp::define_interface!(IBluetoothAdapter2, IBluetoothAdapter2_Vtbl, 0xac94cecc_24d5_41b3_916d_1097c50b102b);
+impl windows_core::RuntimeType for IBluetoothAdapter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothAdapter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +36,9 @@ pub struct IBluetoothAdapter2_Vtbl {
     pub AreLowEnergySecureConnectionsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothAdapter3, IBluetoothAdapter3_Vtbl, 0x8f8624e0_cba9_5211_9f89_3aac62b4c6b8);
+impl windows_core::RuntimeType for IBluetoothAdapter3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothAdapter3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +46,9 @@ pub struct IBluetoothAdapter3_Vtbl {
     pub MaxAdvertisementDataLength: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothAdapterStatics, IBluetoothAdapterStatics_Vtbl, 0x8b02fb6a_ac4c_4741_8661_8eab7d17ea9f);
+impl windows_core::RuntimeType for IBluetoothAdapterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothAdapterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +57,9 @@ pub struct IBluetoothAdapterStatics_Vtbl {
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothClassOfDevice, IBluetoothClassOfDevice_Vtbl, 0xd640227e_d7d7_4661_9454_65039ca17a2b);
+impl windows_core::RuntimeType for IBluetoothClassOfDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothClassOfDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +69,9 @@ pub struct IBluetoothClassOfDevice_Vtbl {
     pub ServiceCapabilities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut BluetoothServiceCapabilities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothClassOfDeviceStatics, IBluetoothClassOfDeviceStatics_Vtbl, 0xe46135bd_0fa2_416c_91b4_c1e48ca061c1);
+impl windows_core::RuntimeType for IBluetoothClassOfDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothClassOfDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +79,9 @@ pub struct IBluetoothClassOfDeviceStatics_Vtbl {
     pub FromParts: unsafe extern "system" fn(*mut core::ffi::c_void, BluetoothMajorClass, BluetoothMinorClass, BluetoothServiceCapabilities, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothDevice, IBluetoothDevice_Vtbl, 0x2335b156_90d2_4a04_aef5_0e20b9e6b707);
+impl windows_core::RuntimeType for IBluetoothDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +110,9 @@ pub struct IBluetoothDevice_Vtbl {
     pub RemoveConnectionStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothDevice2, IBluetoothDevice2_Vtbl, 0x0133f954_b156_4dd0_b1f5_c11bc31a5163);
+impl windows_core::RuntimeType for IBluetoothDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,6 +122,9 @@ pub struct IBluetoothDevice2_Vtbl {
     DeviceInformation: usize,
 }
 windows_core::imp::define_interface!(IBluetoothDevice3, IBluetoothDevice3_Vtbl, 0x57fff78b_651a_4454_b90f_eb21ef0b0d71);
+impl windows_core::RuntimeType for IBluetoothDevice3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDevice3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,18 +154,27 @@ pub struct IBluetoothDevice3_Vtbl {
     GetRfcommServicesForIdWithCacheModeAsync: usize,
 }
 windows_core::imp::define_interface!(IBluetoothDevice4, IBluetoothDevice4_Vtbl, 0x817c34ad_0e9c_42b2_a8dc_3e8094940d12);
+impl windows_core::RuntimeType for IBluetoothDevice4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDevice4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BluetoothDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothDevice5, IBluetoothDevice5_Vtbl, 0xb5e0b385_5e85_4559_a10d_1c7281379f96);
+impl windows_core::RuntimeType for IBluetoothDevice5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDevice5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub WasSecureConnectionUsedForPairing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothDeviceId, IBluetoothDeviceId_Vtbl, 0xc17949af_57c1_4642_bcce_e6c06b20ae76);
+impl windows_core::RuntimeType for IBluetoothDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,12 +183,18 @@ pub struct IBluetoothDeviceId_Vtbl {
     pub IsLowEnergyDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothDeviceIdStatics, IBluetoothDeviceIdStatics_Vtbl, 0xa7884e67_3efb_4f31_bbc2_810e09977404);
+impl windows_core::RuntimeType for IBluetoothDeviceIdStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDeviceIdStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothDeviceStatics, IBluetoothDeviceStatics_Vtbl, 0x0991df51_57db_4725_bbd7_84f64327ec2c);
+impl windows_core::RuntimeType for IBluetoothDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +207,9 @@ pub struct IBluetoothDeviceStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothDeviceStatics2, IBluetoothDeviceStatics2_Vtbl, 0xc29e8e2f_4e14_4477_aa1b_b8b47e5b7ece);
+impl windows_core::RuntimeType for IBluetoothDeviceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothDeviceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,6 +220,9 @@ pub struct IBluetoothDeviceStatics2_Vtbl {
     pub GetDeviceSelectorFromClassOfDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAppearance, IBluetoothLEAppearance_Vtbl, 0x5d2079f2_66a8_4258_985e_02b4d9509f18);
+impl windows_core::RuntimeType for IBluetoothLEAppearance {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAppearance_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +231,9 @@ pub struct IBluetoothLEAppearance_Vtbl {
     pub SubCategory: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAppearanceCategoriesStatics, IBluetoothLEAppearanceCategoriesStatics_Vtbl, 0x6d4d54fe_046a_4185_aab6_824cf0610861);
+impl windows_core::RuntimeType for IBluetoothLEAppearanceCategoriesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAppearanceCategoriesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -210,6 +261,9 @@ pub struct IBluetoothLEAppearanceCategoriesStatics_Vtbl {
     pub OutdoorSportActivity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAppearanceStatics, IBluetoothLEAppearanceStatics_Vtbl, 0xa193c0c7_4504_4f4a_9ba5_cd1054e5e065);
+impl windows_core::RuntimeType for IBluetoothLEAppearanceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAppearanceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -217,6 +271,9 @@ pub struct IBluetoothLEAppearanceStatics_Vtbl {
     pub FromParts: unsafe extern "system" fn(*mut core::ffi::c_void, u16, u16, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEAppearanceSubcategoriesStatics, IBluetoothLEAppearanceSubcategoriesStatics_Vtbl, 0xe57ba606_2144_415a_8312_71ccf291f8d1);
+impl windows_core::RuntimeType for IBluetoothLEAppearanceSubcategoriesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEAppearanceSubcategoriesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -250,6 +307,9 @@ pub struct IBluetoothLEAppearanceSubcategoriesStatics_Vtbl {
     pub LocationNavigationPod: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEConnectionParameters, IBluetoothLEConnectionParameters_Vtbl, 0x33cb0771_8da9_508f_a366_1ca388c929ab);
+impl windows_core::RuntimeType for IBluetoothLEConnectionParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEConnectionParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -258,6 +318,9 @@ pub struct IBluetoothLEConnectionParameters_Vtbl {
     pub ConnectionInterval: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEConnectionPhy, IBluetoothLEConnectionPhy_Vtbl, 0x781e5e48_621e_5a7e_8be6_1b9561ff63c9);
+impl windows_core::RuntimeType for IBluetoothLEConnectionPhy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEConnectionPhy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -265,6 +328,9 @@ pub struct IBluetoothLEConnectionPhy_Vtbl {
     pub ReceiveInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEConnectionPhyInfo, IBluetoothLEConnectionPhyInfo_Vtbl, 0x9a100bdd_602e_5c27_a1ae_b230015a6394);
+impl windows_core::RuntimeType for IBluetoothLEConnectionPhyInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEConnectionPhyInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -273,6 +339,9 @@ pub struct IBluetoothLEConnectionPhyInfo_Vtbl {
     pub IsCodedPhy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEDevice, IBluetoothLEDevice_Vtbl, 0xb5ee2f7b_4ad8_4642_ac48_80a0b500e887);
+impl windows_core::RuntimeType for IBluetoothLEDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -296,6 +365,9 @@ pub struct IBluetoothLEDevice_Vtbl {
     pub RemoveConnectionStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEDevice2, IBluetoothLEDevice2_Vtbl, 0x26f062b3_7aee_4d31_baba_b1b9775f5916);
+impl windows_core::RuntimeType for IBluetoothLEDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -307,6 +379,9 @@ pub struct IBluetoothLEDevice2_Vtbl {
     pub BluetoothAddressType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut BluetoothAddressType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEDevice3, IBluetoothLEDevice3_Vtbl, 0xaee9e493_44ac_40dc_af33_b2c13c01ca46);
+impl windows_core::RuntimeType for IBluetoothLEDevice3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDevice3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -336,18 +411,27 @@ pub struct IBluetoothLEDevice3_Vtbl {
     GetGattServicesForUuidWithCacheModeAsync: usize,
 }
 windows_core::imp::define_interface!(IBluetoothLEDevice4, IBluetoothLEDevice4_Vtbl, 0x2b605031_2248_4b2f_acf0_7cee36fc5870);
+impl windows_core::RuntimeType for IBluetoothLEDevice4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDevice4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BluetoothDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEDevice5, IBluetoothLEDevice5_Vtbl, 0x9d6a1260_5287_458e_95ba_17c8b7bb326e);
+impl windows_core::RuntimeType for IBluetoothLEDevice5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDevice5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub WasSecureConnectionUsedForPairing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEDevice6, IBluetoothLEDevice6_Vtbl, 0xca7190ef_0cae_573c_a1ca_e1fc5bfc39e2);
+impl windows_core::RuntimeType for IBluetoothLEDevice6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDevice6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -360,6 +444,9 @@ pub struct IBluetoothLEDevice6_Vtbl {
     pub RemoveConnectionPhyChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEDeviceStatics, IBluetoothLEDeviceStatics_Vtbl, 0xc8cf1a19_f0b6_4bf0_8689_41303de2d9f4);
+impl windows_core::RuntimeType for IBluetoothLEDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -368,6 +455,9 @@ pub struct IBluetoothLEDeviceStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEDeviceStatics2, IBluetoothLEDeviceStatics2_Vtbl, 0x5f12c06b_3bac_43e8_ad16_563271bd41c2);
+impl windows_core::RuntimeType for IBluetoothLEDeviceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEDeviceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -380,6 +470,9 @@ pub struct IBluetoothLEDeviceStatics2_Vtbl {
     pub FromBluetoothAddressWithBluetoothAddressTypeAsync: unsafe extern "system" fn(*mut core::ffi::c_void, u64, BluetoothAddressType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEPreferredConnectionParameters, IBluetoothLEPreferredConnectionParameters_Vtbl, 0xf2f44344_7372_5f7b_9b34_29c944f5a715);
+impl windows_core::RuntimeType for IBluetoothLEPreferredConnectionParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEPreferredConnectionParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -389,12 +482,18 @@ pub struct IBluetoothLEPreferredConnectionParameters_Vtbl {
     pub MaxConnectionInterval: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEPreferredConnectionParametersRequest, IBluetoothLEPreferredConnectionParametersRequest_Vtbl, 0x8a375276_a528_5266_b661_cce6a5ff9739);
+impl windows_core::RuntimeType for IBluetoothLEPreferredConnectionParametersRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEPreferredConnectionParametersRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut BluetoothLEPreferredConnectionParametersRequestStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothLEPreferredConnectionParametersStatics, IBluetoothLEPreferredConnectionParametersStatics_Vtbl, 0x0e3e8edc_2751_55aa_a838_8faeee818d72);
+impl windows_core::RuntimeType for IBluetoothLEPreferredConnectionParametersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothLEPreferredConnectionParametersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -403,6 +502,9 @@ pub struct IBluetoothLEPreferredConnectionParametersStatics_Vtbl {
     pub PowerOptimized: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothSignalStrengthFilter, IBluetoothSignalStrengthFilter_Vtbl, 0xdf7b7391_6bb5_4cfe_90b1_5d7324edcf7f);
+impl windows_core::RuntimeType for IBluetoothSignalStrengthFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothSignalStrengthFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -416,6 +518,9 @@ pub struct IBluetoothSignalStrengthFilter_Vtbl {
     pub SetSamplingInterval: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBluetoothUuidHelperStatics, IBluetoothUuidHelperStatics_Vtbl, 0x17df0cd8_cf74_4b21_afe6_f57a11bcdea0);
+impl windows_core::RuntimeType for IBluetoothUuidHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBluetoothUuidHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -537,7 +642,7 @@ impl BluetoothAdapter {
     }
 }
 impl windows_core::RuntimeType for BluetoothAdapter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothAdapter>();
 }
 unsafe impl windows_core::Interface for BluetoothAdapter {
     type Vtable = IBluetoothAdapter_Vtbl;
@@ -600,7 +705,7 @@ impl BluetoothClassOfDevice {
     }
 }
 impl windows_core::RuntimeType for BluetoothClassOfDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothClassOfDevice>();
 }
 unsafe impl windows_core::Interface for BluetoothClassOfDevice {
     type Vtable = IBluetoothClassOfDevice_Vtbl;
@@ -871,7 +976,7 @@ impl BluetoothDevice {
     }
 }
 impl windows_core::RuntimeType for BluetoothDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothDevice>();
 }
 unsafe impl windows_core::Interface for BluetoothDevice {
     type Vtable = IBluetoothDevice_Vtbl;
@@ -921,7 +1026,7 @@ impl BluetoothDeviceId {
     }
 }
 impl windows_core::RuntimeType for BluetoothDeviceId {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothDeviceId>();
 }
 unsafe impl windows_core::Interface for BluetoothDeviceId {
     type Vtable = IBluetoothDeviceId_Vtbl;
@@ -977,7 +1082,7 @@ impl BluetoothLEAppearance {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEAppearance {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEAppearance>();
 }
 unsafe impl windows_core::Interface for BluetoothLEAppearance {
     type Vtable = IBluetoothLEAppearance_Vtbl;
@@ -1338,7 +1443,7 @@ impl BluetoothLEConnectionParameters {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEConnectionParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEConnectionParameters>();
 }
 unsafe impl windows_core::Interface for BluetoothLEConnectionParameters {
     type Vtable = IBluetoothLEConnectionParameters_Vtbl;
@@ -1370,7 +1475,7 @@ impl BluetoothLEConnectionPhy {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEConnectionPhy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEConnectionPhy>();
 }
 unsafe impl windows_core::Interface for BluetoothLEConnectionPhy {
     type Vtable = IBluetoothLEConnectionPhy_Vtbl;
@@ -1409,7 +1514,7 @@ impl BluetoothLEConnectionPhyInfo {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEConnectionPhyInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEConnectionPhyInfo>();
 }
 unsafe impl windows_core::Interface for BluetoothLEConnectionPhyInfo {
     type Vtable = IBluetoothLEConnectionPhyInfo_Vtbl;
@@ -1727,7 +1832,7 @@ impl BluetoothLEDevice {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEDevice>();
 }
 unsafe impl windows_core::Interface for BluetoothLEDevice {
     type Vtable = IBluetoothLEDevice_Vtbl;
@@ -1796,7 +1901,7 @@ impl BluetoothLEPreferredConnectionParameters {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEPreferredConnectionParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEPreferredConnectionParameters>();
 }
 unsafe impl windows_core::Interface for BluetoothLEPreferredConnectionParameters {
     type Vtable = IBluetoothLEPreferredConnectionParameters_Vtbl;
@@ -1826,7 +1931,7 @@ impl BluetoothLEPreferredConnectionParametersRequest {
     }
 }
 impl windows_core::RuntimeType for BluetoothLEPreferredConnectionParametersRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothLEPreferredConnectionParametersRequest>();
 }
 unsafe impl windows_core::Interface for BluetoothLEPreferredConnectionParametersRequest {
     type Vtable = IBluetoothLEPreferredConnectionParametersRequest_Vtbl;
@@ -1907,7 +2012,7 @@ impl BluetoothSignalStrengthFilter {
     }
 }
 impl windows_core::RuntimeType for BluetoothSignalStrengthFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBluetoothSignalStrengthFilter>();
 }
 unsafe impl windows_core::Interface for BluetoothSignalStrengthFilter {
     type Vtable = IBluetoothSignalStrengthFilter_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICustomDevice, ICustomDevice_Vtbl, 0xdd30251f_c48b_43bd_bcb1_dec88f15143e);
+impl windows_core::RuntimeType for ICustomDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +23,9 @@ pub struct ICustomDevice_Vtbl {
     TrySendIOControlAsync: usize,
 }
 windows_core::imp::define_interface!(ICustomDeviceStatics, ICustomDeviceStatics_Vtbl, 0xc8220312_ef4c_46b1_a58e_eeb308dc8917);
+impl windows_core::RuntimeType for ICustomDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,12 +84,18 @@ pub struct IIOControlCode_Vtbl {
     pub ControlCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIOControlCodeFactory, IIOControlCodeFactory_Vtbl, 0x856a7cf0_4c11_44ae_afc6_b8d4a212788f);
+impl windows_core::RuntimeType for IIOControlCodeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIOControlCodeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateIOControlCode: unsafe extern "system" fn(*mut core::ffi::c_void, u16, u16, IOControlAccessMode, IOControlBufferingMethod, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownDeviceTypesStatics, IKnownDeviceTypesStatics_Vtbl, 0xee5479c2_5448_45da_ad1b_24948c239094);
+impl windows_core::RuntimeType for IKnownDeviceTypesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownDeviceTypesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -155,7 +167,7 @@ impl CustomDevice {
     }
 }
 impl windows_core::RuntimeType for CustomDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICustomDevice>();
 }
 unsafe impl windows_core::Interface for CustomDevice {
     type Vtable = ICustomDevice_Vtbl;
@@ -220,7 +232,7 @@ impl IOControlCode {
     }
 }
 impl windows_core::RuntimeType for IOControlCode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIOControlCode>();
 }
 unsafe impl windows_core::Interface for IOControlCode {
     type Vtable = IIOControlCode_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDisplayAdapter, IDisplayAdapter_Vtbl, 0xa56f5287_f000_5f2e_b5ac_3783a2b69af5);
+impl windows_core::RuntimeType for IDisplayAdapter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayAdapter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +21,9 @@ pub struct IDisplayAdapter_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IDisplayAdapterStatics, IDisplayAdapterStatics_Vtbl, 0x1dac3cda_481f_5469_8470_82c4ba680a28);
+impl windows_core::RuntimeType for IDisplayAdapterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayAdapterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +33,9 @@ pub struct IDisplayAdapterStatics_Vtbl {
     FromId: usize,
 }
 windows_core::imp::define_interface!(IDisplayDevice, IDisplayDevice_Vtbl, 0xa4c9b62c_335f_5731_8cb4_c1ccd4731070);
+impl windows_core::RuntimeType for IDisplayDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +48,9 @@ pub struct IDisplayDevice_Vtbl {
     pub IsCapabilitySupported: unsafe extern "system" fn(*mut core::ffi::c_void, DisplayDeviceCapability, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayDevice2, IDisplayDevice2_Vtbl, 0x3fefe50c_0940_54bd_a02f_f9c7a536ad60);
+impl windows_core::RuntimeType for IDisplayDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,11 +60,17 @@ pub struct IDisplayDevice2_Vtbl {
     CreateSimpleScanoutWithDirtyRectsAndOptions: usize,
 }
 windows_core::imp::define_interface!(IDisplayFence, IDisplayFence_Vtbl, 0x04dcf9ef_3406_5700_8fec_77eba4c5a74b);
+impl windows_core::RuntimeType for IDisplayFence {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayFence_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IDisplayManager, IDisplayManager_Vtbl, 0x4ed9245b_15ec_56e2_9072_7fe5084a31a7);
+impl windows_core::RuntimeType for IDisplayManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +110,9 @@ pub struct IDisplayManager_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayManagerChangedEventArgs, IDisplayManagerChangedEventArgs_Vtbl, 0x6abfa285_6cca_5731_bcdc_42e5d2f5c50f);
+impl windows_core::RuntimeType for IDisplayManagerChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayManagerChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,6 +121,9 @@ pub struct IDisplayManagerChangedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayManagerDisabledEventArgs, IDisplayManagerDisabledEventArgs_Vtbl, 0x8726dde4_6793_5973_a11f_5ffbc93fdb90);
+impl windows_core::RuntimeType for IDisplayManagerDisabledEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayManagerDisabledEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +132,9 @@ pub struct IDisplayManagerDisabledEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayManagerEnabledEventArgs, IDisplayManagerEnabledEventArgs_Vtbl, 0xf0cf3f6f_42fa_59a2_b297_26e1713de848);
+impl windows_core::RuntimeType for IDisplayManagerEnabledEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayManagerEnabledEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +143,9 @@ pub struct IDisplayManagerEnabledEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayManagerPathsFailedOrInvalidatedEventArgs, IDisplayManagerPathsFailedOrInvalidatedEventArgs_Vtbl, 0x03a65659_1dec_5c15_b2a2_8fe9129869fe);
+impl windows_core::RuntimeType for IDisplayManagerPathsFailedOrInvalidatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayManagerPathsFailedOrInvalidatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +154,9 @@ pub struct IDisplayManagerPathsFailedOrInvalidatedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayManagerResultWithState, IDisplayManagerResultWithState_Vtbl, 0x8e656aa6_6614_54be_bfef_4994547f7be1);
+impl windows_core::RuntimeType for IDisplayManagerResultWithState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayManagerResultWithState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -132,12 +165,18 @@ pub struct IDisplayManagerResultWithState_Vtbl {
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayManagerStatics, IDisplayManagerStatics_Vtbl, 0x2b6b9446_b999_5535_9d69_53f092c780a1);
+impl windows_core::RuntimeType for IDisplayManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, DisplayManagerOptions, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayModeInfo, IDisplayModeInfo_Vtbl, 0x48d513a0_f79b_5a74_a05e_da821f470868);
+impl windows_core::RuntimeType for IDisplayModeInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayModeInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -167,6 +206,9 @@ pub struct IDisplayModeInfo_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IDisplayModeInfo2, IDisplayModeInfo2_Vtbl, 0xc86fa386_0ddb_5473_bfb0_4b7807b5f909);
+impl windows_core::RuntimeType for IDisplayModeInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayModeInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -176,6 +218,9 @@ pub struct IDisplayModeInfo2_Vtbl {
     PhysicalPresentationRate: usize,
 }
 windows_core::imp::define_interface!(IDisplayPath, IDisplayPath_Vtbl, 0xb3dfd64a_7460_5cde_811b_d5ae9f3d9f84);
+impl windows_core::RuntimeType for IDisplayPath {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayPath_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,6 +280,9 @@ pub struct IDisplayPath_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IDisplayPath2, IDisplayPath2_Vtbl, 0xf32459c5_e994_570b_9ec8_ef42c35a8547);
+impl windows_core::RuntimeType for IDisplayPath2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayPath2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +296,9 @@ pub struct IDisplayPath2_Vtbl {
     SetPhysicalPresentationRate: usize,
 }
 windows_core::imp::define_interface!(IDisplayPrimaryDescription, IDisplayPrimaryDescription_Vtbl, 0x872591d2_d533_50ff_a85e_06696194b77c);
+impl windows_core::RuntimeType for IDisplayPrimaryDescription {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayPrimaryDescription_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +323,9 @@ pub struct IDisplayPrimaryDescription_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IDisplayPrimaryDescriptionFactory, IDisplayPrimaryDescriptionFactory_Vtbl, 0x1a6aff7b_3637_5c46_b479_76d576216e65);
+impl windows_core::RuntimeType for IDisplayPrimaryDescriptionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayPrimaryDescriptionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +335,9 @@ pub struct IDisplayPrimaryDescriptionFactory_Vtbl {
     CreateInstance: usize,
 }
 windows_core::imp::define_interface!(IDisplayPrimaryDescriptionStatics, IDisplayPrimaryDescriptionStatics_Vtbl, 0xe60e4cfb_36c9_56dd_8fa1_6ff8c4e0ff07);
+impl windows_core::RuntimeType for IDisplayPrimaryDescriptionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayPrimaryDescriptionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,11 +347,17 @@ pub struct IDisplayPrimaryDescriptionStatics_Vtbl {
     CreateWithProperties: usize,
 }
 windows_core::imp::define_interface!(IDisplayScanout, IDisplayScanout_Vtbl, 0xe3051828_1ba5_50e7_8a39_bb1fd2f4f8b9);
+impl windows_core::RuntimeType for IDisplayScanout {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayScanout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IDisplaySource, IDisplaySource_Vtbl, 0xecd15fc1_eadc_51bc_971d_3bc628db2dd4);
+impl windows_core::RuntimeType for IDisplaySource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplaySource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -309,6 +372,9 @@ pub struct IDisplaySource_Vtbl {
     GetMetadata: usize,
 }
 windows_core::imp::define_interface!(IDisplaySource2, IDisplaySource2_Vtbl, 0x71e18952_b321_5af4_bfe8_03fbea31e40d);
+impl windows_core::RuntimeType for IDisplaySource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplaySource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -317,6 +383,9 @@ pub struct IDisplaySource2_Vtbl {
     pub RemoveStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayState, IDisplayState_Vtbl, 0x08129321_11b5_5cb2_99f8_e90b479a8a1d);
+impl windows_core::RuntimeType for IDisplayState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -345,6 +414,9 @@ pub struct IDisplayState_Vtbl {
     pub Clone: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayStateOperationResult, IDisplayStateOperationResult_Vtbl, 0xfcadbfdf_dc27_5638_b7f2_ebdfa4f7ea93);
+impl windows_core::RuntimeType for IDisplayStateOperationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayStateOperationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -352,11 +424,17 @@ pub struct IDisplayStateOperationResult_Vtbl {
     pub ExtendedErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplaySurface, IDisplaySurface_Vtbl, 0x594f6cc6_139a_56d6_a4b1_15fe2cb76adb);
+impl windows_core::RuntimeType for IDisplaySurface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplaySurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IDisplayTarget, IDisplayTarget_Vtbl, 0xaec57c6f_47b4_546b_987c_e73fa791fe3a);
+impl windows_core::RuntimeType for IDisplayTarget {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayTarget_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -379,6 +457,9 @@ pub struct IDisplayTarget_Vtbl {
     pub IsEqual: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayTask, IDisplayTask_Vtbl, 0x5e087448_135b_5bb0_bf63_637f84227c7a);
+impl windows_core::RuntimeType for IDisplayTask {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayTask_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -386,12 +467,18 @@ pub struct IDisplayTask_Vtbl {
     pub SetWait: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayTask2, IDisplayTask2_Vtbl, 0x0957ea19_bd55_55de_9267_c97b61e71c37);
+impl windows_core::RuntimeType for IDisplayTask2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayTask2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetSignal: unsafe extern "system" fn(*mut core::ffi::c_void, DisplayTaskSignalKind, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayTaskPool, IDisplayTaskPool_Vtbl, 0xc676253d_237d_5548_aafa_3e517fefef1c);
+impl windows_core::RuntimeType for IDisplayTaskPool {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayTaskPool_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -402,12 +489,18 @@ pub struct IDisplayTaskPool_Vtbl {
     ExecuteTask: usize,
 }
 windows_core::imp::define_interface!(IDisplayTaskPool2, IDisplayTaskPool2_Vtbl, 0x46b879b6_5d17_5955_a872_eb38003db586);
+impl windows_core::RuntimeType for IDisplayTaskPool2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayTaskPool2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryExecuteTask: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayTaskResult, IDisplayTaskResult_Vtbl, 0x6fbc7d67_f9b1_55e0_9d88_d3a5197a3f59);
+impl windows_core::RuntimeType for IDisplayTaskResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayTaskResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -416,6 +509,9 @@ pub struct IDisplayTaskResult_Vtbl {
     pub SourceStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DisplaySourceStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayView, IDisplayView_Vtbl, 0xb0c98ca1_b759_5b59_b1ad_f0786aa9e53d);
+impl windows_core::RuntimeType for IDisplayView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -438,6 +534,9 @@ pub struct IDisplayView_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IDisplayWireFormat, IDisplayWireFormat_Vtbl, 0x1acc967d_872c_5a38_bbb9_1d4872b76255);
+impl windows_core::RuntimeType for IDisplayWireFormat {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayWireFormat_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -452,12 +551,18 @@ pub struct IDisplayWireFormat_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IDisplayWireFormatFactory, IDisplayWireFormatFactory_Vtbl, 0xb2efc8d5_09d6_55e6_ad22_9014b3d25229);
+impl windows_core::RuntimeType for IDisplayWireFormatFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayWireFormatFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, DisplayWireFormatPixelEncoding, i32, DisplayWireFormatColorSpace, DisplayWireFormatEotf, DisplayWireFormatHdrMetadata, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayWireFormatStatics, IDisplayWireFormatStatics_Vtbl, 0xc575a22d_c3e6_5f7a_bdfb_87c6ab8661d5);
+impl windows_core::RuntimeType for IDisplayWireFormatStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayWireFormatStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -543,7 +648,7 @@ impl DisplayAdapter {
     }
 }
 impl windows_core::RuntimeType for DisplayAdapter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayAdapter>();
 }
 unsafe impl windows_core::Interface for DisplayAdapter {
     type Vtable = IDisplayAdapter_Vtbl;
@@ -637,7 +742,7 @@ impl DisplayDevice {
     }
 }
 impl windows_core::RuntimeType for DisplayDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayDevice>();
 }
 unsafe impl windows_core::Interface for DisplayDevice {
     type Vtable = IDisplayDevice_Vtbl;
@@ -654,7 +759,7 @@ pub struct DisplayFence(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayFence, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayFence {}
 impl windows_core::RuntimeType for DisplayFence {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayFence>();
 }
 unsafe impl windows_core::Interface for DisplayFence {
     type Vtable = IDisplayFence_Vtbl;
@@ -836,7 +941,7 @@ impl DisplayManager {
     }
 }
 impl windows_core::RuntimeType for DisplayManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayManager>();
 }
 unsafe impl windows_core::Interface for DisplayManager {
     type Vtable = IDisplayManager_Vtbl;
@@ -872,7 +977,7 @@ impl DisplayManagerChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DisplayManagerChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayManagerChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for DisplayManagerChangedEventArgs {
     type Vtable = IDisplayManagerChangedEventArgs_Vtbl;
@@ -908,7 +1013,7 @@ impl DisplayManagerDisabledEventArgs {
     }
 }
 impl windows_core::RuntimeType for DisplayManagerDisabledEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayManagerDisabledEventArgs>();
 }
 unsafe impl windows_core::Interface for DisplayManagerDisabledEventArgs {
     type Vtable = IDisplayManagerDisabledEventArgs_Vtbl;
@@ -944,7 +1049,7 @@ impl DisplayManagerEnabledEventArgs {
     }
 }
 impl windows_core::RuntimeType for DisplayManagerEnabledEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayManagerEnabledEventArgs>();
 }
 unsafe impl windows_core::Interface for DisplayManagerEnabledEventArgs {
     type Vtable = IDisplayManagerEnabledEventArgs_Vtbl;
@@ -980,7 +1085,7 @@ impl DisplayManagerPathsFailedOrInvalidatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DisplayManagerPathsFailedOrInvalidatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayManagerPathsFailedOrInvalidatedEventArgs>();
 }
 unsafe impl windows_core::Interface for DisplayManagerPathsFailedOrInvalidatedEventArgs {
     type Vtable = IDisplayManagerPathsFailedOrInvalidatedEventArgs_Vtbl;
@@ -1019,7 +1124,7 @@ impl DisplayManagerResultWithState {
     }
 }
 impl windows_core::RuntimeType for DisplayManagerResultWithState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayManagerResultWithState>();
 }
 unsafe impl windows_core::Interface for DisplayManagerResultWithState {
     type Vtable = IDisplayManagerResultWithState_Vtbl;
@@ -1116,7 +1221,7 @@ impl DisplayModeInfo {
     }
 }
 impl windows_core::RuntimeType for DisplayModeInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayModeInfo>();
 }
 unsafe impl windows_core::Interface for DisplayModeInfo {
     type Vtable = IDisplayModeInfo_Vtbl;
@@ -1316,7 +1421,7 @@ impl DisplayPath {
     }
 }
 impl windows_core::RuntimeType for DisplayPath {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayPath>();
 }
 unsafe impl windows_core::Interface for DisplayPath {
     type Vtable = IDisplayPath_Vtbl;
@@ -1414,7 +1519,7 @@ impl DisplayPrimaryDescription {
     }
 }
 impl windows_core::RuntimeType for DisplayPrimaryDescription {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayPrimaryDescription>();
 }
 unsafe impl windows_core::Interface for DisplayPrimaryDescription {
     type Vtable = IDisplayPrimaryDescription_Vtbl;
@@ -1431,7 +1536,7 @@ pub struct DisplayScanout(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplayScanout, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplayScanout {}
 impl windows_core::RuntimeType for DisplayScanout {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayScanout>();
 }
 unsafe impl windows_core::Interface for DisplayScanout {
     type Vtable = IDisplayScanout_Vtbl;
@@ -1493,7 +1598,7 @@ impl DisplaySource {
     }
 }
 impl windows_core::RuntimeType for DisplaySource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplaySource>();
 }
 unsafe impl windows_core::Interface for DisplaySource {
     type Vtable = IDisplaySource_Vtbl;
@@ -1629,7 +1734,7 @@ impl DisplayState {
     }
 }
 impl windows_core::RuntimeType for DisplayState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayState>();
 }
 unsafe impl windows_core::Interface for DisplayState {
     type Vtable = IDisplayState_Vtbl;
@@ -1661,7 +1766,7 @@ impl DisplayStateOperationResult {
     }
 }
 impl windows_core::RuntimeType for DisplayStateOperationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayStateOperationResult>();
 }
 unsafe impl windows_core::Interface for DisplayStateOperationResult {
     type Vtable = IDisplayStateOperationResult_Vtbl;
@@ -1678,7 +1783,7 @@ pub struct DisplaySurface(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(DisplaySurface, windows_core::IUnknown, windows_core::IInspectable);
 impl DisplaySurface {}
 impl windows_core::RuntimeType for DisplaySurface {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplaySurface>();
 }
 unsafe impl windows_core::Interface for DisplaySurface {
     type Vtable = IDisplaySurface_Vtbl;
@@ -1801,7 +1906,7 @@ impl DisplayTarget {
     }
 }
 impl windows_core::RuntimeType for DisplayTarget {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayTarget>();
 }
 unsafe impl windows_core::Interface for DisplayTarget {
     type Vtable = IDisplayTarget_Vtbl;
@@ -1840,7 +1945,7 @@ impl DisplayTask {
     }
 }
 impl windows_core::RuntimeType for DisplayTask {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayTask>();
 }
 unsafe impl windows_core::Interface for DisplayTask {
     type Vtable = IDisplayTask_Vtbl;
@@ -1883,7 +1988,7 @@ impl DisplayTaskPool {
     }
 }
 impl windows_core::RuntimeType for DisplayTaskPool {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayTaskPool>();
 }
 unsafe impl windows_core::Interface for DisplayTaskPool {
     type Vtable = IDisplayTaskPool_Vtbl;
@@ -1922,7 +2027,7 @@ impl DisplayTaskResult {
     }
 }
 impl windows_core::RuntimeType for DisplayTaskResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayTaskResult>();
 }
 unsafe impl windows_core::Interface for DisplayTaskResult {
     type Vtable = IDisplayTaskResult_Vtbl;
@@ -1979,7 +2084,7 @@ impl DisplayView {
     }
 }
 impl windows_core::RuntimeType for DisplayView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayView>();
 }
 unsafe impl windows_core::Interface for DisplayView {
     type Vtable = IDisplayView_Vtbl;
@@ -2066,7 +2171,7 @@ impl DisplayWireFormat {
     }
 }
 impl windows_core::RuntimeType for DisplayWireFormat {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayWireFormat>();
 }
 unsafe impl windows_core::Interface for DisplayWireFormat {
     type Vtable = IDisplayWireFormat_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Display_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IDisplayMonitor, IDisplayMonitor_Vtbl, 0x1f6b15d4_1d01_4c51_87e2_6f954a772b59);
+impl windows_core::RuntimeType for IDisplayMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,12 +35,18 @@ pub struct IDisplayMonitor_Vtbl {
     pub GetDescriptor: unsafe extern "system" fn(*mut core::ffi::c_void, DisplayMonitorDescriptorKind, *mut u32, *mut *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayMonitor2, IDisplayMonitor2_Vtbl, 0x023018e6_cb23_5830_96df_a7bf6e602577);
+impl windows_core::RuntimeType for IDisplayMonitor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayMonitor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsDolbyVisionSupportedInHdrMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayMonitorStatics, IDisplayMonitorStatics_Vtbl, 0x6eae698f_a228_4c05_821d_b695d667de8e);
+impl windows_core::RuntimeType for IDisplayMonitorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayMonitorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -224,7 +233,7 @@ impl DisplayMonitor {
     }
 }
 impl windows_core::RuntimeType for DisplayMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayMonitor>();
 }
 unsafe impl windows_core::Interface for DisplayMonitor {
     type Vtable = IDisplayMonitor_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPnpObject, IPnpObject_Vtbl, 0x95c66258_733b_4a8f_93a3_db078ac870c1);
+impl windows_core::RuntimeType for IPnpObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPnpObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IPnpObject_Vtbl {
     pub Update: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPnpObjectStatics, IPnpObjectStatics_Vtbl, 0xb3c32a3d_d168_4660_bbf3_a733b14b6e01);
+impl windows_core::RuntimeType for IPnpObjectStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPnpObjectStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +42,9 @@ pub struct IPnpObjectStatics_Vtbl {
     CreateWatcherAqsFilter: usize,
 }
 windows_core::imp::define_interface!(IPnpObjectUpdate, IPnpObjectUpdate_Vtbl, 0x6f59e812_001e_4844_bcc6_432886856a17);
+impl windows_core::RuntimeType for IPnpObjectUpdate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPnpObjectUpdate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +56,9 @@ pub struct IPnpObjectUpdate_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IPnpObjectWatcher, IPnpObjectWatcher_Vtbl, 0x83c95ca8_4772_4a7a_aca8_e48c42a89c44);
+impl windows_core::RuntimeType for IPnpObjectWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPnpObjectWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -155,7 +167,7 @@ impl PnpObject {
     }
 }
 impl windows_core::RuntimeType for PnpObject {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPnpObject>();
 }
 unsafe impl windows_core::Interface for PnpObject {
     type Vtable = IPnpObject_Vtbl;
@@ -222,7 +234,7 @@ impl PnpObjectCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PnpObjectCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IVectorView<PnpObject>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PnpObjectCollection {
@@ -282,7 +294,7 @@ impl PnpObjectUpdate {
     }
 }
 impl windows_core::RuntimeType for PnpObjectUpdate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPnpObjectUpdate>();
 }
 unsafe impl windows_core::Interface for PnpObjectUpdate {
     type Vtable = IPnpObjectUpdate_Vtbl;
@@ -385,7 +397,7 @@ impl PnpObjectWatcher {
     }
 }
 impl windows_core::RuntimeType for PnpObjectWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPnpObjectWatcher>();
 }
 unsafe impl windows_core::Interface for PnpObjectWatcher {
     type Vtable = IPnpObjectWatcher_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
@@ -1,18 +1,27 @@
 #[cfg(feature = "Devices_Enumeration_Pnp")]
 pub mod Pnp;
 windows_core::imp::define_interface!(IDeviceAccessChangedEventArgs, IDeviceAccessChangedEventArgs_Vtbl, 0xdeda0bcc_4f9d_4f58_9dba_a9bc800408d5);
+impl windows_core::RuntimeType for IDeviceAccessChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceAccessChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DeviceAccessStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceAccessChangedEventArgs2, IDeviceAccessChangedEventArgs2_Vtbl, 0x82523262_934b_4b30_a178_adc39f2f2be3);
+impl windows_core::RuntimeType for IDeviceAccessChangedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceAccessChangedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceAccessInformation, IDeviceAccessInformation_Vtbl, 0x0baa9a73_6de5_4915_8ddd_9a0554a6f545);
+impl windows_core::RuntimeType for IDeviceAccessInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceAccessInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +30,9 @@ pub struct IDeviceAccessInformation_Vtbl {
     pub CurrentStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DeviceAccessStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceAccessInformationStatics, IDeviceAccessInformationStatics_Vtbl, 0x574bd3d3_5f30_45cd_8a94_724fe5973084);
+impl windows_core::RuntimeType for IDeviceAccessInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceAccessInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,18 +41,27 @@ pub struct IDeviceAccessInformationStatics_Vtbl {
     pub CreateFromDeviceClass: unsafe extern "system" fn(*mut core::ffi::c_void, DeviceClass, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceConnectionChangeTriggerDetails, IDeviceConnectionChangeTriggerDetails_Vtbl, 0xb8578c0c_bbc1_484b_bffa_7b31dcc200b2);
+impl windows_core::RuntimeType for IDeviceConnectionChangeTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceConnectionChangeTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceDisconnectButtonClickedEventArgs, IDeviceDisconnectButtonClickedEventArgs_Vtbl, 0x8e44b56d_f902_4a00_b536_f37992e6a2a7);
+impl windows_core::RuntimeType for IDeviceDisconnectButtonClickedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceDisconnectButtonClickedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Device: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceInformation, IDeviceInformation_Vtbl, 0xaba0fb95_4398_489d_8e44_e6130927011f);
+impl windows_core::RuntimeType for IDeviceInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,6 +85,9 @@ pub struct IDeviceInformation_Vtbl {
     GetGlyphThumbnailAsync: usize,
 }
 windows_core::imp::define_interface!(IDeviceInformation2, IDeviceInformation2_Vtbl, 0xf156a638_7997_48d9_a10c_269d46533f48);
+impl windows_core::RuntimeType for IDeviceInformation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +95,9 @@ pub struct IDeviceInformation2_Vtbl {
     pub Pairing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceInformationCustomPairing, IDeviceInformationCustomPairing_Vtbl, 0x85138c02_4ee6_4914_8370_107a39144c0e);
+impl windows_core::RuntimeType for IDeviceInformationCustomPairing {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationCustomPairing_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -81,6 +108,9 @@ pub struct IDeviceInformationCustomPairing_Vtbl {
     pub RemovePairingRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceInformationPairing, IDeviceInformationPairing_Vtbl, 0x2c4769f5_f684_40d5_8469_e8dbaab70485);
+impl windows_core::RuntimeType for IDeviceInformationPairing {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationPairing_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +120,9 @@ pub struct IDeviceInformationPairing_Vtbl {
     pub PairWithProtectionLevelAsync: unsafe extern "system" fn(*mut core::ffi::c_void, DevicePairingProtectionLevel, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceInformationPairing2, IDeviceInformationPairing2_Vtbl, 0xf68612fd_0aee_4328_85cc_1c742bb1790d);
+impl windows_core::RuntimeType for IDeviceInformationPairing2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationPairing2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,18 +132,27 @@ pub struct IDeviceInformationPairing2_Vtbl {
     pub UnpairAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceInformationPairingStatics, IDeviceInformationPairingStatics_Vtbl, 0xe915c408_36d4_49a1_bf13_514173799b6b);
+impl windows_core::RuntimeType for IDeviceInformationPairingStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationPairingStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryRegisterForAllInboundPairingRequests: unsafe extern "system" fn(*mut core::ffi::c_void, DevicePairingKinds, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceInformationPairingStatics2, IDeviceInformationPairingStatics2_Vtbl, 0x04de5372_b7b7_476b_a74f_c5836a704d98);
+impl windows_core::RuntimeType for IDeviceInformationPairingStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationPairingStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryRegisterForAllInboundPairingRequestsWithProtectionLevel: unsafe extern "system" fn(*mut core::ffi::c_void, DevicePairingKinds, DevicePairingProtectionLevel, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceInformationStatics, IDeviceInformationStatics_Vtbl, 0xc17f100e_3a46_4a78_8013_769dc9b97390);
+impl windows_core::RuntimeType for IDeviceInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -144,6 +186,9 @@ pub struct IDeviceInformationStatics_Vtbl {
     CreateWatcherAqsFilterAndAdditionalProperties: usize,
 }
 windows_core::imp::define_interface!(IDeviceInformationStatics2, IDeviceInformationStatics2_Vtbl, 0x493b4f34_a84f_45fd_9167_15d1cb1bd1f9);
+impl windows_core::RuntimeType for IDeviceInformationStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -162,6 +207,9 @@ pub struct IDeviceInformationStatics2_Vtbl {
     CreateWatcherWithKindAqsFilterAndAdditionalProperties: usize,
 }
 windows_core::imp::define_interface!(IDeviceInformationUpdate, IDeviceInformationUpdate_Vtbl, 0x8f315305_d972_44b7_a37e_9e822c78213b);
+impl windows_core::RuntimeType for IDeviceInformationUpdate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationUpdate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,12 +220,18 @@ pub struct IDeviceInformationUpdate_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IDeviceInformationUpdate2, IDeviceInformationUpdate2_Vtbl, 0x5d9d148c_a873_485e_baa6_aa620788e3cc);
+impl windows_core::RuntimeType for IDeviceInformationUpdate2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceInformationUpdate2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DeviceInformationKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDevicePairingRequestedEventArgs, IDevicePairingRequestedEventArgs_Vtbl, 0xf717fc56_de6b_487f_8376_0180aca69963);
+impl windows_core::RuntimeType for IDevicePairingRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePairingRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +243,9 @@ pub struct IDevicePairingRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDevicePairingRequestedEventArgs2, IDevicePairingRequestedEventArgs2_Vtbl, 0xc83752d9_e4d3_4db0_a360_a105e437dbdc);
+impl windows_core::RuntimeType for IDevicePairingRequestedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePairingRequestedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,6 +255,9 @@ pub struct IDevicePairingRequestedEventArgs2_Vtbl {
     AcceptWithPasswordCredential: usize,
 }
 windows_core::imp::define_interface!(IDevicePairingResult, IDevicePairingResult_Vtbl, 0x072b02bf_dd95_4025_9b37_de51adba37b7);
+impl windows_core::RuntimeType for IDevicePairingResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePairingResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,6 +275,9 @@ pub struct IDevicePairingSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IDevicePicker, IDevicePicker_Vtbl, 0x84997aa2_034a_4440_8813_7d0bd479bf5a);
+impl windows_core::RuntimeType for IDevicePicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -244,6 +307,9 @@ pub struct IDevicePicker_Vtbl {
     pub SetDisplayStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, DevicePickerDisplayStatusOptions) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDevicePickerAppearance, IDevicePickerAppearance_Vtbl, 0xe69a12c6_e627_4ed8_9b6c_460af445e56d);
+impl windows_core::RuntimeType for IDevicePickerAppearance {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePickerAppearance_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -299,6 +365,9 @@ pub struct IDevicePickerAppearance_Vtbl {
     SetSelectedAccentColor: usize,
 }
 windows_core::imp::define_interface!(IDevicePickerFilter, IDevicePickerFilter_Vtbl, 0x91db92a2_57cb_48f1_9b59_a59b7a1f02a2);
+impl windows_core::RuntimeType for IDevicePickerFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePickerFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,18 +381,27 @@ pub struct IDevicePickerFilter_Vtbl {
     SupportedDeviceSelectors: usize,
 }
 windows_core::imp::define_interface!(IDeviceSelectedEventArgs, IDeviceSelectedEventArgs_Vtbl, 0x269edade_1d2f_4940_8402_4156b81d3c77);
+impl windows_core::RuntimeType for IDeviceSelectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceSelectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SelectedDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceUnpairingResult, IDeviceUnpairingResult_Vtbl, 0x66f44ad3_79d9_444b_92cf_a92ef72571c7);
+impl windows_core::RuntimeType for IDeviceUnpairingResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceUnpairingResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DeviceUnpairingResultStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceWatcher, IDeviceWatcher_Vtbl, 0xc9eab97d_8f6b_4f96_a9f4_abc814e22271);
+impl windows_core::RuntimeType for IDeviceWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -342,6 +420,9 @@ pub struct IDeviceWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceWatcher2, IDeviceWatcher2_Vtbl, 0xff08456e_ed14_49e9_9a69_8117c54ae971);
+impl windows_core::RuntimeType for IDeviceWatcher2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceWatcher2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -351,6 +432,9 @@ pub struct IDeviceWatcher2_Vtbl {
     GetBackgroundTrigger: usize,
 }
 windows_core::imp::define_interface!(IDeviceWatcherEvent, IDeviceWatcherEvent_Vtbl, 0x74aa9c0b_1dbd_47fd_b635_3cc556d0ff8b);
+impl windows_core::RuntimeType for IDeviceWatcherEvent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceWatcherEvent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -359,6 +443,9 @@ pub struct IDeviceWatcherEvent_Vtbl {
     pub DeviceInformationUpdate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceWatcherTriggerDetails, IDeviceWatcherTriggerDetails_Vtbl, 0x38808119_4cb7_4e57_a56d_776d07cbfef9);
+impl windows_core::RuntimeType for IDeviceWatcherTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceWatcherTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -368,6 +455,9 @@ pub struct IDeviceWatcherTriggerDetails_Vtbl {
     DeviceWatcherEvents: usize,
 }
 windows_core::imp::define_interface!(IEnclosureLocation, IEnclosureLocation_Vtbl, 0x42340a27_5810_459c_aabb_c65e1f813ecf);
+impl windows_core::RuntimeType for IEnclosureLocation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnclosureLocation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -376,6 +466,9 @@ pub struct IEnclosureLocation_Vtbl {
     pub Panel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut Panel) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEnclosureLocation2, IEnclosureLocation2_Vtbl, 0x2885995b_e07d_485d_8a9e_bdf29aef4f66);
+impl windows_core::RuntimeType for IEnclosureLocation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnclosureLocation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -402,7 +495,7 @@ impl DeviceAccessChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DeviceAccessChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceAccessChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for DeviceAccessChangedEventArgs {
     type Vtable = IDeviceAccessChangedEventArgs_Vtbl;
@@ -464,7 +557,7 @@ impl DeviceAccessInformation {
     }
 }
 impl windows_core::RuntimeType for DeviceAccessInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceAccessInformation>();
 }
 unsafe impl windows_core::Interface for DeviceAccessInformation {
     type Vtable = IDeviceAccessInformation_Vtbl;
@@ -489,7 +582,7 @@ impl DeviceConnectionChangeTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for DeviceConnectionChangeTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceConnectionChangeTriggerDetails>();
 }
 unsafe impl windows_core::Interface for DeviceConnectionChangeTriggerDetails {
     type Vtable = IDeviceConnectionChangeTriggerDetails_Vtbl;
@@ -514,7 +607,7 @@ impl DeviceDisconnectButtonClickedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DeviceDisconnectButtonClickedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceDisconnectButtonClickedEventArgs>();
 }
 unsafe impl windows_core::Interface for DeviceDisconnectButtonClickedEventArgs {
     type Vtable = IDeviceDisconnectButtonClickedEventArgs_Vtbl;
@@ -733,7 +826,7 @@ impl DeviceInformation {
     }
 }
 impl windows_core::RuntimeType for DeviceInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceInformation>();
 }
 unsafe impl windows_core::Interface for DeviceInformation {
     type Vtable = IDeviceInformation_Vtbl;
@@ -800,7 +893,7 @@ impl DeviceInformationCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for DeviceInformationCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVectorView<DeviceInformation>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for DeviceInformationCollection {
@@ -876,7 +969,7 @@ impl DeviceInformationCustomPairing {
     }
 }
 impl windows_core::RuntimeType for DeviceInformationCustomPairing {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceInformationCustomPairing>();
 }
 unsafe impl windows_core::Interface for DeviceInformationCustomPairing {
     type Vtable = IDeviceInformationCustomPairing_Vtbl;
@@ -975,7 +1068,7 @@ impl DeviceInformationPairing {
     }
 }
 impl windows_core::RuntimeType for DeviceInformationPairing {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceInformationPairing>();
 }
 unsafe impl windows_core::Interface for DeviceInformationPairing {
     type Vtable = IDeviceInformationPairing_Vtbl;
@@ -1015,7 +1108,7 @@ impl DeviceInformationUpdate {
     }
 }
 impl windows_core::RuntimeType for DeviceInformationUpdate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceInformationUpdate>();
 }
 unsafe impl windows_core::Interface for DeviceInformationUpdate {
     type Vtable = IDeviceInformationUpdate_Vtbl;
@@ -1077,7 +1170,7 @@ impl DevicePairingRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DevicePairingRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePairingRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for DevicePairingRequestedEventArgs {
     type Vtable = IDevicePairingRequestedEventArgs_Vtbl;
@@ -1109,7 +1202,7 @@ impl DevicePairingResult {
     }
 }
 impl windows_core::RuntimeType for DevicePairingResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePairingResult>();
 }
 unsafe impl windows_core::Interface for DevicePairingResult {
     type Vtable = IDevicePairingResult_Vtbl;
@@ -1233,7 +1326,7 @@ impl DevicePicker {
     }
 }
 impl windows_core::RuntimeType for DevicePicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePicker>();
 }
 unsafe impl windows_core::Interface for DevicePicker {
     type Vtable = IDevicePicker_Vtbl;
@@ -1340,7 +1433,7 @@ impl DevicePickerAppearance {
     }
 }
 impl windows_core::RuntimeType for DevicePickerAppearance {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePickerAppearance>();
 }
 unsafe impl windows_core::Interface for DevicePickerAppearance {
     type Vtable = IDevicePickerAppearance_Vtbl;
@@ -1374,7 +1467,7 @@ impl DevicePickerFilter {
     }
 }
 impl windows_core::RuntimeType for DevicePickerFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePickerFilter>();
 }
 unsafe impl windows_core::Interface for DevicePickerFilter {
     type Vtable = IDevicePickerFilter_Vtbl;
@@ -1399,7 +1492,7 @@ impl DeviceSelectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DeviceSelectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceSelectedEventArgs>();
 }
 unsafe impl windows_core::Interface for DeviceSelectedEventArgs {
     type Vtable = IDeviceSelectedEventArgs_Vtbl;
@@ -1531,7 +1624,7 @@ impl DeviceThumbnail {
 }
 #[cfg(feature = "Storage_Streams")]
 impl windows_core::RuntimeType for DeviceThumbnail {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Storage::Streams::IRandomAccessStreamWithContentType>();
 }
 #[cfg(feature = "Storage_Streams")]
 unsafe impl windows_core::Interface for DeviceThumbnail {
@@ -1560,7 +1653,7 @@ impl DeviceUnpairingResult {
     }
 }
 impl windows_core::RuntimeType for DeviceUnpairingResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceUnpairingResult>();
 }
 unsafe impl windows_core::Interface for DeviceUnpairingResult {
     type Vtable = IDeviceUnpairingResult_Vtbl;
@@ -1674,7 +1767,7 @@ impl DeviceWatcher {
     }
 }
 impl windows_core::RuntimeType for DeviceWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceWatcher>();
 }
 unsafe impl windows_core::Interface for DeviceWatcher {
     type Vtable = IDeviceWatcher_Vtbl;
@@ -1713,7 +1806,7 @@ impl DeviceWatcherEvent {
     }
 }
 impl windows_core::RuntimeType for DeviceWatcherEvent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceWatcherEvent>();
 }
 unsafe impl windows_core::Interface for DeviceWatcherEvent {
     type Vtable = IDeviceWatcherEvent_Vtbl;
@@ -1739,7 +1832,7 @@ impl DeviceWatcherTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for DeviceWatcherTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceWatcherTriggerDetails>();
 }
 unsafe impl windows_core::Interface for DeviceWatcherTriggerDetails {
     type Vtable = IDeviceWatcherTriggerDetails_Vtbl;
@@ -1785,7 +1878,7 @@ impl EnclosureLocation {
     }
 }
 impl windows_core::RuntimeType for EnclosureLocation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEnclosureLocation>();
 }
 unsafe impl windows_core::Interface for EnclosureLocation {
     type Vtable = IEnclosureLocation_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGeofence, IGeofence_Vtbl, 0x9c090823_edb8_47e0_8245_5bf61d321f2d);
+impl windows_core::RuntimeType for IGeofence {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeofence_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IGeofence_Vtbl {
     pub SingleUse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeofenceFactory, IGeofenceFactory_Vtbl, 0x841f624b_325f_4b90_bca7_2b8022a93796);
+impl windows_core::RuntimeType for IGeofenceFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeofenceFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct IGeofenceFactory_Vtbl {
     pub CreateWithMonitorStatesDwellTimeStartTimeAndDuration: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, MonitoredGeofenceStates, bool, super::super::super::Foundation::TimeSpan, super::super::super::Foundation::DateTime, super::super::super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeofenceMonitor, IGeofenceMonitor_Vtbl, 0x4c0f5f78_1c1f_4621_bbbd_833b92247226);
+impl windows_core::RuntimeType for IGeofenceMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeofenceMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,12 +48,18 @@ pub struct IGeofenceMonitor_Vtbl {
     pub RemoveStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeofenceMonitorStatics, IGeofenceMonitorStatics_Vtbl, 0x2dd32fcf_7e75_4899_ace3_2bd0a65cce06);
+impl windows_core::RuntimeType for IGeofenceMonitorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeofenceMonitorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeofenceStateChangeReport, IGeofenceStateChangeReport_Vtbl, 0x9a243c18_2464_4c89_be05_b3ffff5babc5);
+impl windows_core::RuntimeType for IGeofenceStateChangeReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeofenceStateChangeReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -150,7 +165,7 @@ impl Geofence {
     }
 }
 impl windows_core::RuntimeType for Geofence {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeofence>();
 }
 unsafe impl windows_core::Interface for Geofence {
     type Vtable = IGeofence_Vtbl;
@@ -237,7 +252,7 @@ impl GeofenceMonitor {
     }
 }
 impl windows_core::RuntimeType for GeofenceMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeofenceMonitor>();
 }
 unsafe impl windows_core::Interface for GeofenceMonitor {
     type Vtable = IGeofenceMonitor_Vtbl;
@@ -283,7 +298,7 @@ impl GeofenceStateChangeReport {
     }
 }
 impl windows_core::RuntimeType for GeofenceStateChangeReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeofenceStateChangeReport>();
 }
 unsafe impl windows_core::Interface for GeofenceStateChangeReport {
     type Vtable = IGeofenceStateChangeReport_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGeolocationProvider, IGeolocationProvider_Vtbl, 0xe4cf071d_3f64_509f_8dc2_0b74a059829d);
+impl windows_core::RuntimeType for IGeolocationProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeolocationProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,7 +57,7 @@ impl GeolocationProvider {
     }
 }
 impl windows_core::RuntimeType for GeolocationProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeolocationProvider>();
 }
 unsafe impl windows_core::Interface for GeolocationProvider {
     type Vtable = IGeolocationProvider_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
@@ -3,6 +3,9 @@ pub mod Geofencing;
 #[cfg(feature = "Devices_Geolocation_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(ICivicAddress, ICivicAddress_Vtbl, 0xa8567a1a_64f4_4d48_bcea_f6b008eca34c);
+impl windows_core::RuntimeType for ICivicAddress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICivicAddress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +16,9 @@ pub struct ICivicAddress_Vtbl {
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeoboundingBox, IGeoboundingBox_Vtbl, 0x0896c80b_274f_43da_9a06_cbfcdaeb4ec2);
+impl windows_core::RuntimeType for IGeoboundingBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeoboundingBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +29,9 @@ pub struct IGeoboundingBox_Vtbl {
     pub MaxAltitude: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeoboundingBoxFactory, IGeoboundingBoxFactory_Vtbl, 0x4dfba589_0411_4abc_b3b5_5bbccb57d98c);
+impl windows_core::RuntimeType for IGeoboundingBoxFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeoboundingBoxFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +40,9 @@ pub struct IGeoboundingBoxFactory_Vtbl {
     pub CreateWithAltitudeReferenceAndSpatialReference: unsafe extern "system" fn(*mut core::ffi::c_void, BasicGeoposition, BasicGeoposition, AltitudeReferenceSystem, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeoboundingBoxStatics, IGeoboundingBoxStatics_Vtbl, 0x67b80708_e61a_4cd0_841b_93233792b5ca);
+impl windows_core::RuntimeType for IGeoboundingBoxStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeoboundingBoxStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +60,9 @@ pub struct IGeoboundingBoxStatics_Vtbl {
     TryComputeWithAltitudeReferenceAndSpatialReference: usize,
 }
 windows_core::imp::define_interface!(IGeocircle, IGeocircle_Vtbl, 0x39e45843_a7f9_4e63_92a7_ba0c28d124b1);
+impl windows_core::RuntimeType for IGeocircle {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocircle_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,6 +70,9 @@ pub struct IGeocircle_Vtbl {
     pub Radius: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocircleFactory, IGeocircleFactory_Vtbl, 0xafd6531f_72b1_4f7d_87cc_4ed4c9849c05);
+impl windows_core::RuntimeType for IGeocircleFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocircleFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +81,9 @@ pub struct IGeocircleFactory_Vtbl {
     pub CreateWithAltitudeReferenceSystemAndSpatialReferenceId: unsafe extern "system" fn(*mut core::ffi::c_void, BasicGeoposition, f64, AltitudeReferenceSystem, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocoordinate, IGeocoordinate_Vtbl, 0xee21a3aa_976a_4c70_803d_083ea55bcbc4);
+impl windows_core::RuntimeType for IGeocoordinate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocoordinate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,6 +106,9 @@ pub struct IGeocoordinate_Vtbl {
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocoordinateSatelliteData, IGeocoordinateSatelliteData_Vtbl, 0xc32a74d9_2608_474c_912c_06dd490f4af7);
+impl windows_core::RuntimeType for IGeocoordinateSatelliteData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocoordinateSatelliteData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,6 +117,9 @@ pub struct IGeocoordinateSatelliteData_Vtbl {
     pub VerticalDilutionOfPrecision: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocoordinateSatelliteData2, IGeocoordinateSatelliteData2_Vtbl, 0x761c8cfd_a19d_5a51_80f5_71676115483e);
+impl windows_core::RuntimeType for IGeocoordinateSatelliteData2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocoordinateSatelliteData2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,12 +127,18 @@ pub struct IGeocoordinateSatelliteData2_Vtbl {
     pub TimeDilutionOfPrecision: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocoordinateWithPoint, IGeocoordinateWithPoint_Vtbl, 0xfeea0525_d22c_4d46_b527_0b96066fc7db);
+impl windows_core::RuntimeType for IGeocoordinateWithPoint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocoordinateWithPoint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Point: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocoordinateWithPositionData, IGeocoordinateWithPositionData_Vtbl, 0x95e634be_dbd6_40ac_b8f2_a65c0340d9a6);
+impl windows_core::RuntimeType for IGeocoordinateWithPositionData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocoordinateWithPositionData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -113,18 +146,27 @@ pub struct IGeocoordinateWithPositionData_Vtbl {
     pub SatelliteData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocoordinateWithPositionSourceTimestamp, IGeocoordinateWithPositionSourceTimestamp_Vtbl, 0x8543fc02_c9f1_4610_afe0_8bc3a6a87036);
+impl windows_core::RuntimeType for IGeocoordinateWithPositionSourceTimestamp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocoordinateWithPositionSourceTimestamp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PositionSourceTimestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeocoordinateWithRemoteSource, IGeocoordinateWithRemoteSource_Vtbl, 0x397cebd7_ee38_5f3b_8900_c4a7bc9cf953);
+impl windows_core::RuntimeType for IGeocoordinateWithRemoteSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeocoordinateWithRemoteSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsRemoteSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeolocator, IGeolocator_Vtbl, 0xa9c3bf62_4524_4989_8aa9_de019d2e551f);
+impl windows_core::RuntimeType for IGeolocator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeolocator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -143,12 +185,18 @@ pub struct IGeolocator_Vtbl {
     pub RemoveStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeolocator2, IGeolocator2_Vtbl, 0xd1b42e6d_8891_43b4_ad36_27c6fe9a97b1);
+impl windows_core::RuntimeType for IGeolocator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeolocator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AllowFallbackToConsentlessPositions: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeolocatorStatics, IGeolocatorStatics_Vtbl, 0x9a8e7571_2df5_4591_9f87_eb5fd894e9b7);
+impl windows_core::RuntimeType for IGeolocatorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeolocatorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -163,6 +211,9 @@ pub struct IGeolocatorStatics_Vtbl {
     GetGeopositionHistoryWithDurationAsync: usize,
 }
 windows_core::imp::define_interface!(IGeolocatorStatics2, IGeolocatorStatics2_Vtbl, 0x993011a2_fa1c_4631_a71d_0dbeb1250d9c);
+impl windows_core::RuntimeType for IGeolocatorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeolocatorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -171,6 +222,9 @@ pub struct IGeolocatorStatics2_Vtbl {
     pub DefaultGeoposition: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeolocatorWithScalarAccuracy, IGeolocatorWithScalarAccuracy_Vtbl, 0x96f5d3c1_b80f_460a_994d_a96c47a51aa4);
+impl windows_core::RuntimeType for IGeolocatorWithScalarAccuracy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeolocatorWithScalarAccuracy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +232,9 @@ pub struct IGeolocatorWithScalarAccuracy_Vtbl {
     pub SetDesiredAccuracyInMeters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeopath, IGeopath_Vtbl, 0xe53fd7b9_2da4_4714_a652_de8593289898);
+impl windows_core::RuntimeType for IGeopath {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeopath_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -187,6 +244,9 @@ pub struct IGeopath_Vtbl {
     Positions: usize,
 }
 windows_core::imp::define_interface!(IGeopathFactory, IGeopathFactory_Vtbl, 0x27bea9c8_c7e7_4359_9b9b_fca3e05ef593);
+impl windows_core::RuntimeType for IGeopathFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeopathFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -204,12 +264,18 @@ pub struct IGeopathFactory_Vtbl {
     CreateWithAltitudeReferenceAndSpatialReference: usize,
 }
 windows_core::imp::define_interface!(IGeopoint, IGeopoint_Vtbl, 0x6bfa00eb_e56e_49bb_9caf_cbaa78a8bcef);
+impl windows_core::RuntimeType for IGeopoint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeopoint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut BasicGeoposition) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeopointFactory, IGeopointFactory_Vtbl, 0xdb6b8d33_76bd_4e30_8af7_a844dc37b7a0);
+impl windows_core::RuntimeType for IGeopointFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeopointFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -218,6 +284,9 @@ pub struct IGeopointFactory_Vtbl {
     pub CreateWithAltitudeReferenceSystemAndSpatialReferenceId: unsafe extern "system" fn(*mut core::ffi::c_void, BasicGeoposition, AltitudeReferenceSystem, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeoposition, IGeoposition_Vtbl, 0xc18d0454_7d41_4ff7_a957_9dffb4ef7f5b);
+impl windows_core::RuntimeType for IGeoposition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeoposition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -225,6 +294,9 @@ pub struct IGeoposition_Vtbl {
     pub CivicAddress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeoposition2, IGeoposition2_Vtbl, 0x7f62f697_8671_4b0d_86f8_474a8496187c);
+impl windows_core::RuntimeType for IGeoposition2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeoposition2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -266,6 +338,9 @@ pub struct IGeoshape_Vtbl {
     pub AltitudeReferenceSystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AltitudeReferenceSystem) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeovisit, IGeovisit_Vtbl, 0xb1877a76_9ef6_41ab_a0dd_793ece76e2de);
+impl windows_core::RuntimeType for IGeovisit {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeovisit_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +349,9 @@ pub struct IGeovisit_Vtbl {
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeovisitMonitor, IGeovisitMonitor_Vtbl, 0x80118aaf_5944_4591_83c1_396647f54f2c);
+impl windows_core::RuntimeType for IGeovisitMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeovisitMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -284,18 +362,27 @@ pub struct IGeovisitMonitor_Vtbl {
     pub RemoveVisitStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeovisitMonitorStatics, IGeovisitMonitorStatics_Vtbl, 0xbcf976a7_bbf2_4cdd_95cf_554c82edfb87);
+impl windows_core::RuntimeType for IGeovisitMonitorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeovisitMonitorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetLastReportAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeovisitStateChangedEventArgs, IGeovisitStateChangedEventArgs_Vtbl, 0xceb4d1ff_8b53_4968_beed_4cecd029ce15);
+impl windows_core::RuntimeType for IGeovisitStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeovisitStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Visit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeovisitTriggerDetails, IGeovisitTriggerDetails_Vtbl, 0xea770d9e_d1c9_454b_99b7_b2f8cdd2482f);
+impl windows_core::RuntimeType for IGeovisitTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeovisitTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -305,18 +392,27 @@ pub struct IGeovisitTriggerDetails_Vtbl {
     ReadReports: usize,
 }
 windows_core::imp::define_interface!(IPositionChangedEventArgs, IPositionChangedEventArgs_Vtbl, 0x37859ce5_9d1e_46c5_bf3b_6ad8cac1a093);
+impl windows_core::RuntimeType for IPositionChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPositionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStatusChangedEventArgs, IStatusChangedEventArgs_Vtbl, 0x3453d2da_8c93_4111_a205_9aecfc9be5c0);
+impl windows_core::RuntimeType for IStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PositionStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVenueData, IVenueData_Vtbl, 0x66f39187_60e3_4b2f_b527_4f53f1c3c677);
+impl windows_core::RuntimeType for IVenueData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVenueData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -365,7 +461,7 @@ impl CivicAddress {
     }
 }
 impl windows_core::RuntimeType for CivicAddress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICivicAddress>();
 }
 unsafe impl windows_core::Interface for CivicAddress {
     type Vtable = ICivicAddress_Vtbl;
@@ -498,7 +594,7 @@ impl GeoboundingBox {
     }
 }
 impl windows_core::RuntimeType for GeoboundingBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeoboundingBox>();
 }
 unsafe impl windows_core::Interface for GeoboundingBox {
     type Vtable = IGeoboundingBox_Vtbl;
@@ -575,7 +671,7 @@ impl Geocircle {
     }
 }
 impl windows_core::RuntimeType for Geocircle {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeocircle>();
 }
 unsafe impl windows_core::Interface for Geocircle {
     type Vtable = IGeocircle_Vtbl;
@@ -687,7 +783,7 @@ impl Geocoordinate {
     }
 }
 impl windows_core::RuntimeType for Geocoordinate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeocoordinate>();
 }
 unsafe impl windows_core::Interface for Geocoordinate {
     type Vtable = IGeocoordinate_Vtbl;
@@ -740,7 +836,7 @@ impl GeocoordinateSatelliteData {
     }
 }
 impl windows_core::RuntimeType for GeocoordinateSatelliteData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeocoordinateSatelliteData>();
 }
 unsafe impl windows_core::Interface for GeocoordinateSatelliteData {
     type Vtable = IGeocoordinateSatelliteData_Vtbl;
@@ -913,7 +1009,7 @@ impl Geolocator {
     }
 }
 impl windows_core::RuntimeType for Geolocator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeolocator>();
 }
 unsafe impl windows_core::Interface for Geolocator {
     type Vtable = IGeolocator_Vtbl;
@@ -996,7 +1092,7 @@ impl Geopath {
     }
 }
 impl windows_core::RuntimeType for Geopath {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeopath>();
 }
 unsafe impl windows_core::Interface for Geopath {
     type Vtable = IGeopath_Vtbl;
@@ -1066,7 +1162,7 @@ impl Geopoint {
     }
 }
 impl windows_core::RuntimeType for Geopoint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeopoint>();
 }
 unsafe impl windows_core::Interface for Geopoint {
     type Vtable = IGeopoint_Vtbl;
@@ -1105,7 +1201,7 @@ impl Geoposition {
     }
 }
 impl windows_core::RuntimeType for Geoposition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeoposition>();
 }
 unsafe impl windows_core::Interface for Geoposition {
     type Vtable = IGeoposition_Vtbl;
@@ -1144,7 +1240,7 @@ impl Geovisit {
     }
 }
 impl windows_core::RuntimeType for Geovisit {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeovisit>();
 }
 unsafe impl windows_core::Interface for Geovisit {
     type Vtable = IGeovisit_Vtbl;
@@ -1209,7 +1305,7 @@ impl GeovisitMonitor {
     }
 }
 impl windows_core::RuntimeType for GeovisitMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeovisitMonitor>();
 }
 unsafe impl windows_core::Interface for GeovisitMonitor {
     type Vtable = IGeovisitMonitor_Vtbl;
@@ -1234,7 +1330,7 @@ impl GeovisitStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GeovisitStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeovisitStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GeovisitStateChangedEventArgs {
     type Vtable = IGeovisitStateChangedEventArgs_Vtbl;
@@ -1260,7 +1356,7 @@ impl GeovisitTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for GeovisitTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeovisitTriggerDetails>();
 }
 unsafe impl windows_core::Interface for GeovisitTriggerDetails {
     type Vtable = IGeovisitTriggerDetails_Vtbl;
@@ -1285,7 +1381,7 @@ impl PositionChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PositionChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPositionChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PositionChangedEventArgs {
     type Vtable = IPositionChangedEventArgs_Vtbl;
@@ -1310,7 +1406,7 @@ impl StatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for StatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for StatusChangedEventArgs {
     type Vtable = IStatusChangedEventArgs_Vtbl;
@@ -1342,7 +1438,7 @@ impl VenueData {
     }
 }
 impl windows_core::RuntimeType for VenueData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVenueData>();
 }
 unsafe impl windows_core::Interface for VenueData {
     type Vtable = IVenueData_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
@@ -116,12 +116,18 @@ pub struct IGpioPinProvider_Vtbl {
     pub Read: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ProviderGpioPinValue) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioPinProviderValueChangedEventArgs, IGpioPinProviderValueChangedEventArgs_Vtbl, 0x32a6d6f2_3d5b_44cd_8fbe_13a69f2edb24);
+impl windows_core::RuntimeType for IGpioPinProviderValueChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioPinProviderValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Edge: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ProviderGpioPinEdge) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioPinProviderValueChangedEventArgsFactory, IGpioPinProviderValueChangedEventArgsFactory_Vtbl, 0x3ecb0b59_568c_4392_b24a_8a59a902b1f1);
+impl windows_core::RuntimeType for IGpioPinProviderValueChangedEventArgsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioPinProviderValueChangedEventArgsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,7 +181,7 @@ impl GpioPinProviderValueChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GpioPinProviderValueChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGpioPinProviderValueChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GpioPinProviderValueChangedEventArgs {
     type Vtable = IGpioPinProviderValueChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Gpio_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IGpioChangeCounter, IGpioChangeCounter_Vtbl, 0xcb5ec0de_6801_43ff_803d_4576628a8b26);
+impl windows_core::RuntimeType for IGpioChangeCounter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioChangeCounter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,12 +16,18 @@ pub struct IGpioChangeCounter_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GpioChangeCount) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioChangeCounterFactory, IGpioChangeCounterFactory_Vtbl, 0x147d94b6_0a9e_410c_b4fa_f89f4052084d);
+impl windows_core::RuntimeType for IGpioChangeCounterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioChangeCounterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioChangeReader, IGpioChangeReader_Vtbl, 0x0abc885f_e031_48e8_8590_70de78363c6d);
+impl windows_core::RuntimeType for IGpioChangeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioChangeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +50,9 @@ pub struct IGpioChangeReader_Vtbl {
     pub WaitForItemsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioChangeReaderFactory, IGpioChangeReaderFactory_Vtbl, 0xa9598ef3_390e_441a_9d1c_e8de0b2df0df);
+impl windows_core::RuntimeType for IGpioChangeReaderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioChangeReaderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +60,9 @@ pub struct IGpioChangeReaderFactory_Vtbl {
     pub CreateWithCapacity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioController, IGpioController_Vtbl, 0x284012e3_7461_469c_a8bc_61d69d08a53c);
+impl windows_core::RuntimeType for IGpioController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,12 +72,18 @@ pub struct IGpioController_Vtbl {
     pub TryOpenPin: unsafe extern "system" fn(*mut core::ffi::c_void, i32, GpioSharingMode, *mut *mut core::ffi::c_void, *mut GpioOpenStatus, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioControllerStatics, IGpioControllerStatics_Vtbl, 0x2ed6f42e_7af7_4116_9533_c43d99a1fb64);
+impl windows_core::RuntimeType for IGpioControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioControllerStatics2, IGpioControllerStatics2_Vtbl, 0x912b7d20_6ca4_4106_a373_fffd346b0e5b);
+impl windows_core::RuntimeType for IGpioControllerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioControllerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +94,9 @@ pub struct IGpioControllerStatics2_Vtbl {
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioPin, IGpioPin_Vtbl, 0x11d9b087_afae_4790_9ee9_e0eac942d201);
+impl windows_core::RuntimeType for IGpioPin {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioPin_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +113,9 @@ pub struct IGpioPin_Vtbl {
     pub Read: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GpioPinValue) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGpioPinValueChangedEventArgs, IGpioPinValueChangedEventArgs_Vtbl, 0x3137aae1_703d_4059_bd24_b5b25dffb84e);
+impl windows_core::RuntimeType for IGpioPinValueChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGpioPinValueChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -160,7 +187,7 @@ impl GpioChangeCounter {
     }
 }
 impl windows_core::RuntimeType for GpioChangeCounter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGpioChangeCounter>();
 }
 unsafe impl windows_core::Interface for GpioChangeCounter {
     type Vtable = IGpioChangeCounter_Vtbl;
@@ -293,7 +320,7 @@ impl GpioChangeReader {
     }
 }
 impl windows_core::RuntimeType for GpioChangeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGpioChangeReader>();
 }
 unsafe impl windows_core::Interface for GpioChangeReader {
     type Vtable = IGpioChangeReader_Vtbl;
@@ -371,7 +398,7 @@ impl GpioController {
     }
 }
 impl windows_core::RuntimeType for GpioController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGpioController>();
 }
 unsafe impl windows_core::Interface for GpioController {
     type Vtable = IGpioController_Vtbl;
@@ -462,7 +489,7 @@ impl GpioPin {
     }
 }
 impl windows_core::RuntimeType for GpioPin {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGpioPin>();
 }
 unsafe impl windows_core::Interface for GpioPin {
     type Vtable = IGpioPin_Vtbl;
@@ -487,7 +514,7 @@ impl GpioPinValueChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GpioPinValueChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGpioPinValueChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GpioPinValueChangedEventArgs {
     type Vtable = IGpioPinValueChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IKnownSimpleHapticsControllerWaveformsStatics, IKnownSimpleHapticsControllerWaveformsStatics_Vtbl, 0x3d577ef7_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IKnownSimpleHapticsControllerWaveformsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownSimpleHapticsControllerWaveformsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IKnownSimpleHapticsControllerWaveformsStatics_Vtbl {
     pub Release: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownSimpleHapticsControllerWaveformsStatics2, IKnownSimpleHapticsControllerWaveformsStatics2_Vtbl, 0xa7d24c27_b79d_510a_bf79_ff6d49173e1d);
+impl windows_core::RuntimeType for IKnownSimpleHapticsControllerWaveformsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownSimpleHapticsControllerWaveformsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,9 @@ pub struct IKnownSimpleHapticsControllerWaveformsStatics2_Vtbl {
     pub Success: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISimpleHapticsController, ISimpleHapticsController_Vtbl, 0x3d577ef9_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for ISimpleHapticsController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleHapticsController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,6 +52,9 @@ pub struct ISimpleHapticsController_Vtbl {
     pub SendHapticFeedbackForPlayCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, f64, i32, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISimpleHapticsControllerFeedback, ISimpleHapticsControllerFeedback_Vtbl, 0x3d577ef8_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for ISimpleHapticsControllerFeedback {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleHapticsControllerFeedback_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +62,9 @@ pub struct ISimpleHapticsControllerFeedback_Vtbl {
     pub Duration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVibrationDevice, IVibrationDevice_Vtbl, 0x40f21a3e_8844_47ff_b312_06185a3844da);
+impl windows_core::RuntimeType for IVibrationDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVibrationDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +72,9 @@ pub struct IVibrationDevice_Vtbl {
     pub SimpleHapticsController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVibrationDeviceStatics, IVibrationDeviceStatics_Vtbl, 0x53e2eded_2290_4ac9_8eb3_1a84122eb71c);
+impl windows_core::RuntimeType for IVibrationDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVibrationDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -257,7 +275,7 @@ impl SimpleHapticsController {
     }
 }
 impl windows_core::RuntimeType for SimpleHapticsController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISimpleHapticsController>();
 }
 unsafe impl windows_core::Interface for SimpleHapticsController {
     type Vtable = ISimpleHapticsController_Vtbl;
@@ -289,7 +307,7 @@ impl SimpleHapticsControllerFeedback {
     }
 }
 impl windows_core::RuntimeType for SimpleHapticsControllerFeedback {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISimpleHapticsControllerFeedback>();
 }
 unsafe impl windows_core::Interface for SimpleHapticsControllerFeedback {
     type Vtable = ISimpleHapticsControllerFeedback_Vtbl;
@@ -357,7 +375,7 @@ impl VibrationDevice {
     }
 }
 impl windows_core::RuntimeType for VibrationDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVibrationDevice>();
 }
 unsafe impl windows_core::Interface for VibrationDevice {
     type Vtable = IVibrationDevice_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHidBooleanControl, IHidBooleanControl_Vtbl, 0x524df48a_3695_408c_bba2_e2eb5abfbc20);
+impl windows_core::RuntimeType for IHidBooleanControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidBooleanControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IHidBooleanControl_Vtbl {
     pub ControlDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidBooleanControlDescription, IHidBooleanControlDescription_Vtbl, 0x6196e543_29d8_4a2a_8683_849e207bbe31);
+impl windows_core::RuntimeType for IHidBooleanControlDescription {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidBooleanControlDescription_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,12 +30,18 @@ pub struct IHidBooleanControlDescription_Vtbl {
     ParentCollections: usize,
 }
 windows_core::imp::define_interface!(IHidBooleanControlDescription2, IHidBooleanControlDescription2_Vtbl, 0xc8eed2ea_8a77_4c36_aa00_5ff0449d3e73);
+impl windows_core::RuntimeType for IHidBooleanControlDescription2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidBooleanControlDescription2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsAbsolute: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidCollection, IHidCollection_Vtbl, 0x7189f5a3_32f1_46e3_befd_44d2663b7e6a);
+impl windows_core::RuntimeType for IHidCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +51,9 @@ pub struct IHidCollection_Vtbl {
     pub UsageId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidDevice, IHidDevice_Vtbl, 0x5f8a14e7_2200_432e_95da_d09b87d574a8);
+impl windows_core::RuntimeType for IHidDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +84,9 @@ pub struct IHidDevice_Vtbl {
     pub RemoveInputReportReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidDeviceStatics, IHidDeviceStatics_Vtbl, 0x9e5981e4_9856_418c_9f73_77de0cd85754);
+impl windows_core::RuntimeType for IHidDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +98,9 @@ pub struct IHidDeviceStatics_Vtbl {
     FromIdAsync: usize,
 }
 windows_core::imp::define_interface!(IHidFeatureReport, IHidFeatureReport_Vtbl, 0x841d9b79_5ae5_46e3_82ef_1fec5c8942f4);
+impl windows_core::RuntimeType for IHidFeatureReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidFeatureReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,6 +119,9 @@ pub struct IHidFeatureReport_Vtbl {
     pub GetNumericControlByDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidInputReport, IHidInputReport_Vtbl, 0xc35d0e50_f7e7_4e8d_b23e_cabbe56b90e9);
+impl windows_core::RuntimeType for IHidInputReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidInputReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,12 +144,18 @@ pub struct IHidInputReport_Vtbl {
     pub GetNumericControlByDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidInputReportReceivedEventArgs, IHidInputReportReceivedEventArgs_Vtbl, 0x7059c5cb_59b2_4dc2_985c_0adc6136fa2d);
+impl windows_core::RuntimeType for IHidInputReportReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidInputReportReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Report: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidNumericControl, IHidNumericControl_Vtbl, 0xe38a12a5_35a7_4b75_89c8_fb1f28b10823);
+impl windows_core::RuntimeType for IHidNumericControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidNumericControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +170,9 @@ pub struct IHidNumericControl_Vtbl {
     pub ControlDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidNumericControlDescription, IHidNumericControlDescription_Vtbl, 0x638d5e86_1d97_4c75_927f_5ff58ba05e32);
+impl windows_core::RuntimeType for IHidNumericControlDescription {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidNumericControlDescription_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -164,6 +197,9 @@ pub struct IHidNumericControlDescription_Vtbl {
     ParentCollections: usize,
 }
 windows_core::imp::define_interface!(IHidOutputReport, IHidOutputReport_Vtbl, 0x62cb2544_c896_4463_93c1_df9db053c450);
+impl windows_core::RuntimeType for IHidOutputReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidOutputReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -227,7 +263,7 @@ impl HidBooleanControl {
     }
 }
 impl windows_core::RuntimeType for HidBooleanControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidBooleanControl>();
 }
 unsafe impl windows_core::Interface for HidBooleanControl {
     type Vtable = IHidBooleanControl_Vtbl;
@@ -295,7 +331,7 @@ impl HidBooleanControlDescription {
     }
 }
 impl windows_core::RuntimeType for HidBooleanControlDescription {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidBooleanControlDescription>();
 }
 unsafe impl windows_core::Interface for HidBooleanControlDescription {
     type Vtable = IHidBooleanControlDescription_Vtbl;
@@ -341,7 +377,7 @@ impl HidCollection {
     }
 }
 impl windows_core::RuntimeType for HidCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidCollection>();
 }
 unsafe impl windows_core::Interface for HidCollection {
     type Vtable = IHidCollection_Vtbl;
@@ -529,7 +565,7 @@ impl HidDevice {
     }
 }
 impl windows_core::RuntimeType for HidDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidDevice>();
 }
 unsafe impl windows_core::Interface for HidDevice {
     type Vtable = IHidDevice_Vtbl;
@@ -604,7 +640,7 @@ impl HidFeatureReport {
     }
 }
 impl windows_core::RuntimeType for HidFeatureReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidFeatureReport>();
 }
 unsafe impl windows_core::Interface for HidFeatureReport {
     type Vtable = IHidFeatureReport_Vtbl;
@@ -687,7 +723,7 @@ impl HidInputReport {
     }
 }
 impl windows_core::RuntimeType for HidInputReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidInputReport>();
 }
 unsafe impl windows_core::Interface for HidInputReport {
     type Vtable = IHidInputReport_Vtbl;
@@ -712,7 +748,7 @@ impl HidInputReportReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HidInputReportReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidInputReportReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for HidInputReportReceivedEventArgs {
     type Vtable = IHidInputReportReceivedEventArgs_Vtbl;
@@ -787,7 +823,7 @@ impl HidNumericControl {
     }
 }
 impl windows_core::RuntimeType for HidNumericControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidNumericControl>();
 }
 unsafe impl windows_core::Interface for HidNumericControl {
     type Vtable = IHidNumericControl_Vtbl;
@@ -918,7 +954,7 @@ impl HidNumericControlDescription {
     }
 }
 impl windows_core::RuntimeType for HidNumericControlDescription {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidNumericControlDescription>();
 }
 unsafe impl windows_core::Interface for HidNumericControlDescription {
     type Vtable = IHidNumericControlDescription_Vtbl;
@@ -993,7 +1029,7 @@ impl HidOutputReport {
     }
 }
 impl windows_core::RuntimeType for HidOutputReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidOutputReport>();
 }
 unsafe impl windows_core::Interface for HidOutputReport {
     type Vtable = IHidOutputReport_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
@@ -107,6 +107,9 @@ pub struct II2cProvider_Vtbl {
     GetControllersAsync: usize,
 }
 windows_core::imp::define_interface!(IProviderI2cConnectionSettings, IProviderI2cConnectionSettings_Vtbl, 0xe9db4e34_e510_44b7_809d_f2f85b555339);
+impl windows_core::RuntimeType for IProviderI2cConnectionSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProviderI2cConnectionSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -157,7 +160,7 @@ impl ProviderI2cConnectionSettings {
     }
 }
 impl windows_core::RuntimeType for ProviderI2cConnectionSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProviderI2cConnectionSettings>();
 }
 unsafe impl windows_core::Interface for ProviderI2cConnectionSettings {
     type Vtable = IProviderI2cConnectionSettings_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_I2c_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(II2cConnectionSettings, II2cConnectionSettings_Vtbl, 0xf2db1307_ab6f_4639_a767_54536dc3460f);
+impl windows_core::RuntimeType for II2cConnectionSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct II2cConnectionSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,18 +15,27 @@ pub struct II2cConnectionSettings_Vtbl {
     pub SetSharingMode: unsafe extern "system" fn(*mut core::ffi::c_void, I2cSharingMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(II2cConnectionSettingsFactory, II2cConnectionSettingsFactory_Vtbl, 0x81b586b3_9693_41b1_a243_ded4f6e66926);
+impl windows_core::RuntimeType for II2cConnectionSettingsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct II2cConnectionSettingsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(II2cController, II2cController_Vtbl, 0xc48ab1b2_87a0_4166_8e3e_b4b8f97cd729);
+impl windows_core::RuntimeType for II2cController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct II2cController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(II2cControllerStatics, II2cControllerStatics_Vtbl, 0x40fc0365_5f05_4e7e_84bd_100db8e0aec5);
+impl windows_core::RuntimeType for II2cControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct II2cControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +46,9 @@ pub struct II2cControllerStatics_Vtbl {
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(II2cDevice, II2cDevice_Vtbl, 0x8636c136_b9c5_4f70_9449_cc46dc6f57eb);
+impl windows_core::RuntimeType for II2cDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct II2cDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,7 +150,7 @@ impl I2cConnectionSettings {
     }
 }
 impl windows_core::RuntimeType for I2cConnectionSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, II2cConnectionSettings>();
 }
 unsafe impl windows_core::Interface for I2cConnectionSettings {
     type Vtable = II2cConnectionSettings_Vtbl;
@@ -184,7 +199,7 @@ impl I2cController {
     }
 }
 impl windows_core::RuntimeType for I2cController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, II2cController>();
 }
 unsafe impl windows_core::Interface for I2cController {
     type Vtable = II2cController_Vtbl;
@@ -280,7 +295,7 @@ impl I2cDevice {
     }
 }
 impl windows_core::RuntimeType for I2cDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, II2cDevice>();
 }
 unsafe impl windows_core::Interface for I2cDevice {
     type Vtable = II2cDevice_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGazeDevicePreview, IGazeDevicePreview_Vtbl, 0xe79e7ee9_b389_11e7_b201_c8d3ffb75721);
+impl windows_core::RuntimeType for IGazeDevicePreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeDevicePreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,12 +20,18 @@ pub struct IGazeDevicePreview_Vtbl {
     GetBooleanControlDescriptions: usize,
 }
 windows_core::imp::define_interface!(IGazeDeviceWatcherAddedPreviewEventArgs, IGazeDeviceWatcherAddedPreviewEventArgs_Vtbl, 0xe79e7eed_b389_11e7_b201_c8d3ffb75721);
+impl windows_core::RuntimeType for IGazeDeviceWatcherAddedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeDeviceWatcherAddedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Device: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeDeviceWatcherPreview, IGazeDeviceWatcherPreview_Vtbl, 0xe79e7ee7_b389_11e7_b201_c8d3ffb75721);
+impl windows_core::RuntimeType for IGazeDeviceWatcherPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeDeviceWatcherPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,18 +47,27 @@ pub struct IGazeDeviceWatcherPreview_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeDeviceWatcherRemovedPreviewEventArgs, IGazeDeviceWatcherRemovedPreviewEventArgs_Vtbl, 0xf2631f08_0e3f_431f_a606_50b35af94a1c);
+impl windows_core::RuntimeType for IGazeDeviceWatcherRemovedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeDeviceWatcherRemovedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Device: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeDeviceWatcherUpdatedPreviewEventArgs, IGazeDeviceWatcherUpdatedPreviewEventArgs_Vtbl, 0x7fe830ef_7f08_4737_88e1_4a83ae4e4885);
+impl windows_core::RuntimeType for IGazeDeviceWatcherUpdatedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeDeviceWatcherUpdatedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Device: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeEnteredPreviewEventArgs, IGazeEnteredPreviewEventArgs_Vtbl, 0x2567bf43_1225_489f_9dd1_daa7c50fbf4b);
+impl windows_core::RuntimeType for IGazeEnteredPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeEnteredPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +76,9 @@ pub struct IGazeEnteredPreviewEventArgs_Vtbl {
     pub CurrentPoint: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeExitedPreviewEventArgs, IGazeExitedPreviewEventArgs_Vtbl, 0x5d0af07e_7d83_40ef_9f0a_fbc1bbdcc5ac);
+impl windows_core::RuntimeType for IGazeExitedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeExitedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +87,9 @@ pub struct IGazeExitedPreviewEventArgs_Vtbl {
     pub CurrentPoint: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeInputSourcePreview, IGazeInputSourcePreview_Vtbl, 0xe79e7ee8_b389_11e7_b201_c8d3ffb75721);
+impl windows_core::RuntimeType for IGazeInputSourcePreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeInputSourcePreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +101,9 @@ pub struct IGazeInputSourcePreview_Vtbl {
     pub RemoveGazeExited: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeInputSourcePreviewStatics, IGazeInputSourcePreviewStatics_Vtbl, 0xe79e7ee6_b389_11e7_b201_c8d3ffb75721);
+impl windows_core::RuntimeType for IGazeInputSourcePreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeInputSourcePreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +111,9 @@ pub struct IGazeInputSourcePreviewStatics_Vtbl {
     pub CreateWatcher: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGazeMovedPreviewEventArgs, IGazeMovedPreviewEventArgs_Vtbl, 0xe79e7eeb_b389_11e7_b201_c8d3ffb75721);
+impl windows_core::RuntimeType for IGazeMovedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazeMovedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,6 +126,9 @@ pub struct IGazeMovedPreviewEventArgs_Vtbl {
     GetIntermediatePoints: usize,
 }
 windows_core::imp::define_interface!(IGazePointPreview, IGazePointPreview_Vtbl, 0xe79e7eea_b389_11e7_b201_c8d3ffb75721);
+impl windows_core::RuntimeType for IGazePointPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGazePointPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -166,7 +199,7 @@ impl GazeDevicePreview {
     }
 }
 impl windows_core::RuntimeType for GazeDevicePreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeDevicePreview>();
 }
 unsafe impl windows_core::Interface for GazeDevicePreview {
     type Vtable = IGazeDevicePreview_Vtbl;
@@ -191,7 +224,7 @@ impl GazeDeviceWatcherAddedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for GazeDeviceWatcherAddedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeDeviceWatcherAddedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for GazeDeviceWatcherAddedPreviewEventArgs {
     type Vtable = IGazeDeviceWatcherAddedPreviewEventArgs_Vtbl;
@@ -273,7 +306,7 @@ impl GazeDeviceWatcherPreview {
     }
 }
 impl windows_core::RuntimeType for GazeDeviceWatcherPreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeDeviceWatcherPreview>();
 }
 unsafe impl windows_core::Interface for GazeDeviceWatcherPreview {
     type Vtable = IGazeDeviceWatcherPreview_Vtbl;
@@ -298,7 +331,7 @@ impl GazeDeviceWatcherRemovedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for GazeDeviceWatcherRemovedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeDeviceWatcherRemovedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for GazeDeviceWatcherRemovedPreviewEventArgs {
     type Vtable = IGazeDeviceWatcherRemovedPreviewEventArgs_Vtbl;
@@ -323,7 +356,7 @@ impl GazeDeviceWatcherUpdatedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for GazeDeviceWatcherUpdatedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeDeviceWatcherUpdatedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for GazeDeviceWatcherUpdatedPreviewEventArgs {
     type Vtable = IGazeDeviceWatcherUpdatedPreviewEventArgs_Vtbl;
@@ -359,7 +392,7 @@ impl GazeEnteredPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for GazeEnteredPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeEnteredPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for GazeEnteredPreviewEventArgs {
     type Vtable = IGazeEnteredPreviewEventArgs_Vtbl;
@@ -395,7 +428,7 @@ impl GazeExitedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for GazeExitedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeExitedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for GazeExitedPreviewEventArgs {
     type Vtable = IGazeExitedPreviewEventArgs_Vtbl;
@@ -472,7 +505,7 @@ impl GazeInputSourcePreview {
     }
 }
 impl windows_core::RuntimeType for GazeInputSourcePreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeInputSourcePreview>();
 }
 unsafe impl windows_core::Interface for GazeInputSourcePreview {
     type Vtable = IGazeInputSourcePreview_Vtbl;
@@ -516,7 +549,7 @@ impl GazeMovedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for GazeMovedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazeMovedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for GazeMovedPreviewEventArgs {
     type Vtable = IGazeMovedPreviewEventArgs_Vtbl;
@@ -570,7 +603,7 @@ impl GazePointPreview {
     }
 }
 impl windows_core::RuntimeType for GazePointPreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGazePointPreview>();
 }
 unsafe impl windows_core::Interface for GazePointPreview {
     type Vtable = IGazePointPreview_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/mod.rs
@@ -1,12 +1,18 @@
 #[cfg(feature = "Devices_Input_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(IKeyboardCapabilities, IKeyboardCapabilities_Vtbl, 0x3a3f9b56_6798_4bbc_833e_0f34b17c65ff);
+impl windows_core::RuntimeType for IKeyboardCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyboardCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub KeyboardPresent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMouseCapabilities, IMouseCapabilities_Vtbl, 0xbca5e023_7dd9_4b6b_9a92_55d43cb38f73);
+impl windows_core::RuntimeType for IMouseCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMouseCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IMouseCapabilities_Vtbl {
     pub NumberOfButtons: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMouseDevice, IMouseDevice_Vtbl, 0x88edf458_f2c8_49f4_be1f_c256b388bc11);
+impl windows_core::RuntimeType for IMouseDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMouseDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,18 +33,27 @@ pub struct IMouseDevice_Vtbl {
     pub RemoveMouseMoved: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMouseDeviceStatics, IMouseDeviceStatics_Vtbl, 0x484a9045_6d70_49db_8e68_46ffbd17d38d);
+impl windows_core::RuntimeType for IMouseDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMouseDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMouseEventArgs, IMouseEventArgs_Vtbl, 0xf625aa5d_2354_4cc7_9230_96941c969fde);
+impl windows_core::RuntimeType for IMouseEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMouseEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MouseDelta: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MouseDelta) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenButtonListener, IPenButtonListener_Vtbl, 0x8245c376_1ee3_53f7_b1f7_8334a16f2815);
+impl windows_core::RuntimeType for IPenButtonListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenButtonListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,18 +68,27 @@ pub struct IPenButtonListener_Vtbl {
     pub RemoveTailButtonLongPressed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenButtonListenerStatics, IPenButtonListenerStatics_Vtbl, 0x19a8a584_862f_5f69_bfea_05f6584f133f);
+impl windows_core::RuntimeType for IPenButtonListenerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenButtonListenerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenDevice, IPenDevice_Vtbl, 0x31856eba_a738_5a8c_b8f6_f97ef68d18ef);
+impl windows_core::RuntimeType for IPenDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PenId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenDevice2, IPenDevice2_Vtbl, 0x0207d327_7fb8_5566_8c34_f8342037b7f9);
+impl windows_core::RuntimeType for IPenDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,12 +98,18 @@ pub struct IPenDevice2_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IPenDeviceStatics, IPenDeviceStatics_Vtbl, 0x9dfbbe01_0966_5180_bcb4_b85060e39479);
+impl windows_core::RuntimeType for IPenDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetFromPointerId: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenDockListener, IPenDockListener_Vtbl, 0x759f4d90_1dc0_55cb_ad18_b9101456f592);
+impl windows_core::RuntimeType for IPenDockListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenDockListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,37 +122,58 @@ pub struct IPenDockListener_Vtbl {
     pub RemoveUndocked: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenDockListenerStatics, IPenDockListenerStatics_Vtbl, 0xcab75e9a_0016_5c72_969e_a97e11992a93);
+impl windows_core::RuntimeType for IPenDockListenerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenDockListenerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenDockedEventArgs, IPenDockedEventArgs_Vtbl, 0xfd4277c6_ca63_5d4e_9ed3_a28a54521c8c);
+impl windows_core::RuntimeType for IPenDockedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenDockedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPenTailButtonClickedEventArgs, IPenTailButtonClickedEventArgs_Vtbl, 0x5d2fb7b6_6ad3_5d3e_ab29_05ea2410e390);
+impl windows_core::RuntimeType for IPenTailButtonClickedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenTailButtonClickedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPenTailButtonDoubleClickedEventArgs, IPenTailButtonDoubleClickedEventArgs_Vtbl, 0x846321a2_618a_5478_b04c_b358231da4a7);
+impl windows_core::RuntimeType for IPenTailButtonDoubleClickedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenTailButtonDoubleClickedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPenTailButtonLongPressedEventArgs, IPenTailButtonLongPressedEventArgs_Vtbl, 0xf37c606e_c60a_5f42_b818_a53112406c13);
+impl windows_core::RuntimeType for IPenTailButtonLongPressedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenTailButtonLongPressedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPenUndockedEventArgs, IPenUndockedEventArgs_Vtbl, 0xccd09150_261b_59e6_a5d4_c1964cd03feb);
+impl windows_core::RuntimeType for IPenUndockedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenUndockedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPointerDevice, IPointerDevice_Vtbl, 0x93c9bafc_ebcb_467e_82c6_276feae36b5a);
+impl windows_core::RuntimeType for IPointerDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -134,12 +188,18 @@ pub struct IPointerDevice_Vtbl {
     SupportedUsages: usize,
 }
 windows_core::imp::define_interface!(IPointerDevice2, IPointerDevice2_Vtbl, 0xf8a6d2a0_c484_489f_ae3e_30d2ee1ffd3e);
+impl windows_core::RuntimeType for IPointerDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MaxPointersWithZDistance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerDeviceStatics, IPointerDeviceStatics_Vtbl, 0xd8b89aa1_d1c6_416e_bd8d_5790914dc563);
+impl windows_core::RuntimeType for IPointerDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -150,6 +210,9 @@ pub struct IPointerDeviceStatics_Vtbl {
     GetPointerDevices: usize,
 }
 windows_core::imp::define_interface!(ITouchCapabilities, ITouchCapabilities_Vtbl, 0x20dd55f9_13f1_46c8_9285_2c05fa3eda6f);
+impl windows_core::RuntimeType for ITouchCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITouchCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -177,7 +240,7 @@ impl KeyboardCapabilities {
     }
 }
 impl windows_core::RuntimeType for KeyboardCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyboardCapabilities>();
 }
 unsafe impl windows_core::Interface for KeyboardCapabilities {
     type Vtable = IKeyboardCapabilities_Vtbl;
@@ -237,7 +300,7 @@ impl MouseCapabilities {
     }
 }
 impl windows_core::RuntimeType for MouseCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMouseCapabilities>();
 }
 unsafe impl windows_core::Interface for MouseCapabilities {
     type Vtable = IMouseCapabilities_Vtbl;
@@ -280,7 +343,7 @@ impl MouseDevice {
     }
 }
 impl windows_core::RuntimeType for MouseDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMouseDevice>();
 }
 unsafe impl windows_core::Interface for MouseDevice {
     type Vtable = IMouseDevice_Vtbl;
@@ -303,7 +366,7 @@ impl MouseEventArgs {
     }
 }
 impl windows_core::RuntimeType for MouseEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMouseEventArgs>();
 }
 unsafe impl windows_core::Interface for MouseEventArgs {
     type Vtable = IMouseEventArgs_Vtbl;
@@ -393,7 +456,7 @@ impl PenButtonListener {
     }
 }
 impl windows_core::RuntimeType for PenButtonListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenButtonListener>();
 }
 unsafe impl windows_core::Interface for PenButtonListener {
     type Vtable = IPenButtonListener_Vtbl;
@@ -437,7 +500,7 @@ impl PenDevice {
     }
 }
 impl windows_core::RuntimeType for PenDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenDevice>();
 }
 unsafe impl windows_core::Interface for PenDevice {
     type Vtable = IPenDevice_Vtbl;
@@ -515,7 +578,7 @@ impl PenDockListener {
     }
 }
 impl windows_core::RuntimeType for PenDockListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenDockListener>();
 }
 unsafe impl windows_core::Interface for PenDockListener {
     type Vtable = IPenDockListener_Vtbl;
@@ -532,7 +595,7 @@ pub struct PenDockedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenDockedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenDockedEventArgs {}
 impl windows_core::RuntimeType for PenDockedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenDockedEventArgs>();
 }
 unsafe impl windows_core::Interface for PenDockedEventArgs {
     type Vtable = IPenDockedEventArgs_Vtbl;
@@ -549,7 +612,7 @@ pub struct PenTailButtonClickedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenTailButtonClickedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenTailButtonClickedEventArgs {}
 impl windows_core::RuntimeType for PenTailButtonClickedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenTailButtonClickedEventArgs>();
 }
 unsafe impl windows_core::Interface for PenTailButtonClickedEventArgs {
     type Vtable = IPenTailButtonClickedEventArgs_Vtbl;
@@ -566,7 +629,7 @@ pub struct PenTailButtonDoubleClickedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenTailButtonDoubleClickedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenTailButtonDoubleClickedEventArgs {}
 impl windows_core::RuntimeType for PenTailButtonDoubleClickedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenTailButtonDoubleClickedEventArgs>();
 }
 unsafe impl windows_core::Interface for PenTailButtonDoubleClickedEventArgs {
     type Vtable = IPenTailButtonDoubleClickedEventArgs_Vtbl;
@@ -583,7 +646,7 @@ pub struct PenTailButtonLongPressedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenTailButtonLongPressedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenTailButtonLongPressedEventArgs {}
 impl windows_core::RuntimeType for PenTailButtonLongPressedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenTailButtonLongPressedEventArgs>();
 }
 unsafe impl windows_core::Interface for PenTailButtonLongPressedEventArgs {
     type Vtable = IPenTailButtonLongPressedEventArgs_Vtbl;
@@ -600,7 +663,7 @@ pub struct PenUndockedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PenUndockedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PenUndockedEventArgs {}
 impl windows_core::RuntimeType for PenUndockedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenUndockedEventArgs>();
 }
 unsafe impl windows_core::Interface for PenUndockedEventArgs {
     type Vtable = IPenUndockedEventArgs_Vtbl;
@@ -686,7 +749,7 @@ impl PointerDevice {
     }
 }
 impl windows_core::RuntimeType for PointerDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPointerDevice>();
 }
 unsafe impl windows_core::Interface for PointerDevice {
     type Vtable = IPointerDevice_Vtbl;
@@ -723,7 +786,7 @@ impl TouchCapabilities {
     }
 }
 impl windows_core::RuntimeType for TouchCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITouchCapabilities>();
 }
 unsafe impl windows_core::Interface for TouchCapabilities {
     type Vtable = ITouchCapabilities_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ILampArrayBitmapEffect, ILampArrayBitmapEffect_Vtbl, 0x3238e065_d877_4627_89e5_2a88f7052fa6);
+impl windows_core::RuntimeType for ILampArrayBitmapEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayBitmapEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,12 +16,18 @@ pub struct ILampArrayBitmapEffect_Vtbl {
     pub RemoveBitmapRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayBitmapEffectFactory, ILampArrayBitmapEffectFactory_Vtbl, 0x13608090_e336_4c8f_9053_a92407ca7b1d);
+impl windows_core::RuntimeType for ILampArrayBitmapEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayBitmapEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayBitmapRequestedEventArgs, ILampArrayBitmapRequestedEventArgs_Vtbl, 0xc8b4af9e_fe63_4d51_babd_619defb454ba);
+impl windows_core::RuntimeType for ILampArrayBitmapRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayBitmapRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +38,9 @@ pub struct ILampArrayBitmapRequestedEventArgs_Vtbl {
     UpdateBitmap: usize,
 }
 windows_core::imp::define_interface!(ILampArrayBlinkEffect, ILampArrayBlinkEffect_Vtbl, 0xebbf35f6_2fc5_4bb3_b3c3_6221a7680d13);
+impl windows_core::RuntimeType for ILampArrayBlinkEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayBlinkEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,12 +68,18 @@ pub struct ILampArrayBlinkEffect_Vtbl {
     pub SetRepetitionMode: unsafe extern "system" fn(*mut core::ffi::c_void, LampArrayRepetitionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayBlinkEffectFactory, ILampArrayBlinkEffectFactory_Vtbl, 0x879f1d97_9f50_49b2_a56f_013aa08d55e0);
+impl windows_core::RuntimeType for ILampArrayBlinkEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayBlinkEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayColorRampEffect, ILampArrayColorRampEffect_Vtbl, 0x2b004437_40a7_432e_a0b9_0d570c2153ff);
+impl windows_core::RuntimeType for ILampArrayColorRampEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayColorRampEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -81,12 +99,18 @@ pub struct ILampArrayColorRampEffect_Vtbl {
     pub SetCompletionBehavior: unsafe extern "system" fn(*mut core::ffi::c_void, LampArrayEffectCompletionBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayColorRampEffectFactory, ILampArrayColorRampEffectFactory_Vtbl, 0x520bd133_0c74_4df5_bea7_4899e0266b0f);
+impl windows_core::RuntimeType for ILampArrayColorRampEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayColorRampEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayCustomEffect, ILampArrayCustomEffect_Vtbl, 0xec579170_3c34_4876_818b_5765f78b0ee4);
+impl windows_core::RuntimeType for ILampArrayCustomEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayCustomEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,6 +122,9 @@ pub struct ILampArrayCustomEffect_Vtbl {
     pub RemoveUpdateRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayCustomEffectFactory, ILampArrayCustomEffectFactory_Vtbl, 0x68b4774d_63e5_4af0_a58b_3e535b94e8c9);
+impl windows_core::RuntimeType for ILampArrayCustomEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayCustomEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -128,6 +155,9 @@ pub struct ILampArrayEffect_Vtbl {
     pub SetZIndex: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayEffectPlaylist, ILampArrayEffectPlaylist_Vtbl, 0x7de58bfe_6f61_4103_98c7_d6632f7b9169);
+impl windows_core::RuntimeType for ILampArrayEffectPlaylist {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayEffectPlaylist_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -144,6 +174,9 @@ pub struct ILampArrayEffectPlaylist_Vtbl {
     pub SetRepetitionMode: unsafe extern "system" fn(*mut core::ffi::c_void, LampArrayRepetitionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayEffectPlaylistStatics, ILampArrayEffectPlaylistStatics_Vtbl, 0xfb15235c_ea35_4c7f_a016_f3bfc6a6c47d);
+impl windows_core::RuntimeType for ILampArrayEffectPlaylistStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayEffectPlaylistStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +194,9 @@ pub struct ILampArrayEffectPlaylistStatics_Vtbl {
     PauseAll: usize,
 }
 windows_core::imp::define_interface!(ILampArraySolidEffect, ILampArraySolidEffect_Vtbl, 0x441f8213_43cc_4b33_80eb_c6ddde7dc8ed);
+impl windows_core::RuntimeType for ILampArraySolidEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArraySolidEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -180,12 +216,18 @@ pub struct ILampArraySolidEffect_Vtbl {
     pub SetCompletionBehavior: unsafe extern "system" fn(*mut core::ffi::c_void, LampArrayEffectCompletionBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArraySolidEffectFactory, ILampArraySolidEffectFactory_Vtbl, 0xf862a32c_5576_4341_961b_aee1f13cf9dd);
+impl windows_core::RuntimeType for ILampArraySolidEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArraySolidEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayUpdateRequestedEventArgs, ILampArrayUpdateRequestedEventArgs_Vtbl, 0x73560d6a_576a_48af_8539_67ffa0ab3516);
+impl windows_core::RuntimeType for ILampArrayUpdateRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayUpdateRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,7 +336,7 @@ impl LampArrayBitmapEffect {
     }
 }
 impl windows_core::RuntimeType for LampArrayBitmapEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArrayBitmapEffect>();
 }
 unsafe impl windows_core::Interface for LampArrayBitmapEffect {
     type Vtable = ILampArrayBitmapEffect_Vtbl;
@@ -327,7 +369,7 @@ impl LampArrayBitmapRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LampArrayBitmapRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArrayBitmapRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for LampArrayBitmapRequestedEventArgs {
     type Vtable = ILampArrayBitmapRequestedEventArgs_Vtbl;
@@ -461,7 +503,7 @@ impl LampArrayBlinkEffect {
     }
 }
 impl windows_core::RuntimeType for LampArrayBlinkEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArrayBlinkEffect>();
 }
 unsafe impl windows_core::Interface for LampArrayBlinkEffect {
     type Vtable = ILampArrayBlinkEffect_Vtbl;
@@ -551,7 +593,7 @@ impl LampArrayColorRampEffect {
     }
 }
 impl windows_core::RuntimeType for LampArrayColorRampEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArrayColorRampEffect>();
 }
 unsafe impl windows_core::Interface for LampArrayColorRampEffect {
     type Vtable = ILampArrayColorRampEffect_Vtbl;
@@ -631,7 +673,7 @@ impl LampArrayCustomEffect {
     }
 }
 impl windows_core::RuntimeType for LampArrayCustomEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArrayCustomEffect>();
 }
 unsafe impl windows_core::Interface for LampArrayCustomEffect {
     type Vtable = ILampArrayCustomEffect_Vtbl;
@@ -783,7 +825,7 @@ impl LampArrayEffectPlaylist {
     }
 }
 impl windows_core::RuntimeType for LampArrayEffectPlaylist {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArrayEffectPlaylist>();
 }
 unsafe impl windows_core::Interface for LampArrayEffectPlaylist {
     type Vtable = ILampArrayEffectPlaylist_Vtbl;
@@ -889,7 +931,7 @@ impl LampArraySolidEffect {
     }
 }
 impl windows_core::RuntimeType for LampArraySolidEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArraySolidEffect>();
 }
 unsafe impl windows_core::Interface for LampArraySolidEffect {
     type Vtable = ILampArraySolidEffect_Vtbl;
@@ -934,7 +976,7 @@ impl LampArrayUpdateRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LampArrayUpdateRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArrayUpdateRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for LampArrayUpdateRequestedEventArgs {
     type Vtable = ILampArrayUpdateRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Lights_Effects")]
 pub mod Effects;
 windows_core::imp::define_interface!(ILamp, ILamp_Vtbl, 0x047d5b9a_ea45_4b2b_b1a2_14dff00bde7b);
+impl windows_core::RuntimeType for ILamp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILamp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +25,9 @@ pub struct ILamp_Vtbl {
     pub RemoveAvailabilityChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArray, ILampArray_Vtbl, 0x7ace9787_c8a0_4e95_a1e0_d58676538649);
+impl windows_core::RuntimeType for ILampArray {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArray_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +92,9 @@ pub struct ILampArray_Vtbl {
     RequestMessageAsync: usize,
 }
 windows_core::imp::define_interface!(ILampArray2, ILampArray2_Vtbl, 0x050c181f_60a8_4711_a1af_1b1b4c658ea2);
+impl windows_core::RuntimeType for ILampArray2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArray2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +103,9 @@ pub struct ILampArray2_Vtbl {
     pub RemoveAvailabilityChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampArrayStatics, ILampArrayStatics_Vtbl, 0x7bb8c98d_5fc1_452d_bb1f_4ad410d398ff);
+impl windows_core::RuntimeType for ILampArrayStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampArrayStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,12 +113,18 @@ pub struct ILampArrayStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampAvailabilityChangedEventArgs, ILampAvailabilityChangedEventArgs_Vtbl, 0x4f6e3ded_07a2_499d_9260_67e304532ba4);
+impl windows_core::RuntimeType for ILampAvailabilityChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampAvailabilityChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsAvailable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampInfo, ILampInfo_Vtbl, 0x30bb521c_0acf_49da_8c10_150b9cf62713);
+impl windows_core::RuntimeType for ILampInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -131,6 +149,9 @@ pub struct ILampInfo_Vtbl {
     pub UpdateLatency: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILampStatics, ILampStatics_Vtbl, 0xa822416c_8885_401e_b821_8e8b38a8e8ec);
+impl windows_core::RuntimeType for ILampStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILampStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -236,7 +257,7 @@ impl Lamp {
     }
 }
 impl windows_core::RuntimeType for Lamp {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILamp>();
 }
 unsafe impl windows_core::Interface for Lamp {
     type Vtable = ILamp_Vtbl;
@@ -461,7 +482,7 @@ impl LampArray {
     }
 }
 impl windows_core::RuntimeType for LampArray {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampArray>();
 }
 unsafe impl windows_core::Interface for LampArray {
     type Vtable = ILampArray_Vtbl;
@@ -486,7 +507,7 @@ impl LampAvailabilityChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LampAvailabilityChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampAvailabilityChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for LampAvailabilityChangedEventArgs {
     type Vtable = ILampAvailabilityChangedEventArgs_Vtbl;
@@ -577,7 +598,7 @@ impl LampInfo {
     }
 }
 impl windows_core::RuntimeType for LampInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILampInfo>();
 }
 unsafe impl windows_core::Interface for LampInfo {
     type Vtable = ILampInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IMidiChannelPressureMessage, IMidiChannelPressureMessage_Vtbl, 0xbe1fa860_62b4_4d52_a37e_92e54d35b909);
+impl windows_core::RuntimeType for IMidiChannelPressureMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiChannelPressureMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,12 +9,18 @@ pub struct IMidiChannelPressureMessage_Vtbl {
     pub Pressure: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiChannelPressureMessageFactory, IMidiChannelPressureMessageFactory_Vtbl, 0x6218ed2f_2284_412a_94cf_10fb04842c6c);
+impl windows_core::RuntimeType for IMidiChannelPressureMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiChannelPressureMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiChannelPressureMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiControlChangeMessage, IMidiControlChangeMessage_Vtbl, 0xb7e15f83_780d_405f_b781_3e1598c97f40);
+impl windows_core::RuntimeType for IMidiControlChangeMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiControlChangeMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,12 +29,18 @@ pub struct IMidiControlChangeMessage_Vtbl {
     pub ControlValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiControlChangeMessageFactory, IMidiControlChangeMessageFactory_Vtbl, 0x2ab14321_956c_46ad_9752_f87f55052fe3);
+impl windows_core::RuntimeType for IMidiControlChangeMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiControlChangeMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiControlChangeMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u8, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiInPort, IMidiInPort_Vtbl, 0xd5c1d9db_971a_4eaf_a23d_ea19fe607ff9);
+impl windows_core::RuntimeType for IMidiInPort {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiInPort_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +49,9 @@ pub struct IMidiInPort_Vtbl {
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiInPortStatics, IMidiInPortStatics_Vtbl, 0x44c439dc_67ff_4a6e_8bac_fdb6610cf296);
+impl windows_core::RuntimeType for IMidiInPortStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiInPortStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,12 +98,18 @@ pub struct IMidiMessage_Vtbl {
     pub Type: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MidiMessageType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiMessageReceivedEventArgs, IMidiMessageReceivedEventArgs_Vtbl, 0x76566e56_f328_4b51_907d_b3a8ce96bf80);
+impl windows_core::RuntimeType for IMidiMessageReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiMessageReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Message: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiNoteOffMessage, IMidiNoteOffMessage_Vtbl, 0x16fd8af4_198e_4d8f_a654_d305a293548f);
+impl windows_core::RuntimeType for IMidiNoteOffMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiNoteOffMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,12 +118,18 @@ pub struct IMidiNoteOffMessage_Vtbl {
     pub Velocity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiNoteOffMessageFactory, IMidiNoteOffMessageFactory_Vtbl, 0xa6b240e0_a749_425f_8af4_a4d979cc15b5);
+impl windows_core::RuntimeType for IMidiNoteOffMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiNoteOffMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiNoteOffMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u8, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiNoteOnMessage, IMidiNoteOnMessage_Vtbl, 0xe0224af5_6181_46dd_afa2_410004c057aa);
+impl windows_core::RuntimeType for IMidiNoteOnMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiNoteOnMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +138,9 @@ pub struct IMidiNoteOnMessage_Vtbl {
     pub Velocity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiNoteOnMessageFactory, IMidiNoteOnMessageFactory_Vtbl, 0x9b4280a0_59c1_420e_b517_15a10aa9606b);
+impl windows_core::RuntimeType for IMidiNoteOnMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiNoteOnMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +191,9 @@ pub struct IMidiOutPort_Vtbl {
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiOutPortStatics, IMidiOutPortStatics_Vtbl, 0x065cc3e9_0f88_448b_9b64_a95826c65b8f);
+impl windows_core::RuntimeType for IMidiOutPortStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiOutPortStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +201,9 @@ pub struct IMidiOutPortStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiPitchBendChangeMessage, IMidiPitchBendChangeMessage_Vtbl, 0x29df4cb1_2e9f_4faf_8c2b_9cb82a9079ca);
+impl windows_core::RuntimeType for IMidiPitchBendChangeMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiPitchBendChangeMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,12 +211,18 @@ pub struct IMidiPitchBendChangeMessage_Vtbl {
     pub Bend: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiPitchBendChangeMessageFactory, IMidiPitchBendChangeMessageFactory_Vtbl, 0xf5eedf55_cfc8_4926_b30e_a3622393306c);
+impl windows_core::RuntimeType for IMidiPitchBendChangeMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiPitchBendChangeMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiPitchBendChangeMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u16, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiPolyphonicKeyPressureMessage, IMidiPolyphonicKeyPressureMessage_Vtbl, 0x1f7337fe_ace8_48a0_868e_7cdbf20f04d6);
+impl windows_core::RuntimeType for IMidiPolyphonicKeyPressureMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiPolyphonicKeyPressureMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -186,12 +231,18 @@ pub struct IMidiPolyphonicKeyPressureMessage_Vtbl {
     pub Pressure: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiPolyphonicKeyPressureMessageFactory, IMidiPolyphonicKeyPressureMessageFactory_Vtbl, 0xe98f483e_c4b3_4dd2_917c_e349815a1b3b);
+impl windows_core::RuntimeType for IMidiPolyphonicKeyPressureMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiPolyphonicKeyPressureMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiPolyphonicKeyPressureMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u8, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiProgramChangeMessage, IMidiProgramChangeMessage_Vtbl, 0x9cbb3c78_7a3e_4327_aa98_20b8e4485af8);
+impl windows_core::RuntimeType for IMidiProgramChangeMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiProgramChangeMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,36 +250,54 @@ pub struct IMidiProgramChangeMessage_Vtbl {
     pub Program: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiProgramChangeMessageFactory, IMidiProgramChangeMessageFactory_Vtbl, 0xd6b04387_524b_4104_9c99_6572bfd2e261);
+impl windows_core::RuntimeType for IMidiProgramChangeMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiProgramChangeMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiProgramChangeMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiSongPositionPointerMessage, IMidiSongPositionPointerMessage_Vtbl, 0x4ca50c56_ec5e_4ae4_a115_88dc57cc2b79);
+impl windows_core::RuntimeType for IMidiSongPositionPointerMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiSongPositionPointerMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Beats: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiSongPositionPointerMessageFactory, IMidiSongPositionPointerMessageFactory_Vtbl, 0x9c00e996_f10b_4fea_b395_f5d6cf80f64e);
+impl windows_core::RuntimeType for IMidiSongPositionPointerMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiSongPositionPointerMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiSongPositionPointerMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u16, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiSongSelectMessage, IMidiSongSelectMessage_Vtbl, 0x49f0f27f_6d83_4741_a5bf_4629f6be974f);
+impl windows_core::RuntimeType for IMidiSongSelectMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiSongSelectMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Song: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiSongSelectMessageFactory, IMidiSongSelectMessageFactory_Vtbl, 0x848878e4_8748_4129_a66c_a05493f75daa);
+impl windows_core::RuntimeType for IMidiSongSelectMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiSongSelectMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMidiSongSelectMessage: unsafe extern "system" fn(*mut core::ffi::c_void, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiSynthesizer, IMidiSynthesizer_Vtbl, 0xf0da155e_db90_405f_b8ae_21d2e17f2e45);
+impl windows_core::RuntimeType for IMidiSynthesizer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiSynthesizer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,6 +309,9 @@ pub struct IMidiSynthesizer_Vtbl {
     pub SetVolume: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiSynthesizerStatics, IMidiSynthesizerStatics_Vtbl, 0x4224eaa8_6629_4d6b_aa8f_d4521a5a31ce);
+impl windows_core::RuntimeType for IMidiSynthesizerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiSynthesizerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +326,9 @@ pub struct IMidiSynthesizerStatics_Vtbl {
     IsSynthesizer: usize,
 }
 windows_core::imp::define_interface!(IMidiSystemExclusiveMessageFactory, IMidiSystemExclusiveMessageFactory_Vtbl, 0x083de222_3b74_4320_9b42_0ca8545f8a24);
+impl windows_core::RuntimeType for IMidiSystemExclusiveMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiSystemExclusiveMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -263,6 +338,9 @@ pub struct IMidiSystemExclusiveMessageFactory_Vtbl {
     CreateMidiSystemExclusiveMessage: usize,
 }
 windows_core::imp::define_interface!(IMidiTimeCodeMessage, IMidiTimeCodeMessage_Vtbl, 0x0bf7087d_fa63_4a1c_8deb_c0e87796a6d7);
+impl windows_core::RuntimeType for IMidiTimeCodeMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiTimeCodeMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -270,6 +348,9 @@ pub struct IMidiTimeCodeMessage_Vtbl {
     pub Values: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMidiTimeCodeMessageFactory, IMidiTimeCodeMessageFactory_Vtbl, 0xeb3099c5_771c_40de_b961_175a7489a85e);
+impl windows_core::RuntimeType for IMidiTimeCodeMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMidiTimeCodeMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,7 +393,7 @@ impl MidiActiveSensingMessage {
     }
 }
 impl windows_core::RuntimeType for MidiActiveSensingMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiActiveSensingMessage {
     type Vtable = IMidiMessage_Vtbl;
@@ -378,7 +459,7 @@ impl MidiChannelPressureMessage {
     }
 }
 impl windows_core::RuntimeType for MidiChannelPressureMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiChannelPressureMessage>();
 }
 unsafe impl windows_core::Interface for MidiChannelPressureMessage {
     type Vtable = IMidiChannelPressureMessage_Vtbl;
@@ -426,7 +507,7 @@ impl MidiContinueMessage {
     }
 }
 impl windows_core::RuntimeType for MidiContinueMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiContinueMessage {
     type Vtable = IMidiMessage_Vtbl;
@@ -499,7 +580,7 @@ impl MidiControlChangeMessage {
     }
 }
 impl windows_core::RuntimeType for MidiControlChangeMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiControlChangeMessage>();
 }
 unsafe impl windows_core::Interface for MidiControlChangeMessage {
     type Vtable = IMidiControlChangeMessage_Vtbl;
@@ -560,7 +641,7 @@ impl MidiInPort {
     }
 }
 impl windows_core::RuntimeType for MidiInPort {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiInPort>();
 }
 unsafe impl windows_core::Interface for MidiInPort {
     type Vtable = IMidiInPort_Vtbl;
@@ -585,7 +666,7 @@ impl MidiMessageReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MidiMessageReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessageReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MidiMessageReceivedEventArgs {
     type Vtable = IMidiMessageReceivedEventArgs_Vtbl;
@@ -658,7 +739,7 @@ impl MidiNoteOffMessage {
     }
 }
 impl windows_core::RuntimeType for MidiNoteOffMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiNoteOffMessage>();
 }
 unsafe impl windows_core::Interface for MidiNoteOffMessage {
     type Vtable = IMidiNoteOffMessage_Vtbl;
@@ -731,7 +812,7 @@ impl MidiNoteOnMessage {
     }
 }
 impl windows_core::RuntimeType for MidiNoteOnMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiNoteOnMessage>();
 }
 unsafe impl windows_core::Interface for MidiNoteOnMessage {
     type Vtable = IMidiNoteOnMessage_Vtbl;
@@ -793,7 +874,7 @@ impl MidiOutPort {
     }
 }
 impl windows_core::RuntimeType for MidiOutPort {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiOutPort>();
 }
 unsafe impl windows_core::Interface for MidiOutPort {
     type Vtable = IMidiOutPort_Vtbl;
@@ -859,7 +940,7 @@ impl MidiPitchBendChangeMessage {
     }
 }
 impl windows_core::RuntimeType for MidiPitchBendChangeMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiPitchBendChangeMessage>();
 }
 unsafe impl windows_core::Interface for MidiPitchBendChangeMessage {
     type Vtable = IMidiPitchBendChangeMessage_Vtbl;
@@ -932,7 +1013,7 @@ impl MidiPolyphonicKeyPressureMessage {
     }
 }
 impl windows_core::RuntimeType for MidiPolyphonicKeyPressureMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiPolyphonicKeyPressureMessage>();
 }
 unsafe impl windows_core::Interface for MidiPolyphonicKeyPressureMessage {
     type Vtable = IMidiPolyphonicKeyPressureMessage_Vtbl;
@@ -998,7 +1079,7 @@ impl MidiProgramChangeMessage {
     }
 }
 impl windows_core::RuntimeType for MidiProgramChangeMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiProgramChangeMessage>();
 }
 unsafe impl windows_core::Interface for MidiProgramChangeMessage {
     type Vtable = IMidiProgramChangeMessage_Vtbl;
@@ -1057,7 +1138,7 @@ impl MidiSongPositionPointerMessage {
     }
 }
 impl windows_core::RuntimeType for MidiSongPositionPointerMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiSongPositionPointerMessage>();
 }
 unsafe impl windows_core::Interface for MidiSongPositionPointerMessage {
     type Vtable = IMidiSongPositionPointerMessage_Vtbl;
@@ -1116,7 +1197,7 @@ impl MidiSongSelectMessage {
     }
 }
 impl windows_core::RuntimeType for MidiSongSelectMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiSongSelectMessage>();
 }
 unsafe impl windows_core::Interface for MidiSongSelectMessage {
     type Vtable = IMidiSongSelectMessage_Vtbl;
@@ -1164,7 +1245,7 @@ impl MidiStartMessage {
     }
 }
 impl windows_core::RuntimeType for MidiStartMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiStartMessage {
     type Vtable = IMidiMessage_Vtbl;
@@ -1212,7 +1293,7 @@ impl MidiStopMessage {
     }
 }
 impl windows_core::RuntimeType for MidiStopMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiStopMessage {
     type Vtable = IMidiMessage_Vtbl;
@@ -1307,7 +1388,7 @@ impl MidiSynthesizer {
     }
 }
 impl windows_core::RuntimeType for MidiSynthesizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiSynthesizer>();
 }
 unsafe impl windows_core::Interface for MidiSynthesizer {
     type Vtable = IMidiSynthesizer_Vtbl;
@@ -1363,7 +1444,7 @@ impl MidiSystemExclusiveMessage {
     }
 }
 impl windows_core::RuntimeType for MidiSystemExclusiveMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiSystemExclusiveMessage {
     type Vtable = IMidiMessage_Vtbl;
@@ -1411,7 +1492,7 @@ impl MidiSystemResetMessage {
     }
 }
 impl windows_core::RuntimeType for MidiSystemResetMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiSystemResetMessage {
     type Vtable = IMidiMessage_Vtbl;
@@ -1477,7 +1558,7 @@ impl MidiTimeCodeMessage {
     }
 }
 impl windows_core::RuntimeType for MidiTimeCodeMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiTimeCodeMessage>();
 }
 unsafe impl windows_core::Interface for MidiTimeCodeMessage {
     type Vtable = IMidiTimeCodeMessage_Vtbl;
@@ -1525,7 +1606,7 @@ impl MidiTimingClockMessage {
     }
 }
 impl windows_core::RuntimeType for MidiTimingClockMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiTimingClockMessage {
     type Vtable = IMidiMessage_Vtbl;
@@ -1573,7 +1654,7 @@ impl MidiTuneRequestMessage {
     }
 }
 impl windows_core::RuntimeType for MidiTuneRequestMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMidiMessage>();
 }
 unsafe impl windows_core::Interface for MidiTuneRequestMessage {
     type Vtable = IMidiMessage_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBarcodeScannerDisableScannerRequest, IBarcodeScannerDisableScannerRequest_Vtbl, 0x88ecf7c0_37b9_4275_8e77_c8e52ae5a9c8);
+impl windows_core::RuntimeType for IBarcodeScannerDisableScannerRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerDisableScannerRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IBarcodeScannerDisableScannerRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerDisableScannerRequest2, IBarcodeScannerDisableScannerRequest2_Vtbl, 0xccdfe625_65c3_4ccc_b457_f39c7a9ea60d);
+impl windows_core::RuntimeType for IBarcodeScannerDisableScannerRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerDisableScannerRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +19,9 @@ pub struct IBarcodeScannerDisableScannerRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerDisableScannerRequestEventArgs, IBarcodeScannerDisableScannerRequestEventArgs_Vtbl, 0x7006e142_e802_46f5_b604_352a15ce9232);
+impl windows_core::RuntimeType for IBarcodeScannerDisableScannerRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerDisableScannerRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +29,9 @@ pub struct IBarcodeScannerDisableScannerRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerEnableScannerRequest, IBarcodeScannerEnableScannerRequest_Vtbl, 0xc0b3e9ba_816a_452b_bd77_b7e453ec446d);
+impl windows_core::RuntimeType for IBarcodeScannerEnableScannerRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerEnableScannerRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +39,9 @@ pub struct IBarcodeScannerEnableScannerRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerEnableScannerRequest2, IBarcodeScannerEnableScannerRequest2_Vtbl, 0x71a4f2a8_9905_41ac_9121_b645916a84a1);
+impl windows_core::RuntimeType for IBarcodeScannerEnableScannerRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerEnableScannerRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +49,9 @@ pub struct IBarcodeScannerEnableScannerRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerEnableScannerRequestEventArgs, IBarcodeScannerEnableScannerRequestEventArgs_Vtbl, 0x956c9419_7b4e_4451_8c41_8e10cfbc5b41);
+impl windows_core::RuntimeType for IBarcodeScannerEnableScannerRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerEnableScannerRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +59,9 @@ pub struct IBarcodeScannerEnableScannerRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerFrameReader, IBarcodeScannerFrameReader_Vtbl, 0xdbc72b07_64c3_482b_93c8_65fb33c22208);
+impl windows_core::RuntimeType for IBarcodeScannerFrameReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerFrameReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,12 +73,18 @@ pub struct IBarcodeScannerFrameReader_Vtbl {
     pub RemoveFrameArrived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerFrameReaderFrameArrivedEventArgs, IBarcodeScannerFrameReaderFrameArrivedEventArgs_Vtbl, 0xb0bbd604_54fd_436d_8629_712e787223dd);
+impl windows_core::RuntimeType for IBarcodeScannerFrameReaderFrameArrivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerFrameReaderFrameArrivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerGetSymbologyAttributesRequest, IBarcodeScannerGetSymbologyAttributesRequest_Vtbl, 0x9774c46a_58e4_4c5f_b8e9_e41467632700);
+impl windows_core::RuntimeType for IBarcodeScannerGetSymbologyAttributesRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerGetSymbologyAttributesRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +93,9 @@ pub struct IBarcodeScannerGetSymbologyAttributesRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerGetSymbologyAttributesRequest2, IBarcodeScannerGetSymbologyAttributesRequest2_Vtbl, 0x6a6a2b13_75a8_49fb_b852_bfb93d760af7);
+impl windows_core::RuntimeType for IBarcodeScannerGetSymbologyAttributesRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerGetSymbologyAttributesRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +103,9 @@ pub struct IBarcodeScannerGetSymbologyAttributesRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerGetSymbologyAttributesRequestEventArgs, IBarcodeScannerGetSymbologyAttributesRequestEventArgs_Vtbl, 0x7f89de3e_fb5d_493c_b402_356b24d574a6);
+impl windows_core::RuntimeType for IBarcodeScannerGetSymbologyAttributesRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerGetSymbologyAttributesRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +113,9 @@ pub struct IBarcodeScannerGetSymbologyAttributesRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerHideVideoPreviewRequest, IBarcodeScannerHideVideoPreviewRequest_Vtbl, 0xfa4ebe7f_6670_40e1_b90b_bb10d8d425fa);
+impl windows_core::RuntimeType for IBarcodeScannerHideVideoPreviewRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerHideVideoPreviewRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -87,6 +123,9 @@ pub struct IBarcodeScannerHideVideoPreviewRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerHideVideoPreviewRequest2, IBarcodeScannerHideVideoPreviewRequest2_Vtbl, 0x7e28435d_9814_431d_a2f2_d6248c5ad4b5);
+impl windows_core::RuntimeType for IBarcodeScannerHideVideoPreviewRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerHideVideoPreviewRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +133,9 @@ pub struct IBarcodeScannerHideVideoPreviewRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerHideVideoPreviewRequestEventArgs, IBarcodeScannerHideVideoPreviewRequestEventArgs_Vtbl, 0x16a281fc_d6be_4bc7_9df1_33741f3eadea);
+impl windows_core::RuntimeType for IBarcodeScannerHideVideoPreviewRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerHideVideoPreviewRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,6 +143,9 @@ pub struct IBarcodeScannerHideVideoPreviewRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerProviderConnection, IBarcodeScannerProviderConnection_Vtbl, 0xb44acbed_0b3a_4fa3_86c5_491ea30780eb);
+impl windows_core::RuntimeType for IBarcodeScannerProviderConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerProviderConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +184,9 @@ pub struct IBarcodeScannerProviderConnection_Vtbl {
     pub RemoveHideVideoPreviewRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerProviderConnection2, IBarcodeScannerProviderConnection2_Vtbl, 0xbe9b53cd_1134_418c_a06b_04423a73f3d7);
+impl windows_core::RuntimeType for IBarcodeScannerProviderConnection2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerProviderConnection2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -153,12 +201,18 @@ pub struct IBarcodeScannerProviderConnection2_Vtbl {
     CreateFrameReaderWithFormatAndSizeAsync: usize,
 }
 windows_core::imp::define_interface!(IBarcodeScannerProviderTriggerDetails, IBarcodeScannerProviderTriggerDetails_Vtbl, 0x50856d82_24e3_48ce_99c7_70aac1cbc9f7);
+impl windows_core::RuntimeType for IBarcodeScannerProviderTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerProviderTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerSetActiveSymbologiesRequest, IBarcodeScannerSetActiveSymbologiesRequest_Vtbl, 0xdb3f32b9_f7da_41a1_9f79_07bcd95f0bdf);
+impl windows_core::RuntimeType for IBarcodeScannerSetActiveSymbologiesRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerSetActiveSymbologiesRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -170,6 +224,9 @@ pub struct IBarcodeScannerSetActiveSymbologiesRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerSetActiveSymbologiesRequest2, IBarcodeScannerSetActiveSymbologiesRequest2_Vtbl, 0xf5ff6edf_fa9a_4749_b11b_e8fccb75bc6b);
+impl windows_core::RuntimeType for IBarcodeScannerSetActiveSymbologiesRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerSetActiveSymbologiesRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -177,6 +234,9 @@ pub struct IBarcodeScannerSetActiveSymbologiesRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerSetActiveSymbologiesRequestEventArgs, IBarcodeScannerSetActiveSymbologiesRequestEventArgs_Vtbl, 0x06305afa_7bf6_4d52_801a_330272f60ae1);
+impl windows_core::RuntimeType for IBarcodeScannerSetActiveSymbologiesRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerSetActiveSymbologiesRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -184,6 +244,9 @@ pub struct IBarcodeScannerSetActiveSymbologiesRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerSetSymbologyAttributesRequest, IBarcodeScannerSetSymbologyAttributesRequest_Vtbl, 0x32fb814f_a37f_48b0_acea_dce1480f12ae);
+impl windows_core::RuntimeType for IBarcodeScannerSetSymbologyAttributesRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerSetSymbologyAttributesRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -193,6 +256,9 @@ pub struct IBarcodeScannerSetSymbologyAttributesRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerSetSymbologyAttributesRequest2, IBarcodeScannerSetSymbologyAttributesRequest2_Vtbl, 0xdffbbfc1_dba8_4b77_be1e_b56cd72f65b3);
+impl windows_core::RuntimeType for IBarcodeScannerSetSymbologyAttributesRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerSetSymbologyAttributesRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -200,6 +266,9 @@ pub struct IBarcodeScannerSetSymbologyAttributesRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerSetSymbologyAttributesRequestEventArgs, IBarcodeScannerSetSymbologyAttributesRequestEventArgs_Vtbl, 0xb2b89809_9824_47d4_85bd_d0077baa7bd2);
+impl windows_core::RuntimeType for IBarcodeScannerSetSymbologyAttributesRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerSetSymbologyAttributesRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,6 +276,9 @@ pub struct IBarcodeScannerSetSymbologyAttributesRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStartSoftwareTriggerRequest, IBarcodeScannerStartSoftwareTriggerRequest_Vtbl, 0xe3fa7b27_ff62_4454_af4a_cb6144a3e3f7);
+impl windows_core::RuntimeType for IBarcodeScannerStartSoftwareTriggerRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStartSoftwareTriggerRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,6 +286,9 @@ pub struct IBarcodeScannerStartSoftwareTriggerRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStartSoftwareTriggerRequest2, IBarcodeScannerStartSoftwareTriggerRequest2_Vtbl, 0xeb72a25c_6658_4765_a68e_327482653deb);
+impl windows_core::RuntimeType for IBarcodeScannerStartSoftwareTriggerRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStartSoftwareTriggerRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +296,9 @@ pub struct IBarcodeScannerStartSoftwareTriggerRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStartSoftwareTriggerRequestEventArgs, IBarcodeScannerStartSoftwareTriggerRequestEventArgs_Vtbl, 0x2305d843_c88f_4f3b_8c3b_d3df071051ec);
+impl windows_core::RuntimeType for IBarcodeScannerStartSoftwareTriggerRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStartSoftwareTriggerRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -228,6 +306,9 @@ pub struct IBarcodeScannerStartSoftwareTriggerRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStopSoftwareTriggerRequest, IBarcodeScannerStopSoftwareTriggerRequest_Vtbl, 0x6f9faf35_e287_4ca8_b70d_5a91d694f668);
+impl windows_core::RuntimeType for IBarcodeScannerStopSoftwareTriggerRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStopSoftwareTriggerRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,6 +316,9 @@ pub struct IBarcodeScannerStopSoftwareTriggerRequest_Vtbl {
     pub ReportFailedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStopSoftwareTriggerRequest2, IBarcodeScannerStopSoftwareTriggerRequest2_Vtbl, 0xcb57c5dd_fe50_49f8_a0b4_bdc230814da2);
+impl windows_core::RuntimeType for IBarcodeScannerStopSoftwareTriggerRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStopSoftwareTriggerRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -242,6 +326,9 @@ pub struct IBarcodeScannerStopSoftwareTriggerRequest2_Vtbl {
     pub ReportFailedWithFailedReasonAndDescriptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStopSoftwareTriggerRequestEventArgs, IBarcodeScannerStopSoftwareTriggerRequestEventArgs_Vtbl, 0xeac34450_4eb7_481a_9273_147a273b99b8);
+impl windows_core::RuntimeType for IBarcodeScannerStopSoftwareTriggerRequestEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStopSoftwareTriggerRequestEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -249,6 +336,9 @@ pub struct IBarcodeScannerStopSoftwareTriggerRequestEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerVideoFrame, IBarcodeScannerVideoFrame_Vtbl, 0x7e585248_9df7_4121_a175_801d8000112e);
+impl windows_core::RuntimeType for IBarcodeScannerVideoFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerVideoFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -264,6 +354,9 @@ pub struct IBarcodeScannerVideoFrame_Vtbl {
     PixelData: usize,
 }
 windows_core::imp::define_interface!(IBarcodeSymbologyAttributesBuilder, IBarcodeSymbologyAttributesBuilder_Vtbl, 0xc57b0cbf_e4f5_40b9_84cf_e63fbaea42b4);
+impl windows_core::RuntimeType for IBarcodeSymbologyAttributesBuilder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeSymbologyAttributesBuilder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -310,7 +403,7 @@ impl BarcodeScannerDisableScannerRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerDisableScannerRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerDisableScannerRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerDisableScannerRequest {
     type Vtable = IBarcodeScannerDisableScannerRequest_Vtbl;
@@ -342,7 +435,7 @@ impl BarcodeScannerDisableScannerRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerDisableScannerRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerDisableScannerRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerDisableScannerRequestEventArgs {
     type Vtable = IBarcodeScannerDisableScannerRequestEventArgs_Vtbl;
@@ -388,7 +481,7 @@ impl BarcodeScannerEnableScannerRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerEnableScannerRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerEnableScannerRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerEnableScannerRequest {
     type Vtable = IBarcodeScannerEnableScannerRequest_Vtbl;
@@ -420,7 +513,7 @@ impl BarcodeScannerEnableScannerRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerEnableScannerRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerEnableScannerRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerEnableScannerRequestEventArgs {
     type Vtable = IBarcodeScannerEnableScannerRequestEventArgs_Vtbl;
@@ -485,7 +578,7 @@ impl BarcodeScannerFrameReader {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerFrameReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerFrameReader>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerFrameReader {
     type Vtable = IBarcodeScannerFrameReader_Vtbl;
@@ -510,7 +603,7 @@ impl BarcodeScannerFrameReaderFrameArrivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerFrameReaderFrameArrivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerFrameReaderFrameArrivedEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerFrameReaderFrameArrivedEventArgs {
     type Vtable = IBarcodeScannerFrameReaderFrameArrivedEventArgs_Vtbl;
@@ -566,7 +659,7 @@ impl BarcodeScannerGetSymbologyAttributesRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerGetSymbologyAttributesRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerGetSymbologyAttributesRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerGetSymbologyAttributesRequest {
     type Vtable = IBarcodeScannerGetSymbologyAttributesRequest_Vtbl;
@@ -598,7 +691,7 @@ impl BarcodeScannerGetSymbologyAttributesRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerGetSymbologyAttributesRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerGetSymbologyAttributesRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerGetSymbologyAttributesRequestEventArgs {
     type Vtable = IBarcodeScannerGetSymbologyAttributesRequestEventArgs_Vtbl;
@@ -644,7 +737,7 @@ impl BarcodeScannerHideVideoPreviewRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerHideVideoPreviewRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerHideVideoPreviewRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerHideVideoPreviewRequest {
     type Vtable = IBarcodeScannerHideVideoPreviewRequest_Vtbl;
@@ -676,7 +769,7 @@ impl BarcodeScannerHideVideoPreviewRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerHideVideoPreviewRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerHideVideoPreviewRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerHideVideoPreviewRequestEventArgs {
     type Vtable = IBarcodeScannerHideVideoPreviewRequestEventArgs_Vtbl;
@@ -931,7 +1024,7 @@ impl BarcodeScannerProviderConnection {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerProviderConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerProviderConnection>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerProviderConnection {
     type Vtable = IBarcodeScannerProviderConnection_Vtbl;
@@ -956,7 +1049,7 @@ impl BarcodeScannerProviderTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerProviderTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerProviderTriggerDetails>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerProviderTriggerDetails {
     type Vtable = IBarcodeScannerProviderTriggerDetails_Vtbl;
@@ -1010,7 +1103,7 @@ impl BarcodeScannerSetActiveSymbologiesRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerSetActiveSymbologiesRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerSetActiveSymbologiesRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerSetActiveSymbologiesRequest {
     type Vtable = IBarcodeScannerSetActiveSymbologiesRequest_Vtbl;
@@ -1042,7 +1135,7 @@ impl BarcodeScannerSetActiveSymbologiesRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerSetActiveSymbologiesRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerSetActiveSymbologiesRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerSetActiveSymbologiesRequestEventArgs {
     type Vtable = IBarcodeScannerSetActiveSymbologiesRequestEventArgs_Vtbl;
@@ -1102,7 +1195,7 @@ impl BarcodeScannerSetSymbologyAttributesRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerSetSymbologyAttributesRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerSetSymbologyAttributesRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerSetSymbologyAttributesRequest {
     type Vtable = IBarcodeScannerSetSymbologyAttributesRequest_Vtbl;
@@ -1134,7 +1227,7 @@ impl BarcodeScannerSetSymbologyAttributesRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerSetSymbologyAttributesRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerSetSymbologyAttributesRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerSetSymbologyAttributesRequestEventArgs {
     type Vtable = IBarcodeScannerSetSymbologyAttributesRequestEventArgs_Vtbl;
@@ -1180,7 +1273,7 @@ impl BarcodeScannerStartSoftwareTriggerRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerStartSoftwareTriggerRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerStartSoftwareTriggerRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerStartSoftwareTriggerRequest {
     type Vtable = IBarcodeScannerStartSoftwareTriggerRequest_Vtbl;
@@ -1212,7 +1305,7 @@ impl BarcodeScannerStartSoftwareTriggerRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerStartSoftwareTriggerRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerStartSoftwareTriggerRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerStartSoftwareTriggerRequestEventArgs {
     type Vtable = IBarcodeScannerStartSoftwareTriggerRequestEventArgs_Vtbl;
@@ -1258,7 +1351,7 @@ impl BarcodeScannerStopSoftwareTriggerRequest {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerStopSoftwareTriggerRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerStopSoftwareTriggerRequest>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerStopSoftwareTriggerRequest {
     type Vtable = IBarcodeScannerStopSoftwareTriggerRequest_Vtbl;
@@ -1290,7 +1383,7 @@ impl BarcodeScannerStopSoftwareTriggerRequestEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerStopSoftwareTriggerRequestEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerStopSoftwareTriggerRequestEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerStopSoftwareTriggerRequestEventArgs {
     type Vtable = IBarcodeScannerStopSoftwareTriggerRequestEventArgs_Vtbl;
@@ -1343,7 +1436,7 @@ impl BarcodeScannerVideoFrame {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerVideoFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerVideoFrame>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerVideoFrame {
     type Vtable = IBarcodeScannerVideoFrame_Vtbl;
@@ -1408,7 +1501,7 @@ impl BarcodeSymbologyAttributesBuilder {
     }
 }
 impl windows_core::RuntimeType for BarcodeSymbologyAttributesBuilder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeSymbologyAttributesBuilder>();
 }
 unsafe impl windows_core::Interface for BarcodeSymbologyAttributesBuilder {
     type Vtable = IBarcodeSymbologyAttributesBuilder_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_PointOfService_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IBarcodeScanner, IBarcodeScanner_Vtbl, 0xbea33e06_b264_4f03_a9c1_45b20f01134f);
+impl windows_core::RuntimeType for IBarcodeScanner {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScanner_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,12 +29,18 @@ pub struct IBarcodeScanner_Vtbl {
     pub RemoveStatusUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScanner2, IBarcodeScanner2_Vtbl, 0x89215167_8cee_436d_89ab_8dfb43bb4286);
+impl windows_core::RuntimeType for IBarcodeScanner2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScanner2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub VideoDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerCapabilities, IBarcodeScannerCapabilities_Vtbl, 0xc60691e4_f2c8_4420_a307_b12ef6622857);
+impl windows_core::RuntimeType for IBarcodeScannerCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,24 +50,36 @@ pub struct IBarcodeScannerCapabilities_Vtbl {
     pub IsImagePreviewSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerCapabilities1, IBarcodeScannerCapabilities1_Vtbl, 0x8e5ab3e9_0e2c_472f_a1cc_ee8054b6a684);
+impl windows_core::RuntimeType for IBarcodeScannerCapabilities1 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerCapabilities1_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSoftwareTriggerSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerCapabilities2, IBarcodeScannerCapabilities2_Vtbl, 0xf211cfec_e1a1_4ea8_9abc_92b1596270ab);
+impl windows_core::RuntimeType for IBarcodeScannerCapabilities2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerCapabilities2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsVideoPreviewSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerDataReceivedEventArgs, IBarcodeScannerDataReceivedEventArgs_Vtbl, 0x4234a7e2_ed97_467d_ad2b_01e44313a929);
+impl windows_core::RuntimeType for IBarcodeScannerDataReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerDataReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Report: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerErrorOccurredEventArgs, IBarcodeScannerErrorOccurredEventArgs_Vtbl, 0x2cd2602f_cf3a_4002_a75a_c5ec468f0a20);
+impl windows_core::RuntimeType for IBarcodeScannerErrorOccurredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerErrorOccurredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +88,9 @@ pub struct IBarcodeScannerErrorOccurredEventArgs_Vtbl {
     pub ErrorData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerImagePreviewReceivedEventArgs, IBarcodeScannerImagePreviewReceivedEventArgs_Vtbl, 0xf3b7de85_6e8b_434e_9f58_06ef26bc4baf);
+impl windows_core::RuntimeType for IBarcodeScannerImagePreviewReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerImagePreviewReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +100,9 @@ pub struct IBarcodeScannerImagePreviewReceivedEventArgs_Vtbl {
     Preview: usize,
 }
 windows_core::imp::define_interface!(IBarcodeScannerReport, IBarcodeScannerReport_Vtbl, 0x5ce4d8b0_a489_4b96_86c4_f0bf8a37753d);
+impl windows_core::RuntimeType for IBarcodeScannerReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +117,9 @@ pub struct IBarcodeScannerReport_Vtbl {
     ScanDataLabel: usize,
 }
 windows_core::imp::define_interface!(IBarcodeScannerReportFactory, IBarcodeScannerReportFactory_Vtbl, 0xa2547326_2013_457c_8963_49c15dca78ce);
+impl windows_core::RuntimeType for IBarcodeScannerReportFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerReportFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +129,9 @@ pub struct IBarcodeScannerReportFactory_Vtbl {
     CreateInstance: usize,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStatics, IBarcodeScannerStatics_Vtbl, 0x5d115f6f_da49_41e8_8c8c_f0cb62a9c4fc);
+impl windows_core::RuntimeType for IBarcodeScannerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -107,12 +140,18 @@ pub struct IBarcodeScannerStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStatics2, IBarcodeScannerStatics2_Vtbl, 0xb8652473_a36f_4007_b1d0_279ebe92a656);
+impl windows_core::RuntimeType for IBarcodeScannerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeviceSelectorWithConnectionTypes: unsafe extern "system" fn(*mut core::ffi::c_void, PosConnectionTypes, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeScannerStatusUpdatedEventArgs, IBarcodeScannerStatusUpdatedEventArgs_Vtbl, 0x355d8586_9c43_462b_a91a_816dc97f452c);
+impl windows_core::RuntimeType for IBarcodeScannerStatusUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeScannerStatusUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,6 +159,9 @@ pub struct IBarcodeScannerStatusUpdatedEventArgs_Vtbl {
     pub ExtendedStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeSymbologiesStatics, IBarcodeSymbologiesStatics_Vtbl, 0xca8549bb_06d2_43f4_a44b_c620679fd8d0);
+impl windows_core::RuntimeType for IBarcodeSymbologiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeSymbologiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -219,12 +261,18 @@ pub struct IBarcodeSymbologiesStatics_Vtbl {
     pub GetName: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeSymbologiesStatics2, IBarcodeSymbologiesStatics2_Vtbl, 0x8b7518f4_99d0_40bf_9424_b91d6dd4c6e0);
+impl windows_core::RuntimeType for IBarcodeSymbologiesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeSymbologiesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Gs1DWCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarcodeSymbologyAttributes, IBarcodeSymbologyAttributes_Vtbl, 0x66413a78_ab7a_4ada_8ece_936014b2ead7);
+impl windows_core::RuntimeType for IBarcodeSymbologyAttributes {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarcodeSymbologyAttributes_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -243,6 +291,9 @@ pub struct IBarcodeSymbologyAttributes_Vtbl {
     pub IsDecodeLengthSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawer, ICashDrawer_Vtbl, 0x9f88f5c8_de54_4aee_a890_920bcbfe30fc);
+impl windows_core::RuntimeType for ICashDrawer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -261,6 +312,9 @@ pub struct ICashDrawer_Vtbl {
     pub RemoveStatusUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawerCapabilities, ICashDrawerCapabilities_Vtbl, 0x0bc6de0b_e8e7_4b1f_b1d1_3e501ad08247);
+impl windows_core::RuntimeType for ICashDrawerCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawerCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +326,9 @@ pub struct ICashDrawerCapabilities_Vtbl {
     pub IsDrawerOpenSensorAvailable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawerCloseAlarm, ICashDrawerCloseAlarm_Vtbl, 0x6bf88cc7_6f63_430e_ab3b_95d75ffbe87f);
+impl windows_core::RuntimeType for ICashDrawerCloseAlarm {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawerCloseAlarm_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -288,6 +345,9 @@ pub struct ICashDrawerCloseAlarm_Vtbl {
     pub StartAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawerEventSource, ICashDrawerEventSource_Vtbl, 0xe006e46c_f2f9_442f_8dd6_06c10a4227ba);
+impl windows_core::RuntimeType for ICashDrawerEventSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawerEventSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -316,6 +376,9 @@ pub struct ICashDrawerEventSourceEventArgs_Vtbl {
     pub CashDrawer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawerStatics, ICashDrawerStatics_Vtbl, 0xdfa0955a_d437_4fff_b547_dda969a4f883);
+impl windows_core::RuntimeType for ICashDrawerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -324,12 +387,18 @@ pub struct ICashDrawerStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawerStatics2, ICashDrawerStatics2_Vtbl, 0x3e818121_8c42_40e8_9c0e_40297048104c);
+impl windows_core::RuntimeType for ICashDrawerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeviceSelectorWithConnectionTypes: unsafe extern "system" fn(*mut core::ffi::c_void, PosConnectionTypes, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawerStatus, ICashDrawerStatus_Vtbl, 0x6bbd78bf_dca1_4e06_99eb_5af6a5aec108);
+impl windows_core::RuntimeType for ICashDrawerStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawerStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -337,12 +406,18 @@ pub struct ICashDrawerStatus_Vtbl {
     pub ExtendedStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICashDrawerStatusUpdatedEventArgs, ICashDrawerStatusUpdatedEventArgs_Vtbl, 0x30aae98a_0d70_459c_9553_87e124c52488);
+impl windows_core::RuntimeType for ICashDrawerStatusUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICashDrawerStatusUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedBarcodeScanner, IClaimedBarcodeScanner_Vtbl, 0x4a63b49c_8fa4_4332_bb26_945d11d81e0f);
+impl windows_core::RuntimeType for IClaimedBarcodeScanner {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedBarcodeScanner_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -382,6 +457,9 @@ pub struct IClaimedBarcodeScanner_Vtbl {
     pub RemoveErrorOccurred: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedBarcodeScanner1, IClaimedBarcodeScanner1_Vtbl, 0xf61aad0c_8551_42b4_998c_970c20210a22);
+impl windows_core::RuntimeType for IClaimedBarcodeScanner1 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedBarcodeScanner1_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -389,6 +467,9 @@ pub struct IClaimedBarcodeScanner1_Vtbl {
     pub StopSoftwareTriggerAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedBarcodeScanner2, IClaimedBarcodeScanner2_Vtbl, 0xe3b59e8c_2d8b_4f70_8af3_3448bedd5fe2);
+impl windows_core::RuntimeType for IClaimedBarcodeScanner2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedBarcodeScanner2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -396,6 +477,9 @@ pub struct IClaimedBarcodeScanner2_Vtbl {
     pub SetSymbologyAttributesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedBarcodeScanner3, IClaimedBarcodeScanner3_Vtbl, 0xe6ceb430_712e_45fc_8b86_cd55f5aef79d);
+impl windows_core::RuntimeType for IClaimedBarcodeScanner3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedBarcodeScanner3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -405,6 +489,9 @@ pub struct IClaimedBarcodeScanner3_Vtbl {
     pub IsVideoPreviewShownOnEnable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedBarcodeScanner4, IClaimedBarcodeScanner4_Vtbl, 0x5d501f97_376a_41a8_a230_2f37c1949dde);
+impl windows_core::RuntimeType for IClaimedBarcodeScanner4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedBarcodeScanner4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -412,11 +499,17 @@ pub struct IClaimedBarcodeScanner4_Vtbl {
     pub RemoveClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedBarcodeScannerClosedEventArgs, IClaimedBarcodeScannerClosedEventArgs_Vtbl, 0xcf7d5489_a22c_4c65_a901_88d77d833954);
+impl windows_core::RuntimeType for IClaimedBarcodeScannerClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedBarcodeScannerClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IClaimedCashDrawer, IClaimedCashDrawer_Vtbl, 0xca3f99af_abb8_42c1_8a84_5c66512f5a75);
+impl windows_core::RuntimeType for IClaimedCashDrawer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedCashDrawer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -440,6 +533,9 @@ pub struct IClaimedCashDrawer_Vtbl {
     pub RemoveReleaseDeviceRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedCashDrawer2, IClaimedCashDrawer2_Vtbl, 0x9cbab5a2_de42_4d5b_b0c1_9b57a2ba89c3);
+impl windows_core::RuntimeType for IClaimedCashDrawer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedCashDrawer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -447,17 +543,26 @@ pub struct IClaimedCashDrawer2_Vtbl {
     pub RemoveClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedCashDrawerClosedEventArgs, IClaimedCashDrawerClosedEventArgs_Vtbl, 0xcc573f33_3f34_4c5c_baae_deadf16cd7fa);
+impl windows_core::RuntimeType for IClaimedCashDrawerClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedCashDrawerClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IClaimedJournalPrinter, IClaimedJournalPrinter_Vtbl, 0x67ea0630_517d_487f_9fdf_d2e0a0a264a5);
+impl windows_core::RuntimeType for IClaimedJournalPrinter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedJournalPrinter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateJob: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedLineDisplay, IClaimedLineDisplay_Vtbl, 0x120ac970_9a75_4acf_aae7_09972bcf8794);
+impl windows_core::RuntimeType for IClaimedLineDisplay {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedLineDisplay_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -474,6 +579,9 @@ pub struct IClaimedLineDisplay_Vtbl {
     pub RemoveReleaseDeviceRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedLineDisplay2, IClaimedLineDisplay2_Vtbl, 0xa31c75ed_41f5_4e76_a074_795e47a46e97);
+impl windows_core::RuntimeType for IClaimedLineDisplay2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedLineDisplay2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -514,6 +622,9 @@ pub struct IClaimedLineDisplay2_Vtbl {
     TryStoreStorageFileBitmapWithAlignmentAndWidthAsync: usize,
 }
 windows_core::imp::define_interface!(IClaimedLineDisplay3, IClaimedLineDisplay3_Vtbl, 0x642ecd92_e9d4_4ecc_af75_329c274cd18f);
+impl windows_core::RuntimeType for IClaimedLineDisplay3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedLineDisplay3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -521,11 +632,17 @@ pub struct IClaimedLineDisplay3_Vtbl {
     pub RemoveClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedLineDisplayClosedEventArgs, IClaimedLineDisplayClosedEventArgs_Vtbl, 0xf915f364_d3d5_4f10_b511_90939edfacd8);
+impl windows_core::RuntimeType for IClaimedLineDisplayClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedLineDisplayClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IClaimedLineDisplayStatics, IClaimedLineDisplayStatics_Vtbl, 0x78ca98fb_8b6b_4973_86f0_3e570c351825);
+impl windows_core::RuntimeType for IClaimedLineDisplayStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedLineDisplayStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -534,6 +651,9 @@ pub struct IClaimedLineDisplayStatics_Vtbl {
     pub GetDeviceSelectorWithConnectionTypes: unsafe extern "system" fn(*mut core::ffi::c_void, PosConnectionTypes, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedMagneticStripeReader, IClaimedMagneticStripeReader_Vtbl, 0x475ca8f3_9417_48bc_b9d7_4163a7844c02);
+impl windows_core::RuntimeType for IClaimedMagneticStripeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedMagneticStripeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -581,6 +701,9 @@ pub struct IClaimedMagneticStripeReader_Vtbl {
     pub RemoveErrorOccurred: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedMagneticStripeReader2, IClaimedMagneticStripeReader2_Vtbl, 0x236fafdf_e2dc_4d7d_9c78_060df2bf2928);
+impl windows_core::RuntimeType for IClaimedMagneticStripeReader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedMagneticStripeReader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -588,11 +711,17 @@ pub struct IClaimedMagneticStripeReader2_Vtbl {
     pub RemoveClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedMagneticStripeReaderClosedEventArgs, IClaimedMagneticStripeReaderClosedEventArgs_Vtbl, 0x14ada93a_adcd_4c80_acda_c3eaed2647e1);
+impl windows_core::RuntimeType for IClaimedMagneticStripeReaderClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedMagneticStripeReaderClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IClaimedPosPrinter, IClaimedPosPrinter_Vtbl, 0x6d64ce0c_e03e_4b14_a38e_c28c34b86353);
+impl windows_core::RuntimeType for IClaimedPosPrinter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedPosPrinter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -623,6 +752,9 @@ pub struct IClaimedPosPrinter_Vtbl {
     pub RemoveReleaseDeviceRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedPosPrinter2, IClaimedPosPrinter2_Vtbl, 0x5bf7a3d5_5198_437a_82df_589993fa77e1);
+impl windows_core::RuntimeType for IClaimedPosPrinter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedPosPrinter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -630,11 +762,17 @@ pub struct IClaimedPosPrinter2_Vtbl {
     pub RemoveClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedPosPrinterClosedEventArgs, IClaimedPosPrinterClosedEventArgs_Vtbl, 0xe2b7a27b_4d40_471d_92ed_63375b18c788);
+impl windows_core::RuntimeType for IClaimedPosPrinterClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedPosPrinterClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IClaimedReceiptPrinter, IClaimedReceiptPrinter_Vtbl, 0x9ad27a74_dd61_4ee2_9837_5b5d72d538b9);
+impl windows_core::RuntimeType for IClaimedReceiptPrinter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedReceiptPrinter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -646,6 +784,9 @@ pub struct IClaimedReceiptPrinter_Vtbl {
     pub CreateJob: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClaimedSlipPrinter, IClaimedSlipPrinter_Vtbl, 0xbd5deff2_af90_4e8a_b77b_e3ae9ca63a7f);
+impl windows_core::RuntimeType for IClaimedSlipPrinter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClaimedSlipPrinter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1115,6 +1256,9 @@ pub struct ICommonReceiptSlipCapabilities_Vtbl {
     SupportedBitmapRotations: usize,
 }
 windows_core::imp::define_interface!(IJournalPrintJob, IJournalPrintJob_Vtbl, 0x9f4f2864_f3f0_55d0_8c39_74cc91783eed);
+impl windows_core::RuntimeType for IJournalPrintJob {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJournalPrintJob_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1123,11 +1267,17 @@ pub struct IJournalPrintJob_Vtbl {
     pub FeedPaperByMapModeUnit: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJournalPrinterCapabilities, IJournalPrinterCapabilities_Vtbl, 0x3b5ccc43_e047_4463_bb58_17b5ba1d8056);
+impl windows_core::RuntimeType for IJournalPrinterCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJournalPrinterCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IJournalPrinterCapabilities2, IJournalPrinterCapabilities2_Vtbl, 0x03b0b645_33b8_533b_baaa_a4389283ab0a);
+impl windows_core::RuntimeType for IJournalPrinterCapabilities2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJournalPrinterCapabilities2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1139,6 +1289,9 @@ pub struct IJournalPrinterCapabilities2_Vtbl {
     pub IsReversePaperFeedByMapModeUnitSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplay, ILineDisplay_Vtbl, 0x24f5df4e_3c99_44e2_b73f_e51be3637a8c);
+impl windows_core::RuntimeType for ILineDisplay {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplay_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1152,12 +1305,18 @@ pub struct ILineDisplay_Vtbl {
     pub ClaimAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplay2, ILineDisplay2_Vtbl, 0xc296a628_ef44_40f3_bd1c_b04c6a5cdc7d);
+impl windows_core::RuntimeType for ILineDisplay2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplay2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CheckPowerStatusAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayAttributes, ILineDisplayAttributes_Vtbl, 0xc17de99c_229a_4c14_a6f1_b4e4b1fead92);
+impl windows_core::RuntimeType for ILineDisplayAttributes {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayAttributes_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1177,6 +1336,9 @@ pub struct ILineDisplayAttributes_Vtbl {
     pub SetCurrentWindow: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayCapabilities, ILineDisplayCapabilities_Vtbl, 0x5a15b5d1_8dc5_4b9c_9172_303e47b70c55);
+impl windows_core::RuntimeType for ILineDisplayCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1200,6 +1362,9 @@ pub struct ILineDisplayCapabilities_Vtbl {
     pub SupportedWindows: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayCursor, ILineDisplayCursor_Vtbl, 0xecdffc45_754a_4e3b_ab2b_151181085605);
+impl windows_core::RuntimeType for ILineDisplayCursor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayCursor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1214,6 +1379,9 @@ pub struct ILineDisplayCursor_Vtbl {
     pub TryUpdateAttributesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayCursorAttributes, ILineDisplayCursorAttributes_Vtbl, 0x4e2d54fe_4ffd_4190_aae1_ce285f20c896);
+impl windows_core::RuntimeType for ILineDisplayCursorAttributes {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayCursorAttributes_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1227,6 +1395,9 @@ pub struct ILineDisplayCursorAttributes_Vtbl {
     pub SetPosition: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayCustomGlyphs, ILineDisplayCustomGlyphs_Vtbl, 0x2257f63c_f263_44f1_a1a0_e750a6a0ec54);
+impl windows_core::RuntimeType for ILineDisplayCustomGlyphs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayCustomGlyphs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1241,6 +1412,9 @@ pub struct ILineDisplayCustomGlyphs_Vtbl {
     TryRedefineAsync: usize,
 }
 windows_core::imp::define_interface!(ILineDisplayMarquee, ILineDisplayMarquee_Vtbl, 0xa3d33e3e_f46a_4b7a_bc21_53eb3b57f8b4);
+impl windows_core::RuntimeType for ILineDisplayMarquee {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayMarquee_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1254,6 +1428,9 @@ pub struct ILineDisplayMarquee_Vtbl {
     pub TryStopScrollingAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayStatics, ILineDisplayStatics_Vtbl, 0x022dc0b6_11b0_4690_9547_0b39c5af2114);
+impl windows_core::RuntimeType for ILineDisplayStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1263,12 +1440,18 @@ pub struct ILineDisplayStatics_Vtbl {
     pub GetDeviceSelectorWithConnectionTypes: unsafe extern "system" fn(*mut core::ffi::c_void, PosConnectionTypes, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayStatics2, ILineDisplayStatics2_Vtbl, 0x600c3f1c_77ab_4968_a7de_c02ff169f2cc);
+impl windows_core::RuntimeType for ILineDisplayStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub StatisticsCategorySelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayStatisticsCategorySelector, ILineDisplayStatisticsCategorySelector_Vtbl, 0xb521c46b_9274_4d24_94f3_b6017b832444);
+impl windows_core::RuntimeType for ILineDisplayStatisticsCategorySelector {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayStatisticsCategorySelector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1277,12 +1460,18 @@ pub struct ILineDisplayStatisticsCategorySelector_Vtbl {
     pub ManufacturerStatistics: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayStatusUpdatedEventArgs, ILineDisplayStatusUpdatedEventArgs_Vtbl, 0xddd57c1a_86fb_4eba_93d1_6f5eda52b752);
+impl windows_core::RuntimeType for ILineDisplayStatusUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayStatusUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut LineDisplayPowerStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayStoredBitmap, ILineDisplayStoredBitmap_Vtbl, 0xf621515b_d81e_43ba_bf1b_bcfa3c785ba0);
+impl windows_core::RuntimeType for ILineDisplayStoredBitmap {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayStoredBitmap_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1290,6 +1479,9 @@ pub struct ILineDisplayStoredBitmap_Vtbl {
     pub TryDeleteAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayWindow, ILineDisplayWindow_Vtbl, 0xd21feef4_2364_4be5_bee1_851680af4964);
+impl windows_core::RuntimeType for ILineDisplayWindow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1304,6 +1496,9 @@ pub struct ILineDisplayWindow_Vtbl {
     pub TryClearTextAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILineDisplayWindow2, ILineDisplayWindow2_Vtbl, 0xa95ce2e6_bdd8_4365_8e11_de94de8dff02);
+impl windows_core::RuntimeType for ILineDisplayWindow2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILineDisplayWindow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1333,6 +1528,9 @@ pub struct ILineDisplayWindow2_Vtbl {
     TryDisplayStorageFileBitmapAtPointWithWidthAsync: usize,
 }
 windows_core::imp::define_interface!(IMagneticStripeReader, IMagneticStripeReader_Vtbl, 0x1a92b015_47c3_468a_9333_0c6517574883);
+impl windows_core::RuntimeType for IMagneticStripeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1351,6 +1549,9 @@ pub struct IMagneticStripeReader_Vtbl {
     pub RemoveStatusUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderAamvaCardDataReceivedEventArgs, IMagneticStripeReaderAamvaCardDataReceivedEventArgs_Vtbl, 0x0a4bbd51_c316_4910_87f3_7a62ba862d31);
+impl windows_core::RuntimeType for IMagneticStripeReaderAamvaCardDataReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderAamvaCardDataReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1375,6 +1576,9 @@ pub struct IMagneticStripeReaderAamvaCardDataReceivedEventArgs_Vtbl {
     pub PostalCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderBankCardDataReceivedEventArgs, IMagneticStripeReaderBankCardDataReceivedEventArgs_Vtbl, 0x2e958823_a31a_4763_882c_23725e39b08e);
+impl windows_core::RuntimeType for IMagneticStripeReaderBankCardDataReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderBankCardDataReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1389,6 +1593,9 @@ pub struct IMagneticStripeReaderBankCardDataReceivedEventArgs_Vtbl {
     pub Suffix: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderCapabilities, IMagneticStripeReaderCapabilities_Vtbl, 0x7128809c_c440_44a2_a467_469175d02896);
+impl windows_core::RuntimeType for IMagneticStripeReaderCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1405,6 +1612,9 @@ pub struct IMagneticStripeReaderCapabilities_Vtbl {
     pub IsTransmitSentinelsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderCardTypesStatics, IMagneticStripeReaderCardTypesStatics_Vtbl, 0x528f2c5d_2986_474f_8454_7ccd05928d5f);
+impl windows_core::RuntimeType for IMagneticStripeReaderCardTypesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderCardTypesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1414,6 +1624,9 @@ pub struct IMagneticStripeReaderCardTypesStatics_Vtbl {
     pub ExtendedBase: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderEncryptionAlgorithmsStatics, IMagneticStripeReaderEncryptionAlgorithmsStatics_Vtbl, 0x53b57350_c3db_4754_9c00_41392374a109);
+impl windows_core::RuntimeType for IMagneticStripeReaderEncryptionAlgorithmsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderEncryptionAlgorithmsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1422,6 +1635,9 @@ pub struct IMagneticStripeReaderEncryptionAlgorithmsStatics_Vtbl {
     pub ExtendedBase: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderErrorOccurredEventArgs, IMagneticStripeReaderErrorOccurredEventArgs_Vtbl, 0x1fedf95d_2c84_41ad_b778_f2356a789ab1);
+impl windows_core::RuntimeType for IMagneticStripeReaderErrorOccurredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderErrorOccurredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1433,6 +1649,9 @@ pub struct IMagneticStripeReaderErrorOccurredEventArgs_Vtbl {
     pub PartialInputData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderReport, IMagneticStripeReaderReport_Vtbl, 0x6a5b6047_99b0_4188_bef1_eddf79f78fe6);
+impl windows_core::RuntimeType for IMagneticStripeReaderReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1456,6 +1675,9 @@ pub struct IMagneticStripeReaderReport_Vtbl {
     AdditionalSecurityInformation: usize,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderStatics, IMagneticStripeReaderStatics_Vtbl, 0xc45fab4a_efd7_4760_a5ce_15b0e47e94eb);
+impl windows_core::RuntimeType for IMagneticStripeReaderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1464,12 +1686,18 @@ pub struct IMagneticStripeReaderStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderStatics2, IMagneticStripeReaderStatics2_Vtbl, 0x8cadc362_d667_48fa_86bc_f5ae1189262b);
+impl windows_core::RuntimeType for IMagneticStripeReaderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeviceSelectorWithConnectionTypes: unsafe extern "system" fn(*mut core::ffi::c_void, PosConnectionTypes, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderStatusUpdatedEventArgs, IMagneticStripeReaderStatusUpdatedEventArgs_Vtbl, 0x09cc6bb0_3262_401d_9e8a_e80d6358906b);
+impl windows_core::RuntimeType for IMagneticStripeReaderStatusUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderStatusUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1477,6 +1705,9 @@ pub struct IMagneticStripeReaderStatusUpdatedEventArgs_Vtbl {
     pub ExtendedStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderTrackData, IMagneticStripeReaderTrackData_Vtbl, 0x104cf671_4a9d_446e_abc5_20402307ba36);
+impl windows_core::RuntimeType for IMagneticStripeReaderTrackData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderTrackData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1494,12 +1725,18 @@ pub struct IMagneticStripeReaderTrackData_Vtbl {
     EncryptedData: usize,
 }
 windows_core::imp::define_interface!(IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs, IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs_Vtbl, 0xaf0a5514_59cc_4a60_99e8_99a53dace5aa);
+impl windows_core::RuntimeType for IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Report: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinter, IPosPrinter_Vtbl, 0x2a03c10e_9a19_4a01_994f_12dfad6adcbf);
+impl windows_core::RuntimeType for IPosPrinter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1524,6 +1761,9 @@ pub struct IPosPrinter_Vtbl {
     pub RemoveStatusUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinter2, IPosPrinter2_Vtbl, 0x248475e8_8b98_5517_8e48_760e86f68987);
+impl windows_core::RuntimeType for IPosPrinter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1534,6 +1774,9 @@ pub struct IPosPrinter2_Vtbl {
     pub GetFontProperty: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterCapabilities, IPosPrinterCapabilities_Vtbl, 0xcde95721_4380_4985_adc5_39db30cd93bc);
+impl windows_core::RuntimeType for IPosPrinterCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1549,6 +1792,9 @@ pub struct IPosPrinterCapabilities_Vtbl {
     pub Journal: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterCharacterSetIdsStatics, IPosPrinterCharacterSetIdsStatics_Vtbl, 0x5c709eff_709a_4fe7_b215_06a748a38b39);
+impl windows_core::RuntimeType for IPosPrinterCharacterSetIdsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterCharacterSetIdsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1557,6 +1803,9 @@ pub struct IPosPrinterCharacterSetIdsStatics_Vtbl {
     pub Ansi: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterFontProperty, IPosPrinterFontProperty_Vtbl, 0xa7f4e93a_f8ac_5f04_84d2_29b16d8a633c);
+impl windows_core::RuntimeType for IPosPrinterFontProperty {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterFontProperty_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1602,6 +1851,9 @@ pub struct IPosPrinterJob_Vtbl {
     pub ExecuteAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterPrintOptions, IPosPrinterPrintOptions_Vtbl, 0x0a2e16fd_1d02_5a58_9d59_bfcde76fde86);
+impl windows_core::RuntimeType for IPosPrinterPrintOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterPrintOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1633,11 +1885,17 @@ pub struct IPosPrinterPrintOptions_Vtbl {
     pub SetCharacterSet: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterReleaseDeviceRequestedEventArgs, IPosPrinterReleaseDeviceRequestedEventArgs_Vtbl, 0x2bcba359_1cef_40b2_9ecb_f927f856ae3c);
+impl windows_core::RuntimeType for IPosPrinterReleaseDeviceRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterReleaseDeviceRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPosPrinterStatics, IPosPrinterStatics_Vtbl, 0x8ce0d4ea_132f_4cdf_a64a_2d0d7c96a85b);
+impl windows_core::RuntimeType for IPosPrinterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1646,12 +1904,18 @@ pub struct IPosPrinterStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterStatics2, IPosPrinterStatics2_Vtbl, 0xeecd2c1c_b0d0_42e7_b137_b89b16244d41);
+impl windows_core::RuntimeType for IPosPrinterStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeviceSelectorWithConnectionTypes: unsafe extern "system" fn(*mut core::ffi::c_void, PosConnectionTypes, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterStatus, IPosPrinterStatus_Vtbl, 0xd1f0c730_da40_4328_bf76_5156fa33b747);
+impl windows_core::RuntimeType for IPosPrinterStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1659,6 +1923,9 @@ pub struct IPosPrinterStatus_Vtbl {
     pub ExtendedStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPosPrinterStatusUpdatedEventArgs, IPosPrinterStatusUpdatedEventArgs_Vtbl, 0x2edb87df_13a6_428d_ba81_b0e7c3e5a3cd);
+impl windows_core::RuntimeType for IPosPrinterStatusUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPosPrinterStatusUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1827,6 +2094,9 @@ pub struct IReceiptOrSlipJob_Vtbl {
     PrintBitmapCustomWidthCustomAlign: usize,
 }
 windows_core::imp::define_interface!(IReceiptPrintJob, IReceiptPrintJob_Vtbl, 0xaa96066e_acad_4b79_9d0f_c0cfc08dc77b);
+impl windows_core::RuntimeType for IReceiptPrintJob {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReceiptPrintJob_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1835,6 +2105,9 @@ pub struct IReceiptPrintJob_Vtbl {
     pub CutPaperDefault: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReceiptPrintJob2, IReceiptPrintJob2_Vtbl, 0x0cbc12e3_9e29_5179_bcd8_1811d3b9a10e);
+impl windows_core::RuntimeType for IReceiptPrintJob2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReceiptPrintJob2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1844,6 +2117,9 @@ pub struct IReceiptPrintJob2_Vtbl {
     pub FeedPaperByMapModeUnit: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReceiptPrinterCapabilities, IReceiptPrinterCapabilities_Vtbl, 0xb8f0b58f_51a8_43fc_9bd5_8de272a6415b);
+impl windows_core::RuntimeType for IReceiptPrinterCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReceiptPrinterCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1852,6 +2128,9 @@ pub struct IReceiptPrinterCapabilities_Vtbl {
     pub MarkFeedCapabilities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PosPrinterMarkFeedCapabilities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReceiptPrinterCapabilities2, IReceiptPrinterCapabilities2_Vtbl, 0x20030638_8a2c_55ac_9a7b_7576d8869e99);
+impl windows_core::RuntimeType for IReceiptPrinterCapabilities2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReceiptPrinterCapabilities2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1863,6 +2142,9 @@ pub struct IReceiptPrinterCapabilities2_Vtbl {
     pub IsReversePaperFeedByMapModeUnitSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISlipPrintJob, ISlipPrintJob_Vtbl, 0x5d88f95d_6131_5a4b_b7d5_8ef2da7b4165);
+impl windows_core::RuntimeType for ISlipPrintJob {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISlipPrintJob_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1871,6 +2153,9 @@ pub struct ISlipPrintJob_Vtbl {
     pub FeedPaperByMapModeUnit: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISlipPrinterCapabilities, ISlipPrinterCapabilities_Vtbl, 0x99b16399_488c_4157_8ac2_9f57f708d3db);
+impl windows_core::RuntimeType for ISlipPrinterCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISlipPrinterCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1878,6 +2163,9 @@ pub struct ISlipPrinterCapabilities_Vtbl {
     pub IsBothSidesPrintingSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISlipPrinterCapabilities2, ISlipPrinterCapabilities2_Vtbl, 0x6ff89671_2d1a_5000_87c2_b0851bfdf07e);
+impl windows_core::RuntimeType for ISlipPrinterCapabilities2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISlipPrinterCapabilities2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1889,6 +2177,9 @@ pub struct ISlipPrinterCapabilities2_Vtbl {
     pub IsReversePaperFeedByMapModeUnitSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUnifiedPosErrorData, IUnifiedPosErrorData_Vtbl, 0x2b998c3a_555c_4889_8ed8_c599bb3a712a);
+impl windows_core::RuntimeType for IUnifiedPosErrorData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUnifiedPosErrorData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1898,6 +2189,9 @@ pub struct IUnifiedPosErrorData_Vtbl {
     pub ExtendedReason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUnifiedPosErrorDataFactory, IUnifiedPosErrorDataFactory_Vtbl, 0x4b982551_1ffe_451b_a368_63e0ce465f5a);
+impl windows_core::RuntimeType for IUnifiedPosErrorDataFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUnifiedPosErrorDataFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2039,7 +2333,7 @@ impl BarcodeScanner {
     }
 }
 impl windows_core::RuntimeType for BarcodeScanner {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScanner>();
 }
 unsafe impl windows_core::Interface for BarcodeScanner {
     type Vtable = IBarcodeScanner_Vtbl;
@@ -2099,7 +2393,7 @@ impl BarcodeScannerCapabilities {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerCapabilities>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerCapabilities {
     type Vtable = IBarcodeScannerCapabilities_Vtbl;
@@ -2124,7 +2418,7 @@ impl BarcodeScannerDataReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerDataReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerDataReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerDataReceivedEventArgs {
     type Vtable = IBarcodeScannerDataReceivedEventArgs_Vtbl;
@@ -2163,7 +2457,7 @@ impl BarcodeScannerErrorOccurredEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerErrorOccurredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerErrorOccurredEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerErrorOccurredEventArgs {
     type Vtable = IBarcodeScannerErrorOccurredEventArgs_Vtbl;
@@ -2189,7 +2483,7 @@ impl BarcodeScannerImagePreviewReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerImagePreviewReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerImagePreviewReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerImagePreviewReceivedEventArgs {
     type Vtable = IBarcodeScannerImagePreviewReceivedEventArgs_Vtbl;
@@ -2246,7 +2540,7 @@ impl BarcodeScannerReport {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerReport>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerReport {
     type Vtable = IBarcodeScannerReport_Vtbl;
@@ -2278,7 +2572,7 @@ impl BarcodeScannerStatusUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarcodeScannerStatusUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeScannerStatusUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for BarcodeScannerStatusUpdatedEventArgs {
     type Vtable = IBarcodeScannerStatusUpdatedEventArgs_Vtbl;
@@ -2958,7 +3252,7 @@ impl BarcodeSymbologyAttributes {
     }
 }
 impl windows_core::RuntimeType for BarcodeSymbologyAttributes {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarcodeSymbologyAttributes>();
 }
 unsafe impl windows_core::Interface for BarcodeSymbologyAttributes {
     type Vtable = IBarcodeSymbologyAttributes_Vtbl;
@@ -3089,7 +3383,7 @@ impl CashDrawer {
     }
 }
 impl windows_core::RuntimeType for CashDrawer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawer>();
 }
 unsafe impl windows_core::Interface for CashDrawer {
     type Vtable = ICashDrawer_Vtbl;
@@ -3149,7 +3443,7 @@ impl CashDrawerCapabilities {
     }
 }
 impl windows_core::RuntimeType for CashDrawerCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawerCapabilities>();
 }
 unsafe impl windows_core::Interface for CashDrawerCapabilities {
     type Vtable = ICashDrawerCapabilities_Vtbl;
@@ -3232,7 +3526,7 @@ impl CashDrawerCloseAlarm {
     }
 }
 impl windows_core::RuntimeType for CashDrawerCloseAlarm {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawerCloseAlarm>();
 }
 unsafe impl windows_core::Interface for CashDrawerCloseAlarm {
     type Vtable = ICashDrawerCloseAlarm_Vtbl;
@@ -3258,7 +3552,7 @@ impl CashDrawerClosedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CashDrawerClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawerEventSourceEventArgs>();
 }
 unsafe impl windows_core::Interface for CashDrawerClosedEventArgs {
     type Vtable = ICashDrawerEventSourceEventArgs_Vtbl;
@@ -3304,7 +3598,7 @@ impl CashDrawerEventSource {
     }
 }
 impl windows_core::RuntimeType for CashDrawerEventSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawerEventSource>();
 }
 unsafe impl windows_core::Interface for CashDrawerEventSource {
     type Vtable = ICashDrawerEventSource_Vtbl;
@@ -3330,7 +3624,7 @@ impl CashDrawerOpenedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CashDrawerOpenedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawerEventSourceEventArgs>();
 }
 unsafe impl windows_core::Interface for CashDrawerOpenedEventArgs {
     type Vtable = ICashDrawerEventSourceEventArgs_Vtbl;
@@ -3362,7 +3656,7 @@ impl CashDrawerStatus {
     }
 }
 impl windows_core::RuntimeType for CashDrawerStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawerStatus>();
 }
 unsafe impl windows_core::Interface for CashDrawerStatus {
     type Vtable = ICashDrawerStatus_Vtbl;
@@ -3387,7 +3681,7 @@ impl CashDrawerStatusUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CashDrawerStatusUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICashDrawerStatusUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for CashDrawerStatusUpdatedEventArgs {
     type Vtable = ICashDrawerStatusUpdatedEventArgs_Vtbl;
@@ -3655,7 +3949,7 @@ impl ClaimedBarcodeScanner {
     }
 }
 impl windows_core::RuntimeType for ClaimedBarcodeScanner {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedBarcodeScanner>();
 }
 unsafe impl windows_core::Interface for ClaimedBarcodeScanner {
     type Vtable = IClaimedBarcodeScanner_Vtbl;
@@ -3672,7 +3966,7 @@ pub struct ClaimedBarcodeScannerClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedBarcodeScannerClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedBarcodeScannerClosedEventArgs {}
 impl windows_core::RuntimeType for ClaimedBarcodeScannerClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedBarcodeScannerClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for ClaimedBarcodeScannerClosedEventArgs {
     type Vtable = IClaimedBarcodeScannerClosedEventArgs_Vtbl;
@@ -3801,7 +4095,7 @@ impl ClaimedCashDrawer {
     }
 }
 impl windows_core::RuntimeType for ClaimedCashDrawer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedCashDrawer>();
 }
 unsafe impl windows_core::Interface for ClaimedCashDrawer {
     type Vtable = IClaimedCashDrawer_Vtbl;
@@ -3818,7 +4112,7 @@ pub struct ClaimedCashDrawerClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedCashDrawerClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedCashDrawerClosedEventArgs {}
 impl windows_core::RuntimeType for ClaimedCashDrawerClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedCashDrawerClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for ClaimedCashDrawerClosedEventArgs {
     type Vtable = IClaimedCashDrawerClosedEventArgs_Vtbl;
@@ -3962,7 +4256,7 @@ impl ClaimedJournalPrinter {
     }
 }
 impl windows_core::RuntimeType for ClaimedJournalPrinter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedJournalPrinter>();
 }
 unsafe impl windows_core::Interface for ClaimedJournalPrinter {
     type Vtable = IClaimedJournalPrinter_Vtbl;
@@ -4236,7 +4530,7 @@ impl ClaimedLineDisplay {
     }
 }
 impl windows_core::RuntimeType for ClaimedLineDisplay {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedLineDisplay>();
 }
 unsafe impl windows_core::Interface for ClaimedLineDisplay {
     type Vtable = IClaimedLineDisplay_Vtbl;
@@ -4253,7 +4547,7 @@ pub struct ClaimedLineDisplayClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedLineDisplayClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedLineDisplayClosedEventArgs {}
 impl windows_core::RuntimeType for ClaimedLineDisplayClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedLineDisplayClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for ClaimedLineDisplayClosedEventArgs {
     type Vtable = IClaimedLineDisplayClosedEventArgs_Vtbl;
@@ -4509,7 +4803,7 @@ impl ClaimedMagneticStripeReader {
     }
 }
 impl windows_core::RuntimeType for ClaimedMagneticStripeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedMagneticStripeReader>();
 }
 unsafe impl windows_core::Interface for ClaimedMagneticStripeReader {
     type Vtable = IClaimedMagneticStripeReader_Vtbl;
@@ -4526,7 +4820,7 @@ pub struct ClaimedMagneticStripeReaderClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedMagneticStripeReaderClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedMagneticStripeReaderClosedEventArgs {}
 impl windows_core::RuntimeType for ClaimedMagneticStripeReaderClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedMagneticStripeReaderClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for ClaimedMagneticStripeReaderClosedEventArgs {
     type Vtable = IClaimedMagneticStripeReaderClosedEventArgs_Vtbl;
@@ -4695,7 +4989,7 @@ impl ClaimedPosPrinter {
     }
 }
 impl windows_core::RuntimeType for ClaimedPosPrinter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedPosPrinter>();
 }
 unsafe impl windows_core::Interface for ClaimedPosPrinter {
     type Vtable = IClaimedPosPrinter_Vtbl;
@@ -4712,7 +5006,7 @@ pub struct ClaimedPosPrinterClosedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(ClaimedPosPrinterClosedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl ClaimedPosPrinterClosedEventArgs {}
 impl windows_core::RuntimeType for ClaimedPosPrinterClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedPosPrinterClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for ClaimedPosPrinterClosedEventArgs {
     type Vtable = IClaimedPosPrinterClosedEventArgs_Vtbl;
@@ -4891,7 +5185,7 @@ impl ClaimedReceiptPrinter {
     }
 }
 impl windows_core::RuntimeType for ClaimedReceiptPrinter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedReceiptPrinter>();
 }
 unsafe impl windows_core::Interface for ClaimedReceiptPrinter {
     type Vtable = IClaimedReceiptPrinter_Vtbl;
@@ -5110,7 +5404,7 @@ impl ClaimedSlipPrinter {
     }
 }
 impl windows_core::RuntimeType for ClaimedSlipPrinter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClaimedSlipPrinter>();
 }
 unsafe impl windows_core::Interface for ClaimedSlipPrinter {
     type Vtable = IClaimedSlipPrinter_Vtbl;
@@ -5163,7 +5457,7 @@ impl JournalPrintJob {
     }
 }
 impl windows_core::RuntimeType for JournalPrintJob {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinterJob>();
 }
 unsafe impl windows_core::Interface for JournalPrintJob {
     type Vtable = IPosPrinterJob_Vtbl;
@@ -5316,7 +5610,7 @@ impl JournalPrinterCapabilities {
     }
 }
 impl windows_core::RuntimeType for JournalPrinterCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IJournalPrinterCapabilities>();
 }
 unsafe impl windows_core::Interface for JournalPrinterCapabilities {
     type Vtable = IJournalPrinterCapabilities_Vtbl;
@@ -5442,7 +5736,7 @@ impl LineDisplay {
     }
 }
 impl windows_core::RuntimeType for LineDisplay {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplay>();
 }
 unsafe impl windows_core::Interface for LineDisplay {
     type Vtable = ILineDisplay_Vtbl;
@@ -5540,7 +5834,7 @@ impl LineDisplayAttributes {
     }
 }
 impl windows_core::RuntimeType for LineDisplayAttributes {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayAttributes>();
 }
 unsafe impl windows_core::Interface for LineDisplayAttributes {
     type Vtable = ILineDisplayAttributes_Vtbl;
@@ -5684,7 +5978,7 @@ impl LineDisplayCapabilities {
     }
 }
 impl windows_core::RuntimeType for LineDisplayCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayCapabilities>();
 }
 unsafe impl windows_core::Interface for LineDisplayCapabilities {
     type Vtable = ILineDisplayCapabilities_Vtbl;
@@ -5768,7 +6062,7 @@ impl LineDisplayCursor {
     }
 }
 impl windows_core::RuntimeType for LineDisplayCursor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayCursor>();
 }
 unsafe impl windows_core::Interface for LineDisplayCursor {
     type Vtable = ILineDisplayCursor_Vtbl;
@@ -5830,7 +6124,7 @@ impl LineDisplayCursorAttributes {
     }
 }
 impl windows_core::RuntimeType for LineDisplayCursorAttributes {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayCursorAttributes>();
 }
 unsafe impl windows_core::Interface for LineDisplayCursorAttributes {
     type Vtable = ILineDisplayCursorAttributes_Vtbl;
@@ -5874,7 +6168,7 @@ impl LineDisplayCustomGlyphs {
     }
 }
 impl windows_core::RuntimeType for LineDisplayCustomGlyphs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayCustomGlyphs>();
 }
 unsafe impl windows_core::Interface for LineDisplayCustomGlyphs {
     type Vtable = ILineDisplayCustomGlyphs_Vtbl;
@@ -5939,7 +6233,7 @@ impl LineDisplayMarquee {
     }
 }
 impl windows_core::RuntimeType for LineDisplayMarquee {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayMarquee>();
 }
 unsafe impl windows_core::Interface for LineDisplayMarquee {
     type Vtable = ILineDisplayMarquee_Vtbl;
@@ -5978,7 +6272,7 @@ impl LineDisplayStatisticsCategorySelector {
     }
 }
 impl windows_core::RuntimeType for LineDisplayStatisticsCategorySelector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayStatisticsCategorySelector>();
 }
 unsafe impl windows_core::Interface for LineDisplayStatisticsCategorySelector {
     type Vtable = ILineDisplayStatisticsCategorySelector_Vtbl;
@@ -6003,7 +6297,7 @@ impl LineDisplayStatusUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LineDisplayStatusUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayStatusUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for LineDisplayStatusUpdatedEventArgs {
     type Vtable = ILineDisplayStatusUpdatedEventArgs_Vtbl;
@@ -6035,7 +6329,7 @@ impl LineDisplayStoredBitmap {
     }
 }
 impl windows_core::RuntimeType for LineDisplayStoredBitmap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayStoredBitmap>();
 }
 unsafe impl windows_core::Interface for LineDisplayStoredBitmap {
     type Vtable = ILineDisplayStoredBitmap_Vtbl;
@@ -6204,7 +6498,7 @@ impl LineDisplayWindow {
     }
 }
 impl windows_core::RuntimeType for LineDisplayWindow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILineDisplayWindow>();
 }
 unsafe impl windows_core::Interface for LineDisplayWindow {
     type Vtable = ILineDisplayWindow_Vtbl;
@@ -6335,7 +6629,7 @@ impl MagneticStripeReader {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReader>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReader {
     type Vtable = IMagneticStripeReader_Vtbl;
@@ -6486,7 +6780,7 @@ impl MagneticStripeReaderAamvaCardDataReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderAamvaCardDataReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderAamvaCardDataReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderAamvaCardDataReceivedEventArgs {
     type Vtable = IMagneticStripeReaderAamvaCardDataReceivedEventArgs_Vtbl;
@@ -6567,7 +6861,7 @@ impl MagneticStripeReaderBankCardDataReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderBankCardDataReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderBankCardDataReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderBankCardDataReceivedEventArgs {
     type Vtable = IMagneticStripeReaderBankCardDataReceivedEventArgs_Vtbl;
@@ -6662,7 +6956,7 @@ impl MagneticStripeReaderCapabilities {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderCapabilities>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderCapabilities {
     type Vtable = IMagneticStripeReaderCapabilities_Vtbl;
@@ -6786,7 +7080,7 @@ impl MagneticStripeReaderErrorOccurredEventArgs {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderErrorOccurredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderErrorOccurredEventArgs>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderErrorOccurredEventArgs {
     type Vtable = IMagneticStripeReaderErrorOccurredEventArgs_Vtbl;
@@ -6870,7 +7164,7 @@ impl MagneticStripeReaderReport {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderReport>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderReport {
     type Vtable = IMagneticStripeReaderReport_Vtbl;
@@ -6902,7 +7196,7 @@ impl MagneticStripeReaderStatusUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderStatusUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderStatusUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderStatusUpdatedEventArgs {
     type Vtable = IMagneticStripeReaderStatusUpdatedEventArgs_Vtbl;
@@ -6944,7 +7238,7 @@ impl MagneticStripeReaderTrackData {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderTrackData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderTrackData>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderTrackData {
     type Vtable = IMagneticStripeReaderTrackData_Vtbl;
@@ -6969,7 +7263,7 @@ impl MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {
     type Vtable = IMagneticStripeReaderVendorSpecificCardDataReceivedEventArgs_Vtbl;
@@ -7117,7 +7411,7 @@ impl PosPrinter {
     }
 }
 impl windows_core::RuntimeType for PosPrinter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinter>();
 }
 unsafe impl windows_core::Interface for PosPrinter {
     type Vtable = IPosPrinter_Vtbl;
@@ -7205,7 +7499,7 @@ impl PosPrinterCapabilities {
     }
 }
 impl windows_core::RuntimeType for PosPrinterCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinterCapabilities>();
 }
 unsafe impl windows_core::Interface for PosPrinterCapabilities {
     type Vtable = IPosPrinterCapabilities_Vtbl;
@@ -7274,7 +7568,7 @@ impl PosPrinterFontProperty {
     }
 }
 impl windows_core::RuntimeType for PosPrinterFontProperty {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinterFontProperty>();
 }
 unsafe impl windows_core::Interface for PosPrinterFontProperty {
     type Vtable = IPosPrinterFontProperty_Vtbl;
@@ -7442,7 +7736,7 @@ impl PosPrinterPrintOptions {
     }
 }
 impl windows_core::RuntimeType for PosPrinterPrintOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinterPrintOptions>();
 }
 unsafe impl windows_core::Interface for PosPrinterPrintOptions {
     type Vtable = IPosPrinterPrintOptions_Vtbl;
@@ -7459,7 +7753,7 @@ pub struct PosPrinterReleaseDeviceRequestedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PosPrinterReleaseDeviceRequestedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PosPrinterReleaseDeviceRequestedEventArgs {}
 impl windows_core::RuntimeType for PosPrinterReleaseDeviceRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinterReleaseDeviceRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PosPrinterReleaseDeviceRequestedEventArgs {
     type Vtable = IPosPrinterReleaseDeviceRequestedEventArgs_Vtbl;
@@ -7491,7 +7785,7 @@ impl PosPrinterStatus {
     }
 }
 impl windows_core::RuntimeType for PosPrinterStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinterStatus>();
 }
 unsafe impl windows_core::Interface for PosPrinterStatus {
     type Vtable = IPosPrinterStatus_Vtbl;
@@ -7516,7 +7810,7 @@ impl PosPrinterStatusUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PosPrinterStatusUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPosPrinterStatusUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for PosPrinterStatusUpdatedEventArgs {
     type Vtable = IPosPrinterStatusUpdatedEventArgs_Vtbl;
@@ -7677,7 +7971,7 @@ impl ReceiptPrintJob {
     }
 }
 impl windows_core::RuntimeType for ReceiptPrintJob {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IReceiptPrintJob>();
 }
 unsafe impl windows_core::Interface for ReceiptPrintJob {
     type Vtable = IReceiptPrintJob_Vtbl;
@@ -7916,7 +8210,7 @@ impl ReceiptPrinterCapabilities {
     }
 }
 impl windows_core::RuntimeType for ReceiptPrinterCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IReceiptPrinterCapabilities>();
 }
 unsafe impl windows_core::Interface for ReceiptPrinterCapabilities {
     type Vtable = IReceiptPrinterCapabilities_Vtbl;
@@ -8061,7 +8355,7 @@ impl SlipPrintJob {
     }
 }
 impl windows_core::RuntimeType for SlipPrintJob {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IReceiptOrSlipJob>();
 }
 unsafe impl windows_core::Interface for SlipPrintJob {
     type Vtable = IReceiptOrSlipJob_Vtbl;
@@ -8293,7 +8587,7 @@ impl SlipPrinterCapabilities {
     }
 }
 impl windows_core::RuntimeType for SlipPrinterCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISlipPrinterCapabilities>();
 }
 unsafe impl windows_core::Interface for SlipPrinterCapabilities {
     type Vtable = ISlipPrinterCapabilities_Vtbl;
@@ -8350,7 +8644,7 @@ impl UnifiedPosErrorData {
     }
 }
 impl windows_core::RuntimeType for UnifiedPosErrorData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUnifiedPosErrorData>();
 }
 unsafe impl windows_core::Interface for UnifiedPosErrorData {
     type Vtable = IUnifiedPosErrorData_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Portable/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Portable/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IServiceDeviceStatics, IServiceDeviceStatics_Vtbl, 0xa88214e1_59c7_4a20_aba6_9f6707937230);
+impl windows_core::RuntimeType for IServiceDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServiceDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IServiceDeviceStatics_Vtbl {
     pub GetDeviceSelectorFromServiceId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageDeviceStatics, IStorageDeviceStatics_Vtbl, 0x5ece44ee_1b23_4dd2_8652_bc164f003128);
+impl windows_core::RuntimeType for IStorageDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Devices/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Power/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBattery, IBattery_Vtbl, 0xbc894fc6_0072_47c8_8b5d_614aaa7a437e);
+impl windows_core::RuntimeType for IBattery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBattery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IBattery_Vtbl {
     pub RemoveReportUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBatteryReport, IBatteryReport_Vtbl, 0xc9858c3a_4e13_420a_a8d0_24f18f395401);
+impl windows_core::RuntimeType for IBatteryReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBatteryReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +27,9 @@ pub struct IBatteryReport_Vtbl {
     Status: usize,
 }
 windows_core::imp::define_interface!(IBatteryStatics, IBatteryStatics_Vtbl, 0x79cd72b6_9e5e_4452_bea6_dfcd541e597f);
+impl windows_core::RuntimeType for IBatteryStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBatteryStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,7 +95,7 @@ impl Battery {
     }
 }
 impl windows_core::RuntimeType for Battery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBattery>();
 }
 unsafe impl windows_core::Interface for Battery {
     type Vtable = IBattery_Vtbl;
@@ -140,7 +149,7 @@ impl BatteryReport {
     }
 }
 impl windows_core::RuntimeType for BatteryReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBatteryReport>();
 }
 unsafe impl windows_core::Interface for BatteryReport {
     type Vtable = IBatteryReport_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPrint3DWorkflow, IPrint3DWorkflow_Vtbl, 0xc56f74bd_3669_4a66_ab42_c8151930cd34);
+impl windows_core::RuntimeType for IPrint3DWorkflow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DWorkflow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IPrint3DWorkflow_Vtbl {
     pub RemovePrintRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DWorkflow2, IPrint3DWorkflow2_Vtbl, 0xa2a6c54f_8ac1_4918_9741_e34f3004239e);
+impl windows_core::RuntimeType for IPrint3DWorkflow2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DWorkflow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IPrint3DWorkflow2_Vtbl {
     pub RemovePrinterChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DWorkflowPrintRequestedEventArgs, IPrint3DWorkflowPrintRequestedEventArgs_Vtbl, 0x19f8c858_5ac8_4b55_8a5f_e61567dafb4d);
+impl windows_core::RuntimeType for IPrint3DWorkflowPrintRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DWorkflowPrintRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,18 +35,27 @@ pub struct IPrint3DWorkflowPrintRequestedEventArgs_Vtbl {
     pub SetSourceChanged: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DWorkflowPrinterChangedEventArgs, IPrint3DWorkflowPrinterChangedEventArgs_Vtbl, 0x45226402_95fc_4847_93b3_134dbf5c60f7);
+impl windows_core::RuntimeType for IPrint3DWorkflowPrinterChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DWorkflowPrinterChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub NewDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintExtensionContextStatic, IPrintExtensionContextStatic_Vtbl, 0xe70d9fc1_ff79_4aa4_8c9b_0c93aedfde8a);
+impl windows_core::RuntimeType for IPrintExtensionContextStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintExtensionContextStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintNotificationEventDetails, IPrintNotificationEventDetails_Vtbl, 0xe00e4c8a_4828_4da1_8bb8_8672df8515e7);
+impl windows_core::RuntimeType for IPrintNotificationEventDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintNotificationEventDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +64,9 @@ pub struct IPrintNotificationEventDetails_Vtbl {
     pub SetEventData: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskConfiguration, IPrintTaskConfiguration_Vtbl, 0xe3c22451_3aa4_4885_9240_311f5f8fbe9d);
+impl windows_core::RuntimeType for IPrintTaskConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +75,9 @@ pub struct IPrintTaskConfiguration_Vtbl {
     pub RemoveSaveRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskConfigurationSaveRequest, IPrintTaskConfigurationSaveRequest_Vtbl, 0xeeaf2fcb_621e_4b62_ac77_b281cce08d60);
+impl windows_core::RuntimeType for IPrintTaskConfigurationSaveRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskConfigurationSaveRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,12 +87,18 @@ pub struct IPrintTaskConfigurationSaveRequest_Vtbl {
     pub Deadline: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskConfigurationSaveRequestedDeferral, IPrintTaskConfigurationSaveRequestedDeferral_Vtbl, 0xe959d568_f729_44a4_871d_bd0628696a33);
+impl windows_core::RuntimeType for IPrintTaskConfigurationSaveRequestedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskConfigurationSaveRequestedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskConfigurationSaveRequestedEventArgs, IPrintTaskConfigurationSaveRequestedEventArgs_Vtbl, 0xe06c2879_0d61_4938_91d0_96a45bee8479);
+impl windows_core::RuntimeType for IPrintTaskConfigurationSaveRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskConfigurationSaveRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -134,7 +164,7 @@ impl Print3DWorkflow {
     }
 }
 impl windows_core::RuntimeType for Print3DWorkflow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DWorkflow>();
 }
 unsafe impl windows_core::Interface for Print3DWorkflow {
     type Vtable = IPrint3DWorkflow_Vtbl;
@@ -174,7 +204,7 @@ impl Print3DWorkflowPrintRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for Print3DWorkflowPrintRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DWorkflowPrintRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for Print3DWorkflowPrintRequestedEventArgs {
     type Vtable = IPrint3DWorkflowPrintRequestedEventArgs_Vtbl;
@@ -199,7 +229,7 @@ impl Print3DWorkflowPrinterChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for Print3DWorkflowPrinterChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DWorkflowPrinterChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for Print3DWorkflowPrinterChangedEventArgs {
     type Vtable = IPrint3DWorkflowPrinterChangedEventArgs_Vtbl;
@@ -252,7 +282,7 @@ impl PrintNotificationEventDetails {
     }
 }
 impl windows_core::RuntimeType for PrintNotificationEventDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintNotificationEventDetails>();
 }
 unsafe impl windows_core::Interface for PrintNotificationEventDetails {
     type Vtable = IPrintNotificationEventDetails_Vtbl;
@@ -291,7 +321,7 @@ impl PrintTaskConfiguration {
     }
 }
 impl windows_core::RuntimeType for PrintTaskConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskConfiguration>();
 }
 unsafe impl windows_core::Interface for PrintTaskConfiguration {
     type Vtable = IPrintTaskConfiguration_Vtbl;
@@ -332,7 +362,7 @@ impl PrintTaskConfigurationSaveRequest {
     }
 }
 impl windows_core::RuntimeType for PrintTaskConfigurationSaveRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskConfigurationSaveRequest>();
 }
 unsafe impl windows_core::Interface for PrintTaskConfigurationSaveRequest {
     type Vtable = IPrintTaskConfigurationSaveRequest_Vtbl;
@@ -352,7 +382,7 @@ impl PrintTaskConfigurationSaveRequestedDeferral {
     }
 }
 impl windows_core::RuntimeType for PrintTaskConfigurationSaveRequestedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskConfigurationSaveRequestedDeferral>();
 }
 unsafe impl windows_core::Interface for PrintTaskConfigurationSaveRequestedDeferral {
     type Vtable = IPrintTaskConfigurationSaveRequestedDeferral_Vtbl;
@@ -375,7 +405,7 @@ impl PrintTaskConfigurationSaveRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintTaskConfigurationSaveRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskConfigurationSaveRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintTaskConfigurationSaveRequestedEventArgs {
     type Vtable = IPrintTaskConfigurationSaveRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Printers_Extensions")]
 pub mod Extensions;
 windows_core::imp::define_interface!(IIppAttributeError, IIppAttributeError_Vtbl, 0x750feda1_9eef_5c39_93e4_46149bbcef27);
+impl windows_core::RuntimeType for IIppAttributeError {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppAttributeError_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct IIppAttributeError_Vtbl {
     GetUnsupportedValues: usize,
 }
 windows_core::imp::define_interface!(IIppAttributeValue, IIppAttributeValue_Vtbl, 0x99407fed_e2bb_59a3_988b_28a974052a26);
+impl windows_core::RuntimeType for IIppAttributeValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppAttributeValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +96,9 @@ pub struct IIppAttributeValue_Vtbl {
     GetMimeMediaTypeArray: usize,
 }
 windows_core::imp::define_interface!(IIppAttributeValueStatics, IIppAttributeValueStatics_Vtbl, 0x10d43942_dd94_5998_b235_afafb6fa7935);
+impl windows_core::RuntimeType for IIppAttributeValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppAttributeValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -194,6 +203,9 @@ pub struct IIppAttributeValueStatics_Vtbl {
     CreateMimeMediaArray: usize,
 }
 windows_core::imp::define_interface!(IIppIntegerRange, IIppIntegerRange_Vtbl, 0x92907346_c3ea_5ed6_bdb1_3752c62c6f7f);
+impl windows_core::RuntimeType for IIppIntegerRange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppIntegerRange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -201,12 +213,18 @@ pub struct IIppIntegerRange_Vtbl {
     pub End: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIppIntegerRangeFactory, IIppIntegerRangeFactory_Vtbl, 0x75d4ecae_f87e_54ad_b5d0_465204db7553);
+impl windows_core::RuntimeType for IIppIntegerRangeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppIntegerRangeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, i32, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIppPrintDevice, IIppPrintDevice_Vtbl, 0xd748ac56_76f3_5dc6_afd4_c2a8686b9359);
+impl windows_core::RuntimeType for IIppPrintDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppPrintDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -230,6 +248,9 @@ pub struct IIppPrintDevice_Vtbl {
     SetPrinterAttributes: usize,
 }
 windows_core::imp::define_interface!(IIppPrintDevice2, IIppPrintDevice2_Vtbl, 0xf7c844c9_9d21_5c63_ac20_3676915be2d7);
+impl windows_core::RuntimeType for IIppPrintDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppPrintDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -239,6 +260,9 @@ pub struct IIppPrintDevice2_Vtbl {
     pub GetPdlPassthroughProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIppPrintDeviceStatics, IIppPrintDeviceStatics_Vtbl, 0x7dc19f08_7f20_52ab_94a7_894b83b2a17e);
+impl windows_core::RuntimeType for IIppPrintDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppPrintDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +272,9 @@ pub struct IIppPrintDeviceStatics_Vtbl {
     pub IsIppPrinter: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIppResolution, IIppResolution_Vtbl, 0xcb493f86_6bf3_56f5_86ce_263d08aead63);
+impl windows_core::RuntimeType for IIppResolution {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppResolution_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -256,12 +283,18 @@ pub struct IIppResolution_Vtbl {
     pub Unit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut IppResolutionUnit) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIppResolutionFactory, IIppResolutionFactory_Vtbl, 0xe481c2ae_251a_5326_b173_95543ed99a35);
+impl windows_core::RuntimeType for IIppResolutionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppResolutionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, i32, i32, IppResolutionUnit, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIppSetAttributesResult, IIppSetAttributesResult_Vtbl, 0x7d1c7f55_aa9d_58a3_90e9_17bdc5281f07);
+impl windows_core::RuntimeType for IIppSetAttributesResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppSetAttributesResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +305,9 @@ pub struct IIppSetAttributesResult_Vtbl {
     AttributeErrors: usize,
 }
 windows_core::imp::define_interface!(IIppTextWithLanguage, IIppTextWithLanguage_Vtbl, 0x326447a6_5149_5936_90e8_0c736036bf77);
+impl windows_core::RuntimeType for IIppTextWithLanguage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppTextWithLanguage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -279,12 +315,18 @@ pub struct IIppTextWithLanguage_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIppTextWithLanguageFactory, IIppTextWithLanguageFactory_Vtbl, 0xca4a1e8d_2968_5775_997c_8a46f1a574ed);
+impl windows_core::RuntimeType for IIppTextWithLanguageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIppTextWithLanguageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPageConfigurationSettings, IPageConfigurationSettings_Vtbl, 0xb6fc1e02_5331_54ff_95a0_1fcb76bb97a9);
+impl windows_core::RuntimeType for IPageConfigurationSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPageConfigurationSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,6 +336,9 @@ pub struct IPageConfigurationSettings_Vtbl {
     pub SetSizeSource: unsafe extern "system" fn(*mut core::ffi::c_void, PageConfigurationSource) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPdlPassthroughProvider, IPdlPassthroughProvider_Vtbl, 0x23c71dd2_6117_553f_9378_180af5849a49);
+impl windows_core::RuntimeType for IPdlPassthroughProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPdlPassthroughProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -311,6 +356,9 @@ pub struct IPdlPassthroughProvider_Vtbl {
     StartPrintJobWithPrintTicket: usize,
 }
 windows_core::imp::define_interface!(IPdlPassthroughTarget, IPdlPassthroughTarget_Vtbl, 0x9840be79_67f8_5385_a5b9_e8c96e0fca76);
+impl windows_core::RuntimeType for IPdlPassthroughTarget {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPdlPassthroughTarget_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -322,12 +370,18 @@ pub struct IPdlPassthroughTarget_Vtbl {
     pub Submit: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DDevice, IPrint3DDevice_Vtbl, 0x041c3d19_9713_42a2_9813_7dc3337428d3);
+impl windows_core::RuntimeType for IPrint3DDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PrintSchema: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DDeviceStatics, IPrint3DDeviceStatics_Vtbl, 0xfde3620a_67cd_41b7_a344_5150a1fd75b5);
+impl windows_core::RuntimeType for IPrint3DDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -335,6 +389,9 @@ pub struct IPrint3DDeviceStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSchema, IPrintSchema_Vtbl, 0xc2b98316_26b8_4bfb_8138_9f962c22a35b);
+impl windows_core::RuntimeType for IPrintSchema {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSchema_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -380,7 +437,7 @@ impl IppAttributeError {
     }
 }
 impl windows_core::RuntimeType for IppAttributeError {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIppAttributeError>();
 }
 unsafe impl windows_core::Interface for IppAttributeError {
     type Vtable = IIppAttributeError_Vtbl;
@@ -883,7 +940,7 @@ impl IppAttributeValue {
     }
 }
 impl windows_core::RuntimeType for IppAttributeValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIppAttributeValue>();
 }
 unsafe impl windows_core::Interface for IppAttributeValue {
     type Vtable = IIppAttributeValue_Vtbl;
@@ -926,7 +983,7 @@ impl IppIntegerRange {
     }
 }
 impl windows_core::RuntimeType for IppIntegerRange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIppIntegerRange>();
 }
 unsafe impl windows_core::Interface for IppIntegerRange {
     type Vtable = IIppIntegerRange_Vtbl;
@@ -1059,7 +1116,7 @@ impl IppPrintDevice {
     }
 }
 impl windows_core::RuntimeType for IppPrintDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIppPrintDevice>();
 }
 unsafe impl windows_core::Interface for IppPrintDevice {
     type Vtable = IIppPrintDevice_Vtbl;
@@ -1109,7 +1166,7 @@ impl IppResolution {
     }
 }
 impl windows_core::RuntimeType for IppResolution {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIppResolution>();
 }
 unsafe impl windows_core::Interface for IppResolution {
     type Vtable = IIppResolution_Vtbl;
@@ -1142,7 +1199,7 @@ impl IppSetAttributesResult {
     }
 }
 impl windows_core::RuntimeType for IppSetAttributesResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIppSetAttributesResult>();
 }
 unsafe impl windows_core::Interface for IppSetAttributesResult {
     type Vtable = IIppSetAttributesResult_Vtbl;
@@ -1185,7 +1242,7 @@ impl IppTextWithLanguage {
     }
 }
 impl windows_core::RuntimeType for IppTextWithLanguage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIppTextWithLanguage>();
 }
 unsafe impl windows_core::Interface for IppTextWithLanguage {
     type Vtable = IIppTextWithLanguage_Vtbl;
@@ -1232,7 +1289,7 @@ impl PageConfigurationSettings {
     }
 }
 impl windows_core::RuntimeType for PageConfigurationSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPageConfigurationSettings>();
 }
 unsafe impl windows_core::Interface for PageConfigurationSettings {
     type Vtable = IPageConfigurationSettings_Vtbl;
@@ -1282,7 +1339,7 @@ impl PdlPassthroughProvider {
     }
 }
 impl windows_core::RuntimeType for PdlPassthroughProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPdlPassthroughProvider>();
 }
 unsafe impl windows_core::Interface for PdlPassthroughProvider {
     type Vtable = IPdlPassthroughProvider_Vtbl;
@@ -1324,7 +1381,7 @@ impl PdlPassthroughTarget {
     }
 }
 impl windows_core::RuntimeType for PdlPassthroughTarget {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPdlPassthroughTarget>();
 }
 unsafe impl windows_core::Interface for PdlPassthroughTarget {
     type Vtable = IPdlPassthroughTarget_Vtbl;
@@ -1366,7 +1423,7 @@ impl Print3DDevice {
     }
 }
 impl windows_core::RuntimeType for Print3DDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DDevice>();
 }
 unsafe impl windows_core::Interface for Print3DDevice {
     type Vtable = IPrint3DDevice_Vtbl;
@@ -1414,7 +1471,7 @@ impl PrintSchema {
     }
 }
 impl windows_core::RuntimeType for PrintSchema {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSchema>();
 }
 unsafe impl windows_core::Interface for PrintSchema {
     type Vtable = IPrintSchema_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Pwm_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IPwmController, IPwmController_Vtbl, 0xc45f5c85_d2e8_42cf_9bd6_cf5ed029e6a7);
+impl windows_core::RuntimeType for IPwmController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPwmController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct IPwmController_Vtbl {
     pub OpenPin: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPwmControllerStatics, IPwmControllerStatics_Vtbl, 0x4263bda1_8946_4404_bd48_81dd124af4d9);
+impl windows_core::RuntimeType for IPwmControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPwmControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,12 +27,18 @@ pub struct IPwmControllerStatics_Vtbl {
     GetControllersAsync: usize,
 }
 windows_core::imp::define_interface!(IPwmControllerStatics2, IPwmControllerStatics2_Vtbl, 0x44fc5b1f_f119_4bdd_97ad_f76ef986736d);
+impl windows_core::RuntimeType for IPwmControllerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPwmControllerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPwmControllerStatics3, IPwmControllerStatics3_Vtbl, 0xb2581871_0229_4344_ae3f_9b7cd0e66b94);
+impl windows_core::RuntimeType for IPwmControllerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPwmControllerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,6 +47,9 @@ pub struct IPwmControllerStatics3_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPwmPin, IPwmPin_Vtbl, 0x22972dc8_c6cf_4821_b7f9_c6454fb6af79);
+impl windows_core::RuntimeType for IPwmPin {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPwmPin_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,7 +160,7 @@ impl PwmController {
     }
 }
 impl windows_core::RuntimeType for PwmController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPwmController>();
 }
 unsafe impl windows_core::Interface for PwmController {
     type Vtable = IPwmController_Vtbl;
@@ -212,7 +227,7 @@ impl PwmPin {
     }
 }
 impl windows_core::RuntimeType for PwmPin {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPwmPin>();
 }
 unsafe impl windows_core::Interface for PwmPin {
     type Vtable = IPwmPin_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IRadio, IRadio_Vtbl, 0x252118df_b33e_416a_875f_1cf38ae2d83e);
+impl windows_core::RuntimeType for IRadio {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadio_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IRadio_Vtbl {
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RadioKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadioStatics, IRadioStatics_Vtbl, 0x5fb6a12e_67cb_46ae_aae9_65919f86eff4);
+impl windows_core::RuntimeType for IRadioStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadioStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,7 +106,7 @@ impl Radio {
     }
 }
 impl windows_core::RuntimeType for Radio {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadio>();
 }
 unsafe impl windows_core::Interface for Radio {
     type Vtable = IRadio_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IImageScanner, IImageScanner_Vtbl, 0x53a88f78_5298_48a0_8da3_8087519665e0);
+impl windows_core::RuntimeType for IImageScanner {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageScanner_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +22,9 @@ pub struct IImageScanner_Vtbl {
     ScanFilesToFolderAsync: usize,
 }
 windows_core::imp::define_interface!(IImageScannerFeederConfiguration, IImageScannerFeederConfiguration_Vtbl, 0x74bdacee_fa97_4c17_8280_40e39c6dcc67);
+impl windows_core::RuntimeType for IImageScannerFeederConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageScannerFeederConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,6 +102,9 @@ pub struct IImageScannerFormatConfiguration_Vtbl {
     pub IsFormatSupported: unsafe extern "system" fn(*mut core::ffi::c_void, ImageScannerFormat, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageScannerPreviewResult, IImageScannerPreviewResult_Vtbl, 0x08b7fe8e_8891_441d_be9c_176fa109c8bb);
+impl windows_core::RuntimeType for IImageScannerPreviewResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageScannerPreviewResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,6 +112,9 @@ pub struct IImageScannerPreviewResult_Vtbl {
     pub Format: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ImageScannerFormat) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageScannerScanResult, IImageScannerScanResult_Vtbl, 0xc91624cd_9037_4e48_84c1_ac0975076bc5);
+impl windows_core::RuntimeType for IImageScannerScanResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageScannerScanResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -363,6 +375,9 @@ pub struct IImageScannerSourceConfiguration_Vtbl {
     pub SetContrast: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageScannerStatics, IImageScannerStatics_Vtbl, 0xbc57e70e_d804_4477_9fb5_b911b5473897);
+impl windows_core::RuntimeType for IImageScannerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageScannerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -464,7 +479,7 @@ impl ImageScanner {
     }
 }
 impl windows_core::RuntimeType for ImageScanner {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageScanner>();
 }
 unsafe impl windows_core::Interface for ImageScanner {
     type Vtable = IImageScanner_Vtbl;
@@ -508,7 +523,7 @@ impl ImageScannerAutoConfiguration {
     }
 }
 impl windows_core::RuntimeType for ImageScannerAutoConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageScannerFormatConfiguration>();
 }
 unsafe impl windows_core::Interface for ImageScannerAutoConfiguration {
     type Vtable = IImageScannerFormatConfiguration_Vtbl;
@@ -843,7 +858,7 @@ impl ImageScannerFeederConfiguration {
     }
 }
 impl windows_core::RuntimeType for ImageScannerFeederConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageScannerFormatConfiguration>();
 }
 unsafe impl windows_core::Interface for ImageScannerFeederConfiguration {
     type Vtable = IImageScannerFormatConfiguration_Vtbl;
@@ -1072,7 +1087,7 @@ impl ImageScannerFlatbedConfiguration {
     }
 }
 impl windows_core::RuntimeType for ImageScannerFlatbedConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageScannerFormatConfiguration>();
 }
 unsafe impl windows_core::Interface for ImageScannerFlatbedConfiguration {
     type Vtable = IImageScannerFormatConfiguration_Vtbl;
@@ -1104,7 +1119,7 @@ impl ImageScannerPreviewResult {
     }
 }
 impl windows_core::RuntimeType for ImageScannerPreviewResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageScannerPreviewResult>();
 }
 unsafe impl windows_core::Interface for ImageScannerPreviewResult {
     type Vtable = IImageScannerPreviewResult_Vtbl;
@@ -1130,7 +1145,7 @@ impl ImageScannerScanResult {
     }
 }
 impl windows_core::RuntimeType for ImageScannerScanResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageScannerScanResult>();
 }
 unsafe impl windows_core::Interface for ImageScannerScanResult {
     type Vtable = IImageScannerScanResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Sensors/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/Custom/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICustomSensor, ICustomSensor_Vtbl, 0xa136f9ad_4034_4b4d_99dd_531aac649c09);
+impl windows_core::RuntimeType for ICustomSensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct ICustomSensor_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICustomSensor2, ICustomSensor2_Vtbl, 0x20db3111_ec58_4d9f_bfbd_e77825088510);
+impl windows_core::RuntimeType for ICustomSensor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSensor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +25,9 @@ pub struct ICustomSensor2_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICustomSensorReading, ICustomSensorReading_Vtbl, 0x64004f4d_446a_4366_a87a_5f963268ec53);
+impl windows_core::RuntimeType for ICustomSensorReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSensorReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,18 +38,27 @@ pub struct ICustomSensorReading_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(ICustomSensorReading2, ICustomSensorReading2_Vtbl, 0x223c98ea_bf73_4992_9a48_d3c897594ccb);
+impl windows_core::RuntimeType for ICustomSensorReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSensorReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PerformanceCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICustomSensorReadingChangedEventArgs, ICustomSensorReadingChangedEventArgs_Vtbl, 0x6b202023_cffd_4cc1_8ff0_e21823d76fcc);
+impl windows_core::RuntimeType for ICustomSensorReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSensorReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICustomSensorStatics, ICustomSensorStatics_Vtbl, 0x992052cf_f422_4c7d_836b_e7dc74a7124b);
+impl windows_core::RuntimeType for ICustomSensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICustomSensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,7 +153,7 @@ impl CustomSensor {
     }
 }
 impl windows_core::RuntimeType for CustomSensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICustomSensor>();
 }
 unsafe impl windows_core::Interface for CustomSensor {
     type Vtable = ICustomSensor_Vtbl;
@@ -175,7 +193,7 @@ impl CustomSensorReading {
     }
 }
 impl windows_core::RuntimeType for CustomSensorReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICustomSensorReading>();
 }
 unsafe impl windows_core::Interface for CustomSensorReading {
     type Vtable = ICustomSensorReading_Vtbl;
@@ -200,7 +218,7 @@ impl CustomSensorReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CustomSensorReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICustomSensorReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for CustomSensorReadingChangedEventArgs {
     type Vtable = ICustomSensorReadingChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Sensors_Custom")]
 pub mod Custom;
 windows_core::imp::define_interface!(IAccelerometer, IAccelerometer_Vtbl, 0xdf184548_2711_4da7_8098_4b82205d3c7d);
+impl windows_core::RuntimeType for IAccelerometer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +17,9 @@ pub struct IAccelerometer_Vtbl {
     pub RemoveShaken: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometer2, IAccelerometer2_Vtbl, 0xe8f092ee_4964_401a_b602_220d7153c60a);
+impl windows_core::RuntimeType for IAccelerometer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +33,9 @@ pub struct IAccelerometer2_Vtbl {
     ReadingTransform: usize,
 }
 windows_core::imp::define_interface!(IAccelerometer3, IAccelerometer3_Vtbl, 0x87e0022a_ed80_49eb_bf8a_a4ea31e5cd84);
+impl windows_core::RuntimeType for IAccelerometer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,18 +44,27 @@ pub struct IAccelerometer3_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometer4, IAccelerometer4_Vtbl, 0x1d373c4f_42d3_45b2_8144_ab7fb665eb59);
+impl windows_core::RuntimeType for IAccelerometer4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometer4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReadingType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AccelerometerReadingType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometer5, IAccelerometer5_Vtbl, 0x7e7e7021_def4_53a6_af43_806fd538edf6);
+impl windows_core::RuntimeType for IAccelerometer5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometer5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportThreshold: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerDataThreshold, IAccelerometerDataThreshold_Vtbl, 0xf92c1b68_6320_5577_879e_9942621c3dd9);
+impl windows_core::RuntimeType for IAccelerometerDataThreshold {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,12 +76,18 @@ pub struct IAccelerometerDataThreshold_Vtbl {
     pub SetZAxisInGForce: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerDeviceId, IAccelerometerDeviceId_Vtbl, 0x7eac64a9_97d5_446d_ab5a_917df9b96a2c);
+impl windows_core::RuntimeType for IAccelerometerDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerReading, IAccelerometerReading_Vtbl, 0xb9fe7acb_d351_40af_8bb6_7aa9ae641fb7);
+impl windows_core::RuntimeType for IAccelerometerReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +97,9 @@ pub struct IAccelerometerReading_Vtbl {
     pub AccelerationZ: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerReading2, IAccelerometerReading2_Vtbl, 0x0a864aa2_15ae_4a40_be55_db58d7de7389);
+impl windows_core::RuntimeType for IAccelerometerReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,30 +110,45 @@ pub struct IAccelerometerReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IAccelerometerReadingChangedEventArgs, IAccelerometerReadingChangedEventArgs_Vtbl, 0x0095c65b_b6ac_475a_9f44_8b32d35a3f25);
+impl windows_core::RuntimeType for IAccelerometerReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerShakenEventArgs, IAccelerometerShakenEventArgs_Vtbl, 0x95ff01d1_4a28_4f35_98e8_8178aae4084a);
+impl windows_core::RuntimeType for IAccelerometerShakenEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerShakenEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerStatics, IAccelerometerStatics_Vtbl, 0xa5e28b74_5a87_4a2d_becc_0f906ea061dd);
+impl windows_core::RuntimeType for IAccelerometerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerStatics2, IAccelerometerStatics2_Vtbl, 0xc4c4842f_d86b_4685_b2d7_3396f798d57b);
+impl windows_core::RuntimeType for IAccelerometerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefaultWithAccelerometerReadingType: unsafe extern "system" fn(*mut core::ffi::c_void, AccelerometerReadingType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccelerometerStatics3, IAccelerometerStatics3_Vtbl, 0x9de218cf_455d_4cf3_8200_70e1410340f8);
+impl windows_core::RuntimeType for IAccelerometerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccelerometerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +156,9 @@ pub struct IAccelerometerStatics3_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, AccelerometerReadingType, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivitySensor, IActivitySensor_Vtbl, 0xcd7a630c_fb5f_48eb_b09b_a2708d1c61ef);
+impl windows_core::RuntimeType for IActivitySensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,6 +178,9 @@ pub struct IActivitySensor_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivitySensorReading, IActivitySensorReading_Vtbl, 0x85125a96_1472_40a2_b2ae_e1ef29226c78);
+impl windows_core::RuntimeType for IActivitySensorReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensorReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,18 +189,27 @@ pub struct IActivitySensorReading_Vtbl {
     pub Confidence: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ActivitySensorReadingConfidence) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivitySensorReadingChangeReport, IActivitySensorReadingChangeReport_Vtbl, 0x4f3c2915_d93b_47bd_960a_f20fb2f322b9);
+impl windows_core::RuntimeType for IActivitySensorReadingChangeReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensorReadingChangeReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivitySensorReadingChangedEventArgs, IActivitySensorReadingChangedEventArgs_Vtbl, 0xde386717_aeb6_4ec7_946a_d9cc19b951ec);
+impl windows_core::RuntimeType for IActivitySensorReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensorReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivitySensorStatics, IActivitySensorStatics_Vtbl, 0xa71e0e9d_ee8b_45d1_b25b_08cc0df92ab6);
+impl windows_core::RuntimeType for IActivitySensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +226,9 @@ pub struct IActivitySensorStatics_Vtbl {
     GetSystemHistoryWithDurationAsync: usize,
 }
 windows_core::imp::define_interface!(IActivitySensorTriggerDetails, IActivitySensorTriggerDetails_Vtbl, 0x2c9e6612_b9ca_4677_b263_243297f79d3a);
+impl windows_core::RuntimeType for IActivitySensorTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivitySensorTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +238,9 @@ pub struct IActivitySensorTriggerDetails_Vtbl {
     ReadReports: usize,
 }
 windows_core::imp::define_interface!(IAdaptiveDimmingOptions, IAdaptiveDimmingOptions_Vtbl, 0xd3213cf7_89b5_5732_b2a0_aefe324f54e6);
+impl windows_core::RuntimeType for IAdaptiveDimmingOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveDimmingOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -185,6 +248,9 @@ pub struct IAdaptiveDimmingOptions_Vtbl {
     pub SetAllowWhenExternalDisplayConnected: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAltimeter, IAltimeter_Vtbl, 0x72f057fd_8f04_49f1_b4a7_f4e363b701a2);
+impl windows_core::RuntimeType for IAltimeter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAltimeter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,6 +263,9 @@ pub struct IAltimeter_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAltimeter2, IAltimeter2_Vtbl, 0xc9471bf9_2add_48f5_9f08_3d0c7660d938);
+impl windows_core::RuntimeType for IAltimeter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAltimeter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -205,6 +274,9 @@ pub struct IAltimeter2_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAltimeterReading, IAltimeterReading_Vtbl, 0xfbe8ef73_7f5e_48c8_aa1a_f1f3befc1144);
+impl windows_core::RuntimeType for IAltimeterReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAltimeterReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -212,6 +284,9 @@ pub struct IAltimeterReading_Vtbl {
     pub AltitudeChangeInMeters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAltimeterReading2, IAltimeterReading2_Vtbl, 0x543a1bd9_6d0b_42b2_bd69_bc8fae0f782c);
+impl windows_core::RuntimeType for IAltimeterReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAltimeterReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,18 +297,27 @@ pub struct IAltimeterReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IAltimeterReadingChangedEventArgs, IAltimeterReadingChangedEventArgs_Vtbl, 0x7069d077_446d_47f7_998c_ebc23b45e4a2);
+impl windows_core::RuntimeType for IAltimeterReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAltimeterReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAltimeterStatics, IAltimeterStatics_Vtbl, 0x9eb4d7c3_e5ac_47ce_8eef_d3718168c01f);
+impl windows_core::RuntimeType for IAltimeterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAltimeterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometer, IBarometer_Vtbl, 0x934475a8_78bf_452f_b017_f0209ce6dab4);
+impl windows_core::RuntimeType for IBarometer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -246,6 +330,9 @@ pub struct IBarometer_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometer2, IBarometer2_Vtbl, 0x32bcc418_3eeb_4d04_9574_7633a8781f9f);
+impl windows_core::RuntimeType for IBarometer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,12 +341,18 @@ pub struct IBarometer2_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometer3, IBarometer3_Vtbl, 0x0e35f0ea_02b5_5a04_b03d_822084863a54);
+impl windows_core::RuntimeType for IBarometer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportThreshold: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometerDataThreshold, IBarometerDataThreshold_Vtbl, 0x076b952c_cb62_5a90_a0d1_f85e4a936394);
+impl windows_core::RuntimeType for IBarometerDataThreshold {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometerDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -267,6 +360,9 @@ pub struct IBarometerDataThreshold_Vtbl {
     pub SetHectopascals: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometerReading, IBarometerReading_Vtbl, 0xf5b9d2e6_1df6_4a1a_a7ad_321d4f5db247);
+impl windows_core::RuntimeType for IBarometerReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometerReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +370,9 @@ pub struct IBarometerReading_Vtbl {
     pub StationPressureInHectopascals: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometerReading2, IBarometerReading2_Vtbl, 0x85a244eb_90c5_4875_891c_3865b4c357e7);
+impl windows_core::RuntimeType for IBarometerReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometerReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -284,18 +383,27 @@ pub struct IBarometerReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IBarometerReadingChangedEventArgs, IBarometerReadingChangedEventArgs_Vtbl, 0x3d84945f_037b_404f_9bbb_6232d69543c3);
+impl windows_core::RuntimeType for IBarometerReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometerReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometerStatics, IBarometerStatics_Vtbl, 0x286b270a_02e3_4f86_84fc_fdd892b5940f);
+impl windows_core::RuntimeType for IBarometerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBarometerStatics2, IBarometerStatics2_Vtbl, 0x8fc6b1e7_95ff_44ac_878e_d65c8308c34c);
+impl windows_core::RuntimeType for IBarometerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBarometerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -303,6 +411,9 @@ pub struct IBarometerStatics2_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompass, ICompass_Vtbl, 0x292ffa94_1b45_403c_ba06_b106dba69a64);
+impl windows_core::RuntimeType for ICompass {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +425,9 @@ pub struct ICompass_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompass2, ICompass2_Vtbl, 0x36f26d09_c7d7_434f_b461_979ddfc2322f);
+impl windows_core::RuntimeType for ICompass2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompass2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -327,6 +441,9 @@ pub struct ICompass2_Vtbl {
     ReadingTransform: usize,
 }
 windows_core::imp::define_interface!(ICompass3, ICompass3_Vtbl, 0xa424801b_c5ea_4d45_a0ec_4b791f041a89);
+impl windows_core::RuntimeType for ICompass3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompass3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -335,12 +452,18 @@ pub struct ICompass3_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompass4, ICompass4_Vtbl, 0x291e7f11_ec32_5dcc_bfcb_0bb39eba5774);
+impl windows_core::RuntimeType for ICompass4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompass4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportThreshold: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompassDataThreshold, ICompassDataThreshold_Vtbl, 0xd15b52b3_d39d_5ec8_b2e4_f193e6ab34ed);
+impl windows_core::RuntimeType for ICompassDataThreshold {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -348,12 +471,18 @@ pub struct ICompassDataThreshold_Vtbl {
     pub SetDegrees: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompassDeviceId, ICompassDeviceId_Vtbl, 0xd181ca29_b085_4b1d_870a_4ff57ba74fd4);
+impl windows_core::RuntimeType for ICompassDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompassReading, ICompassReading_Vtbl, 0x82911128_513d_4dc9_b781_5eedfbf02d0c);
+impl windows_core::RuntimeType for ICompassReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -362,6 +491,9 @@ pub struct ICompassReading_Vtbl {
     pub HeadingTrueNorth: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompassReading2, ICompassReading2_Vtbl, 0xb13a661e_51bb_4a12_bedd_ad47ff87d2e8);
+impl windows_core::RuntimeType for ICompassReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -372,24 +504,36 @@ pub struct ICompassReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(ICompassReadingChangedEventArgs, ICompassReadingChangedEventArgs_Vtbl, 0x8f1549b0_e8bc_4c7e_b009_4e41df137072);
+impl windows_core::RuntimeType for ICompassReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompassReadingHeadingAccuracy, ICompassReadingHeadingAccuracy_Vtbl, 0xe761354e_8911_40f7_9e16_6ecc7daec5de);
+impl windows_core::RuntimeType for ICompassReadingHeadingAccuracy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassReadingHeadingAccuracy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub HeadingAccuracy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MagnetometerAccuracy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompassStatics, ICompassStatics_Vtbl, 0x9abc97df_56ec_4c25_b54d_40a68bb5b269);
+impl windows_core::RuntimeType for ICompassStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompassStatics2, ICompassStatics2_Vtbl, 0x0ace0ead_3baa_4990_9ce4_be0913754ed2);
+impl windows_core::RuntimeType for ICompassStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompassStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -397,6 +541,9 @@ pub struct ICompassStatics2_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometer, IGyrometer_Vtbl, 0xfdb9a9c4_84b1_4ca2_9763_9b589506c70c);
+impl windows_core::RuntimeType for IGyrometer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -408,6 +555,9 @@ pub struct IGyrometer_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometer2, IGyrometer2_Vtbl, 0x63df2443_8ce8_41c3_ac44_8698810b557f);
+impl windows_core::RuntimeType for IGyrometer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -421,6 +571,9 @@ pub struct IGyrometer2_Vtbl {
     ReadingTransform: usize,
 }
 windows_core::imp::define_interface!(IGyrometer3, IGyrometer3_Vtbl, 0x5d6f88d5_8fbc_4484_914b_528adfd947b1);
+impl windows_core::RuntimeType for IGyrometer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -429,12 +582,18 @@ pub struct IGyrometer3_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometer4, IGyrometer4_Vtbl, 0x0628a60c_4c4b_5096_94e6_c356df68bef7);
+impl windows_core::RuntimeType for IGyrometer4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometer4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportThreshold: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometerDataThreshold, IGyrometerDataThreshold_Vtbl, 0x8648b31e_6e52_5259_bbad_242a69dc38c8);
+impl windows_core::RuntimeType for IGyrometerDataThreshold {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometerDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -446,12 +605,18 @@ pub struct IGyrometerDataThreshold_Vtbl {
     pub SetZAxisInDegreesPerSecond: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometerDeviceId, IGyrometerDeviceId_Vtbl, 0x1ee5e978_89a2_4275_9e95_7126f4708760);
+impl windows_core::RuntimeType for IGyrometerDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometerDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometerReading, IGyrometerReading_Vtbl, 0xb3d6de5c_1ee4_456f_9de7_e2493b5c8e03);
+impl windows_core::RuntimeType for IGyrometerReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometerReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -461,6 +626,9 @@ pub struct IGyrometerReading_Vtbl {
     pub AngularVelocityZ: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometerReading2, IGyrometerReading2_Vtbl, 0x16afe13c_2b89_44bb_822b_d1e1556ff09b);
+impl windows_core::RuntimeType for IGyrometerReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometerReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -471,18 +639,27 @@ pub struct IGyrometerReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IGyrometerReadingChangedEventArgs, IGyrometerReadingChangedEventArgs_Vtbl, 0x0fdf1895_6f9e_42ce_8d58_388c0ab8356d);
+impl windows_core::RuntimeType for IGyrometerReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometerReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometerStatics, IGyrometerStatics_Vtbl, 0x83b6e7c9_e49d_4b39_86e6_cd554be4c5c1);
+impl windows_core::RuntimeType for IGyrometerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGyrometerStatics2, IGyrometerStatics2_Vtbl, 0xef83f7a1_d700_4204_9613_79c6b161df4e);
+impl windows_core::RuntimeType for IGyrometerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGyrometerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -490,6 +667,9 @@ pub struct IGyrometerStatics2_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHingeAngleReading, IHingeAngleReading_Vtbl, 0xa3cd45b9_1bf1_4f65_a704_e2da04f182c0);
+impl windows_core::RuntimeType for IHingeAngleReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHingeAngleReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -501,6 +681,9 @@ pub struct IHingeAngleReading_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IHingeAngleSensor, IHingeAngleSensor_Vtbl, 0xe9d3be02_bfdf_437f_8c29_88c77393d309);
+impl windows_core::RuntimeType for IHingeAngleSensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHingeAngleSensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -513,12 +696,18 @@ pub struct IHingeAngleSensor_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHingeAngleSensorReadingChangedEventArgs, IHingeAngleSensorReadingChangedEventArgs_Vtbl, 0x24d9558b_fad0_42b8_a854_78923049a1ba);
+impl windows_core::RuntimeType for IHingeAngleSensorReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHingeAngleSensorReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHingeAngleSensorStatics, IHingeAngleSensorStatics_Vtbl, 0xb7b63910_fbb1_4123_89ce_4ea34eb0dfca);
+impl windows_core::RuntimeType for IHingeAngleSensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHingeAngleSensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -528,6 +717,9 @@ pub struct IHingeAngleSensorStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceFeatures, IHumanPresenceFeatures_Vtbl, 0xbdb09fda_3244_557a_bd29_8b004f59f2cc);
+impl windows_core::RuntimeType for IHumanPresenceFeatures {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceFeatures_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -544,12 +736,18 @@ pub struct IHumanPresenceFeatures_Vtbl {
     IsAttentionAwareDimmingSupported: usize,
 }
 windows_core::imp::define_interface!(IHumanPresenceFeatures2, IHumanPresenceFeatures2_Vtbl, 0x08a9cdda_d929_5ec2_81e2_940bafa089cf);
+impl windows_core::RuntimeType for IHumanPresenceFeatures2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceFeatures2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsAdaptiveDimmingSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensor, IHumanPresenceSensor_Vtbl, 0x2116788b_e389_5cc3_9a97_cb17be1008bd);
+impl windows_core::RuntimeType for IHumanPresenceSensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -561,6 +759,9 @@ pub struct IHumanPresenceSensor_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensor2, IHumanPresenceSensor2_Vtbl, 0xf8833779_65fe_541a_b9d6_1e474a485e7a);
+impl windows_core::RuntimeType for IHumanPresenceSensor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -623,6 +824,9 @@ pub struct IHumanPresenceSensorExtension_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensorReading, IHumanPresenceSensorReading_Vtbl, 0x83533bf5_a85a_5d50_8be4_6072d745a3bb);
+impl windows_core::RuntimeType for IHumanPresenceSensorReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensorReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -632,6 +836,9 @@ pub struct IHumanPresenceSensorReading_Vtbl {
     pub DistanceInMillimeters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensorReading2, IHumanPresenceSensorReading2_Vtbl, 0xc4f0e950_3bff_53d6_a0f8_514ea3705c66);
+impl windows_core::RuntimeType for IHumanPresenceSensorReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensorReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -641,12 +848,18 @@ pub struct IHumanPresenceSensorReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensorReadingChangedEventArgs, IHumanPresenceSensorReadingChangedEventArgs_Vtbl, 0xa9dc4583_fd69_5c5e_ab1f_942204eae2db);
+impl windows_core::RuntimeType for IHumanPresenceSensorReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensorReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensorReadingUpdate, IHumanPresenceSensorReadingUpdate_Vtbl, 0x42419c77_6d2f_55a0_9e01_c9cbe7b2d6df);
+impl windows_core::RuntimeType for IHumanPresenceSensorReadingUpdate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensorReadingUpdate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -660,6 +873,9 @@ pub struct IHumanPresenceSensorReadingUpdate_Vtbl {
     pub SetDistanceInMillimeters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensorStatics, IHumanPresenceSensorStatics_Vtbl, 0x2ae89842_dba9_56b2_9f27_eac69d621004);
+impl windows_core::RuntimeType for IHumanPresenceSensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -668,6 +884,9 @@ pub struct IHumanPresenceSensorStatics_Vtbl {
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSensorStatics2, IHumanPresenceSensorStatics2_Vtbl, 0x5de35843_d260_5a87_995e_ace91326e1c4);
+impl windows_core::RuntimeType for IHumanPresenceSensorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSensorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -675,6 +894,9 @@ pub struct IHumanPresenceSensorStatics2_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSettings, IHumanPresenceSettings_Vtbl, 0xef4daf5b_07b7_5eb6_86bb_b7ff49ce44fb);
+impl windows_core::RuntimeType for IHumanPresenceSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -700,6 +922,9 @@ pub struct IHumanPresenceSettings_Vtbl {
     SetIsAttentionAwareDimmingEnabled: usize,
 }
 windows_core::imp::define_interface!(IHumanPresenceSettings2, IHumanPresenceSettings2_Vtbl, 0xa26f705e_8696_5eb4_b9e1_26a508de1cd4);
+impl windows_core::RuntimeType for IHumanPresenceSettings2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSettings2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -710,6 +935,9 @@ pub struct IHumanPresenceSettings2_Vtbl {
     pub LockOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHumanPresenceSettingsStatics, IHumanPresenceSettingsStatics_Vtbl, 0x7f343202_e010_52c4_af0c_04a8f1e033da);
+impl windows_core::RuntimeType for IHumanPresenceSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHumanPresenceSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -727,6 +955,9 @@ pub struct IHumanPresenceSettingsStatics_Vtbl {
     pub RemoveSettingsChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometer, IInclinometer_Vtbl, 0x2648ca6f_2286_406f_9161_f0c4bd806ebf);
+impl windows_core::RuntimeType for IInclinometer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -738,6 +969,9 @@ pub struct IInclinometer_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometer2, IInclinometer2_Vtbl, 0x029f3393_28b2_45f8_bb16_61e86a7fae6e);
+impl windows_core::RuntimeType for IInclinometer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -752,6 +986,9 @@ pub struct IInclinometer2_Vtbl {
     pub ReadingType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SensorReadingType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometer3, IInclinometer3_Vtbl, 0x3a095004_d765_4384_a3d7_0283f3abe6ae);
+impl windows_core::RuntimeType for IInclinometer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -760,12 +997,18 @@ pub struct IInclinometer3_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometer4, IInclinometer4_Vtbl, 0x43852618_8fca_548e_bbf5_5c50412b6aa4);
+impl windows_core::RuntimeType for IInclinometer4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometer4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportThreshold: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerDataThreshold, IInclinometerDataThreshold_Vtbl, 0xf80a4783_7bfe_545e_bb60_a0ebc47bd2fb);
+impl windows_core::RuntimeType for IInclinometerDataThreshold {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -777,12 +1020,18 @@ pub struct IInclinometerDataThreshold_Vtbl {
     pub SetYawInDegrees: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerDeviceId, IInclinometerDeviceId_Vtbl, 0x01e91982_41ff_4406_ae83_62210ff16fe3);
+impl windows_core::RuntimeType for IInclinometerDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerReading, IInclinometerReading_Vtbl, 0x9f44f055_b6f6_497f_b127_1a775e501458);
+impl windows_core::RuntimeType for IInclinometerReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -792,6 +1041,9 @@ pub struct IInclinometerReading_Vtbl {
     pub YawDegrees: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerReading2, IInclinometerReading2_Vtbl, 0x4f164781_e90b_4658_8915_0103e08a805a);
+impl windows_core::RuntimeType for IInclinometerReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -802,36 +1054,54 @@ pub struct IInclinometerReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IInclinometerReadingChangedEventArgs, IInclinometerReadingChangedEventArgs_Vtbl, 0x4ae91dc1_e7eb_4938_8511_ae0d6b440438);
+impl windows_core::RuntimeType for IInclinometerReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerReadingYawAccuracy, IInclinometerReadingYawAccuracy_Vtbl, 0xb453e880_1fe3_4986_a257_e6ece2723949);
+impl windows_core::RuntimeType for IInclinometerReadingYawAccuracy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerReadingYawAccuracy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub YawAccuracy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MagnetometerAccuracy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerStatics, IInclinometerStatics_Vtbl, 0xf22ec551_9c30_453a_8b49_3c3eeb33cb61);
+impl windows_core::RuntimeType for IInclinometerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerStatics2, IInclinometerStatics2_Vtbl, 0x043f9775_6a1e_499c_86e0_638c1a864b00);
+impl windows_core::RuntimeType for IInclinometerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefaultForRelativeReadings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerStatics3, IInclinometerStatics3_Vtbl, 0xbd9a4280_b91a_4829_9392_abc0b6bdf2b4);
+impl windows_core::RuntimeType for IInclinometerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefaultWithSensorReadingType: unsafe extern "system" fn(*mut core::ffi::c_void, SensorReadingType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInclinometerStatics4, IInclinometerStatics4_Vtbl, 0xe8ba96f9_6e85_4a83_aed0_d7cdcc9856c8);
+impl windows_core::RuntimeType for IInclinometerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInclinometerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -839,6 +1109,9 @@ pub struct IInclinometerStatics4_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensor, ILightSensor_Vtbl, 0xf84c0718_0c54_47ae_922e_789f57fb03a0);
+impl windows_core::RuntimeType for ILightSensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -850,6 +1123,9 @@ pub struct ILightSensor_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensor2, ILightSensor2_Vtbl, 0x486b24e8_a94c_4090_8f48_09f782a9f7d5);
+impl windows_core::RuntimeType for ILightSensor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -858,12 +1134,18 @@ pub struct ILightSensor2_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensor3, ILightSensor3_Vtbl, 0x4876d0ff_9f4c_5f72_adbd_a3471b063c00);
+impl windows_core::RuntimeType for ILightSensor3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensor3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportThreshold: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensorDataThreshold, ILightSensorDataThreshold_Vtbl, 0xb160afd1_878f_5492_9f2c_33dc3ae584a3);
+impl windows_core::RuntimeType for ILightSensorDataThreshold {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensorDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -873,12 +1155,18 @@ pub struct ILightSensorDataThreshold_Vtbl {
     pub SetAbsoluteLux: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensorDeviceId, ILightSensorDeviceId_Vtbl, 0x7fee49f8_0afb_4f51_87f0_6c26375ce94f);
+impl windows_core::RuntimeType for ILightSensorDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensorDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensorReading, ILightSensorReading_Vtbl, 0xffdf6300_227c_4d2b_b302_fc0142485c68);
+impl windows_core::RuntimeType for ILightSensorReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensorReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -886,6 +1174,9 @@ pub struct ILightSensorReading_Vtbl {
     pub IlluminanceInLux: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensorReading2, ILightSensorReading2_Vtbl, 0xb7512185_44a3_44c9_8190_9ef6de0a8a74);
+impl windows_core::RuntimeType for ILightSensorReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensorReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -896,18 +1187,27 @@ pub struct ILightSensorReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(ILightSensorReadingChangedEventArgs, ILightSensorReadingChangedEventArgs_Vtbl, 0xa3a2f4cf_258b_420c_b8ab_8edd601ecf50);
+impl windows_core::RuntimeType for ILightSensorReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensorReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensorStatics, ILightSensorStatics_Vtbl, 0x45db8c84_c3a8_471e_9a53_6457fad87c0e);
+impl windows_core::RuntimeType for ILightSensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILightSensorStatics2, ILightSensorStatics2_Vtbl, 0x0ec0a650_ddc6_40ab_ace3_ec3359d42c51);
+impl windows_core::RuntimeType for ILightSensorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILightSensorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -915,6 +1215,9 @@ pub struct ILightSensorStatics2_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockOnLeaveOptions, ILockOnLeaveOptions_Vtbl, 0x3c6bf8bd_04c1_5829_8d4e_70521755b8be);
+impl windows_core::RuntimeType for ILockOnLeaveOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockOnLeaveOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -922,6 +1225,9 @@ pub struct ILockOnLeaveOptions_Vtbl {
     pub SetAllowWhenExternalDisplayConnected: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometer, IMagnetometer_Vtbl, 0x484f626e_d3c9_4111_b3f6_2cf1faa418d5);
+impl windows_core::RuntimeType for IMagnetometer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -933,6 +1239,9 @@ pub struct IMagnetometer_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometer2, IMagnetometer2_Vtbl, 0xb4656c85_26f6_444b_a9e2_a23f966cd368);
+impl windows_core::RuntimeType for IMagnetometer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -946,6 +1255,9 @@ pub struct IMagnetometer2_Vtbl {
     ReadingTransform: usize,
 }
 windows_core::imp::define_interface!(IMagnetometer3, IMagnetometer3_Vtbl, 0xbe93db7c_a625_48ef_acf7_fac104832671);
+impl windows_core::RuntimeType for IMagnetometer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -954,12 +1266,18 @@ pub struct IMagnetometer3_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometer4, IMagnetometer4_Vtbl, 0xdfb17901_3e0f_508f_b24b_f2bb75015f40);
+impl windows_core::RuntimeType for IMagnetometer4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometer4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportThreshold: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometerDataThreshold, IMagnetometerDataThreshold_Vtbl, 0xd177cb01_9063_5fa5_b596_b445e9dc3401);
+impl windows_core::RuntimeType for IMagnetometerDataThreshold {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometerDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -971,12 +1289,18 @@ pub struct IMagnetometerDataThreshold_Vtbl {
     pub SetZAxisMicroteslas: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometerDeviceId, IMagnetometerDeviceId_Vtbl, 0x58b498c2_7e4b_404c_9fc5_5de8b40ebae3);
+impl windows_core::RuntimeType for IMagnetometerDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometerDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometerReading, IMagnetometerReading_Vtbl, 0x0c2cc40d_ebfd_4e5c_bb11_afc29b3cae61);
+impl windows_core::RuntimeType for IMagnetometerReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometerReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -987,6 +1311,9 @@ pub struct IMagnetometerReading_Vtbl {
     pub DirectionalAccuracy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MagnetometerAccuracy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometerReading2, IMagnetometerReading2_Vtbl, 0xd4c95c61_61d9_404b_a328_066f177a1409);
+impl windows_core::RuntimeType for IMagnetometerReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometerReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -997,18 +1324,27 @@ pub struct IMagnetometerReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IMagnetometerReadingChangedEventArgs, IMagnetometerReadingChangedEventArgs_Vtbl, 0x17eae872_2eb9_4ee7_8ad0_3127537d949b);
+impl windows_core::RuntimeType for IMagnetometerReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometerReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometerStatics, IMagnetometerStatics_Vtbl, 0x853c64cc_0698_4dda_a6df_9cb9cc4ab40a);
+impl windows_core::RuntimeType for IMagnetometerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMagnetometerStatics2, IMagnetometerStatics2_Vtbl, 0x2c0819f0_ffc6_4f89_a06f_18fa10792933);
+impl windows_core::RuntimeType for IMagnetometerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMagnetometerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1016,6 +1352,9 @@ pub struct IMagnetometerStatics2_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensor, IOrientationSensor_Vtbl, 0x5e354635_cf6b_4c63_abd8_10252b0bf6ec);
+impl windows_core::RuntimeType for IOrientationSensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1027,6 +1366,9 @@ pub struct IOrientationSensor_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensor2, IOrientationSensor2_Vtbl, 0x0d924cf9_2f1f_49c9_8042_4a1813d67760);
+impl windows_core::RuntimeType for IOrientationSensor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1041,6 +1383,9 @@ pub struct IOrientationSensor2_Vtbl {
     pub ReadingType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SensorReadingType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensor3, IOrientationSensor3_Vtbl, 0x2cce578d_646b_48c5_b7ee_44fdc4c6aafd);
+impl windows_core::RuntimeType for IOrientationSensor3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensor3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1049,12 +1394,18 @@ pub struct IOrientationSensor3_Vtbl {
     pub MaxBatchSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorDeviceId, IOrientationSensorDeviceId_Vtbl, 0x5a69b648_4c29_49ec_b28f_ea1d117b66f0);
+impl windows_core::RuntimeType for IOrientationSensorDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorReading, IOrientationSensorReading_Vtbl, 0x4756c993_6595_4897_bcc6_d537ee757564);
+impl windows_core::RuntimeType for IOrientationSensorReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1063,6 +1414,9 @@ pub struct IOrientationSensorReading_Vtbl {
     pub Quaternion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorReading2, IOrientationSensorReading2_Vtbl, 0x00576e5f_49f8_4c05_9e07_24fac79408c3);
+impl windows_core::RuntimeType for IOrientationSensorReading2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorReading2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1073,30 +1427,45 @@ pub struct IOrientationSensorReading2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IOrientationSensorReadingChangedEventArgs, IOrientationSensorReadingChangedEventArgs_Vtbl, 0x012c1186_c3ba_46bc_ae65_7a98996cbfb8);
+impl windows_core::RuntimeType for IOrientationSensorReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorReadingYawAccuracy, IOrientationSensorReadingYawAccuracy_Vtbl, 0xd1ac9824_3f5a_49a2_bc7b_1180bc38cd2b);
+impl windows_core::RuntimeType for IOrientationSensorReadingYawAccuracy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorReadingYawAccuracy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub YawAccuracy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MagnetometerAccuracy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorStatics, IOrientationSensorStatics_Vtbl, 0x10ef8712_fb4c_428a_898b_2765e409e669);
+impl windows_core::RuntimeType for IOrientationSensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorStatics2, IOrientationSensorStatics2_Vtbl, 0x59da0d0b_d40a_4c71_9276_8a272a0a6619);
+impl windows_core::RuntimeType for IOrientationSensorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefaultForRelativeReadings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorStatics3, IOrientationSensorStatics3_Vtbl, 0xd82ce920_2777_40ff_9f59_d654b085f12f);
+impl windows_core::RuntimeType for IOrientationSensorStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1104,6 +1473,9 @@ pub struct IOrientationSensorStatics3_Vtbl {
     pub GetDefaultWithSensorReadingTypeAndSensorOptimizationGoal: unsafe extern "system" fn(*mut core::ffi::c_void, SensorReadingType, SensorOptimizationGoal, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOrientationSensorStatics4, IOrientationSensorStatics4_Vtbl, 0xa67feb55_2c85_4b28_a0fe_58c4b20495f5);
+impl windows_core::RuntimeType for IOrientationSensorStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOrientationSensorStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1112,6 +1484,9 @@ pub struct IOrientationSensorStatics4_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPedometer, IPedometer_Vtbl, 0x9a1e013d_3d98_45f8_8920_8e4ecaca5f97);
+impl windows_core::RuntimeType for IPedometer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPedometer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1124,6 +1499,9 @@ pub struct IPedometer_Vtbl {
     pub RemoveReadingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPedometer2, IPedometer2_Vtbl, 0xe5a406df_2b81_4add_b2ff_77ab6c98ba19);
+impl windows_core::RuntimeType for IPedometer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPedometer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1133,12 +1511,18 @@ pub struct IPedometer2_Vtbl {
     GetCurrentReadings: usize,
 }
 windows_core::imp::define_interface!(IPedometerDataThresholdFactory, IPedometerDataThresholdFactory_Vtbl, 0xcbad8f50_7a54_466b_9010_77a162fca5d7);
+impl windows_core::RuntimeType for IPedometerDataThresholdFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPedometerDataThresholdFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPedometerReading, IPedometerReading_Vtbl, 0x2245dcf4_a8e1_432f_896a_be0dd9b02d24);
+impl windows_core::RuntimeType for IPedometerReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPedometerReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1148,12 +1532,18 @@ pub struct IPedometerReading_Vtbl {
     pub CumulativeStepsDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPedometerReadingChangedEventArgs, IPedometerReadingChangedEventArgs_Vtbl, 0xf855e47e_abbc_4456_86a8_25cf2b333742);
+impl windows_core::RuntimeType for IPedometerReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPedometerReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPedometerStatics, IPedometerStatics_Vtbl, 0x82980a2f_4083_4dfb_b411_938ea0f4b946);
+impl windows_core::RuntimeType for IPedometerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPedometerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1170,6 +1560,9 @@ pub struct IPedometerStatics_Vtbl {
     GetSystemHistoryWithDurationAsync: usize,
 }
 windows_core::imp::define_interface!(IPedometerStatics2, IPedometerStatics2_Vtbl, 0x79f5c6bb_ce0e_4133_b47e_8627ea72f677);
+impl windows_core::RuntimeType for IPedometerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPedometerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1179,6 +1572,9 @@ pub struct IPedometerStatics2_Vtbl {
     GetReadingsFromTriggerDetails: usize,
 }
 windows_core::imp::define_interface!(IProximitySensor, IProximitySensor_Vtbl, 0x54c076b8_ecfb_4944_b928_74fc504d47ee);
+impl windows_core::RuntimeType for IProximitySensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximitySensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1191,12 +1587,18 @@ pub struct IProximitySensor_Vtbl {
     pub CreateDisplayOnOffController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximitySensorDataThresholdFactory, IProximitySensorDataThresholdFactory_Vtbl, 0x905ac121_6d27_4ad3_9db5_6467f2a5ad9d);
+impl windows_core::RuntimeType for IProximitySensorDataThresholdFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximitySensorDataThresholdFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximitySensorReading, IProximitySensorReading_Vtbl, 0x71228d59_132d_4d5f_8ff9_2f0db8751ced);
+impl windows_core::RuntimeType for IProximitySensorReading {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximitySensorReading_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1205,12 +1607,18 @@ pub struct IProximitySensorReading_Vtbl {
     pub DistanceInMillimeters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximitySensorReadingChangedEventArgs, IProximitySensorReadingChangedEventArgs_Vtbl, 0xcfc2f366_c3e8_40fd_8cc3_67e289004938);
+impl windows_core::RuntimeType for IProximitySensorReadingChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximitySensorReadingChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximitySensorStatics, IProximitySensorStatics_Vtbl, 0x29186649_6269_4e57_a5ad_82be80813392);
+impl windows_core::RuntimeType for IProximitySensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximitySensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1218,6 +1626,9 @@ pub struct IProximitySensorStatics_Vtbl {
     pub FromId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximitySensorStatics2, IProximitySensorStatics2_Vtbl, 0xcbf473ae_e9ca_422f_ad67_4c3d25df350c);
+impl windows_core::RuntimeType for IProximitySensorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximitySensorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1237,6 +1648,9 @@ pub struct ISensorDataThreshold_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISensorDataThresholdTriggerDetails, ISensorDataThresholdTriggerDetails_Vtbl, 0x9106f1b7_e88d_48b1_bc90_619c7b349391);
+impl windows_core::RuntimeType for ISensorDataThresholdTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISensorDataThresholdTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1244,6 +1658,9 @@ pub struct ISensorDataThresholdTriggerDetails_Vtbl {
     pub SensorType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SensorType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISensorQuaternion, ISensorQuaternion_Vtbl, 0xc9c5c827_c71c_46e7_9da3_36a193b232bc);
+impl windows_core::RuntimeType for ISensorQuaternion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISensorQuaternion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1253,6 +1670,9 @@ pub struct ISensorQuaternion_Vtbl {
     pub Z: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISensorRotationMatrix, ISensorRotationMatrix_Vtbl, 0x0a3d5a67_22f4_4392_9538_65d0bd064aa6);
+impl windows_core::RuntimeType for ISensorRotationMatrix {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISensorRotationMatrix_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1267,6 +1687,9 @@ pub struct ISensorRotationMatrix_Vtbl {
     pub M33: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISimpleOrientationSensor, ISimpleOrientationSensor_Vtbl, 0x5ff53856_214a_4dee_a3f9_616f1ab06ffd);
+impl windows_core::RuntimeType for ISimpleOrientationSensor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleOrientationSensor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1275,6 +1698,9 @@ pub struct ISimpleOrientationSensor_Vtbl {
     pub RemoveOrientationChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISimpleOrientationSensor2, ISimpleOrientationSensor2_Vtbl, 0xa277a798_8870_453e_8bd6_b8f5d8d7941b);
+impl windows_core::RuntimeType for ISimpleOrientationSensor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleOrientationSensor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1288,12 +1714,18 @@ pub struct ISimpleOrientationSensor2_Vtbl {
     ReadingTransform: usize,
 }
 windows_core::imp::define_interface!(ISimpleOrientationSensorDeviceId, ISimpleOrientationSensorDeviceId_Vtbl, 0xfbc00acb_3b76_41f6_8091_30efe646d3cf);
+impl windows_core::RuntimeType for ISimpleOrientationSensorDeviceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleOrientationSensorDeviceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISimpleOrientationSensorOrientationChangedEventArgs, ISimpleOrientationSensorOrientationChangedEventArgs_Vtbl, 0xbcd5c660_23d4_4b4c_a22e_ba81ade0c601);
+impl windows_core::RuntimeType for ISimpleOrientationSensorOrientationChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleOrientationSensorOrientationChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1301,12 +1733,18 @@ pub struct ISimpleOrientationSensorOrientationChangedEventArgs_Vtbl {
     pub Orientation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SimpleOrientation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISimpleOrientationSensorStatics, ISimpleOrientationSensorStatics_Vtbl, 0x72ed066f_70aa_40c6_9b1b_3433f7459b4e);
+impl windows_core::RuntimeType for ISimpleOrientationSensorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleOrientationSensorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISimpleOrientationSensorStatics2, ISimpleOrientationSensorStatics2_Vtbl, 0x848f9c7f_b138_4e11_8910_a2a2a3b56d83);
+impl windows_core::RuntimeType for ISimpleOrientationSensorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISimpleOrientationSensorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1314,6 +1752,9 @@ pub struct ISimpleOrientationSensorStatics2_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWakeOnApproachOptions, IWakeOnApproachOptions_Vtbl, 0xf0b87ae7_7e1f_5ea5_814d_6b7e07defc2b);
+impl windows_core::RuntimeType for IWakeOnApproachOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWakeOnApproachOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1473,7 +1914,7 @@ impl Accelerometer {
     }
 }
 impl windows_core::RuntimeType for Accelerometer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccelerometer>();
 }
 unsafe impl windows_core::Interface for Accelerometer {
     type Vtable = IAccelerometer_Vtbl;
@@ -1524,7 +1965,7 @@ impl AccelerometerDataThreshold {
     }
 }
 impl windows_core::RuntimeType for AccelerometerDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccelerometerDataThreshold>();
 }
 unsafe impl windows_core::Interface for AccelerometerDataThreshold {
     type Vtable = IAccelerometerDataThreshold_Vtbl;
@@ -1585,7 +2026,7 @@ impl AccelerometerReading {
     }
 }
 impl windows_core::RuntimeType for AccelerometerReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccelerometerReading>();
 }
 unsafe impl windows_core::Interface for AccelerometerReading {
     type Vtable = IAccelerometerReading_Vtbl;
@@ -1610,7 +2051,7 @@ impl AccelerometerReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AccelerometerReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccelerometerReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AccelerometerReadingChangedEventArgs {
     type Vtable = IAccelerometerReadingChangedEventArgs_Vtbl;
@@ -1635,7 +2076,7 @@ impl AccelerometerShakenEventArgs {
     }
 }
 impl windows_core::RuntimeType for AccelerometerShakenEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccelerometerShakenEventArgs>();
 }
 unsafe impl windows_core::Interface for AccelerometerShakenEventArgs {
     type Vtable = IAccelerometerShakenEventArgs_Vtbl;
@@ -1748,7 +2189,7 @@ impl ActivitySensor {
     }
 }
 impl windows_core::RuntimeType for ActivitySensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivitySensor>();
 }
 unsafe impl windows_core::Interface for ActivitySensor {
     type Vtable = IActivitySensor_Vtbl;
@@ -1787,7 +2228,7 @@ impl ActivitySensorReading {
     }
 }
 impl windows_core::RuntimeType for ActivitySensorReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivitySensorReading>();
 }
 unsafe impl windows_core::Interface for ActivitySensorReading {
     type Vtable = IActivitySensorReading_Vtbl;
@@ -1812,7 +2253,7 @@ impl ActivitySensorReadingChangeReport {
     }
 }
 impl windows_core::RuntimeType for ActivitySensorReadingChangeReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivitySensorReadingChangeReport>();
 }
 unsafe impl windows_core::Interface for ActivitySensorReadingChangeReport {
     type Vtable = IActivitySensorReadingChangeReport_Vtbl;
@@ -1837,7 +2278,7 @@ impl ActivitySensorReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ActivitySensorReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivitySensorReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ActivitySensorReadingChangedEventArgs {
     type Vtable = IActivitySensorReadingChangedEventArgs_Vtbl;
@@ -1863,7 +2304,7 @@ impl ActivitySensorTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for ActivitySensorTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivitySensorTriggerDetails>();
 }
 unsafe impl windows_core::Interface for ActivitySensorTriggerDetails {
     type Vtable = IActivitySensorTriggerDetails_Vtbl;
@@ -1892,7 +2333,7 @@ impl AdaptiveDimmingOptions {
     }
 }
 impl windows_core::RuntimeType for AdaptiveDimmingOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveDimmingOptions>();
 }
 unsafe impl windows_core::Interface for AdaptiveDimmingOptions {
     type Vtable = IAdaptiveDimmingOptions_Vtbl;
@@ -1985,7 +2426,7 @@ impl Altimeter {
     }
 }
 impl windows_core::RuntimeType for Altimeter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAltimeter>();
 }
 unsafe impl windows_core::Interface for Altimeter {
     type Vtable = IAltimeter_Vtbl;
@@ -2032,7 +2473,7 @@ impl AltimeterReading {
     }
 }
 impl windows_core::RuntimeType for AltimeterReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAltimeterReading>();
 }
 unsafe impl windows_core::Interface for AltimeterReading {
     type Vtable = IAltimeterReading_Vtbl;
@@ -2057,7 +2498,7 @@ impl AltimeterReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AltimeterReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAltimeterReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AltimeterReadingChangedEventArgs {
     type Vtable = IAltimeterReadingChangedEventArgs_Vtbl;
@@ -2174,7 +2615,7 @@ impl Barometer {
     }
 }
 impl windows_core::RuntimeType for Barometer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarometer>();
 }
 unsafe impl windows_core::Interface for Barometer {
     type Vtable = IBarometer_Vtbl;
@@ -2203,7 +2644,7 @@ impl BarometerDataThreshold {
     }
 }
 impl windows_core::RuntimeType for BarometerDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarometerDataThreshold>();
 }
 unsafe impl windows_core::Interface for BarometerDataThreshold {
     type Vtable = IBarometerDataThreshold_Vtbl;
@@ -2250,7 +2691,7 @@ impl BarometerReading {
     }
 }
 impl windows_core::RuntimeType for BarometerReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarometerReading>();
 }
 unsafe impl windows_core::Interface for BarometerReading {
     type Vtable = IBarometerReading_Vtbl;
@@ -2275,7 +2716,7 @@ impl BarometerReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BarometerReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBarometerReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for BarometerReadingChangedEventArgs {
     type Vtable = IBarometerReadingChangedEventArgs_Vtbl;
@@ -2405,7 +2846,7 @@ impl Compass {
     }
 }
 impl windows_core::RuntimeType for Compass {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompass>();
 }
 unsafe impl windows_core::Interface for Compass {
     type Vtable = ICompass_Vtbl;
@@ -2434,7 +2875,7 @@ impl CompassDataThreshold {
     }
 }
 impl windows_core::RuntimeType for CompassDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompassDataThreshold>();
 }
 unsafe impl windows_core::Interface for CompassDataThreshold {
     type Vtable = ICompassDataThreshold_Vtbl;
@@ -2495,7 +2936,7 @@ impl CompassReading {
     }
 }
 impl windows_core::RuntimeType for CompassReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompassReading>();
 }
 unsafe impl windows_core::Interface for CompassReading {
     type Vtable = ICompassReading_Vtbl;
@@ -2520,7 +2961,7 @@ impl CompassReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CompassReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompassReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for CompassReadingChangedEventArgs {
     type Vtable = ICompassReadingChangedEventArgs_Vtbl;
@@ -2650,7 +3091,7 @@ impl Gyrometer {
     }
 }
 impl windows_core::RuntimeType for Gyrometer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGyrometer>();
 }
 unsafe impl windows_core::Interface for Gyrometer {
     type Vtable = IGyrometer_Vtbl;
@@ -2701,7 +3142,7 @@ impl GyrometerDataThreshold {
     }
 }
 impl windows_core::RuntimeType for GyrometerDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGyrometerDataThreshold>();
 }
 unsafe impl windows_core::Interface for GyrometerDataThreshold {
     type Vtable = IGyrometerDataThreshold_Vtbl;
@@ -2762,7 +3203,7 @@ impl GyrometerReading {
     }
 }
 impl windows_core::RuntimeType for GyrometerReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGyrometerReading>();
 }
 unsafe impl windows_core::Interface for GyrometerReading {
     type Vtable = IGyrometerReading_Vtbl;
@@ -2787,7 +3228,7 @@ impl GyrometerReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GyrometerReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGyrometerReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for GyrometerReadingChangedEventArgs {
     type Vtable = IGyrometerReadingChangedEventArgs_Vtbl;
@@ -2827,7 +3268,7 @@ impl HingeAngleReading {
     }
 }
 impl windows_core::RuntimeType for HingeAngleReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHingeAngleReading>();
 }
 unsafe impl windows_core::Interface for HingeAngleReading {
     type Vtable = IHingeAngleReading_Vtbl;
@@ -2920,7 +3361,7 @@ impl HingeAngleSensor {
     }
 }
 impl windows_core::RuntimeType for HingeAngleSensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHingeAngleSensor>();
 }
 unsafe impl windows_core::Interface for HingeAngleSensor {
     type Vtable = IHingeAngleSensor_Vtbl;
@@ -2945,7 +3386,7 @@ impl HingeAngleSensorReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HingeAngleSensorReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHingeAngleSensorReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for HingeAngleSensorReadingChangedEventArgs {
     type Vtable = IHingeAngleSensorReadingChangedEventArgs_Vtbl;
@@ -3007,7 +3448,7 @@ impl HumanPresenceFeatures {
     }
 }
 impl windows_core::RuntimeType for HumanPresenceFeatures {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHumanPresenceFeatures>();
 }
 unsafe impl windows_core::Interface for HumanPresenceFeatures {
     type Vtable = IHumanPresenceFeatures_Vtbl;
@@ -3121,7 +3562,7 @@ impl HumanPresenceSensor {
     }
 }
 impl windows_core::RuntimeType for HumanPresenceSensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHumanPresenceSensor>();
 }
 unsafe impl windows_core::Interface for HumanPresenceSensor {
     type Vtable = IHumanPresenceSensor_Vtbl;
@@ -3175,7 +3616,7 @@ impl HumanPresenceSensorReading {
     }
 }
 impl windows_core::RuntimeType for HumanPresenceSensorReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHumanPresenceSensorReading>();
 }
 unsafe impl windows_core::Interface for HumanPresenceSensorReading {
     type Vtable = IHumanPresenceSensorReading_Vtbl;
@@ -3200,7 +3641,7 @@ impl HumanPresenceSensorReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HumanPresenceSensorReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHumanPresenceSensorReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for HumanPresenceSensorReadingChangedEventArgs {
     type Vtable = IHumanPresenceSensorReadingChangedEventArgs_Vtbl;
@@ -3281,7 +3722,7 @@ impl HumanPresenceSensorReadingUpdate {
     }
 }
 impl windows_core::RuntimeType for HumanPresenceSensorReadingUpdate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHumanPresenceSensorReadingUpdate>();
 }
 unsafe impl windows_core::Interface for HumanPresenceSensorReadingUpdate {
     type Vtable = IHumanPresenceSensorReadingUpdate_Vtbl;
@@ -3479,7 +3920,7 @@ impl HumanPresenceSettings {
     }
 }
 impl windows_core::RuntimeType for HumanPresenceSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHumanPresenceSettings>();
 }
 unsafe impl windows_core::Interface for HumanPresenceSettings {
     type Vtable = IHumanPresenceSettings_Vtbl;
@@ -3638,7 +4079,7 @@ impl Inclinometer {
     }
 }
 impl windows_core::RuntimeType for Inclinometer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInclinometer>();
 }
 unsafe impl windows_core::Interface for Inclinometer {
     type Vtable = IInclinometer_Vtbl;
@@ -3689,7 +4130,7 @@ impl InclinometerDataThreshold {
     }
 }
 impl windows_core::RuntimeType for InclinometerDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInclinometerDataThreshold>();
 }
 unsafe impl windows_core::Interface for InclinometerDataThreshold {
     type Vtable = IInclinometerDataThreshold_Vtbl;
@@ -3757,7 +4198,7 @@ impl InclinometerReading {
     }
 }
 impl windows_core::RuntimeType for InclinometerReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInclinometerReading>();
 }
 unsafe impl windows_core::Interface for InclinometerReading {
     type Vtable = IInclinometerReading_Vtbl;
@@ -3782,7 +4223,7 @@ impl InclinometerReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for InclinometerReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInclinometerReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for InclinometerReadingChangedEventArgs {
     type Vtable = IInclinometerReadingChangedEventArgs_Vtbl;
@@ -3899,7 +4340,7 @@ impl LightSensor {
     }
 }
 impl windows_core::RuntimeType for LightSensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILightSensor>();
 }
 unsafe impl windows_core::Interface for LightSensor {
     type Vtable = ILightSensor_Vtbl;
@@ -3939,7 +4380,7 @@ impl LightSensorDataThreshold {
     }
 }
 impl windows_core::RuntimeType for LightSensorDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILightSensorDataThreshold>();
 }
 unsafe impl windows_core::Interface for LightSensorDataThreshold {
     type Vtable = ILightSensorDataThreshold_Vtbl;
@@ -3986,7 +4427,7 @@ impl LightSensorReading {
     }
 }
 impl windows_core::RuntimeType for LightSensorReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILightSensorReading>();
 }
 unsafe impl windows_core::Interface for LightSensorReading {
     type Vtable = ILightSensorReading_Vtbl;
@@ -4011,7 +4452,7 @@ impl LightSensorReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LightSensorReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILightSensorReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for LightSensorReadingChangedEventArgs {
     type Vtable = ILightSensorReadingChangedEventArgs_Vtbl;
@@ -4040,7 +4481,7 @@ impl LockOnLeaveOptions {
     }
 }
 impl windows_core::RuntimeType for LockOnLeaveOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILockOnLeaveOptions>();
 }
 unsafe impl windows_core::Interface for LockOnLeaveOptions {
     type Vtable = ILockOnLeaveOptions_Vtbl;
@@ -4170,7 +4611,7 @@ impl Magnetometer {
     }
 }
 impl windows_core::RuntimeType for Magnetometer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagnetometer>();
 }
 unsafe impl windows_core::Interface for Magnetometer {
     type Vtable = IMagnetometer_Vtbl;
@@ -4221,7 +4662,7 @@ impl MagnetometerDataThreshold {
     }
 }
 impl windows_core::RuntimeType for MagnetometerDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagnetometerDataThreshold>();
 }
 unsafe impl windows_core::Interface for MagnetometerDataThreshold {
     type Vtable = IMagnetometerDataThreshold_Vtbl;
@@ -4289,7 +4730,7 @@ impl MagnetometerReading {
     }
 }
 impl windows_core::RuntimeType for MagnetometerReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagnetometerReading>();
 }
 unsafe impl windows_core::Interface for MagnetometerReading {
     type Vtable = IMagnetometerReading_Vtbl;
@@ -4314,7 +4755,7 @@ impl MagnetometerReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MagnetometerReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMagnetometerReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MagnetometerReadingChangedEventArgs {
     type Vtable = IMagnetometerReadingChangedEventArgs_Vtbl;
@@ -4478,7 +4919,7 @@ impl OrientationSensor {
     }
 }
 impl windows_core::RuntimeType for OrientationSensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOrientationSensor>();
 }
 unsafe impl windows_core::Interface for OrientationSensor {
     type Vtable = IOrientationSensor_Vtbl;
@@ -4539,7 +4980,7 @@ impl OrientationSensorReading {
     }
 }
 impl windows_core::RuntimeType for OrientationSensorReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOrientationSensorReading>();
 }
 unsafe impl windows_core::Interface for OrientationSensorReading {
     type Vtable = IOrientationSensorReading_Vtbl;
@@ -4564,7 +5005,7 @@ impl OrientationSensorReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for OrientationSensorReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOrientationSensorReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for OrientationSensorReadingChangedEventArgs {
     type Vtable = IOrientationSensorReadingChangedEventArgs_Vtbl;
@@ -4688,7 +5129,7 @@ impl Pedometer {
     }
 }
 impl windows_core::RuntimeType for Pedometer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPedometer>();
 }
 unsafe impl windows_core::Interface for Pedometer {
     type Vtable = IPedometer_Vtbl;
@@ -4721,7 +5162,7 @@ impl PedometerDataThreshold {
     }
 }
 impl windows_core::RuntimeType for PedometerDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISensorDataThreshold>();
 }
 unsafe impl windows_core::Interface for PedometerDataThreshold {
     type Vtable = ISensorDataThreshold_Vtbl;
@@ -4767,7 +5208,7 @@ impl PedometerReading {
     }
 }
 impl windows_core::RuntimeType for PedometerReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPedometerReading>();
 }
 unsafe impl windows_core::Interface for PedometerReading {
     type Vtable = IPedometerReading_Vtbl;
@@ -4792,7 +5233,7 @@ impl PedometerReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PedometerReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPedometerReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PedometerReadingChangedEventArgs {
     type Vtable = IPedometerReadingChangedEventArgs_Vtbl;
@@ -4891,7 +5332,7 @@ impl ProximitySensor {
     }
 }
 impl windows_core::RuntimeType for ProximitySensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProximitySensor>();
 }
 unsafe impl windows_core::Interface for ProximitySensor {
     type Vtable = IProximitySensor_Vtbl;
@@ -4924,7 +5365,7 @@ impl ProximitySensorDataThreshold {
     }
 }
 impl windows_core::RuntimeType for ProximitySensorDataThreshold {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISensorDataThreshold>();
 }
 unsafe impl windows_core::Interface for ProximitySensorDataThreshold {
     type Vtable = ISensorDataThreshold_Vtbl;
@@ -4947,7 +5388,7 @@ impl ProximitySensorDisplayOnOffController {
     }
 }
 impl windows_core::RuntimeType for ProximitySensorDisplayOnOffController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IClosable>();
 }
 unsafe impl windows_core::Interface for ProximitySensorDisplayOnOffController {
     type Vtable = super::super::Foundation::IClosable_Vtbl;
@@ -4986,7 +5427,7 @@ impl ProximitySensorReading {
     }
 }
 impl windows_core::RuntimeType for ProximitySensorReading {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProximitySensorReading>();
 }
 unsafe impl windows_core::Interface for ProximitySensorReading {
     type Vtable = IProximitySensorReading_Vtbl;
@@ -5011,7 +5452,7 @@ impl ProximitySensorReadingChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ProximitySensorReadingChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProximitySensorReadingChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ProximitySensorReadingChangedEventArgs {
     type Vtable = IProximitySensorReadingChangedEventArgs_Vtbl;
@@ -5043,7 +5484,7 @@ impl SensorDataThresholdTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for SensorDataThresholdTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISensorDataThresholdTriggerDetails>();
 }
 unsafe impl windows_core::Interface for SensorDataThresholdTriggerDetails {
     type Vtable = ISensorDataThresholdTriggerDetails_Vtbl;
@@ -5089,7 +5530,7 @@ impl SensorQuaternion {
     }
 }
 impl windows_core::RuntimeType for SensorQuaternion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISensorQuaternion>();
 }
 unsafe impl windows_core::Interface for SensorQuaternion {
     type Vtable = ISensorQuaternion_Vtbl;
@@ -5170,7 +5611,7 @@ impl SensorRotationMatrix {
     }
 }
 impl windows_core::RuntimeType for SensorRotationMatrix {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISensorRotationMatrix>();
 }
 unsafe impl windows_core::Interface for SensorRotationMatrix {
     type Vtable = ISensorRotationMatrix_Vtbl;
@@ -5257,7 +5698,7 @@ impl SimpleOrientationSensor {
     }
 }
 impl windows_core::RuntimeType for SimpleOrientationSensor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISimpleOrientationSensor>();
 }
 unsafe impl windows_core::Interface for SimpleOrientationSensor {
     type Vtable = ISimpleOrientationSensor_Vtbl;
@@ -5289,7 +5730,7 @@ impl SimpleOrientationSensorOrientationChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SimpleOrientationSensorOrientationChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISimpleOrientationSensorOrientationChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for SimpleOrientationSensorOrientationChangedEventArgs {
     type Vtable = ISimpleOrientationSensorOrientationChangedEventArgs_Vtbl;
@@ -5329,7 +5770,7 @@ impl WakeOnApproachOptions {
     }
 }
 impl windows_core::RuntimeType for WakeOnApproachOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWakeOnApproachOptions>();
 }
 unsafe impl windows_core::Interface for WakeOnApproachOptions {
     type Vtable = IWakeOnApproachOptions_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
@@ -1,16 +1,25 @@
 windows_core::imp::define_interface!(IErrorReceivedEventArgs, IErrorReceivedEventArgs_Vtbl, 0xfcc6bf59_1283_4d8a_bfdf_566b33ddb28f);
+impl windows_core::RuntimeType for IErrorReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IErrorReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SerialError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPinChangedEventArgs, IPinChangedEventArgs_Vtbl, 0xa2bf1db0_fc9c_4607_93d0_fa5e8343ee22);
+impl windows_core::RuntimeType for IPinChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPinChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PinChange: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SerialPinChange) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISerialDevice, ISerialDevice_Vtbl, 0xe187ccc6_2210_414f_b65a_f5553a03372a);
+impl windows_core::RuntimeType for ISerialDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISerialDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,6 +64,9 @@ pub struct ISerialDevice_Vtbl {
     pub RemovePinChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISerialDeviceStatics, ISerialDeviceStatics_Vtbl, 0x058c4a70_0836_4993_ae1a_b61ae3be056b);
+impl windows_core::RuntimeType for ISerialDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISerialDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,7 +89,7 @@ impl ErrorReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ErrorReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IErrorReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for ErrorReceivedEventArgs {
     type Vtable = IErrorReceivedEventArgs_Vtbl;
@@ -102,7 +114,7 @@ impl PinChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PinChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPinChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PinChangedEventArgs {
     type Vtable = IPinChangedEventArgs_Vtbl;
@@ -357,7 +369,7 @@ impl SerialDevice {
     }
 }
 impl windows_core::RuntimeType for SerialDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISerialDevice>();
 }
 unsafe impl windows_core::Interface for SerialDevice {
     type Vtable = ISerialDevice_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -1,16 +1,25 @@
 windows_core::imp::define_interface!(ICardAddedEventArgs, ICardAddedEventArgs_Vtbl, 0x18bbef98_f18b_4dd3_b118_dfb2c8e23cc6);
+impl windows_core::RuntimeType for ICardAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICardAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SmartCard: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICardRemovedEventArgs, ICardRemovedEventArgs_Vtbl, 0x15331aaf_22d7_4945_afc9_03b46f42a6cd);
+impl windows_core::RuntimeType for ICardRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICardRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SmartCard: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownSmartCardAppletIds, IKnownSmartCardAppletIds_Vtbl, 0x7b04d8d8_95b4_4c88_8cea_411e55511efc);
+impl windows_core::RuntimeType for IKnownSmartCardAppletIds {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownSmartCardAppletIds_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +33,9 @@ pub struct IKnownSmartCardAppletIds_Vtbl {
     ProximityPaymentSystemEnvironment: usize,
 }
 windows_core::imp::define_interface!(ISmartCard, ISmartCard_Vtbl, 0x1b718871_6434_43f4_b55a_6a29623870aa);
+impl windows_core::RuntimeType for ISmartCard {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCard_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,6 +47,9 @@ pub struct ISmartCard_Vtbl {
     GetAnswerToResetAsync: usize,
 }
 windows_core::imp::define_interface!(ISmartCardAppletIdGroup, ISmartCardAppletIdGroup_Vtbl, 0x7db165e6_6264_56f4_5e03_c86385395eb1);
+impl windows_core::RuntimeType for ISmartCardAppletIdGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAppletIdGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,6 +67,9 @@ pub struct ISmartCardAppletIdGroup_Vtbl {
     pub SetAutomaticEnablement: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardAppletIdGroup2, ISmartCardAppletIdGroup2_Vtbl, 0x6b0ef9dc_9956_4a62_8d4e_d37a68ebc3a6);
+impl windows_core::RuntimeType for ISmartCardAppletIdGroup2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAppletIdGroup2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +91,9 @@ pub struct ISmartCardAppletIdGroup2_Vtbl {
     pub SetSecureUserAuthenticationRequired: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardAppletIdGroupFactory, ISmartCardAppletIdGroupFactory_Vtbl, 0x9105eb4d_4a65_4e41_8061_cbe83f3695e5);
+impl windows_core::RuntimeType for ISmartCardAppletIdGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAppletIdGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -82,6 +103,9 @@ pub struct ISmartCardAppletIdGroupFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ISmartCardAppletIdGroupRegistration, ISmartCardAppletIdGroupRegistration_Vtbl, 0xdf1208d1_31bb_5596_43b1_6d69a0257b3a);
+impl windows_core::RuntimeType for ISmartCardAppletIdGroupRegistration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAppletIdGroupRegistration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,6 +119,9 @@ pub struct ISmartCardAppletIdGroupRegistration_Vtbl {
     SetAutomaticResponseApdusAsync: usize,
 }
 windows_core::imp::define_interface!(ISmartCardAppletIdGroupRegistration2, ISmartCardAppletIdGroupRegistration2_Vtbl, 0x5f5508d8_98a7_4f2e_91d9_6cfcceda407f);
+impl windows_core::RuntimeType for ISmartCardAppletIdGroupRegistration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAppletIdGroupRegistration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,12 +132,18 @@ pub struct ISmartCardAppletIdGroupRegistration2_Vtbl {
     SetPropertiesAsync: usize,
 }
 windows_core::imp::define_interface!(ISmartCardAppletIdGroupStatics, ISmartCardAppletIdGroupStatics_Vtbl, 0xab2899a9_e76c_45cf_bf1d_90eaa6205927);
+impl windows_core::RuntimeType for ISmartCardAppletIdGroupStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAppletIdGroupStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MaxAppletIds: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardAutomaticResponseApdu, ISmartCardAutomaticResponseApdu_Vtbl, 0x52152bab_c63e_4531_a857_d756d99b986a);
+impl windows_core::RuntimeType for ISmartCardAutomaticResponseApdu {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAutomaticResponseApdu_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -150,6 +183,9 @@ pub struct ISmartCardAutomaticResponseApdu_Vtbl {
     SetResponseApdu: usize,
 }
 windows_core::imp::define_interface!(ISmartCardAutomaticResponseApdu2, ISmartCardAutomaticResponseApdu2_Vtbl, 0x44aebb14_559d_4531_4e51_89db6fa8a57a);
+impl windows_core::RuntimeType for ISmartCardAutomaticResponseApdu2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAutomaticResponseApdu2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -159,6 +195,9 @@ pub struct ISmartCardAutomaticResponseApdu2_Vtbl {
     pub SetOutputState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardAutomaticResponseApdu3, ISmartCardAutomaticResponseApdu3_Vtbl, 0xbf43da74_6576_4392_9367_fe3bc9e2d496);
+impl windows_core::RuntimeType for ISmartCardAutomaticResponseApdu3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAutomaticResponseApdu3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -166,6 +205,9 @@ pub struct ISmartCardAutomaticResponseApdu3_Vtbl {
     pub SetAllowWhenCryptogramGeneratorNotPrepared: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardAutomaticResponseApduFactory, ISmartCardAutomaticResponseApduFactory_Vtbl, 0xe97ea2fa_d02c_4c55_b02a_8cff7fa9f05b);
+impl windows_core::RuntimeType for ISmartCardAutomaticResponseApduFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardAutomaticResponseApduFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,6 +217,9 @@ pub struct ISmartCardAutomaticResponseApduFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ISmartCardChallengeContext, ISmartCardChallengeContext_Vtbl, 0x192a5319_c9c4_4947_81cc_44794a61ef91);
+impl windows_core::RuntimeType for ISmartCardChallengeContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardChallengeContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -200,12 +245,18 @@ pub struct ISmartCardChallengeContext_Vtbl {
     ChangeAdministrativeKeyAsync: usize,
 }
 windows_core::imp::define_interface!(ISmartCardConnect, ISmartCardConnect_Vtbl, 0x2fdf87e5_028d_491e_a058_3382c3986f40);
+impl windows_core::RuntimeType for ISmartCardConnect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardConnect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ConnectAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardConnection, ISmartCardConnection_Vtbl, 0x7edb991a_a81a_47bc_a649_156be6b7f231);
+impl windows_core::RuntimeType for ISmartCardConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,6 +266,9 @@ pub struct ISmartCardConnection_Vtbl {
     TransmitAsync: usize,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramGenerator, ISmartCardCryptogramGenerator_Vtbl, 0xe39f587b_edd3_4e49_b594_0ff5e4d0c76f);
+impl windows_core::RuntimeType for ISmartCardCryptogramGenerator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramGenerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -256,6 +310,9 @@ pub struct ISmartCardCryptogramGenerator_Vtbl {
     pub DeleteCryptogramMaterialPackageAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramGenerator2, ISmartCardCryptogramGenerator2_Vtbl, 0x7116aa34_5d6d_4b4a_96a3_efa47d2a7e25);
+impl windows_core::RuntimeType for ISmartCardCryptogramGenerator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramGenerator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -269,18 +326,27 @@ pub struct ISmartCardCryptogramGenerator2_Vtbl {
     pub GetAllCryptogramMaterialCharacteristicsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, SmartCardUnlockPromptingBehavior, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramGeneratorStatics, ISmartCardCryptogramGeneratorStatics_Vtbl, 0x09933910_cb9c_4015_967d_5234f3b02900);
+impl windows_core::RuntimeType for ISmartCardCryptogramGeneratorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramGeneratorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetSmartCardCryptogramGeneratorAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramGeneratorStatics2, ISmartCardCryptogramGeneratorStatics2_Vtbl, 0x09bdf5e5_b4bd_4e23_a588_74469204c128);
+impl windows_core::RuntimeType for ISmartCardCryptogramGeneratorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramGeneratorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult, ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult_Vtbl, 0x2798e029_d687_4c92_86c6_399e9a0ecb09);
+impl windows_core::RuntimeType for ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -291,6 +357,9 @@ pub struct ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult_Vtb
     Characteristics: usize,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult, ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult_Vtbl, 0x4e6a8a5c_9773_46c4_a32f_b1e543159e04);
+impl windows_core::RuntimeType for ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -301,6 +370,9 @@ pub struct ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsRes
     Characteristics: usize,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult, ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult_Vtbl, 0x8c7ce857_a7e7_489d_b9d6_368061515012);
+impl windows_core::RuntimeType for ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -311,6 +383,9 @@ pub struct ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult_V
     Characteristics: usize,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramMaterialCharacteristics, ISmartCardCryptogramMaterialCharacteristics_Vtbl, 0xfc9ac5cc_c1d7_4153_923b_a2d43c6c8d49);
+impl windows_core::RuntimeType for ISmartCardCryptogramMaterialCharacteristics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramMaterialCharacteristics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -333,6 +408,9 @@ pub struct ISmartCardCryptogramMaterialCharacteristics_Vtbl {
     pub MaterialLength: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramMaterialPackageCharacteristics, ISmartCardCryptogramMaterialPackageCharacteristics_Vtbl, 0xffb58e1f_0692_4c47_93cf_34d91f9dcd00);
+impl windows_core::RuntimeType for ISmartCardCryptogramMaterialPackageCharacteristics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramMaterialPackageCharacteristics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -342,6 +420,9 @@ pub struct ISmartCardCryptogramMaterialPackageCharacteristics_Vtbl {
     pub PackageFormat: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SmartCardCryptogramMaterialPackageFormat) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramMaterialPossessionProof, ISmartCardCryptogramMaterialPossessionProof_Vtbl, 0xe5b9ab8c_a141_4135_9add_b0d2e3aa1fc9);
+impl windows_core::RuntimeType for ISmartCardCryptogramMaterialPossessionProof {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramMaterialPossessionProof_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -352,6 +433,9 @@ pub struct ISmartCardCryptogramMaterialPossessionProof_Vtbl {
     Proof: usize,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramPlacementStep, ISmartCardCryptogramPlacementStep_Vtbl, 0x947b03eb_8342_4792_a2e5_925636378a53);
+impl windows_core::RuntimeType for ISmartCardCryptogramPlacementStep {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramPlacementStep_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -381,6 +465,9 @@ pub struct ISmartCardCryptogramPlacementStep_Vtbl {
     pub SetChainedOutputStep: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramStorageKeyCharacteristics, ISmartCardCryptogramStorageKeyCharacteristics_Vtbl, 0x8552546e_4457_4825_b464_635471a39f5c);
+impl windows_core::RuntimeType for ISmartCardCryptogramStorageKeyCharacteristics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramStorageKeyCharacteristics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -390,6 +477,9 @@ pub struct ISmartCardCryptogramStorageKeyCharacteristics_Vtbl {
     pub Capabilities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SmartCardCryptogramStorageKeyCapabilities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramStorageKeyInfo, ISmartCardCryptogramStorageKeyInfo_Vtbl, 0x77b0f00d_b097_4f61_a26a_9561639c9c3a);
+impl windows_core::RuntimeType for ISmartCardCryptogramStorageKeyInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramStorageKeyInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -414,18 +504,27 @@ pub struct ISmartCardCryptogramStorageKeyInfo_Vtbl {
     pub Capabilities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SmartCardCryptogramStorageKeyCapabilities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardCryptogramStorageKeyInfo2, ISmartCardCryptogramStorageKeyInfo2_Vtbl, 0x000440f9_f7fd_417d_89e1_fbb0382adc4d);
+impl windows_core::RuntimeType for ISmartCardCryptogramStorageKeyInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardCryptogramStorageKeyInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OperationalRequirements: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulator, ISmartCardEmulator_Vtbl, 0xdfb906b2_875e_47e5_8077_e8bff1b1c6fb);
+impl windows_core::RuntimeType for ISmartCardEmulator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub EnablementPolicy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SmartCardEmulatorEnablementPolicy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulator2, ISmartCardEmulator2_Vtbl, 0xfe3fc0b8_8529_411a_807b_48edc2a0ab44);
+impl windows_core::RuntimeType for ISmartCardEmulator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -437,6 +536,9 @@ pub struct ISmartCardEmulator2_Vtbl {
     pub IsHostCardEmulationSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorApduReceivedEventArgs, ISmartCardEmulatorApduReceivedEventArgs_Vtbl, 0xd55d1576_69d2_5333_5b5f_f8c0d6e9f09f);
+impl windows_core::RuntimeType for ISmartCardEmulatorApduReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorApduReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -452,6 +554,9 @@ pub struct ISmartCardEmulatorApduReceivedEventArgs_Vtbl {
     pub AutomaticResponseStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SmartCardAutomaticResponseStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorApduReceivedEventArgs2, ISmartCardEmulatorApduReceivedEventArgs2_Vtbl, 0x8bf93df0_22e1_4238_8610_94ce4a965425);
+impl windows_core::RuntimeType for ISmartCardEmulatorApduReceivedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorApduReceivedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -462,6 +567,9 @@ pub struct ISmartCardEmulatorApduReceivedEventArgs2_Vtbl {
     TryRespondWithStateAsync: usize,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorApduReceivedEventArgsWithCryptograms, ISmartCardEmulatorApduReceivedEventArgsWithCryptograms_Vtbl, 0xd550bac7_b7bf_4e29_9294_0c4ac3c941bd);
+impl windows_core::RuntimeType for ISmartCardEmulatorApduReceivedEventArgsWithCryptograms {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorApduReceivedEventArgsWithCryptograms_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -475,6 +583,9 @@ pub struct ISmartCardEmulatorApduReceivedEventArgsWithCryptograms_Vtbl {
     TryRespondWithCryptogramsAndStateAsync: usize,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorConnectionDeactivatedEventArgs, ISmartCardEmulatorConnectionDeactivatedEventArgs_Vtbl, 0x2186d8d3_c5eb_5262_43df_62a0a1b55557);
+impl windows_core::RuntimeType for ISmartCardEmulatorConnectionDeactivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorConnectionDeactivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -482,6 +593,9 @@ pub struct ISmartCardEmulatorConnectionDeactivatedEventArgs_Vtbl {
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SmartCardEmulatorConnectionDeactivatedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorConnectionProperties, ISmartCardEmulatorConnectionProperties_Vtbl, 0x4e2ca5ee_f969_507d_6cf9_34e2d18df311);
+impl windows_core::RuntimeType for ISmartCardEmulatorConnectionProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorConnectionProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -489,12 +603,18 @@ pub struct ISmartCardEmulatorConnectionProperties_Vtbl {
     pub Source: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SmartCardEmulatorConnectionSource) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorStatics, ISmartCardEmulatorStatics_Vtbl, 0x7a9bfc4b_c4d3_494f_b8a2_6215d81e85b2);
+impl windows_core::RuntimeType for ISmartCardEmulatorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefaultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorStatics2, ISmartCardEmulatorStatics2_Vtbl, 0x69ae9f8a_b775_488b_8436_6c1e28ed731f);
+impl windows_core::RuntimeType for ISmartCardEmulatorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -507,12 +627,18 @@ pub struct ISmartCardEmulatorStatics2_Vtbl {
     pub MaxAppletIdGroupRegistrations: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardEmulatorStatics3, ISmartCardEmulatorStatics3_Vtbl, 0x59ea142a_9f09_43f5_8565_cfa8148e4cb2);
+impl windows_core::RuntimeType for ISmartCardEmulatorStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardEmulatorStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardPinPolicy, ISmartCardPinPolicy_Vtbl, 0x183ce184_4db6_4841_ac9e_2ac1f39b7304);
+impl windows_core::RuntimeType for ISmartCardPinPolicy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardPinPolicy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -530,12 +656,18 @@ pub struct ISmartCardPinPolicy_Vtbl {
     pub SetSpecialCharacters: unsafe extern "system" fn(*mut core::ffi::c_void, SmartCardPinCharacterPolicyOption) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardPinResetDeferral, ISmartCardPinResetDeferral_Vtbl, 0x18c94aac_7805_4004_85e4_bbefac8f6884);
+impl windows_core::RuntimeType for ISmartCardPinResetDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardPinResetDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardPinResetRequest, ISmartCardPinResetRequest_Vtbl, 0x12fe3c4d_5fb9_4e8e_9ff6_61f475124fef);
+impl windows_core::RuntimeType for ISmartCardPinResetRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardPinResetRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -551,6 +683,9 @@ pub struct ISmartCardPinResetRequest_Vtbl {
     SetResponse: usize,
 }
 windows_core::imp::define_interface!(ISmartCardProvisioning, ISmartCardProvisioning_Vtbl, 0x19eeedbd_1fab_477c_b712_1a2c5af1fd6e);
+impl windows_core::RuntimeType for ISmartCardProvisioning {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardProvisioning_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -562,12 +697,18 @@ pub struct ISmartCardProvisioning_Vtbl {
     pub RequestPinResetAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardProvisioning2, ISmartCardProvisioning2_Vtbl, 0x10fd28eb_3f79_4b66_9b7c_11c149b7d0bc);
+impl windows_core::RuntimeType for ISmartCardProvisioning2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardProvisioning2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetAuthorityKeyContainerNameAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardProvisioningStatics, ISmartCardProvisioningStatics_Vtbl, 0x13882848_0d13_4e70_9735_51daeca5254f);
+impl windows_core::RuntimeType for ISmartCardProvisioningStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardProvisioningStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -583,6 +724,9 @@ pub struct ISmartCardProvisioningStatics_Vtbl {
     pub RequestVirtualSmartCardDeletionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardProvisioningStatics2, ISmartCardProvisioningStatics2_Vtbl, 0x3447c6a8_c9a0_4bd6_b50d_251f4e8d3a62);
+impl windows_core::RuntimeType for ISmartCardProvisioningStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardProvisioningStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -596,6 +740,9 @@ pub struct ISmartCardProvisioningStatics2_Vtbl {
     RequestAttestedVirtualSmartCardCreationAsyncWithCardId: usize,
 }
 windows_core::imp::define_interface!(ISmartCardReader, ISmartCardReader_Vtbl, 0x1074b4e0_54c2_4df0_817a_14c14378f06c);
+impl windows_core::RuntimeType for ISmartCardReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -613,6 +760,9 @@ pub struct ISmartCardReader_Vtbl {
     pub RemoveCardRemoved: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardReaderStatics, ISmartCardReaderStatics_Vtbl, 0x103c04e1_a1ca_48f2_a281_5b6f669af107);
+impl windows_core::RuntimeType for ISmartCardReaderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardReaderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -621,6 +771,9 @@ pub struct ISmartCardReaderStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardTriggerDetails, ISmartCardTriggerDetails_Vtbl, 0x5f9bf11e_39ef_4f2b_b44f_0a9155b177bc);
+impl windows_core::RuntimeType for ISmartCardTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -635,6 +788,9 @@ pub struct ISmartCardTriggerDetails_Vtbl {
     TriggerData: usize,
 }
 windows_core::imp::define_interface!(ISmartCardTriggerDetails2, ISmartCardTriggerDetails2_Vtbl, 0x2945c569_8975_4a51_9e1a_5f8a76ee51af);
+impl windows_core::RuntimeType for ISmartCardTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -643,6 +799,9 @@ pub struct ISmartCardTriggerDetails2_Vtbl {
     pub TryLaunchCurrentAppWithBehaviorAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, SmartCardLaunchBehavior, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartCardTriggerDetails3, ISmartCardTriggerDetails3_Vtbl, 0xb3e2c27d_18c6_4ba8_8376_ef03d4912666);
+impl windows_core::RuntimeType for ISmartCardTriggerDetails3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartCardTriggerDetails3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -662,7 +821,7 @@ impl CardAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CardAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICardAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for CardAddedEventArgs {
     type Vtable = ICardAddedEventArgs_Vtbl;
@@ -687,7 +846,7 @@ impl CardRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CardRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICardRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for CardRemovedEventArgs {
     type Vtable = ICardRemovedEventArgs_Vtbl;
@@ -759,7 +918,7 @@ impl SmartCard {
     }
 }
 impl windows_core::RuntimeType for SmartCard {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCard>();
 }
 unsafe impl windows_core::Interface for SmartCard {
     type Vtable = ISmartCard_Vtbl;
@@ -908,7 +1067,7 @@ impl SmartCardAppletIdGroup {
     }
 }
 impl windows_core::RuntimeType for SmartCardAppletIdGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardAppletIdGroup>();
 }
 unsafe impl windows_core::Interface for SmartCardAppletIdGroup {
     type Vtable = ISmartCardAppletIdGroup_Vtbl;
@@ -983,7 +1142,7 @@ impl SmartCardAppletIdGroupRegistration {
     }
 }
 impl windows_core::RuntimeType for SmartCardAppletIdGroupRegistration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardAppletIdGroupRegistration>();
 }
 unsafe impl windows_core::Interface for SmartCardAppletIdGroupRegistration {
     type Vtable = ISmartCardAppletIdGroupRegistration_Vtbl;
@@ -1131,7 +1290,7 @@ impl SmartCardAutomaticResponseApdu {
     }
 }
 impl windows_core::RuntimeType for SmartCardAutomaticResponseApdu {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardAutomaticResponseApdu>();
 }
 unsafe impl windows_core::Interface for SmartCardAutomaticResponseApdu {
     type Vtable = ISmartCardAutomaticResponseApdu_Vtbl;
@@ -1207,7 +1366,7 @@ impl SmartCardChallengeContext {
     }
 }
 impl windows_core::RuntimeType for SmartCardChallengeContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardChallengeContext>();
 }
 unsafe impl windows_core::Interface for SmartCardChallengeContext {
     type Vtable = ISmartCardChallengeContext_Vtbl;
@@ -1241,7 +1400,7 @@ impl SmartCardConnection {
     }
 }
 impl windows_core::RuntimeType for SmartCardConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardConnection>();
 }
 unsafe impl windows_core::Interface for SmartCardConnection {
     type Vtable = ISmartCardConnection_Vtbl;
@@ -1419,7 +1578,7 @@ impl SmartCardCryptogramGenerator {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramGenerator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramGenerator>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramGenerator {
     type Vtable = ISmartCardCryptogramGenerator_Vtbl;
@@ -1459,7 +1618,7 @@ impl SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult {
     type Vtable = ISmartCardCryptogramGetAllCryptogramMaterialCharacteristicsResult_Vtbl;
@@ -1499,7 +1658,7 @@ impl SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult {
     type Vtable = ISmartCardCryptogramGetAllCryptogramMaterialPackageCharacteristicsResult_Vtbl;
@@ -1539,7 +1698,7 @@ impl SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult {
     type Vtable = ISmartCardCryptogramGetAllCryptogramStorageKeyCharacteristicsResult_Vtbl;
@@ -1623,7 +1782,7 @@ impl SmartCardCryptogramMaterialCharacteristics {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramMaterialCharacteristics {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramMaterialCharacteristics>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramMaterialCharacteristics {
     type Vtable = ISmartCardCryptogramMaterialCharacteristics_Vtbl;
@@ -1676,7 +1835,7 @@ impl SmartCardCryptogramMaterialPackageCharacteristics {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramMaterialPackageCharacteristics {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramMaterialPackageCharacteristics>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramMaterialPackageCharacteristics {
     type Vtable = ISmartCardCryptogramMaterialPackageCharacteristics_Vtbl;
@@ -1709,7 +1868,7 @@ impl SmartCardCryptogramMaterialPossessionProof {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramMaterialPossessionProof {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramMaterialPossessionProof>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramMaterialPossessionProof {
     type Vtable = ISmartCardCryptogramMaterialPossessionProof_Vtbl;
@@ -1841,7 +2000,7 @@ impl SmartCardCryptogramPlacementStep {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramPlacementStep {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramPlacementStep>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramPlacementStep {
     type Vtable = ISmartCardCryptogramPlacementStep_Vtbl;
@@ -1894,7 +2053,7 @@ impl SmartCardCryptogramStorageKeyCharacteristics {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramStorageKeyCharacteristics {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramStorageKeyCharacteristics>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramStorageKeyCharacteristics {
     type Vtable = ISmartCardCryptogramStorageKeyCharacteristics_Vtbl;
@@ -1972,7 +2131,7 @@ impl SmartCardCryptogramStorageKeyInfo {
     }
 }
 impl windows_core::RuntimeType for SmartCardCryptogramStorageKeyInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardCryptogramStorageKeyInfo>();
 }
 unsafe impl windows_core::Interface for SmartCardCryptogramStorageKeyInfo {
     type Vtable = ISmartCardCryptogramStorageKeyInfo_Vtbl;
@@ -2094,7 +2253,7 @@ impl SmartCardEmulator {
     }
 }
 impl windows_core::RuntimeType for SmartCardEmulator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardEmulator>();
 }
 unsafe impl windows_core::Interface for SmartCardEmulator {
     type Vtable = ISmartCardEmulator_Vtbl;
@@ -2189,7 +2348,7 @@ impl SmartCardEmulatorApduReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SmartCardEmulatorApduReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardEmulatorApduReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for SmartCardEmulatorApduReceivedEventArgs {
     type Vtable = ISmartCardEmulatorApduReceivedEventArgs_Vtbl;
@@ -2221,7 +2380,7 @@ impl SmartCardEmulatorConnectionDeactivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SmartCardEmulatorConnectionDeactivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardEmulatorConnectionDeactivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for SmartCardEmulatorConnectionDeactivatedEventArgs {
     type Vtable = ISmartCardEmulatorConnectionDeactivatedEventArgs_Vtbl;
@@ -2253,7 +2412,7 @@ impl SmartCardEmulatorConnectionProperties {
     }
 }
 impl windows_core::RuntimeType for SmartCardEmulatorConnectionProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardEmulatorConnectionProperties>();
 }
 unsafe impl windows_core::Interface for SmartCardEmulatorConnectionProperties {
     type Vtable = ISmartCardEmulatorConnectionProperties_Vtbl;
@@ -2344,7 +2503,7 @@ impl SmartCardPinPolicy {
     }
 }
 impl windows_core::RuntimeType for SmartCardPinPolicy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardPinPolicy>();
 }
 unsafe impl windows_core::Interface for SmartCardPinPolicy {
     type Vtable = ISmartCardPinPolicy_Vtbl;
@@ -2366,7 +2525,7 @@ impl SmartCardPinResetDeferral {
     }
 }
 impl windows_core::RuntimeType for SmartCardPinResetDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardPinResetDeferral>();
 }
 unsafe impl windows_core::Interface for SmartCardPinResetDeferral {
     type Vtable = ISmartCardPinResetDeferral_Vtbl;
@@ -2414,7 +2573,7 @@ impl SmartCardPinResetRequest {
     }
 }
 impl windows_core::RuntimeType for SmartCardPinResetRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardPinResetRequest>();
 }
 unsafe impl windows_core::Interface for SmartCardPinResetRequest {
     type Vtable = ISmartCardPinResetRequest_Vtbl;
@@ -2556,7 +2715,7 @@ impl SmartCardProvisioning {
     }
 }
 impl windows_core::RuntimeType for SmartCardProvisioning {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardProvisioning>();
 }
 unsafe impl windows_core::Interface for SmartCardProvisioning {
     type Vtable = ISmartCardProvisioning_Vtbl;
@@ -2661,7 +2820,7 @@ impl SmartCardReader {
     }
 }
 impl windows_core::RuntimeType for SmartCardReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardReader>();
 }
 unsafe impl windows_core::Interface for SmartCardReader {
     type Vtable = ISmartCardReader_Vtbl;
@@ -2730,7 +2889,7 @@ impl SmartCardTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for SmartCardTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmartCardTriggerDetails>();
 }
 unsafe impl windows_core::Interface for SmartCardTriggerDetails {
     type Vtable = ISmartCardTriggerDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISmsAppMessage, ISmsAppMessage_Vtbl, 0xe8bb8494_d3a0_4a0a_86d7_291033a8cf54);
+impl windows_core::RuntimeType for ISmsAppMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsAppMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,6 +109,9 @@ pub struct ISmsBinaryMessage_Vtbl {
     SetData: usize,
 }
 windows_core::imp::define_interface!(ISmsBroadcastMessage, ISmsBroadcastMessage_Vtbl, 0x75aebbf1_e4b7_4874_a09c_2956e592f957);
+impl windows_core::RuntimeType for ISmsBroadcastMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsBroadcastMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -263,6 +269,9 @@ pub struct ISmsDevice_Vtbl {
     RemoveSmsDeviceStatusChanged: usize,
 }
 windows_core::imp::define_interface!(ISmsDevice2, ISmsDevice2_Vtbl, 0xbd8a5c13_e522_46cb_b8d5_9ead30fb6c47);
+impl windows_core::RuntimeType for ISmsDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -279,6 +288,9 @@ pub struct ISmsDevice2_Vtbl {
     pub RemoveDeviceStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmsDevice2Statics, ISmsDevice2Statics_Vtbl, 0x65c78325_1031_491e_8fb6_ef9991afe363);
+impl windows_core::RuntimeType for ISmsDevice2Statics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsDevice2Statics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -289,6 +301,10 @@ pub struct ISmsDevice2Statics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISmsDeviceMessageStore, ISmsDeviceMessageStore_Vtbl, 0x9889f253_f188_4427_8d54_ce0c2423c5c1);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISmsDeviceMessageStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISmsDeviceMessageStore_Vtbl {
@@ -317,6 +333,10 @@ pub struct ISmsDeviceMessageStore_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISmsDeviceStatics, ISmsDeviceStatics_Vtbl, 0xf88d07ea_d815_4dd1_a234_4520ce4604a4);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISmsDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISmsDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -336,6 +356,10 @@ pub struct ISmsDeviceStatics_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISmsDeviceStatics2, ISmsDeviceStatics2_Vtbl, 0x2ca11c87_0873_4caf_8a7d_bd471e8586d1);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISmsDeviceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISmsDeviceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -345,6 +369,9 @@ pub struct ISmsDeviceStatics2_Vtbl {
     FromNetworkAccountIdAsync: usize,
 }
 windows_core::imp::define_interface!(ISmsFilterRule, ISmsFilterRule_Vtbl, 0x40e32fae_b049_4fbc_afe9_e2a610eff55c);
+impl windows_core::RuntimeType for ISmsFilterRule {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsFilterRule_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -397,12 +424,18 @@ pub struct ISmsFilterRule_Vtbl {
     BroadcastChannels: usize,
 }
 windows_core::imp::define_interface!(ISmsFilterRuleFactory, ISmsFilterRuleFactory_Vtbl, 0x00c36508_6296_4f29_9aad_8920ceba3ce8);
+impl windows_core::RuntimeType for ISmsFilterRuleFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsFilterRuleFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFilterRule: unsafe extern "system" fn(*mut core::ffi::c_void, SmsMessageType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmsFilterRules, ISmsFilterRules_Vtbl, 0x4e47eafb_79cd_4881_9894_55a4135b23fa);
+impl windows_core::RuntimeType for ISmsFilterRules {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsFilterRules_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -413,6 +446,9 @@ pub struct ISmsFilterRules_Vtbl {
     Rules: usize,
 }
 windows_core::imp::define_interface!(ISmsFilterRulesFactory, ISmsFilterRulesFactory_Vtbl, 0xa09924ed_6e2e_4530_9fde_465d02eed00e);
+impl windows_core::RuntimeType for ISmsFilterRulesFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsFilterRulesFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -499,6 +535,10 @@ pub struct ISmsMessageBase_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISmsMessageReceivedEventArgs, ISmsMessageReceivedEventArgs_Vtbl, 0x08e80a98_b8e5_41c1_a3d8_d3abfae22675);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISmsMessageReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISmsMessageReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -512,6 +552,9 @@ pub struct ISmsMessageReceivedEventArgs_Vtbl {
     BinaryMessage: usize,
 }
 windows_core::imp::define_interface!(ISmsMessageReceivedTriggerDetails, ISmsMessageReceivedTriggerDetails_Vtbl, 0x2bcfcbd4_2657_4128_ad5f_e3877132bdb1);
+impl windows_core::RuntimeType for ISmsMessageReceivedTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsMessageReceivedTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -526,6 +569,9 @@ pub struct ISmsMessageReceivedTriggerDetails_Vtbl {
     pub Accept: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmsMessageRegistration, ISmsMessageRegistration_Vtbl, 0x1720503e_f34f_446b_83b3_0ff19923b409);
+impl windows_core::RuntimeType for ISmsMessageRegistration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsMessageRegistration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -535,6 +581,9 @@ pub struct ISmsMessageRegistration_Vtbl {
     pub RemoveMessageReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmsMessageRegistrationStatics, ISmsMessageRegistrationStatics_Vtbl, 0x63a05464_2898_4778_a03c_6f994907d63a);
+impl windows_core::RuntimeType for ISmsMessageRegistrationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsMessageRegistrationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -546,6 +595,10 @@ pub struct ISmsMessageRegistrationStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISmsReceivedEventDetails, ISmsReceivedEventDetails_Vtbl, 0x5bb50f15_e46d_4c82_847d_5a0304c1d53d);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISmsReceivedEventDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISmsReceivedEventDetails_Vtbl {
@@ -562,6 +615,10 @@ pub struct ISmsReceivedEventDetails_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISmsReceivedEventDetails2, ISmsReceivedEventDetails2_Vtbl, 0x40e05c86_a7b4_4771_9ae7_0b5ffb12c03a);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISmsReceivedEventDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISmsReceivedEventDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -575,6 +632,9 @@ pub struct ISmsReceivedEventDetails2_Vtbl {
     BinaryMessage: usize,
 }
 windows_core::imp::define_interface!(ISmsSendMessageResult, ISmsSendMessageResult_Vtbl, 0xdb139af2_78c9_4feb_9622_452328088d62);
+impl windows_core::RuntimeType for ISmsSendMessageResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsSendMessageResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -590,6 +650,9 @@ pub struct ISmsSendMessageResult_Vtbl {
     pub TransportFailureCause: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmsStatusMessage, ISmsStatusMessage_Vtbl, 0xe6d28342_b70b_4677_9379_c9783fdff8f4);
+impl windows_core::RuntimeType for ISmsStatusMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsStatusMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -778,6 +841,9 @@ pub struct ISmsTextMessage_Vtbl {
     ToBinaryMessages: usize,
 }
 windows_core::imp::define_interface!(ISmsTextMessage2, ISmsTextMessage2_Vtbl, 0x22a0d893_4555_4755_b5a1_e7fd84955f8d);
+impl windows_core::RuntimeType for ISmsTextMessage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsTextMessage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -801,6 +867,10 @@ pub struct ISmsTextMessage2_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISmsTextMessageStatics, ISmsTextMessageStatics_Vtbl, 0x7f68c5ed_3ccc_47a3_8c55_380d3b010892);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISmsTextMessageStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISmsTextMessageStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -814,6 +884,9 @@ pub struct ISmsTextMessageStatics_Vtbl {
     FromBinaryData: usize,
 }
 windows_core::imp::define_interface!(ISmsVoicemailMessage, ISmsVoicemailMessage_Vtbl, 0x271aa0a6_95b1_44ff_bcb8_b8fdd7e08bc3);
+impl windows_core::RuntimeType for ISmsVoicemailMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsVoicemailMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -823,6 +896,9 @@ pub struct ISmsVoicemailMessage_Vtbl {
     pub MessageCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmsWapMessage, ISmsWapMessage_Vtbl, 0xcd937743_7a55_4d3b_9021_f22e022d09c5);
+impl windows_core::RuntimeType for ISmsWapMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmsWapMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -900,7 +976,7 @@ impl DeleteSmsMessageOperation {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for DeleteSmsMessageOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncAction>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for DeleteSmsMessageOperation {
@@ -1002,7 +1078,7 @@ impl DeleteSmsMessagesOperation {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for DeleteSmsMessagesOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncAction>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for DeleteSmsMessagesOperation {
@@ -1107,7 +1183,7 @@ impl GetSmsDeviceOperation {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for GetSmsDeviceOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncOperation<SmsDevice>>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for GetSmsDeviceOperation {
@@ -1212,7 +1288,7 @@ impl GetSmsMessageOperation {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for GetSmsMessageOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncOperation<ISmsMessage>>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for GetSmsMessageOperation {
@@ -1336,7 +1412,7 @@ impl GetSmsMessagesOperation {
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 impl windows_core::RuntimeType for GetSmsMessagesOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncOperationWithProgress<super::super::Foundation::Collections::IVectorView<ISmsMessage>, i32>>();
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "deprecated"))]
 unsafe impl windows_core::Interface for GetSmsMessagesOperation {
@@ -1438,7 +1514,7 @@ impl SendSmsMessageOperation {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SendSmsMessageOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncAction>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SendSmsMessageOperation {
@@ -1659,7 +1735,7 @@ impl SmsAppMessage {
     }
 }
 impl windows_core::RuntimeType for SmsAppMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsAppMessage>();
 }
 unsafe impl windows_core::Interface for SmsAppMessage {
     type Vtable = ISmsAppMessage_Vtbl;
@@ -1730,7 +1806,7 @@ impl SmsBinaryMessage {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SmsBinaryMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsBinaryMessage>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SmsBinaryMessage {
@@ -1858,7 +1934,7 @@ impl SmsBroadcastMessage {
     }
 }
 impl windows_core::RuntimeType for SmsBroadcastMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsBroadcastMessage>();
 }
 unsafe impl windows_core::Interface for SmsBroadcastMessage {
     type Vtable = ISmsBroadcastMessage_Vtbl;
@@ -2008,7 +2084,7 @@ impl SmsDevice {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SmsDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsDevice>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SmsDevice {
@@ -2135,7 +2211,7 @@ impl SmsDevice2 {
     }
 }
 impl windows_core::RuntimeType for SmsDevice2 {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsDevice2>();
 }
 unsafe impl windows_core::Interface for SmsDevice2 {
     type Vtable = ISmsDevice2_Vtbl;
@@ -2195,7 +2271,7 @@ impl SmsDeviceMessageStore {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SmsDeviceMessageStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsDeviceMessageStore>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SmsDeviceMessageStore {
@@ -2330,7 +2406,7 @@ impl SmsFilterRule {
     }
 }
 impl windows_core::RuntimeType for SmsFilterRule {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsFilterRule>();
 }
 unsafe impl windows_core::Interface for SmsFilterRule {
     type Vtable = ISmsFilterRule_Vtbl;
@@ -2374,7 +2450,7 @@ impl SmsFilterRules {
     }
 }
 impl windows_core::RuntimeType for SmsFilterRules {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsFilterRules>();
 }
 unsafe impl windows_core::Interface for SmsFilterRules {
     type Vtable = ISmsFilterRules_Vtbl;
@@ -2412,7 +2488,7 @@ impl SmsMessageReceivedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SmsMessageReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsMessageReceivedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SmsMessageReceivedEventArgs {
@@ -2487,7 +2563,7 @@ impl SmsMessageReceivedTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for SmsMessageReceivedTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsMessageReceivedTriggerDetails>();
 }
 unsafe impl windows_core::Interface for SmsMessageReceivedTriggerDetails {
     type Vtable = ISmsMessageReceivedTriggerDetails_Vtbl;
@@ -2551,7 +2627,7 @@ impl SmsMessageRegistration {
     }
 }
 impl windows_core::RuntimeType for SmsMessageRegistration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsMessageRegistration>();
 }
 unsafe impl windows_core::Interface for SmsMessageRegistration {
     type Vtable = ISmsMessageRegistration_Vtbl;
@@ -2603,7 +2679,7 @@ impl SmsReceivedEventDetails {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SmsReceivedEventDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsReceivedEventDetails>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SmsReceivedEventDetails {
@@ -2675,7 +2751,7 @@ impl SmsSendMessageResult {
     }
 }
 impl windows_core::RuntimeType for SmsSendMessageResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsSendMessageResult>();
 }
 unsafe impl windows_core::Interface for SmsSendMessageResult {
     type Vtable = ISmsSendMessageResult_Vtbl;
@@ -2778,7 +2854,7 @@ impl SmsStatusMessage {
     }
 }
 impl windows_core::RuntimeType for SmsStatusMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsStatusMessage>();
 }
 unsafe impl windows_core::Interface for SmsStatusMessage {
     type Vtable = ISmsStatusMessage_Vtbl;
@@ -2938,7 +3014,7 @@ impl SmsTextMessage {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SmsTextMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsTextMessage>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SmsTextMessage {
@@ -3097,7 +3173,7 @@ impl SmsTextMessage2 {
     }
 }
 impl windows_core::RuntimeType for SmsTextMessage2 {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsTextMessage2>();
 }
 unsafe impl windows_core::Interface for SmsTextMessage2 {
     type Vtable = ISmsTextMessage2_Vtbl;
@@ -3179,7 +3255,7 @@ impl SmsVoicemailMessage {
     }
 }
 impl windows_core::RuntimeType for SmsVoicemailMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsVoicemailMessage>();
 }
 unsafe impl windows_core::Interface for SmsVoicemailMessage {
     type Vtable = ISmsVoicemailMessage_Vtbl;
@@ -3284,7 +3360,7 @@ impl SmsWapMessage {
     }
 }
 impl windows_core::RuntimeType for SmsWapMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISmsWapMessage>();
 }
 unsafe impl windows_core::Interface for SmsWapMessage {
     type Vtable = ISmsWapMessage_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IProviderSpiConnectionSettings, IProviderSpiConnectionSettings_Vtbl, 0xf6034550_a542_4ec0_9601_a4dd68f8697b);
+impl windows_core::RuntimeType for IProviderSpiConnectionSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProviderSpiConnectionSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +17,9 @@ pub struct IProviderSpiConnectionSettings_Vtbl {
     pub SetSharingMode: unsafe extern "system" fn(*mut core::ffi::c_void, ProviderSpiSharingMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProviderSpiConnectionSettingsFactory, IProviderSpiConnectionSettingsFactory_Vtbl, 0x66456b5a_0c79_43e3_9f3c_e59780ac18fa);
+impl windows_core::RuntimeType for IProviderSpiConnectionSettingsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProviderSpiConnectionSettingsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,7 +195,7 @@ impl ProviderSpiConnectionSettings {
     }
 }
 impl windows_core::RuntimeType for ProviderSpiConnectionSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProviderSpiConnectionSettings>();
 }
 unsafe impl windows_core::Interface for ProviderSpiConnectionSettings {
     type Vtable = IProviderSpiConnectionSettings_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_Spi_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(ISpiBusInfo, ISpiBusInfo_Vtbl, 0x9929444a_54f2_48c6_b952_9c32fc02c669);
+impl windows_core::RuntimeType for ISpiBusInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpiBusInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +16,9 @@ pub struct ISpiBusInfo_Vtbl {
     SupportedDataBitLengths: usize,
 }
 windows_core::imp::define_interface!(ISpiConnectionSettings, ISpiConnectionSettings_Vtbl, 0x5283a37f_f935_4b9f_a7a7_3a7890afa5ce);
+impl windows_core::RuntimeType for ISpiConnectionSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpiConnectionSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,18 +34,27 @@ pub struct ISpiConnectionSettings_Vtbl {
     pub SetSharingMode: unsafe extern "system" fn(*mut core::ffi::c_void, SpiSharingMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpiConnectionSettingsFactory, ISpiConnectionSettingsFactory_Vtbl, 0xff99081e_10c4_44b7_9fea_a748b5a46f31);
+impl windows_core::RuntimeType for ISpiConnectionSettingsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpiConnectionSettingsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpiController, ISpiController_Vtbl, 0xa8d3c829_9895_4159_a934_8741f1ee6d27);
+impl windows_core::RuntimeType for ISpiController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpiController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpiControllerStatics, ISpiControllerStatics_Vtbl, 0x0d5229e2_138b_4e48_b964_4f2f79b9c5a2);
+impl windows_core::RuntimeType for ISpiControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpiControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +65,9 @@ pub struct ISpiControllerStatics_Vtbl {
     GetControllersAsync: usize,
 }
 windows_core::imp::define_interface!(ISpiDevice, ISpiDevice_Vtbl, 0x05d5356d_11b6_4d39_84d5_95dfb4c9f2ce);
+impl windows_core::RuntimeType for ISpiDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpiDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -142,7 +160,7 @@ impl SpiBusInfo {
     }
 }
 impl windows_core::RuntimeType for SpiBusInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpiBusInfo>();
 }
 unsafe impl windows_core::Interface for SpiBusInfo {
     type Vtable = ISpiBusInfo_Vtbl;
@@ -226,7 +244,7 @@ impl SpiConnectionSettings {
     }
 }
 impl windows_core::RuntimeType for SpiConnectionSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpiConnectionSettings>();
 }
 unsafe impl windows_core::Interface for SpiConnectionSettings {
     type Vtable = ISpiConnectionSettings_Vtbl;
@@ -275,7 +293,7 @@ impl SpiController {
     }
 }
 impl windows_core::RuntimeType for SpiController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpiController>();
 }
 unsafe impl windows_core::Interface for SpiController {
     type Vtable = ISpiController_Vtbl;
@@ -360,7 +378,7 @@ impl SpiDevice {
     }
 }
 impl windows_core::RuntimeType for SpiDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpiDevice>();
 }
 unsafe impl windows_core::Interface for SpiDevice {
     type Vtable = ISpiDevice_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IUsbBulkInEndpointDescriptor, IUsbBulkInEndpointDescriptor_Vtbl, 0x3c6e4846_06cf_42a9_9dc2_971c1b14b6e3);
+impl windows_core::RuntimeType for IUsbBulkInEndpointDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbBulkInEndpointDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IUsbBulkInEndpointDescriptor_Vtbl {
     pub Pipe: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbBulkInPipe, IUsbBulkInPipe_Vtbl, 0xf01d2d3b_4548_4d50_b326_d82cdabe1220);
+impl windows_core::RuntimeType for IUsbBulkInPipe {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbBulkInPipe_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +28,9 @@ pub struct IUsbBulkInPipe_Vtbl {
     InputStream: usize,
 }
 windows_core::imp::define_interface!(IUsbBulkOutEndpointDescriptor, IUsbBulkOutEndpointDescriptor_Vtbl, 0x2820847a_ffee_4f60_9be1_956cac3ecb65);
+impl windows_core::RuntimeType for IUsbBulkOutEndpointDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbBulkOutEndpointDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +39,9 @@ pub struct IUsbBulkOutEndpointDescriptor_Vtbl {
     pub Pipe: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbBulkOutPipe, IUsbBulkOutPipe_Vtbl, 0xa8e9ee6e_0115_45aa_8b21_37b225bccee7);
+impl windows_core::RuntimeType for IUsbBulkOutPipe {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbBulkOutPipe_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,6 +55,9 @@ pub struct IUsbBulkOutPipe_Vtbl {
     OutputStream: usize,
 }
 windows_core::imp::define_interface!(IUsbConfiguration, IUsbConfiguration_Vtbl, 0x68177429_36a9_46d7_b873_fc689251ec30);
+impl windows_core::RuntimeType for IUsbConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +72,9 @@ pub struct IUsbConfiguration_Vtbl {
     Descriptors: usize,
 }
 windows_core::imp::define_interface!(IUsbConfigurationDescriptor, IUsbConfigurationDescriptor_Vtbl, 0xf2176d92_b442_407a_8207_7d646c0385f3);
+impl windows_core::RuntimeType for IUsbConfigurationDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbConfigurationDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +84,9 @@ pub struct IUsbConfigurationDescriptor_Vtbl {
     pub RemoteWakeup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbConfigurationDescriptorStatics, IUsbConfigurationDescriptorStatics_Vtbl, 0x424ced93_e740_40a1_92bd_da120ea04914);
+impl windows_core::RuntimeType for IUsbConfigurationDescriptorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbConfigurationDescriptorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +94,9 @@ pub struct IUsbConfigurationDescriptorStatics_Vtbl {
     pub Parse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbControlRequestType, IUsbControlRequestType_Vtbl, 0x8e9465a6_d73d_46de_94be_aae7f07c0f5c);
+impl windows_core::RuntimeType for IUsbControlRequestType {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbControlRequestType_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +110,9 @@ pub struct IUsbControlRequestType_Vtbl {
     pub SetAsByte: unsafe extern "system" fn(*mut core::ffi::c_void, u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbDescriptor, IUsbDescriptor_Vtbl, 0x0a89f216_5f9d_4874_8904_da9ad3f5528f);
+impl windows_core::RuntimeType for IUsbDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -97,6 +124,9 @@ pub struct IUsbDescriptor_Vtbl {
     ReadDescriptorBuffer: usize,
 }
 windows_core::imp::define_interface!(IUsbDevice, IUsbDevice_Vtbl, 0x5249b992_c456_44d5_ad5e_24f5a089f63b);
+impl windows_core::RuntimeType for IUsbDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,6 +148,9 @@ pub struct IUsbDevice_Vtbl {
     pub Configuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbDeviceClass, IUsbDeviceClass_Vtbl, 0x051942f9_845e_47eb_b12a_38f2f617afe7);
+impl windows_core::RuntimeType for IUsbDeviceClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbDeviceClass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,11 +162,17 @@ pub struct IUsbDeviceClass_Vtbl {
     pub SetProtocolCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbDeviceClasses, IUsbDeviceClasses_Vtbl, 0x686f955d_9b92_4b30_9781_c22c55ac35cb);
+impl windows_core::RuntimeType for IUsbDeviceClasses {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbDeviceClasses_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IUsbDeviceClassesStatics, IUsbDeviceClassesStatics_Vtbl, 0xb20b0527_c580_4599_a165_981b4fd03230);
+impl windows_core::RuntimeType for IUsbDeviceClassesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbDeviceClassesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,6 +187,9 @@ pub struct IUsbDeviceClassesStatics_Vtbl {
     pub VendorSpecific: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbDeviceDescriptor, IUsbDeviceDescriptor_Vtbl, 0x1f48d1f6_ba97_4322_b92c_b5b189216588);
+impl windows_core::RuntimeType for IUsbDeviceDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbDeviceDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -159,6 +201,9 @@ pub struct IUsbDeviceDescriptor_Vtbl {
     pub NumberOfConfigurations: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbDeviceStatics, IUsbDeviceStatics_Vtbl, 0x066b85a2_09b7_4446_8502_6fe6dcaa7309);
+impl windows_core::RuntimeType for IUsbDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +214,9 @@ pub struct IUsbDeviceStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbEndpointDescriptor, IUsbEndpointDescriptor_Vtbl, 0x6b4862d9_8df7_4b40_ac83_578f139f0575);
+impl windows_core::RuntimeType for IUsbEndpointDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbEndpointDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,6 +229,9 @@ pub struct IUsbEndpointDescriptor_Vtbl {
     pub AsInterruptOutEndpointDescriptor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbEndpointDescriptorStatics, IUsbEndpointDescriptorStatics_Vtbl, 0xc890b201_9a6a_495e_a82c_295b9e708106);
+impl windows_core::RuntimeType for IUsbEndpointDescriptorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbEndpointDescriptorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +239,9 @@ pub struct IUsbEndpointDescriptorStatics_Vtbl {
     pub Parse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbInterface, IUsbInterface_Vtbl, 0xa0322b95_7f47_48ab_a727_678c25be2112);
+impl windows_core::RuntimeType for IUsbInterface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -218,6 +272,9 @@ pub struct IUsbInterface_Vtbl {
     Descriptors: usize,
 }
 windows_core::imp::define_interface!(IUsbInterfaceDescriptor, IUsbInterfaceDescriptor_Vtbl, 0x199670c7_b7ee_4f90_8cd5_94a2e257598a);
+impl windows_core::RuntimeType for IUsbInterfaceDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterfaceDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -228,6 +285,9 @@ pub struct IUsbInterfaceDescriptor_Vtbl {
     pub InterfaceNumber: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbInterfaceDescriptorStatics, IUsbInterfaceDescriptorStatics_Vtbl, 0xe34a9ff5_77d6_48b6_b0be_16c6422316fe);
+impl windows_core::RuntimeType for IUsbInterfaceDescriptorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterfaceDescriptorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,6 +295,9 @@ pub struct IUsbInterfaceDescriptorStatics_Vtbl {
     pub Parse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbInterfaceSetting, IUsbInterfaceSetting_Vtbl, 0x1827bba7_8da7_4af7_8f4c_7f3032e781f5);
+impl windows_core::RuntimeType for IUsbInterfaceSetting {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterfaceSetting_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -263,6 +326,9 @@ pub struct IUsbInterfaceSetting_Vtbl {
     Descriptors: usize,
 }
 windows_core::imp::define_interface!(IUsbInterruptInEndpointDescriptor, IUsbInterruptInEndpointDescriptor_Vtbl, 0xc0528967_c911_4c3a_86b2_419c2da89039);
+impl windows_core::RuntimeType for IUsbInterruptInEndpointDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterruptInEndpointDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +338,9 @@ pub struct IUsbInterruptInEndpointDescriptor_Vtbl {
     pub Pipe: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbInterruptInEventArgs, IUsbInterruptInEventArgs_Vtbl, 0xb7b04092_1418_4936_8209_299cf5605583);
+impl windows_core::RuntimeType for IUsbInterruptInEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterruptInEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +350,9 @@ pub struct IUsbInterruptInEventArgs_Vtbl {
     InterruptData: usize,
 }
 windows_core::imp::define_interface!(IUsbInterruptInPipe, IUsbInterruptInPipe_Vtbl, 0xfa007116_84d7_48c7_8a3f_4c0b235f2ea6);
+impl windows_core::RuntimeType for IUsbInterruptInPipe {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterruptInPipe_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,6 +362,9 @@ pub struct IUsbInterruptInPipe_Vtbl {
     pub RemoveDataReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbInterruptOutEndpointDescriptor, IUsbInterruptOutEndpointDescriptor_Vtbl, 0xcc9fed81_10ca_4533_952d_9e278341e80f);
+impl windows_core::RuntimeType for IUsbInterruptOutEndpointDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterruptOutEndpointDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -299,6 +374,9 @@ pub struct IUsbInterruptOutEndpointDescriptor_Vtbl {
     pub Pipe: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbInterruptOutPipe, IUsbInterruptOutPipe_Vtbl, 0xe984c8a9_aaf9_49d0_b96c_f661ab4a7f95);
+impl windows_core::RuntimeType for IUsbInterruptOutPipe {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbInterruptOutPipe_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,6 +390,9 @@ pub struct IUsbInterruptOutPipe_Vtbl {
     OutputStream: usize,
 }
 windows_core::imp::define_interface!(IUsbSetupPacket, IUsbSetupPacket_Vtbl, 0x104ba132_c78f_4c51_b654_e49d02f2cb03);
+impl windows_core::RuntimeType for IUsbSetupPacket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbSetupPacket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -327,6 +408,9 @@ pub struct IUsbSetupPacket_Vtbl {
     pub SetLength: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUsbSetupPacketFactory, IUsbSetupPacketFactory_Vtbl, 0xc9257d50_1b2e_4a41_a2a7_338f0cef3c14);
+impl windows_core::RuntimeType for IUsbSetupPacketFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUsbSetupPacketFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -363,7 +447,7 @@ impl UsbBulkInEndpointDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbBulkInEndpointDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbBulkInEndpointDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbBulkInEndpointDescriptor {
     type Vtable = IUsbBulkInEndpointDescriptor_Vtbl;
@@ -425,7 +509,7 @@ impl UsbBulkInPipe {
     }
 }
 impl windows_core::RuntimeType for UsbBulkInPipe {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbBulkInPipe>();
 }
 unsafe impl windows_core::Interface for UsbBulkInPipe {
     type Vtable = IUsbBulkInPipe_Vtbl;
@@ -464,7 +548,7 @@ impl UsbBulkOutEndpointDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbBulkOutEndpointDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbBulkOutEndpointDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbBulkOutEndpointDescriptor {
     type Vtable = IUsbBulkOutEndpointDescriptor_Vtbl;
@@ -515,7 +599,7 @@ impl UsbBulkOutPipe {
     }
 }
 impl windows_core::RuntimeType for UsbBulkOutPipe {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbBulkOutPipe>();
 }
 unsafe impl windows_core::Interface for UsbBulkOutPipe {
     type Vtable = IUsbBulkOutPipe_Vtbl;
@@ -556,7 +640,7 @@ impl UsbConfiguration {
     }
 }
 impl windows_core::RuntimeType for UsbConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbConfiguration>();
 }
 unsafe impl windows_core::Interface for UsbConfiguration {
     type Vtable = IUsbConfiguration_Vtbl;
@@ -625,7 +709,7 @@ impl UsbConfigurationDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbConfigurationDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbConfigurationDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbConfigurationDescriptor {
     type Vtable = IUsbConfigurationDescriptor_Vtbl;
@@ -694,7 +778,7 @@ impl UsbControlRequestType {
     }
 }
 impl windows_core::RuntimeType for UsbControlRequestType {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbControlRequestType>();
 }
 unsafe impl windows_core::Interface for UsbControlRequestType {
     type Vtable = IUsbControlRequestType_Vtbl;
@@ -734,7 +818,7 @@ impl UsbDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbDescriptor {
     type Vtable = IUsbDescriptor_Vtbl;
@@ -861,7 +945,7 @@ impl UsbDevice {
     }
 }
 impl windows_core::RuntimeType for UsbDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbDevice>();
 }
 unsafe impl windows_core::Interface for UsbDevice {
     type Vtable = IUsbDevice_Vtbl;
@@ -925,7 +1009,7 @@ impl UsbDeviceClass {
     }
 }
 impl windows_core::RuntimeType for UsbDeviceClass {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbDeviceClass>();
 }
 unsafe impl windows_core::Interface for UsbDeviceClass {
     type Vtable = IUsbDeviceClass_Vtbl;
@@ -1002,7 +1086,7 @@ impl UsbDeviceClasses {
     }
 }
 impl windows_core::RuntimeType for UsbDeviceClasses {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbDeviceClasses>();
 }
 unsafe impl windows_core::Interface for UsbDeviceClasses {
     type Vtable = IUsbDeviceClasses_Vtbl;
@@ -1062,7 +1146,7 @@ impl UsbDeviceDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbDeviceDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbDeviceDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbDeviceDescriptor {
     type Vtable = IUsbDeviceDescriptor_Vtbl;
@@ -1152,7 +1236,7 @@ impl UsbEndpointDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbEndpointDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbEndpointDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbEndpointDescriptor {
     type Vtable = IUsbEndpointDescriptor_Vtbl;
@@ -1225,7 +1309,7 @@ impl UsbInterface {
     }
 }
 impl windows_core::RuntimeType for UsbInterface {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterface>();
 }
 unsafe impl windows_core::Interface for UsbInterface {
     type Vtable = IUsbInterface_Vtbl;
@@ -1301,7 +1385,7 @@ impl UsbInterfaceDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbInterfaceDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterfaceDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbInterfaceDescriptor {
     type Vtable = IUsbInterfaceDescriptor_Vtbl;
@@ -1380,7 +1464,7 @@ impl UsbInterfaceSetting {
     }
 }
 impl windows_core::RuntimeType for UsbInterfaceSetting {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterfaceSetting>();
 }
 unsafe impl windows_core::Interface for UsbInterfaceSetting {
     type Vtable = IUsbInterfaceSetting_Vtbl;
@@ -1426,7 +1510,7 @@ impl UsbInterruptInEndpointDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbInterruptInEndpointDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterruptInEndpointDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbInterruptInEndpointDescriptor {
     type Vtable = IUsbInterruptInEndpointDescriptor_Vtbl;
@@ -1452,7 +1536,7 @@ impl UsbInterruptInEventArgs {
     }
 }
 impl windows_core::RuntimeType for UsbInterruptInEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterruptInEventArgs>();
 }
 unsafe impl windows_core::Interface for UsbInterruptInEventArgs {
     type Vtable = IUsbInterruptInEventArgs_Vtbl;
@@ -1498,7 +1582,7 @@ impl UsbInterruptInPipe {
     }
 }
 impl windows_core::RuntimeType for UsbInterruptInPipe {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterruptInPipe>();
 }
 unsafe impl windows_core::Interface for UsbInterruptInPipe {
     type Vtable = IUsbInterruptInPipe_Vtbl;
@@ -1544,7 +1628,7 @@ impl UsbInterruptOutEndpointDescriptor {
     }
 }
 impl windows_core::RuntimeType for UsbInterruptOutEndpointDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterruptOutEndpointDescriptor>();
 }
 unsafe impl windows_core::Interface for UsbInterruptOutEndpointDescriptor {
     type Vtable = IUsbInterruptOutEndpointDescriptor_Vtbl;
@@ -1595,7 +1679,7 @@ impl UsbInterruptOutPipe {
     }
 }
 impl windows_core::RuntimeType for UsbInterruptOutPipe {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbInterruptOutPipe>();
 }
 unsafe impl windows_core::Interface for UsbInterruptOutPipe {
     type Vtable = IUsbInterruptOutPipe_Vtbl;
@@ -1693,7 +1777,7 @@ impl UsbSetupPacket {
     }
 }
 impl windows_core::RuntimeType for UsbSetupPacket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUsbSetupPacket>();
 }
 unsafe impl windows_core::Interface for UsbSetupPacket {
     type Vtable = IUsbSetupPacket_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IWiFiAdapter, IWiFiAdapter_Vtbl, 0xa6c4e423_3d75_43a4_b9de_11e26b72d9b0);
+impl windows_core::RuntimeType for IWiFiAdapter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiAdapter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +25,9 @@ pub struct IWiFiAdapter_Vtbl {
     pub Disconnect: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiAdapter2, IWiFiAdapter2_Vtbl, 0x5bc4501d_81e4_453d_9430_1fcafbadd6b6);
+impl windows_core::RuntimeType for IWiFiAdapter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiAdapter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +38,9 @@ pub struct IWiFiAdapter2_Vtbl {
     ConnectWithPasswordCredentialAndSsidAndConnectionMethodAsync: usize,
 }
 windows_core::imp::define_interface!(IWiFiAdapterStatics, IWiFiAdapterStatics_Vtbl, 0xda25fddd_d24c_43e3_aabd_c4659f730f99);
+impl windows_core::RuntimeType for IWiFiAdapterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiAdapterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +53,9 @@ pub struct IWiFiAdapterStatics_Vtbl {
     pub RequestAccessAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiAvailableNetwork, IWiFiAvailableNetwork_Vtbl, 0x26e96246_183e_4704_9826_71b4a2f0f668);
+impl windows_core::RuntimeType for IWiFiAvailableNetwork {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiAvailableNetwork_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,12 +75,18 @@ pub struct IWiFiAvailableNetwork_Vtbl {
     pub IsWiFiDirect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiConnectionResult, IWiFiConnectionResult_Vtbl, 0x143bdfd9_c37d_40be_a5c8_857bce85a931);
+impl windows_core::RuntimeType for IWiFiConnectionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiConnectionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ConnectionStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WiFiConnectionStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiNetworkReport, IWiFiNetworkReport_Vtbl, 0x9524ded2_5911_445e_8194_be4f1a704895);
+impl windows_core::RuntimeType for IWiFiNetworkReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiNetworkReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +97,9 @@ pub struct IWiFiNetworkReport_Vtbl {
     AvailableNetworks: usize,
 }
 windows_core::imp::define_interface!(IWiFiOnDemandHotspotConnectTriggerDetails, IWiFiOnDemandHotspotConnectTriggerDetails_Vtbl, 0xa268eb58_68f5_59cf_8d38_35bf44b097ef);
+impl windows_core::RuntimeType for IWiFiOnDemandHotspotConnectTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiOnDemandHotspotConnectTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -88,12 +109,18 @@ pub struct IWiFiOnDemandHotspotConnectTriggerDetails_Vtbl {
     pub Connect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiOnDemandHotspotConnectionResult, IWiFiOnDemandHotspotConnectionResult_Vtbl, 0x911794a1_6c82_5de3_8a4a_f9ff22a4957a);
+impl windows_core::RuntimeType for IWiFiOnDemandHotspotConnectionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiOnDemandHotspotConnectionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WiFiOnDemandHotspotConnectStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiOnDemandHotspotNetwork, IWiFiOnDemandHotspotNetwork_Vtbl, 0x18dc7115_a04e_507c_bbaf_b78369d29fa7);
+impl windows_core::RuntimeType for IWiFiOnDemandHotspotNetwork {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiOnDemandHotspotNetwork_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,6 +129,9 @@ pub struct IWiFiOnDemandHotspotNetwork_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiOnDemandHotspotNetworkProperties, IWiFiOnDemandHotspotNetworkProperties_Vtbl, 0xc810a1f2_c81d_5852_be50_e4bd4d81e98d);
+impl windows_core::RuntimeType for IWiFiOnDemandHotspotNetworkProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiOnDemandHotspotNetworkProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,12 +157,18 @@ pub struct IWiFiOnDemandHotspotNetworkProperties_Vtbl {
     SetPassword: usize,
 }
 windows_core::imp::define_interface!(IWiFiOnDemandHotspotNetworkStatics, IWiFiOnDemandHotspotNetworkStatics_Vtbl, 0x00f5b8ac_80e7_5054_871c_8739f374e3c9);
+impl windows_core::RuntimeType for IWiFiOnDemandHotspotNetworkStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiOnDemandHotspotNetworkStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetOrCreateById: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiWpsConfigurationResult, IWiFiWpsConfigurationResult_Vtbl, 0x67b49871_17ee_42d1_b14f_5a11f1226fb5);
+impl windows_core::RuntimeType for IWiFiWpsConfigurationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiWpsConfigurationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -275,7 +311,7 @@ impl WiFiAdapter {
     }
 }
 impl windows_core::RuntimeType for WiFiAdapter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiAdapter>();
 }
 unsafe impl windows_core::Interface for WiFiAdapter {
     type Vtable = IWiFiAdapter_Vtbl;
@@ -371,7 +407,7 @@ impl WiFiAvailableNetwork {
     }
 }
 impl windows_core::RuntimeType for WiFiAvailableNetwork {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiAvailableNetwork>();
 }
 unsafe impl windows_core::Interface for WiFiAvailableNetwork {
     type Vtable = IWiFiAvailableNetwork_Vtbl;
@@ -396,7 +432,7 @@ impl WiFiConnectionResult {
     }
 }
 impl windows_core::RuntimeType for WiFiConnectionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiConnectionResult>();
 }
 unsafe impl windows_core::Interface for WiFiConnectionResult {
     type Vtable = IWiFiConnectionResult_Vtbl;
@@ -429,7 +465,7 @@ impl WiFiNetworkReport {
     }
 }
 impl windows_core::RuntimeType for WiFiNetworkReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiNetworkReport>();
 }
 unsafe impl windows_core::Interface for WiFiNetworkReport {
     type Vtable = IWiFiNetworkReport_Vtbl;
@@ -472,7 +508,7 @@ impl WiFiOnDemandHotspotConnectTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for WiFiOnDemandHotspotConnectTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiOnDemandHotspotConnectTriggerDetails>();
 }
 unsafe impl windows_core::Interface for WiFiOnDemandHotspotConnectTriggerDetails {
     type Vtable = IWiFiOnDemandHotspotConnectTriggerDetails_Vtbl;
@@ -497,7 +533,7 @@ impl WiFiOnDemandHotspotConnectionResult {
     }
 }
 impl windows_core::RuntimeType for WiFiOnDemandHotspotConnectionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiOnDemandHotspotConnectionResult>();
 }
 unsafe impl windows_core::Interface for WiFiOnDemandHotspotConnectionResult {
     type Vtable = IWiFiOnDemandHotspotConnectionResult_Vtbl;
@@ -547,7 +583,7 @@ impl WiFiOnDemandHotspotNetwork {
     }
 }
 impl windows_core::RuntimeType for WiFiOnDemandHotspotNetwork {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiOnDemandHotspotNetwork>();
 }
 unsafe impl windows_core::Interface for WiFiOnDemandHotspotNetwork {
     type Vtable = IWiFiOnDemandHotspotNetwork_Vtbl;
@@ -653,7 +689,7 @@ impl WiFiOnDemandHotspotNetworkProperties {
     }
 }
 impl windows_core::RuntimeType for WiFiOnDemandHotspotNetworkProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiOnDemandHotspotNetworkProperties>();
 }
 unsafe impl windows_core::Interface for WiFiOnDemandHotspotNetworkProperties {
     type Vtable = IWiFiOnDemandHotspotNetworkProperties_Vtbl;
@@ -686,7 +722,7 @@ impl WiFiWpsConfigurationResult {
     }
 }
 impl windows_core::RuntimeType for WiFiWpsConfigurationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiWpsConfigurationResult>();
 }
 unsafe impl windows_core::Interface for WiFiWpsConfigurationResult {
     type Vtable = IWiFiWpsConfigurationResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IWiFiDirectService, IWiFiDirectService_Vtbl, 0x50aabbb8_5f71_45ec_84f1_a1e4fc7879a3);
+impl windows_core::RuntimeType for IWiFiDirectService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +31,9 @@ pub struct IWiFiDirectService_Vtbl {
     pub ConnectAsyncWithPin: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceAdvertiser, IWiFiDirectServiceAdvertiser_Vtbl, 0xa4aa1ee1_9d8f_4f4f_93ee_7ddea2e37f46);
+impl windows_core::RuntimeType for IWiFiDirectServiceAdvertiser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceAdvertiser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,12 +90,18 @@ pub struct IWiFiDirectServiceAdvertiser_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceAdvertiserFactory, IWiFiDirectServiceAdvertiserFactory_Vtbl, 0x3106ac0d_b446_4f13_9f9a_8ae925feba2b);
+impl windows_core::RuntimeType for IWiFiDirectServiceAdvertiserFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceAdvertiserFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWiFiDirectServiceAdvertiser: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs, IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs_Vtbl, 0xdcd9e01e_83df_43e5_8f43_cbe8479e84eb);
+impl windows_core::RuntimeType for IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,6 +112,9 @@ pub struct IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs_Vtbl {
     SessionInfo: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceProvisioningInfo, IWiFiDirectServiceProvisioningInfo_Vtbl, 0x8bdb7cfe_97d9_45a2_8e99_db50910fb6a6);
+impl windows_core::RuntimeType for IWiFiDirectServiceProvisioningInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceProvisioningInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -107,6 +122,9 @@ pub struct IWiFiDirectServiceProvisioningInfo_Vtbl {
     pub IsGroupFormationNeeded: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceRemotePortAddedEventArgs, IWiFiDirectServiceRemotePortAddedEventArgs_Vtbl, 0xd4cebac1_3fd3_4f0e_b7bd_782906f44411);
+impl windows_core::RuntimeType for IWiFiDirectServiceRemotePortAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceRemotePortAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +135,9 @@ pub struct IWiFiDirectServiceRemotePortAddedEventArgs_Vtbl {
     pub Protocol: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WiFiDirectServiceIPProtocol) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceSession, IWiFiDirectServiceSession_Vtbl, 0x81142163_e426_47cb_8640_e1b3588bf26f);
+impl windows_core::RuntimeType for IWiFiDirectServiceSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +166,9 @@ pub struct IWiFiDirectServiceSession_Vtbl {
     pub RemoveRemotePortAdded: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceSessionDeferredEventArgs, IWiFiDirectServiceSessionDeferredEventArgs_Vtbl, 0x8dfc197f_1201_4f1f_b6f4_5df1b7b9fb2e);
+impl windows_core::RuntimeType for IWiFiDirectServiceSessionDeferredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceSessionDeferredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,6 +178,9 @@ pub struct IWiFiDirectServiceSessionDeferredEventArgs_Vtbl {
     DeferredSessionInfo: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceSessionRequest, IWiFiDirectServiceSessionRequest_Vtbl, 0xa0e27c8b_50cb_4a58_9bcf_e472b99fba04);
+impl windows_core::RuntimeType for IWiFiDirectServiceSessionRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceSessionRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -168,12 +195,18 @@ pub struct IWiFiDirectServiceSessionRequest_Vtbl {
     SessionInfo: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceSessionRequestedEventArgs, IWiFiDirectServiceSessionRequestedEventArgs_Vtbl, 0x74bdcc11_53d6_4999_b4f8_6c8ecc1771e7);
+impl windows_core::RuntimeType for IWiFiDirectServiceSessionRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceSessionRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetSessionRequest: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectServiceStatics, IWiFiDirectServiceStatics_Vtbl, 0x7db40045_fd74_4688_b725_5dce86acf233);
+impl windows_core::RuntimeType for IWiFiDirectServiceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectServiceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -303,7 +336,7 @@ impl WiFiDirectService {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectService {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectService>();
 }
 unsafe impl windows_core::Interface for WiFiDirectService {
     type Vtable = IWiFiDirectService_Vtbl;
@@ -517,7 +550,7 @@ impl WiFiDirectServiceAdvertiser {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceAdvertiser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceAdvertiser>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceAdvertiser {
     type Vtable = IWiFiDirectServiceAdvertiser_Vtbl;
@@ -550,7 +583,7 @@ impl WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {
     type Vtable = IWiFiDirectServiceAutoAcceptSessionConnectedEventArgs_Vtbl;
@@ -582,7 +615,7 @@ impl WiFiDirectServiceProvisioningInfo {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceProvisioningInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceProvisioningInfo>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceProvisioningInfo {
     type Vtable = IWiFiDirectServiceProvisioningInfo_Vtbl;
@@ -615,7 +648,7 @@ impl WiFiDirectServiceRemotePortAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceRemotePortAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceRemotePortAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceRemotePortAddedEventArgs {
     type Vtable = IWiFiDirectServiceRemotePortAddedEventArgs_Vtbl;
@@ -745,7 +778,7 @@ impl WiFiDirectServiceSession {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceSession>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceSession {
     type Vtable = IWiFiDirectServiceSession_Vtbl;
@@ -771,7 +804,7 @@ impl WiFiDirectServiceSessionDeferredEventArgs {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceSessionDeferredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceSessionDeferredEventArgs>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceSessionDeferredEventArgs {
     type Vtable = IWiFiDirectServiceSessionDeferredEventArgs_Vtbl;
@@ -817,7 +850,7 @@ impl WiFiDirectServiceSessionRequest {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceSessionRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceSessionRequest>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceSessionRequest {
     type Vtable = IWiFiDirectServiceSessionRequest_Vtbl;
@@ -842,7 +875,7 @@ impl WiFiDirectServiceSessionRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectServiceSessionRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectServiceSessionRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WiFiDirectServiceSessionRequestedEventArgs {
     type Vtable = IWiFiDirectServiceSessionRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Devices_WiFiDirect_Services")]
 pub mod Services;
 windows_core::imp::define_interface!(IWiFiDirectAdvertisement, IWiFiDirectAdvertisement_Vtbl, 0xab511a2d_2a06_49a1_a584_61435c7905a6);
+impl windows_core::RuntimeType for IWiFiDirectAdvertisement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectAdvertisement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +22,9 @@ pub struct IWiFiDirectAdvertisement_Vtbl {
     pub LegacySettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectAdvertisement2, IWiFiDirectAdvertisement2_Vtbl, 0xb759aa46_d816_491b_917a_b40d7dc403a2);
+impl windows_core::RuntimeType for IWiFiDirectAdvertisement2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectAdvertisement2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +34,9 @@ pub struct IWiFiDirectAdvertisement2_Vtbl {
     SupportedConfigurationMethods: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectAdvertisementPublisher, IWiFiDirectAdvertisementPublisher_Vtbl, 0xb35a2d1a_9b1f_45d9_925a_694d66df68ef);
+impl windows_core::RuntimeType for IWiFiDirectAdvertisementPublisher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectAdvertisementPublisher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +48,9 @@ pub struct IWiFiDirectAdvertisementPublisher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectAdvertisementPublisherStatusChangedEventArgs, IWiFiDirectAdvertisementPublisherStatusChangedEventArgs_Vtbl, 0xaafde53c_5481_46e6_90dd_32116518f192);
+impl windows_core::RuntimeType for IWiFiDirectAdvertisementPublisherStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectAdvertisementPublisherStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +58,9 @@ pub struct IWiFiDirectAdvertisementPublisherStatusChangedEventArgs_Vtbl {
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WiFiDirectError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectConnectionListener, IWiFiDirectConnectionListener_Vtbl, 0x699c1b0d_8d13_4ee9_b9ec_9c72f8251f7d);
+impl windows_core::RuntimeType for IWiFiDirectConnectionListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectConnectionListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +68,9 @@ pub struct IWiFiDirectConnectionListener_Vtbl {
     pub RemoveConnectionRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectConnectionParameters, IWiFiDirectConnectionParameters_Vtbl, 0xb2e55405_5702_4b16_a02c_bbcd21ef6098);
+impl windows_core::RuntimeType for IWiFiDirectConnectionParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectConnectionParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +78,9 @@ pub struct IWiFiDirectConnectionParameters_Vtbl {
     pub SetGroupOwnerIntent: unsafe extern "system" fn(*mut core::ffi::c_void, i16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectConnectionParameters2, IWiFiDirectConnectionParameters2_Vtbl, 0xab3b0fbe_aa82_44b4_88c8_e3056b89801d);
+impl windows_core::RuntimeType for IWiFiDirectConnectionParameters2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectConnectionParameters2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +92,9 @@ pub struct IWiFiDirectConnectionParameters2_Vtbl {
     pub SetPreferredPairingProcedure: unsafe extern "system" fn(*mut core::ffi::c_void, WiFiDirectPairingProcedure) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectConnectionParametersStatics, IWiFiDirectConnectionParametersStatics_Vtbl, 0x598af493_7642_456f_b9d8_e8a9eb1f401a);
+impl windows_core::RuntimeType for IWiFiDirectConnectionParametersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectConnectionParametersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +104,9 @@ pub struct IWiFiDirectConnectionParametersStatics_Vtbl {
     GetDevicePairingKinds: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectConnectionRequest, IWiFiDirectConnectionRequest_Vtbl, 0x8eb99605_914f_49c3_a614_d18dc5b19b43);
+impl windows_core::RuntimeType for IWiFiDirectConnectionRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectConnectionRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,12 +116,18 @@ pub struct IWiFiDirectConnectionRequest_Vtbl {
     DeviceInformation: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectConnectionRequestedEventArgs, IWiFiDirectConnectionRequestedEventArgs_Vtbl, 0xf99d20be_d38d_484f_8215_e7b65abf244c);
+impl windows_core::RuntimeType for IWiFiDirectConnectionRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectConnectionRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetConnectionRequest: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectDevice, IWiFiDirectDevice_Vtbl, 0x72deaaa8_72eb_4dae_8a28_8513355d2777);
+impl windows_core::RuntimeType for IWiFiDirectDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +141,9 @@ pub struct IWiFiDirectDevice_Vtbl {
     GetConnectionEndpointPairs: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectDeviceStatics, IWiFiDirectDeviceStatics_Vtbl, 0xe86cb57c_3aac_4851_a792_482aaf931b04);
+impl windows_core::RuntimeType for IWiFiDirectDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,6 +151,9 @@ pub struct IWiFiDirectDeviceStatics_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectDeviceStatics2, IWiFiDirectDeviceStatics2_Vtbl, 0x1a953e49_b103_437e_9226_ab67971342f9);
+impl windows_core::RuntimeType for IWiFiDirectDeviceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectDeviceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,6 +161,9 @@ pub struct IWiFiDirectDeviceStatics2_Vtbl {
     pub FromIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWiFiDirectInformationElement, IWiFiDirectInformationElement_Vtbl, 0xaffb72d6_76bb_497e_ac8b_dc72838bc309);
+impl windows_core::RuntimeType for IWiFiDirectInformationElement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectInformationElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +187,9 @@ pub struct IWiFiDirectInformationElement_Vtbl {
     SetValue: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectInformationElementStatics, IWiFiDirectInformationElementStatics_Vtbl, 0xdbd02f16_11a5_4e60_8caa_34772148378a);
+impl windows_core::RuntimeType for IWiFiDirectInformationElementStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectInformationElementStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +203,9 @@ pub struct IWiFiDirectInformationElementStatics_Vtbl {
     CreateFromDeviceInformation: usize,
 }
 windows_core::imp::define_interface!(IWiFiDirectLegacySettings, IWiFiDirectLegacySettings_Vtbl, 0xa64fdbba_f2fd_4567_a91b_f5c2f5321057);
+impl windows_core::RuntimeType for IWiFiDirectLegacySettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWiFiDirectLegacySettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -234,7 +282,7 @@ impl WiFiDirectAdvertisement {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectAdvertisement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectAdvertisement>();
 }
 unsafe impl windows_core::Interface for WiFiDirectAdvertisement {
     type Vtable = IWiFiDirectAdvertisement_Vtbl;
@@ -295,7 +343,7 @@ impl WiFiDirectAdvertisementPublisher {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectAdvertisementPublisher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectAdvertisementPublisher>();
 }
 unsafe impl windows_core::Interface for WiFiDirectAdvertisementPublisher {
     type Vtable = IWiFiDirectAdvertisementPublisher_Vtbl;
@@ -327,7 +375,7 @@ impl WiFiDirectAdvertisementPublisherStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectAdvertisementPublisherStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {
     type Vtable = IWiFiDirectAdvertisementPublisherStatusChangedEventArgs_Vtbl;
@@ -366,7 +414,7 @@ impl WiFiDirectConnectionListener {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectConnectionListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectConnectionListener>();
 }
 unsafe impl windows_core::Interface for WiFiDirectConnectionListener {
     type Vtable = IWiFiDirectConnectionListener_Vtbl;
@@ -435,7 +483,7 @@ impl WiFiDirectConnectionParameters {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectConnectionParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectConnectionParameters>();
 }
 unsafe impl windows_core::Interface for WiFiDirectConnectionParameters {
     type Vtable = IWiFiDirectConnectionParameters_Vtbl;
@@ -466,7 +514,7 @@ impl WiFiDirectConnectionRequest {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectConnectionRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectConnectionRequest>();
 }
 unsafe impl windows_core::Interface for WiFiDirectConnectionRequest {
     type Vtable = IWiFiDirectConnectionRequest_Vtbl;
@@ -491,7 +539,7 @@ impl WiFiDirectConnectionRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectConnectionRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectConnectionRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WiFiDirectConnectionRequestedEventArgs {
     type Vtable = IWiFiDirectConnectionRequestedEventArgs_Vtbl;
@@ -587,7 +635,7 @@ impl WiFiDirectDevice {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectDevice>();
 }
 unsafe impl windows_core::Interface for WiFiDirectDevice {
     type Vtable = IWiFiDirectDevice_Vtbl;
@@ -680,7 +728,7 @@ impl WiFiDirectInformationElement {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectInformationElement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectInformationElement>();
 }
 unsafe impl windows_core::Interface for WiFiDirectInformationElement {
     type Vtable = IWiFiDirectInformationElement_Vtbl;
@@ -736,7 +784,7 @@ impl WiFiDirectLegacySettings {
     }
 }
 impl windows_core::RuntimeType for WiFiDirectLegacySettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWiFiDirectLegacySettings>();
 }
 unsafe impl windows_core::Interface for WiFiDirectLegacySettings {
     type Vtable = IWiFiDirectLegacySettings_Vtbl;

--- a/crates/libs/windows/src/Windows/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/mod.rs
@@ -128,6 +128,9 @@ pub struct ILowLevelDevicesAggregateProvider_Vtbl {
     SpiControllerProvider: usize,
 }
 windows_core::imp::define_interface!(ILowLevelDevicesAggregateProviderFactory, ILowLevelDevicesAggregateProviderFactory_Vtbl, 0x9ac4aaf6_3473_465e_96d5_36281a2c57af);
+impl windows_core::RuntimeType for ILowLevelDevicesAggregateProviderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLevelDevicesAggregateProviderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -137,11 +140,17 @@ pub struct ILowLevelDevicesAggregateProviderFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ILowLevelDevicesController, ILowLevelDevicesController_Vtbl, 0x2ec23dd4_179b_45de_9b39_3ae02527de52);
+impl windows_core::RuntimeType for ILowLevelDevicesController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLevelDevicesController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ILowLevelDevicesControllerStatics, ILowLevelDevicesControllerStatics_Vtbl, 0x093e926a_fccb_4394_a697_19de637c2db3);
+impl windows_core::RuntimeType for ILowLevelDevicesControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLevelDevicesControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,7 +224,7 @@ impl LowLevelDevicesAggregateProvider {
     }
 }
 impl windows_core::RuntimeType for LowLevelDevicesAggregateProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLevelDevicesAggregateProvider>();
 }
 unsafe impl windows_core::Interface for LowLevelDevicesAggregateProvider {
     type Vtable = ILowLevelDevicesAggregateProvider_Vtbl;
@@ -250,7 +259,7 @@ impl LowLevelDevicesController {
     }
 }
 impl windows_core::RuntimeType for LowLevelDevicesController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLevelDevicesController>();
 }
 unsafe impl windows_core::Interface for LowLevelDevicesController {
     type Vtable = ILowLevelDevicesController_Vtbl;

--- a/crates/libs/windows/src/Windows/Embedded/DeviceLockdown/mod.rs
+++ b/crates/libs/windows/src/Windows/Embedded/DeviceLockdown/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IDeviceLockdownProfileInformation, IDeviceLockdownProfileInformation_Vtbl, 0x7980e14e_45b1_4a96_92fc_62756b739678);
+impl windows_core::RuntimeType for IDeviceLockdownProfileInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceLockdownProfileInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Name: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeviceLockdownProfileStatics, IDeviceLockdownProfileStatics_Vtbl, 0x622f6965_f9a8_41a1_a691_88cd80c7a069);
+impl windows_core::RuntimeType for IDeviceLockdownProfileStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeviceLockdownProfileStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,7 +72,7 @@ impl DeviceLockdownProfileInformation {
     }
 }
 impl windows_core::RuntimeType for DeviceLockdownProfileInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeviceLockdownProfileInformation>();
 }
 unsafe impl windows_core::Interface for DeviceLockdownProfileInformation {
     type Vtable = IDeviceLockdownProfileInformation_Vtbl;

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -14,9 +14,6 @@ impl<T: windows_core::RuntimeType + 'static> IIterable<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterable<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{faa585ea-6214-4217-afda-7f46de5869b3}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
-}
 impl<T: windows_core::RuntimeType> IntoIterator for IIterable<T> {
     type Item = T;
     type IntoIter = IIterator<Self::Item>;
@@ -30,6 +27,9 @@ impl<T: windows_core::RuntimeType> IntoIterator for &IIterable<T> {
     fn into_iter(self) -> Self::IntoIter {
         self.First().unwrap()
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterable<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{faa585ea-6214-4217-afda-7f46de5869b3}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IIterable<T> {
     type Vtable = IIterable_Vtbl<T>;
@@ -81,9 +81,6 @@ impl<T: windows_core::RuntimeType + 'static> IIterator<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterator<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{6a79e863-4300-459a-9966-cbb660963ee1}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
-}
 impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
@@ -93,6 +90,9 @@ impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
         }
         result
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterator<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{6a79e863-4300-459a-9966-cbb660963ee1}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IIterator<T> {
     type Vtable = IIterator_Vtbl<T>;
@@ -229,9 +229,6 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         }
     }
 }
-impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IMap<K, V> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{3c2925fe-8519-45c1-aa79-197b6718c1c1}").push_slice(b";").push_other(K::SIGNATURE).push_slice(b";").push_other(V::SIGNATURE).push_slice(b")") };
-}
 impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> IntoIterator for IMap<K, V> {
     type Item = IKeyValuePair<K, V>;
     type IntoIter = IIterator<Self::Item>;
@@ -245,6 +242,9 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
     fn into_iter(self) -> Self::IntoIter {
         self.First().unwrap()
     }
+}
+impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IMap<K, V> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{3c2925fe-8519-45c1-aa79-197b6718c1c1}").push_slice(b";").push_other(K::SIGNATURE).push_slice(b";").push_other(V::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::Interface for IMap<K, V> {
     type Vtable = IMap_Vtbl<K, V>;
@@ -358,9 +358,6 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         }
     }
 }
-impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IMapView<K, V> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{e480ce40-a338-4ada-adcf-272272e48cb9}").push_slice(b";").push_other(K::SIGNATURE).push_slice(b";").push_other(V::SIGNATURE).push_slice(b")") };
-}
 impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> IntoIterator for IMapView<K, V> {
     type Item = IKeyValuePair<K, V>;
     type IntoIter = IIterator<Self::Item>;
@@ -374,6 +371,9 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
     fn into_iter(self) -> Self::IntoIter {
         self.First().unwrap()
     }
+}
+impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IMapView<K, V> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{e480ce40-a338-4ada-adcf-272272e48cb9}").push_slice(b";").push_other(K::SIGNATURE).push_slice(b";").push_other(V::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::Interface for IMapView<K, V> {
     type Vtable = IMapView_Vtbl<K, V>;
@@ -486,9 +486,6 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
         unsafe { (windows_core::Interface::vtable(this).Clear)(windows_core::Interface::as_raw(this)).ok() }
     }
 }
-impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IObservableMap<K, V> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{65df2bf5-bf39-41b5-aebc-5a9d865e472b}").push_slice(b";").push_other(K::SIGNATURE).push_slice(b";").push_other(V::SIGNATURE).push_slice(b")") };
-}
 impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> IntoIterator for IObservableMap<K, V> {
     type Item = IKeyValuePair<K, V>;
     type IntoIter = IIterator<Self::Item>;
@@ -502,6 +499,9 @@ impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'sta
     fn into_iter(self) -> Self::IntoIter {
         self.First().unwrap()
     }
+}
+impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IObservableMap<K, V> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{65df2bf5-bf39-41b5-aebc-5a9d865e472b}").push_slice(b";").push_other(K::SIGNATURE).push_slice(b";").push_other(V::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<K: windows_core::RuntimeType + 'static, V: windows_core::RuntimeType + 'static> windows_core::Interface for IObservableMap<K, V> {
     type Vtable = IObservableMap_Vtbl<K, V>;
@@ -630,9 +630,6 @@ impl<T: windows_core::RuntimeType + 'static> IObservableVector<T> {
         unsafe { (windows_core::Interface::vtable(this).ReplaceAll)(windows_core::Interface::as_raw(this), items.len().try_into().unwrap(), core::mem::transmute(items.as_ptr())).ok() }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IObservableVector<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{5917eb53-50b4-4a0d-b309-65862b3f1dbc}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
-}
 impl<T: windows_core::RuntimeType + 'static> IntoIterator for IObservableVector<T> {
     type Item = T;
     type IntoIter = VectorIterator<Self::Item>;
@@ -646,6 +643,9 @@ impl<T: windows_core::RuntimeType + 'static> IntoIterator for &IObservableVector
     fn into_iter(self) -> Self::IntoIter {
         VectorIterator::new(windows_core::Interface::cast(self).ok())
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IObservableVector<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{5917eb53-50b4-4a0d-b309-65862b3f1dbc}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IObservableVector<T> {
     type Vtable = IObservableVector_Vtbl<T>;
@@ -733,9 +733,6 @@ impl IPropertySet {
         unsafe { (windows_core::Interface::vtable(this).RemoveMapChanged)(windows_core::Interface::as_raw(this), token).ok() }
     }
 }
-impl windows_core::RuntimeType for IPropertySet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
-}
 impl IntoIterator for IPropertySet {
     type Item = IKeyValuePair<windows_core::HSTRING, windows_core::IInspectable>;
     type IntoIter = IIterator<Self::Item>;
@@ -749,6 +746,9 @@ impl IntoIterator for &IPropertySet {
     fn into_iter(self) -> Self::IntoIter {
         self.First().unwrap()
     }
+}
+impl windows_core::RuntimeType for IPropertySet {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
 }
 #[repr(C)]
 pub struct IPropertySet_Vtbl {
@@ -848,9 +848,6 @@ impl<T: windows_core::RuntimeType + 'static> IVector<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVector<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{913337e9-11a1-4345-a3a2-4e7f956e222d}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
-}
 pub struct VectorIterator<T: windows_core::RuntimeType + 'static> {
     vector: Option<IVector<T>>,
     current: u32,
@@ -882,6 +879,9 @@ impl<T: windows_core::RuntimeType> IntoIterator for &IVector<T> {
     fn into_iter(self) -> Self::IntoIter {
         VectorIterator::new(Some(Clone::clone(self)))
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVector<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{913337e9-11a1-4345-a3a2-4e7f956e222d}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IVector<T> {
     type Vtable = IVector_Vtbl<T>;
@@ -984,9 +984,6 @@ impl<T: windows_core::RuntimeType + 'static> IVectorView<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVectorView<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{bbe1fa4c-b0e3-4583-baef-1f1b2e483e56}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
-}
 pub struct VectorViewIterator<T: windows_core::RuntimeType + 'static> {
     vector: Option<IVectorView<T>>,
     current: u32,
@@ -1018,6 +1015,9 @@ impl<T: windows_core::RuntimeType> IntoIterator for &IVectorView<T> {
     fn into_iter(self) -> Self::IntoIter {
         VectorViewIterator::new(Some(Clone::clone(self)))
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVectorView<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{bbe1fa4c-b0e3-4583-baef-1f1b2e483e56}").push_slice(b";").push_other(T::SIGNATURE).push_slice(b")") };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IVectorView<T> {
     type Vtable = IVectorView_Vtbl<T>;
@@ -1117,7 +1117,7 @@ impl PropertySet {
     }
 }
 impl windows_core::RuntimeType for PropertySet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPropertySet>();
 }
 unsafe impl windows_core::Interface for PropertySet {
     type Vtable = IPropertySet_Vtbl;
@@ -1221,7 +1221,7 @@ impl StringMap {
     }
 }
 impl windows_core::RuntimeType for StringMap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMap<windows_core::HSTRING, windows_core::HSTRING>>();
 }
 unsafe impl windows_core::Interface for StringMap {
     type Vtable = IMap_Vtbl<windows_core::HSTRING, windows_core::HSTRING>;
@@ -1328,7 +1328,7 @@ impl ValueSet {
     }
 }
 impl windows_core::RuntimeType for ValueSet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPropertySet>();
 }
 unsafe impl windows_core::Interface for ValueSet {
     type Vtable = IPropertySet_Vtbl;

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAsyncCausalityTracerStatics, IAsyncCausalityTracerStatics_Vtbl, 0x50850b26_267e_451b_a890_ab6a370245ee);
+impl windows_core::RuntimeType for IAsyncCausalityTracerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAsyncCausalityTracerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IAsyncCausalityTracerStatics_Vtbl {
     pub RemoveTracingStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IErrorDetails, IErrorDetails_Vtbl, 0x378cbb01_2cc9_428f_8c55_2c990d463e8f);
+impl windows_core::RuntimeType for IErrorDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IErrorDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +25,9 @@ pub struct IErrorDetails_Vtbl {
     pub HelpUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IErrorDetailsStatics, IErrorDetailsStatics_Vtbl, 0xb7703750_0b1d_46c8_aa0e_4b8178e4fce9);
+impl windows_core::RuntimeType for IErrorDetailsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IErrorDetailsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -125,12 +134,18 @@ pub struct IFileLoggingSession_Vtbl {
     pub RemoveLogFileGenerated: unsafe extern "system" fn(*mut core::ffi::c_void, super::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileLoggingSessionFactory, IFileLoggingSessionFactory_Vtbl, 0xeea08dce_8447_4daa_9133_12eb46f697d4);
+impl windows_core::RuntimeType for IFileLoggingSessionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileLoggingSessionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILogFileGeneratedEventArgs, ILogFileGeneratedEventArgs_Vtbl, 0x269e976f_0d38_4c1a_b53f_b395d881df84);
+impl windows_core::RuntimeType for ILogFileGeneratedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILogFileGeneratedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +155,9 @@ pub struct ILogFileGeneratedEventArgs_Vtbl {
     File: usize,
 }
 windows_core::imp::define_interface!(ILoggingActivity, ILoggingActivity_Vtbl, 0xbc032941_b766_4cb5_9848_97ac6ba6d60c);
+impl windows_core::RuntimeType for ILoggingActivity {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingActivity_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,6 +165,9 @@ pub struct ILoggingActivity_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingActivity2, ILoggingActivity2_Vtbl, 0x26c29808_6322_456a_af82_80c8642f178b);
+impl windows_core::RuntimeType for ILoggingActivity2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingActivity2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +177,9 @@ pub struct ILoggingActivity2_Vtbl {
     pub StopActivityWithFieldsAndOptions: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingActivityFactory, ILoggingActivityFactory_Vtbl, 0x6b33b483_e10a_4c58_97d5_10fb451074fb);
+impl windows_core::RuntimeType for ILoggingActivityFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingActivityFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -239,12 +263,18 @@ pub struct ILoggingChannel_Vtbl {
     pub RemoveLoggingEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, super::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingChannel2, ILoggingChannel2_Vtbl, 0x9f4c3cf3_0bac_45a5_9e33_baf3f3a246a5);
+impl windows_core::RuntimeType for ILoggingChannel2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingChannel2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingChannelFactory, ILoggingChannelFactory_Vtbl, 0x4edc5b9c_af80_4a9b_b0dc_398f9ae5207b);
+impl windows_core::RuntimeType for ILoggingChannelFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingChannelFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +284,9 @@ pub struct ILoggingChannelFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ILoggingChannelFactory2, ILoggingChannelFactory2_Vtbl, 0x4c6ef5dd_3b27_4dc9_99f0_299c6e4603a1);
+impl windows_core::RuntimeType for ILoggingChannelFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingChannelFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -261,6 +294,9 @@ pub struct ILoggingChannelFactory2_Vtbl {
     pub CreateWithOptionsAndId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingChannelOptions, ILoggingChannelOptions_Vtbl, 0xc3e847ff_0ebb_4a53_8c54_dec24926cb2c);
+impl windows_core::RuntimeType for ILoggingChannelOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingChannelOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -268,12 +304,18 @@ pub struct ILoggingChannelOptions_Vtbl {
     pub SetGroup: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingChannelOptionsFactory, ILoggingChannelOptionsFactory_Vtbl, 0xa93151da_7faf_4191_8755_5e86dc65d896);
+impl windows_core::RuntimeType for ILoggingChannelOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingChannelOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingFields, ILoggingFields_Vtbl, 0xd7f6b7af_762d_4579_83bd_52c23bc333bc);
+impl windows_core::RuntimeType for ILoggingFields {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingFields_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -394,6 +436,9 @@ pub struct ILoggingFields_Vtbl {
     pub AddRectArrayWithFormatAndTags: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, u32, *const super::Rect, LoggingFieldFormat, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingOptions, ILoggingOptions_Vtbl, 0x90bc7850_0192_4f5d_ac26_006adaca12d8);
+impl windows_core::RuntimeType for ILoggingOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -411,6 +456,9 @@ pub struct ILoggingOptions_Vtbl {
     pub SetRelatedActivityId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingOptionsFactory, ILoggingOptionsFactory_Vtbl, 0xd713c6cb_98ab_464b_9f22_a3268478368a);
+impl windows_core::RuntimeType for ILoggingOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -480,6 +528,9 @@ pub struct ILoggingSession_Vtbl {
     pub RemoveLoggingChannel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILoggingSessionFactory, ILoggingSessionFactory_Vtbl, 0x4e937ee5_58fd_45e0_8c2f_a132eff95c1e);
+impl windows_core::RuntimeType for ILoggingSessionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILoggingSessionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -593,6 +644,9 @@ pub struct ILoggingTarget_Vtbl {
     pub StartActivityWithFieldsAndOptions: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, LoggingLevel, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITracingStatusChangedEventArgs, ITracingStatusChangedEventArgs_Vtbl, 0x410b7711_ff3b_477f_9c9a_d2efda302dc3);
+impl windows_core::RuntimeType for ITracingStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITracingStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -676,7 +730,7 @@ impl ErrorDetails {
     }
 }
 impl windows_core::RuntimeType for ErrorDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IErrorDetails>();
 }
 unsafe impl windows_core::Interface for ErrorDetails {
     type Vtable = IErrorDetails_Vtbl;
@@ -760,7 +814,7 @@ impl FileLoggingSession {
     }
 }
 impl windows_core::RuntimeType for FileLoggingSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileLoggingSession>();
 }
 unsafe impl windows_core::Interface for FileLoggingSession {
     type Vtable = IFileLoggingSession_Vtbl;
@@ -786,7 +840,7 @@ impl LogFileGeneratedEventArgs {
     }
 }
 impl windows_core::RuntimeType for LogFileGeneratedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILogFileGeneratedEventArgs>();
 }
 unsafe impl windows_core::Interface for LogFileGeneratedEventArgs {
     type Vtable = ILogFileGeneratedEventArgs_Vtbl;
@@ -957,7 +1011,7 @@ impl LoggingActivity {
     }
 }
 impl windows_core::RuntimeType for LoggingActivity {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILoggingActivity>();
 }
 unsafe impl windows_core::Interface for LoggingActivity {
     type Vtable = ILoggingActivity_Vtbl;
@@ -1158,7 +1212,7 @@ impl LoggingChannel {
     }
 }
 impl windows_core::RuntimeType for LoggingChannel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILoggingChannel>();
 }
 unsafe impl windows_core::Interface for LoggingChannel {
     type Vtable = ILoggingChannel_Vtbl;
@@ -1205,7 +1259,7 @@ impl LoggingChannelOptions {
     }
 }
 impl windows_core::RuntimeType for LoggingChannelOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILoggingChannelOptions>();
 }
 unsafe impl windows_core::Interface for LoggingChannelOptions {
     type Vtable = ILoggingChannelOptions_Vtbl;
@@ -1690,7 +1744,7 @@ impl LoggingFields {
     }
 }
 impl windows_core::RuntimeType for LoggingFields {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILoggingFields>();
 }
 unsafe impl windows_core::Interface for LoggingFields {
     type Vtable = ILoggingFields_Vtbl;
@@ -1792,7 +1846,7 @@ impl LoggingOptions {
     }
 }
 impl windows_core::RuntimeType for LoggingOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILoggingOptions>();
 }
 unsafe impl windows_core::Interface for LoggingOptions {
     type Vtable = ILoggingOptions_Vtbl;
@@ -1865,7 +1919,7 @@ impl LoggingSession {
     }
 }
 impl windows_core::RuntimeType for LoggingSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILoggingSession>();
 }
 unsafe impl windows_core::Interface for LoggingSession {
     type Vtable = ILoggingSession_Vtbl;
@@ -1902,7 +1956,7 @@ impl RuntimeBrokerErrorSettings {
     }
 }
 impl windows_core::RuntimeType for RuntimeBrokerErrorSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IErrorReportingSettings>();
 }
 unsafe impl windows_core::Interface for RuntimeBrokerErrorSettings {
     type Vtable = IErrorReportingSettings_Vtbl;
@@ -1934,7 +1988,7 @@ impl TracingStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TracingStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITracingStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for TracingStatusChangedEventArgs {
     type Vtable = ITracingStatusChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IApiInformationStatics, IApiInformationStatics_Vtbl, 0x997439fe_f681_4a11_b416_c13a47e8ba36);
+impl windows_core::RuntimeType for IApiInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApiInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -58,9 +58,6 @@ impl IAsyncAction {
         unsafe { (windows_core::Interface::vtable(this).Close)(windows_core::Interface::as_raw(this)).ok() }
     }
 }
-impl windows_core::RuntimeType for IAsyncAction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
-}
 impl IAsyncAction {
     pub fn get(&self) -> windows_core::Result<()> {
         if self.Status()? == AsyncStatus::Started {
@@ -92,6 +89,9 @@ impl std::future::Future for IAsyncAction {
 }
 unsafe impl Send for IAsyncAction {}
 unsafe impl Sync for IAsyncAction {}
+impl windows_core::RuntimeType for IAsyncAction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAsyncAction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,9 +172,6 @@ impl<TProgress: windows_core::RuntimeType + 'static> IAsyncActionWithProgress<TP
         unsafe { (windows_core::Interface::vtable(this).Close)(windows_core::Interface::as_raw(this)).ok() }
     }
 }
-impl<TProgress: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IAsyncActionWithProgress<TProgress> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{1f6db258-e803-48a1-9546-eb7353398884}").push_slice(b";").push_other(TProgress::SIGNATURE).push_slice(b")") };
-}
 impl<TProgress: windows_core::RuntimeType + 'static> IAsyncActionWithProgress<TProgress> {
     pub fn get(&self) -> windows_core::Result<()> {
         if self.Status()? == AsyncStatus::Started {
@@ -206,6 +203,9 @@ impl<TProgress: windows_core::RuntimeType + 'static> std::future::Future for IAs
 }
 unsafe impl<TProgress: windows_core::RuntimeType + 'static> Send for IAsyncActionWithProgress<TProgress> {}
 unsafe impl<TProgress: windows_core::RuntimeType + 'static> Sync for IAsyncActionWithProgress<TProgress> {}
+impl<TProgress: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IAsyncActionWithProgress<TProgress> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{1f6db258-e803-48a1-9546-eb7353398884}").push_slice(b";").push_other(TProgress::SIGNATURE).push_slice(b")") };
+}
 unsafe impl<TProgress: windows_core::RuntimeType + 'static> windows_core::Interface for IAsyncActionWithProgress<TProgress> {
     type Vtable = IAsyncActionWithProgress_Vtbl<TProgress>;
     const IID: windows_core::GUID = windows_core::GUID::from_signature(<Self as windows_core::RuntimeType>::SIGNATURE);
@@ -330,9 +330,6 @@ impl<TResult: windows_core::RuntimeType + 'static> IAsyncOperation<TResult> {
         unsafe { (windows_core::Interface::vtable(this).Close)(windows_core::Interface::as_raw(this)).ok() }
     }
 }
-impl<TResult: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IAsyncOperation<TResult> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{9fc2b0bb-e446-44e2-aa61-9cab8f636af2}").push_slice(b";").push_other(TResult::SIGNATURE).push_slice(b")") };
-}
 impl<TResult: windows_core::RuntimeType + 'static> IAsyncOperation<TResult> {
     pub fn get(&self) -> windows_core::Result<TResult> {
         if self.Status()? == AsyncStatus::Started {
@@ -364,6 +361,9 @@ impl<TResult: windows_core::RuntimeType + 'static> std::future::Future for IAsyn
 }
 unsafe impl<TResult: windows_core::RuntimeType + 'static> Send for IAsyncOperation<TResult> {}
 unsafe impl<TResult: windows_core::RuntimeType + 'static> Sync for IAsyncOperation<TResult> {}
+impl<TResult: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IAsyncOperation<TResult> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{9fc2b0bb-e446-44e2-aa61-9cab8f636af2}").push_slice(b";").push_other(TResult::SIGNATURE).push_slice(b")") };
+}
 unsafe impl<TResult: windows_core::RuntimeType + 'static> windows_core::Interface for IAsyncOperation<TResult> {
     type Vtable = IAsyncOperation_Vtbl<TResult>;
     const IID: windows_core::GUID = windows_core::GUID::from_signature(<Self as windows_core::RuntimeType>::SIGNATURE);
@@ -456,9 +456,6 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
         unsafe { (windows_core::Interface::vtable(this).Close)(windows_core::Interface::as_raw(this)).ok() }
     }
 }
-impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IAsyncOperationWithProgress<TResult, TProgress> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{b5d036d7-e297-498f-ba60-0289e76e23dd}").push_slice(b";").push_other(TResult::SIGNATURE).push_slice(b";").push_other(TProgress::SIGNATURE).push_slice(b")") };
-}
 impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> IAsyncOperationWithProgress<TResult, TProgress> {
     pub fn get(&self) -> windows_core::Result<TResult> {
         if self.Status()? == AsyncStatus::Started {
@@ -490,6 +487,9 @@ impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::Runt
 }
 unsafe impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> Send for IAsyncOperationWithProgress<TResult, TProgress> {}
 unsafe impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> Sync for IAsyncOperationWithProgress<TResult, TProgress> {}
+impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IAsyncOperationWithProgress<TResult, TProgress> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = { windows_core::imp::ConstBuffer::new().push_slice(b"pinterface(").push_slice(b"{b5d036d7-e297-498f-ba60-0289e76e23dd}").push_slice(b";").push_other(TResult::SIGNATURE).push_slice(b";").push_other(TProgress::SIGNATURE).push_slice(b")") };
+}
 unsafe impl<TResult: windows_core::RuntimeType + 'static, TProgress: windows_core::RuntimeType + 'static> windows_core::Interface for IAsyncOperationWithProgress<TResult, TProgress> {
     type Vtable = IAsyncOperationWithProgress_Vtbl<TResult, TProgress>;
     const IID: windows_core::GUID = windows_core::GUID::from_signature(<Self as windows_core::RuntimeType>::SIGNATURE);
@@ -526,12 +526,18 @@ pub struct IClosable_Vtbl {
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeferral, IDeferral_Vtbl, 0xd6269732_3b7f_46a7_b40b_4fdca2a2c693);
+impl windows_core::RuntimeType for IDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeferralFactory, IDeferralFactory_Vtbl, 0x65a1ecc5_3fb5_4832_8ca9_f061b281d13a);
+impl windows_core::RuntimeType for IDeferralFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeferralFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -557,6 +563,9 @@ pub struct IGetActivationFactory_Vtbl {
     pub GetActivationFactory: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidHelperStatics, IGuidHelperStatics_Vtbl, 0x59c7966b_ae52_5283_ad7f_a1b9e9678add);
+impl windows_core::RuntimeType for IGuidHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -589,6 +598,9 @@ pub struct IMemoryBuffer_Vtbl {
     pub CreateReference: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMemoryBufferFactory, IMemoryBufferFactory_Vtbl, 0xfbc4dd2b_245b_11e4_af98_689423260cf8);
+impl windows_core::RuntimeType for IMemoryBufferFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMemoryBufferFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -901,6 +913,9 @@ pub struct IPropertyValue_Vtbl {
     pub GetRectArray: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPropertyValueStatics, IPropertyValueStatics_Vtbl, 0x629bdbc8_d932_4ff4_96b9_8d96c5c1e858);
+impl windows_core::RuntimeType for IPropertyValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPropertyValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1466,6 +1481,9 @@ pub struct IStringable_Vtbl {
     pub ToString: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUriEscapeStatics, IUriEscapeStatics_Vtbl, 0xc1d432ba_c824_4452_a7fd_512bc3bbe9a1);
+impl windows_core::RuntimeType for IUriEscapeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriEscapeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1473,6 +1491,9 @@ pub struct IUriEscapeStatics_Vtbl {
     pub EscapeComponent: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUriRuntimeClass, IUriRuntimeClass_Vtbl, 0x9e365e57_48b2_4160_956f_c7385120bbfc);
+impl windows_core::RuntimeType for IUriRuntimeClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriRuntimeClass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1495,6 +1516,9 @@ pub struct IUriRuntimeClass_Vtbl {
     pub CombineUri: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUriRuntimeClassFactory, IUriRuntimeClassFactory_Vtbl, 0x44a9796f_723e_4fdf_a218_033e75b0c084);
+impl windows_core::RuntimeType for IUriRuntimeClassFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriRuntimeClassFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1502,6 +1526,9 @@ pub struct IUriRuntimeClassFactory_Vtbl {
     pub CreateWithRelativeUri: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUriRuntimeClassWithAbsoluteCanonicalUri, IUriRuntimeClassWithAbsoluteCanonicalUri_Vtbl, 0x758d9661_221c_480f_a339_50656673f46f);
+impl windows_core::RuntimeType for IUriRuntimeClassWithAbsoluteCanonicalUri {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriRuntimeClassWithAbsoluteCanonicalUri_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1536,12 +1563,18 @@ pub struct IWwwFormUrlDecoderEntry_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWwwFormUrlDecoderRuntimeClass, IWwwFormUrlDecoderRuntimeClass_Vtbl, 0xd45a0451_f225_4542_9296_0e1df5d254df);
+impl windows_core::RuntimeType for IWwwFormUrlDecoderRuntimeClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWwwFormUrlDecoderRuntimeClass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetFirstValueByName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWwwFormUrlDecoderRuntimeClassFactory, IWwwFormUrlDecoderRuntimeClassFactory_Vtbl, 0x5b8c6b3d_24ae_41b5_a1bf_f0c3d544845b);
+impl windows_core::RuntimeType for IWwwFormUrlDecoderRuntimeClassFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWwwFormUrlDecoderRuntimeClassFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1577,7 +1610,7 @@ impl Deferral {
     }
 }
 impl windows_core::RuntimeType for Deferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeferral>();
 }
 unsafe impl windows_core::Interface for Deferral {
     type Vtable = IDeferral_Vtbl;
@@ -1647,7 +1680,7 @@ impl MemoryBuffer {
     }
 }
 impl windows_core::RuntimeType for MemoryBuffer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMemoryBuffer>();
 }
 unsafe impl windows_core::Interface for MemoryBuffer {
     type Vtable = IMemoryBuffer_Vtbl;
@@ -2091,7 +2124,7 @@ impl Uri {
     }
 }
 impl windows_core::RuntimeType for Uri {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUriRuntimeClass>();
 }
 unsafe impl windows_core::Interface for Uri {
     type Vtable = IUriRuntimeClass_Vtbl;
@@ -2172,7 +2205,7 @@ impl WwwFormUrlDecoder {
     }
 }
 impl windows_core::RuntimeType for WwwFormUrlDecoder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWwwFormUrlDecoderRuntimeClass>();
 }
 unsafe impl windows_core::Interface for WwwFormUrlDecoder {
     type Vtable = IWwwFormUrlDecoderRuntimeClass_Vtbl;
@@ -2221,7 +2254,7 @@ impl WwwFormUrlDecoderEntry {
     }
 }
 impl windows_core::RuntimeType for WwwFormUrlDecoderEntry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWwwFormUrlDecoderEntry>();
 }
 unsafe impl windows_core::Interface for WwwFormUrlDecoderEntry {
     type Vtable = IWwwFormUrlDecoderEntry_Vtbl;

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
@@ -37,6 +37,9 @@ pub struct ICustomGameControllerFactory_Vtbl {
     pub OnGameControllerRemoved: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameControllerFactoryManagerStatics, IGameControllerFactoryManagerStatics_Vtbl, 0x36cb66e3_d0a1_4986_a24c_40b137deba9e);
+impl windows_core::RuntimeType for IGameControllerFactoryManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameControllerFactoryManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +48,9 @@ pub struct IGameControllerFactoryManagerStatics_Vtbl {
     pub RegisterCustomFactoryForXusbType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, XusbDeviceType, XusbDeviceSubtype) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameControllerFactoryManagerStatics2, IGameControllerFactoryManagerStatics2_Vtbl, 0xeace5644_19df_4115_b32a_2793e2aea3bb);
+impl windows_core::RuntimeType for IGameControllerFactoryManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameControllerFactoryManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -123,6 +129,9 @@ pub struct IGameControllerProvider_Vtbl {
     pub IsConnected: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGipFirmwareUpdateResult, IGipFirmwareUpdateResult_Vtbl, 0x6b794d32_8553_4292_8e03_e16651a2f8bc);
+impl windows_core::RuntimeType for IGipFirmwareUpdateResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGipFirmwareUpdateResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +170,9 @@ pub struct IGipGameControllerInputSink_Vtbl {
     pub OnMessageReceived: unsafe extern "system" fn(*mut core::ffi::c_void, u64, GipMessageClass, u8, u8, u32, *const u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGipGameControllerProvider, IGipGameControllerProvider_Vtbl, 0xdbcf1e19_1af5_45a8_bf02_a0ee50c823fc);
+impl windows_core::RuntimeType for IGipGameControllerProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGipGameControllerProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,6 +209,9 @@ pub struct IHidGameControllerInputSink_Vtbl {
     pub OnInputReportReceived: unsafe extern "system" fn(*mut core::ffi::c_void, u64, u8, u32, *const u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHidGameControllerProvider, IHidGameControllerProvider_Vtbl, 0x95ce3af4_abf0_4b68_a081_3b7de73ff0e7);
+impl windows_core::RuntimeType for IHidGameControllerProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHidGameControllerProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -232,6 +247,9 @@ pub struct IXusbGameControllerInputSink_Vtbl {
     pub OnInputReceived: unsafe extern "system" fn(*mut core::ffi::c_void, u64, u8, u32, *const u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXusbGameControllerProvider, IXusbGameControllerProvider_Vtbl, 0x6e2971eb_0efb_48b4_808b_837643b2f216);
+impl windows_core::RuntimeType for IXusbGameControllerProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXusbGameControllerProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -309,7 +327,7 @@ impl GipFirmwareUpdateResult {
     }
 }
 impl windows_core::RuntimeType for GipFirmwareUpdateResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGipFirmwareUpdateResult>();
 }
 unsafe impl windows_core::Interface for GipFirmwareUpdateResult {
     type Vtable = IGipFirmwareUpdateResult_Vtbl;
@@ -382,7 +400,7 @@ impl GipGameControllerProvider {
     }
 }
 impl windows_core::RuntimeType for GipGameControllerProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGipGameControllerProvider>();
 }
 unsafe impl windows_core::Interface for GipGameControllerProvider {
     type Vtable = IGipGameControllerProvider_Vtbl;
@@ -462,7 +480,7 @@ impl HidGameControllerProvider {
     }
 }
 impl windows_core::RuntimeType for HidGameControllerProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHidGameControllerProvider>();
 }
 unsafe impl windows_core::Interface for HidGameControllerProvider {
     type Vtable = IHidGameControllerProvider_Vtbl;
@@ -520,7 +538,7 @@ impl XusbGameControllerProvider {
     }
 }
 impl windows_core::RuntimeType for XusbGameControllerProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXusbGameControllerProvider>();
 }
 unsafe impl windows_core::Interface for XusbGameControllerProvider {
     type Vtable = IXusbGameControllerProvider_Vtbl;

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IConditionForceEffect, IConditionForceEffect_Vtbl, 0x32d1ea68_3695_4e69_85c0_cd1944189140);
+impl windows_core::RuntimeType for IConditionForceEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConditionForceEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,12 +12,18 @@ pub struct IConditionForceEffect_Vtbl {
     SetParameters: usize,
 }
 windows_core::imp::define_interface!(IConditionForceEffectFactory, IConditionForceEffectFactory_Vtbl, 0x91a99264_1810_4eb6_a773_bfd3b8cddbab);
+impl windows_core::RuntimeType for IConditionForceEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConditionForceEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, ConditionForceEffectKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConstantForceEffect, IConstantForceEffect_Vtbl, 0x9bfa0140_f3c7_415c_b068_0f068734bce0);
+impl windows_core::RuntimeType for IConstantForceEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConstantForceEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -70,6 +79,9 @@ pub struct IForceFeedbackEffect_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IForceFeedbackMotor, IForceFeedbackMotor_Vtbl, 0x8d3d417c_a5ea_4516_8026_2b00f74ef6e5);
+impl windows_core::RuntimeType for IForceFeedbackMotor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IForceFeedbackMotor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -88,6 +100,9 @@ pub struct IForceFeedbackMotor_Vtbl {
     pub TryUnloadEffectAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPeriodicForceEffect, IPeriodicForceEffect_Vtbl, 0x5c5138d7_fc75_4d52_9a0a_efe4cab5fe64);
+impl windows_core::RuntimeType for IPeriodicForceEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeriodicForceEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,12 +117,18 @@ pub struct IPeriodicForceEffect_Vtbl {
     SetParametersWithEnvelope: usize,
 }
 windows_core::imp::define_interface!(IPeriodicForceEffectFactory, IPeriodicForceEffectFactory_Vtbl, 0x6f62eb1a_9851_477b_b318_35ecaa15070f);
+impl windows_core::RuntimeType for IPeriodicForceEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeriodicForceEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, PeriodicForceEffectKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRampForceEffect, IRampForceEffect_Vtbl, 0xf1f81259_1ca6_4080_b56d_b43f3354d052);
+impl windows_core::RuntimeType for IRampForceEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRampForceEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -177,7 +198,7 @@ impl ConditionForceEffect {
     }
 }
 impl windows_core::RuntimeType for ConditionForceEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IForceFeedbackEffect>();
 }
 unsafe impl windows_core::Interface for ConditionForceEffect {
     type Vtable = IForceFeedbackEffect_Vtbl;
@@ -239,7 +260,7 @@ impl ConstantForceEffect {
     }
 }
 impl windows_core::RuntimeType for ConstantForceEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IForceFeedbackEffect>();
 }
 unsafe impl windows_core::Interface for ConstantForceEffect {
     type Vtable = IForceFeedbackEffect_Vtbl;
@@ -342,7 +363,7 @@ impl ForceFeedbackMotor {
     }
 }
 impl windows_core::RuntimeType for ForceFeedbackMotor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IForceFeedbackMotor>();
 }
 unsafe impl windows_core::Interface for ForceFeedbackMotor {
     type Vtable = IForceFeedbackMotor_Vtbl;
@@ -415,7 +436,7 @@ impl PeriodicForceEffect {
     }
 }
 impl windows_core::RuntimeType for PeriodicForceEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IForceFeedbackEffect>();
 }
 unsafe impl windows_core::Interface for PeriodicForceEffect {
     type Vtable = IForceFeedbackEffect_Vtbl;
@@ -477,7 +498,7 @@ impl RampForceEffect {
     }
 }
 impl windows_core::RuntimeType for RampForceEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IForceFeedbackEffect>();
 }
 unsafe impl windows_core::Interface for RampForceEffect {
     type Vtable = IForceFeedbackEffect_Vtbl;

--- a/crates/libs/windows/src/Windows/Gaming/Input/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Preview/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGameControllerProviderInfoStatics, IGameControllerProviderInfoStatics_Vtbl, 0x0be1e6c5_d9bd_44ee_8362_488b2e464bfb);
+impl windows_core::RuntimeType for IGameControllerProviderInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameControllerProviderInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
@@ -5,6 +5,9 @@ pub mod ForceFeedback;
 #[cfg(feature = "Gaming_Input_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(IArcadeStick, IArcadeStick_Vtbl, 0xb14a539d_befb_4c81_8051_15ecf3b13036);
+impl windows_core::RuntimeType for IArcadeStick {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IArcadeStick_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct IArcadeStick_Vtbl {
     pub GetCurrentReading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ArcadeStickReading) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IArcadeStickStatics, IArcadeStickStatics_Vtbl, 0x5c37b8c8_37b1_4ad8_9458_200f1a30018e);
+impl windows_core::RuntimeType for IArcadeStickStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IArcadeStickStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,12 +31,18 @@ pub struct IArcadeStickStatics_Vtbl {
     ArcadeSticks: usize,
 }
 windows_core::imp::define_interface!(IArcadeStickStatics2, IArcadeStickStatics2_Vtbl, 0x52b5d744_bb86_445a_b59c_596f0e2a49df);
+impl windows_core::RuntimeType for IArcadeStickStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IArcadeStickStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromGameController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFlightStick, IFlightStick_Vtbl, 0xb4a2c01c_b83b_4459_a1a9_97b03c33da7c);
+impl windows_core::RuntimeType for IFlightStick {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFlightStick_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +51,9 @@ pub struct IFlightStick_Vtbl {
     pub GetCurrentReading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut FlightStickReading) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFlightStickStatics, IFlightStickStatics_Vtbl, 0x5514924a_fecc_435e_83dc_5cec8a18a520);
+impl windows_core::RuntimeType for IFlightStickStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFlightStickStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -167,6 +182,9 @@ pub struct IGameControllerBatteryInfo_Vtbl {
     TryGetBatteryReport: usize,
 }
 windows_core::imp::define_interface!(IGamepad, IGamepad_Vtbl, 0xbc7bb43c_0a69_3903_9e9d_a50f86a45de5);
+impl windows_core::RuntimeType for IGamepad {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGamepad_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,12 +193,18 @@ pub struct IGamepad_Vtbl {
     pub GetCurrentReading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GamepadReading) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGamepad2, IGamepad2_Vtbl, 0x3c1689bd_5915_4245_b0c0_c89fae0308ff);
+impl windows_core::RuntimeType for IGamepad2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGamepad2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetButtonLabel: unsafe extern "system" fn(*mut core::ffi::c_void, GamepadButtons, *mut GameControllerButtonLabel) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGamepadStatics, IGamepadStatics_Vtbl, 0x8bbce529_d49c_39e9_9560_e47dde96b7c8);
+impl windows_core::RuntimeType for IGamepadStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGamepadStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -194,12 +218,18 @@ pub struct IGamepadStatics_Vtbl {
     Gamepads: usize,
 }
 windows_core::imp::define_interface!(IGamepadStatics2, IGamepadStatics2_Vtbl, 0x42676dc5_0856_47c4_9213_b395504c3a3c);
+impl windows_core::RuntimeType for IGamepadStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGamepadStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromGameController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHeadset, IHeadset_Vtbl, 0x3fd156ef_6925_3fa8_9181_029c5223ae3b);
+impl windows_core::RuntimeType for IHeadset {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHeadset_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,6 +237,9 @@ pub struct IHeadset_Vtbl {
     pub RenderDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRacingWheel, IRacingWheel_Vtbl, 0xf546656f_e106_4c82_a90f_554012904b85);
+impl windows_core::RuntimeType for IRacingWheel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRacingWheel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -223,6 +256,9 @@ pub struct IRacingWheel_Vtbl {
     pub GetCurrentReading: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RacingWheelReading) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRacingWheelStatics, IRacingWheelStatics_Vtbl, 0x3ac12cd5_581b_4936_9f94_69f1e6514c7d);
+impl windows_core::RuntimeType for IRacingWheelStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRacingWheelStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -236,12 +272,18 @@ pub struct IRacingWheelStatics_Vtbl {
     RacingWheels: usize,
 }
 windows_core::imp::define_interface!(IRacingWheelStatics2, IRacingWheelStatics2_Vtbl, 0xe666bcaa_edfd_4323_a9f6_3c384048d1ed);
+impl windows_core::RuntimeType for IRacingWheelStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRacingWheelStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromGameController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRawGameController, IRawGameController_Vtbl, 0x7cad6d91_a7e1_4f71_9a78_33e9c5dfea62);
+impl windows_core::RuntimeType for IRawGameController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRawGameController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -259,6 +301,9 @@ pub struct IRawGameController_Vtbl {
     pub GetSwitchKind: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut GameControllerSwitchKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRawGameController2, IRawGameController2_Vtbl, 0x43c0c035_bb73_4756_a787_3ed6bea617bd);
+impl windows_core::RuntimeType for IRawGameController2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRawGameController2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -270,6 +315,9 @@ pub struct IRawGameController2_Vtbl {
     pub DisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRawGameControllerStatics, IRawGameControllerStatics_Vtbl, 0xeb8d0792_e95a_4b19_afc7_0a59f8bf759e);
+impl windows_core::RuntimeType for IRawGameControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRawGameControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -284,6 +332,9 @@ pub struct IRawGameControllerStatics_Vtbl {
     pub FromGameController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUINavigationController, IUINavigationController_Vtbl, 0xe5aeefdd_f50e_4a55_8cdc_d33229548175);
+impl windows_core::RuntimeType for IUINavigationController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUINavigationController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -292,6 +343,9 @@ pub struct IUINavigationController_Vtbl {
     pub GetRequiredButtonLabel: unsafe extern "system" fn(*mut core::ffi::c_void, RequiredUINavigationButtons, *mut GameControllerButtonLabel) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUINavigationControllerStatics, IUINavigationControllerStatics_Vtbl, 0x2f14930a_f6f8_4a48_8d89_94786cca0c2e);
+impl windows_core::RuntimeType for IUINavigationControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUINavigationControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -305,6 +359,9 @@ pub struct IUINavigationControllerStatics_Vtbl {
     UINavigationControllers: usize,
 }
 windows_core::imp::define_interface!(IUINavigationControllerStatics2, IUINavigationControllerStatics2_Vtbl, 0xe0cb28e3_b20b_4b0b_9ed4_f3d53cec0de4);
+impl windows_core::RuntimeType for IUINavigationControllerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUINavigationControllerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -455,7 +512,7 @@ impl ArcadeStick {
     }
 }
 impl windows_core::RuntimeType for ArcadeStick {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IArcadeStick>();
 }
 unsafe impl windows_core::Interface for ArcadeStick {
     type Vtable = IArcadeStick_Vtbl;
@@ -613,7 +670,7 @@ impl FlightStick {
     }
 }
 impl windows_core::RuntimeType for FlightStick {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFlightStick>();
 }
 unsafe impl windows_core::Interface for FlightStick {
     type Vtable = IFlightStick_Vtbl;
@@ -780,7 +837,7 @@ impl Gamepad {
     }
 }
 impl windows_core::RuntimeType for Gamepad {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGamepad>();
 }
 unsafe impl windows_core::Interface for Gamepad {
     type Vtable = IGamepad_Vtbl;
@@ -821,7 +878,7 @@ impl Headset {
     }
 }
 impl windows_core::RuntimeType for Headset {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHeadset>();
 }
 unsafe impl windows_core::Interface for Headset {
     type Vtable = IHeadset_Vtbl;
@@ -1020,7 +1077,7 @@ impl RacingWheel {
     }
 }
 impl windows_core::RuntimeType for RacingWheel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRacingWheel>();
 }
 unsafe impl windows_core::Interface for RacingWheel {
     type Vtable = IRacingWheel_Vtbl;
@@ -1243,7 +1300,7 @@ impl RawGameController {
     }
 }
 impl windows_core::RuntimeType for RawGameController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRawGameController>();
 }
 unsafe impl windows_core::Interface for RawGameController {
     type Vtable = IRawGameController_Vtbl;
@@ -1406,7 +1463,7 @@ impl UINavigationController {
     }
 }
 impl windows_core::RuntimeType for UINavigationController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUINavigationController>();
 }
 unsafe impl windows_core::Interface for UINavigationController {
     type Vtable = IUINavigationController_Vtbl;

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
@@ -58,6 +58,9 @@ pub struct IGameListEntry_Vtbl {
     pub SetCategoryAsync: unsafe extern "system" fn(*mut core::ffi::c_void, GameListCategory, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameListEntry2, IGameListEntry2_Vtbl, 0xd84a8f8b_8749_4a25_90d3_f6c5a427886d);
+impl windows_core::RuntimeType for IGameListEntry2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameListEntry2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +83,9 @@ pub struct IGameListEntry2_Vtbl {
     pub GameModeConfiguration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameListStatics, IGameListStatics_Vtbl, 0x2ddd0f6f_9c66_4b05_945c_d6ed78491b8c);
+impl windows_core::RuntimeType for IGameListStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameListStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +105,9 @@ pub struct IGameListStatics_Vtbl {
     pub RemoveGameUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameListStatics2, IGameListStatics2_Vtbl, 0x395f2098_ea1a_45aa_9268_a83905686f27);
+impl windows_core::RuntimeType for IGameListStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameListStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,6 +118,9 @@ pub struct IGameListStatics2_Vtbl {
     UnmergeEntryAsync: usize,
 }
 windows_core::imp::define_interface!(IGameModeConfiguration, IGameModeConfiguration_Vtbl, 0x78e591af_b142_4ef0_8830_55bc2be4f5ea);
+impl windows_core::RuntimeType for IGameModeConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameModeConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,6 +147,9 @@ pub struct IGameModeConfiguration_Vtbl {
     pub SaveAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameModeUserConfiguration, IGameModeUserConfiguration_Vtbl, 0x72d34af4_756b_470f_a0c2_ba62a90795db);
+impl windows_core::RuntimeType for IGameModeUserConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameModeUserConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +160,9 @@ pub struct IGameModeUserConfiguration_Vtbl {
     pub SaveAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameModeUserConfigurationStatics, IGameModeUserConfigurationStatics_Vtbl, 0x6e50d97c_66ea_478e_a4a1_f57c0e8d00e7);
+impl windows_core::RuntimeType for IGameModeUserConfigurationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameModeUserConfigurationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -346,7 +364,7 @@ impl GameListEntry {
     }
 }
 impl windows_core::RuntimeType for GameListEntry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameListEntry>();
 }
 unsafe impl windows_core::Interface for GameListEntry {
     type Vtable = IGameListEntry_Vtbl;
@@ -485,7 +503,7 @@ impl GameModeConfiguration {
     }
 }
 impl windows_core::RuntimeType for GameModeConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameModeConfiguration>();
 }
 unsafe impl windows_core::Interface for GameModeConfiguration {
     type Vtable = IGameModeConfiguration_Vtbl;
@@ -529,7 +547,7 @@ impl GameModeUserConfiguration {
     }
 }
 impl windows_core::RuntimeType for GameModeUserConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameModeUserConfiguration>();
 }
 unsafe impl windows_core::Interface for GameModeUserConfiguration {
     type Vtable = IGameModeUserConfiguration_Vtbl;

--- a/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGameBarStatics, IGameBarStatics_Vtbl, 0x1db9a292_cc78_4173_be45_b61e67283ea7);
+impl windows_core::RuntimeType for IGameBarStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameBarStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IGameBarStatics_Vtbl {
     pub IsInputRedirected: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameChatMessageReceivedEventArgs, IGameChatMessageReceivedEventArgs_Vtbl, 0xa28201f1_3fb9_4e42_a403_7afce2023b1e);
+impl windows_core::RuntimeType for IGameChatMessageReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameChatMessageReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct IGameChatMessageReceivedEventArgs_Vtbl {
     pub Origin: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GameChatMessageOrigin) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameChatOverlay, IGameChatOverlay_Vtbl, 0xfbc64865_f6fc_4a48_ae07_03ac6ed43704);
+impl windows_core::RuntimeType for IGameChatOverlay {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameChatOverlay_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +37,9 @@ pub struct IGameChatOverlay_Vtbl {
     pub AddMessage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, GameChatMessageOrigin) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameChatOverlayMessageSource, IGameChatOverlayMessageSource_Vtbl, 0x1e177397_59fb_4f4f_8e9a_80acf817743c);
+impl windows_core::RuntimeType for IGameChatOverlayMessageSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameChatOverlayMessageSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,12 +48,18 @@ pub struct IGameChatOverlayMessageSource_Vtbl {
     pub SetDelayBeforeClosingAfterMessageReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameChatOverlayStatics, IGameChatOverlayStatics_Vtbl, 0x89acf614_7867_49f7_9687_25d9dbf444d1);
+impl windows_core::RuntimeType for IGameChatOverlayStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameChatOverlayStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameUIProviderActivatedEventArgs, IGameUIProviderActivatedEventArgs_Vtbl, 0xa7b3203e_caf7_4ded_bbd2_47de43bb6dd5);
+impl windows_core::RuntimeType for IGameUIProviderActivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameUIProviderActivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -143,7 +161,7 @@ impl GameChatMessageReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GameChatMessageReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameChatMessageReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for GameChatMessageReceivedEventArgs {
     type Vtable = IGameChatMessageReceivedEventArgs_Vtbl;
@@ -187,7 +205,7 @@ impl GameChatOverlay {
     }
 }
 impl windows_core::RuntimeType for GameChatOverlay {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameChatOverlay>();
 }
 unsafe impl windows_core::Interface for GameChatOverlay {
     type Vtable = IGameChatOverlay_Vtbl;
@@ -230,7 +248,7 @@ impl GameChatOverlayMessageSource {
     }
 }
 impl windows_core::RuntimeType for GameChatOverlayMessageSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameChatOverlayMessageSource>();
 }
 unsafe impl windows_core::Interface for GameChatOverlayMessageSource {
     type Vtable = IGameChatOverlayMessageSource_Vtbl;
@@ -290,7 +308,7 @@ impl GameUIProviderActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GameUIProviderActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameUIProviderActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for GameUIProviderActivatedEventArgs {
     type Vtable = IGameUIProviderActivatedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGameSaveBlobGetResult, IGameSaveBlobGetResult_Vtbl, 0x917281e0_7201_4953_aa2c_4008f03aef45);
+impl windows_core::RuntimeType for IGameSaveBlobGetResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveBlobGetResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IGameSaveBlobGetResult_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(IGameSaveBlobInfo, IGameSaveBlobInfo_Vtbl, 0xadd38034_baf0_4645_b6d0_46edaffb3c2b);
+impl windows_core::RuntimeType for IGameSaveBlobInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveBlobInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +22,9 @@ pub struct IGameSaveBlobInfo_Vtbl {
     pub Size: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameSaveBlobInfoGetResult, IGameSaveBlobInfoGetResult_Vtbl, 0xc7578582_3697_42bf_989c_665d923b5231);
+impl windows_core::RuntimeType for IGameSaveBlobInfoGetResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveBlobInfoGetResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +35,9 @@ pub struct IGameSaveBlobInfoGetResult_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(IGameSaveBlobInfoQuery, IGameSaveBlobInfoQuery_Vtbl, 0x9fdd74b2_eeee_447b_a9d2_7f96c0f83208);
+impl windows_core::RuntimeType for IGameSaveBlobInfoQuery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveBlobInfoQuery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +46,9 @@ pub struct IGameSaveBlobInfoQuery_Vtbl {
     pub GetItemCountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameSaveContainer, IGameSaveContainer_Vtbl, 0xc3c08f89_563f_4ecd_9c6f_33fd0e323d10);
+impl windows_core::RuntimeType for IGameSaveContainer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveContainer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +73,9 @@ pub struct IGameSaveContainer_Vtbl {
     pub CreateBlobInfoQuery: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameSaveContainerInfo, IGameSaveContainerInfo_Vtbl, 0xb7e27300_155d_4bb4_b2ba_930306f391b5);
+impl windows_core::RuntimeType for IGameSaveContainerInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveContainerInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,6 +86,9 @@ pub struct IGameSaveContainerInfo_Vtbl {
     pub NeedsSync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameSaveContainerInfoGetResult, IGameSaveContainerInfoGetResult_Vtbl, 0xffc50d74_c581_4f9d_9e39_30a10c1e4c50);
+impl windows_core::RuntimeType for IGameSaveContainerInfoGetResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveContainerInfoGetResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +99,9 @@ pub struct IGameSaveContainerInfoGetResult_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(IGameSaveContainerInfoQuery, IGameSaveContainerInfoQuery_Vtbl, 0x3c94e863_6f80_4327_9327_ffc11afd42b3);
+impl windows_core::RuntimeType for IGameSaveContainerInfoQuery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveContainerInfoQuery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,12 +110,18 @@ pub struct IGameSaveContainerInfoQuery_Vtbl {
     pub GetItemCountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameSaveOperationResult, IGameSaveOperationResult_Vtbl, 0xcf0f1a05_24a0_4582_9a55_b1bbbb9388d8);
+impl windows_core::RuntimeType for IGameSaveOperationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveOperationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GameSaveErrorStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameSaveProvider, IGameSaveProvider_Vtbl, 0x90a60394_80fe_4211_97f8_a5de14dd95d2);
+impl windows_core::RuntimeType for IGameSaveProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -110,6 +140,9 @@ pub struct IGameSaveProvider_Vtbl {
     ContainersChangedSinceLastSync: usize,
 }
 windows_core::imp::define_interface!(IGameSaveProviderGetResult, IGameSaveProviderGetResult_Vtbl, 0x3ab90816_d393_4d65_ac16_41c3e67ab945);
+impl windows_core::RuntimeType for IGameSaveProviderGetResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveProviderGetResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +150,9 @@ pub struct IGameSaveProviderGetResult_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameSaveProviderStatics, IGameSaveProviderStatics_Vtbl, 0xd01d3ed0_7b03_449d_8cbd_3402842a1048);
+impl windows_core::RuntimeType for IGameSaveProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameSaveProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,7 +187,7 @@ impl GameSaveBlobGetResult {
     }
 }
 impl windows_core::RuntimeType for GameSaveBlobGetResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveBlobGetResult>();
 }
 unsafe impl windows_core::Interface for GameSaveBlobGetResult {
     type Vtable = IGameSaveBlobGetResult_Vtbl;
@@ -183,7 +219,7 @@ impl GameSaveBlobInfo {
     }
 }
 impl windows_core::RuntimeType for GameSaveBlobInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveBlobInfo>();
 }
 unsafe impl windows_core::Interface for GameSaveBlobInfo {
     type Vtable = IGameSaveBlobInfo_Vtbl;
@@ -216,7 +252,7 @@ impl GameSaveBlobInfoGetResult {
     }
 }
 impl windows_core::RuntimeType for GameSaveBlobInfoGetResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveBlobInfoGetResult>();
 }
 unsafe impl windows_core::Interface for GameSaveBlobInfoGetResult {
     type Vtable = IGameSaveBlobInfoGetResult_Vtbl;
@@ -255,7 +291,7 @@ impl GameSaveBlobInfoQuery {
     }
 }
 impl windows_core::RuntimeType for GameSaveBlobInfoQuery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveBlobInfoQuery>();
 }
 unsafe impl windows_core::Interface for GameSaveBlobInfoQuery {
     type Vtable = IGameSaveBlobInfoQuery_Vtbl;
@@ -340,7 +376,7 @@ impl GameSaveContainer {
     }
 }
 impl windows_core::RuntimeType for GameSaveContainer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveContainer>();
 }
 unsafe impl windows_core::Interface for GameSaveContainer {
     type Vtable = IGameSaveContainer_Vtbl;
@@ -393,7 +429,7 @@ impl GameSaveContainerInfo {
     }
 }
 impl windows_core::RuntimeType for GameSaveContainerInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveContainerInfo>();
 }
 unsafe impl windows_core::Interface for GameSaveContainerInfo {
     type Vtable = IGameSaveContainerInfo_Vtbl;
@@ -426,7 +462,7 @@ impl GameSaveContainerInfoGetResult {
     }
 }
 impl windows_core::RuntimeType for GameSaveContainerInfoGetResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveContainerInfoGetResult>();
 }
 unsafe impl windows_core::Interface for GameSaveContainerInfoGetResult {
     type Vtable = IGameSaveContainerInfoGetResult_Vtbl;
@@ -465,7 +501,7 @@ impl GameSaveContainerInfoQuery {
     }
 }
 impl windows_core::RuntimeType for GameSaveContainerInfoQuery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveContainerInfoQuery>();
 }
 unsafe impl windows_core::Interface for GameSaveContainerInfoQuery {
     type Vtable = IGameSaveContainerInfoQuery_Vtbl;
@@ -490,7 +526,7 @@ impl GameSaveOperationResult {
     }
 }
 impl windows_core::RuntimeType for GameSaveOperationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveOperationResult>();
 }
 unsafe impl windows_core::Interface for GameSaveOperationResult {
     type Vtable = IGameSaveOperationResult_Vtbl;
@@ -584,7 +620,7 @@ impl GameSaveProvider {
     }
 }
 impl windows_core::RuntimeType for GameSaveProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveProvider>();
 }
 unsafe impl windows_core::Interface for GameSaveProvider {
     type Vtable = IGameSaveProvider_Vtbl;
@@ -616,7 +652,7 @@ impl GameSaveProviderGetResult {
     }
 }
 impl windows_core::RuntimeType for GameSaveProviderGetResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameSaveProviderGetResult>();
 }
 unsafe impl windows_core::Interface for GameSaveProviderGetResult {
     type Vtable = IGameSaveProviderGetResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Globalization/Collation/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/Collation/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICharacterGrouping, ICharacterGrouping_Vtbl, 0xfae761bb_805d_4bb0_95bb_c1f7c3e8eb8e);
+impl windows_core::RuntimeType for ICharacterGrouping {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICharacterGrouping_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,12 +9,18 @@ pub struct ICharacterGrouping_Vtbl {
     pub Label: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICharacterGroupings, ICharacterGroupings_Vtbl, 0xb8d20a75_d4cf_4055_80e5_ce169c226496);
+impl windows_core::RuntimeType for ICharacterGroupings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICharacterGroupings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Lookup: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICharacterGroupingsFactory, ICharacterGroupingsFactory_Vtbl, 0x99ea9fd9_886d_4401_9f98_69c82d4c2f78);
+impl windows_core::RuntimeType for ICharacterGroupingsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICharacterGroupingsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,7 +47,7 @@ impl CharacterGrouping {
     }
 }
 impl windows_core::RuntimeType for CharacterGrouping {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICharacterGrouping>();
 }
 unsafe impl windows_core::Interface for CharacterGrouping {
     type Vtable = ICharacterGrouping_Vtbl;
@@ -126,7 +135,7 @@ impl CharacterGroupings {
     }
 }
 impl windows_core::RuntimeType for CharacterGroupings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICharacterGroupings>();
 }
 unsafe impl windows_core::Interface for CharacterGroupings {
     type Vtable = ICharacterGroupings_Vtbl;

--- a/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDateTimeFormatter, IDateTimeFormatter_Vtbl, 0x95eeca10_73e0_4e4b_a183_3d6ad0ba35ec);
+impl windows_core::RuntimeType for IDateTimeFormatter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDateTimeFormatter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,12 +31,18 @@ pub struct IDateTimeFormatter_Vtbl {
     pub ResolvedGeographicRegion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDateTimeFormatter2, IDateTimeFormatter2_Vtbl, 0x27c91a86_bdaa_4fd0_9e36_671d5aa5ee03);
+impl windows_core::RuntimeType for IDateTimeFormatter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDateTimeFormatter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FormatUsingTimeZone: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDateTimeFormatterFactory, IDateTimeFormatterFactory_Vtbl, 0xec8d8a53_1a2e_412d_8815_3b745fb1a2a0);
+impl windows_core::RuntimeType for IDateTimeFormatterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDateTimeFormatterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +67,9 @@ pub struct IDateTimeFormatterFactory_Vtbl {
     CreateDateTimeFormatterDateTimeContext: usize,
 }
 windows_core::imp::define_interface!(IDateTimeFormatterStatics, IDateTimeFormatterStatics_Vtbl, 0xbfcde7c0_df4c_4a2e_9012_f47daf3f1212);
+impl windows_core::RuntimeType for IDateTimeFormatterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDateTimeFormatterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -297,7 +309,7 @@ impl DateTimeFormatter {
     }
 }
 impl windows_core::RuntimeType for DateTimeFormatter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDateTimeFormatter>();
 }
 unsafe impl windows_core::Interface for DateTimeFormatter {
     type Vtable = IDateTimeFormatter_Vtbl;

--- a/crates/libs/windows/src/Windows/Globalization/Fonts/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/Fonts/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ILanguageFont, ILanguageFont_Vtbl, 0xb12e5c3a_b76d_459b_beeb_901151cd77d1);
+impl windows_core::RuntimeType for ILanguageFont {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageFont_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +21,9 @@ pub struct ILanguageFont_Vtbl {
     pub ScaleFactor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguageFontGroup, ILanguageFontGroup_Vtbl, 0xf33a7fc3_3a5c_4aea_b9ff_b39fb242f7f6);
+impl windows_core::RuntimeType for ILanguageFontGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageFontGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +40,9 @@ pub struct ILanguageFontGroup_Vtbl {
     pub DocumentAlternate2Font: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguageFontGroupFactory, ILanguageFontGroupFactory_Vtbl, 0xfcaeac67_4e77_49c7_b856_dde934fc735b);
+impl windows_core::RuntimeType for ILanguageFontGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageFontGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,7 +93,7 @@ impl LanguageFont {
     }
 }
 impl windows_core::RuntimeType for LanguageFont {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILanguageFont>();
 }
 unsafe impl windows_core::Interface for LanguageFont {
     type Vtable = ILanguageFont_Vtbl;
@@ -190,7 +199,7 @@ impl LanguageFontGroup {
     }
 }
 impl windows_core::RuntimeType for LanguageFontGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILanguageFontGroup>();
 }
 unsafe impl windows_core::Interface for LanguageFontGroup {
     type Vtable = ILanguageFontGroup_Vtbl;

--- a/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICurrencyFormatter, ICurrencyFormatter_Vtbl, 0x11730ca5_4b00_41b2_b332_73b12a497d54);
+impl windows_core::RuntimeType for ICurrencyFormatter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyFormatter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct ICurrencyFormatter_Vtbl {
     SetCurrency: usize,
 }
 windows_core::imp::define_interface!(ICurrencyFormatter2, ICurrencyFormatter2_Vtbl, 0x072c2f1d_e7ba_4197_920e_247c92f7dea6);
+impl windows_core::RuntimeType for ICurrencyFormatter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyFormatter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct ICurrencyFormatter2_Vtbl {
     pub ApplyRoundingForCurrency: unsafe extern "system" fn(*mut core::ffi::c_void, RoundingAlgorithm) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrencyFormatterFactory, ICurrencyFormatterFactory_Vtbl, 0x86c7537e_b938_4aa2_84b0_2c33dc5b1450);
+impl windows_core::RuntimeType for ICurrencyFormatterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyFormatterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +36,9 @@ pub struct ICurrencyFormatterFactory_Vtbl {
     CreateCurrencyFormatterCodeContext: usize,
 }
 windows_core::imp::define_interface!(IDecimalFormatterFactory, IDecimalFormatterFactory_Vtbl, 0x0d018c9a_e393_46b8_b830_7a69c8f89fbb);
+impl windows_core::RuntimeType for IDecimalFormatterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDecimalFormatterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +48,9 @@ pub struct IDecimalFormatterFactory_Vtbl {
     CreateDecimalFormatter: usize,
 }
 windows_core::imp::define_interface!(IIncrementNumberRounder, IIncrementNumberRounder_Vtbl, 0x70a64ff8_66ab_4155_9da1_739e46764543);
+impl windows_core::RuntimeType for IIncrementNumberRounder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIncrementNumberRounder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -348,6 +363,9 @@ pub struct INumberRounderOption_Vtbl {
     pub SetNumberRounder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INumeralSystemTranslator, INumeralSystemTranslator_Vtbl, 0x28f5bc2c_8c23_4234_ad2e_fa5a3a426e9b);
+impl windows_core::RuntimeType for INumeralSystemTranslator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INumeralSystemTranslator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -361,6 +379,9 @@ pub struct INumeralSystemTranslator_Vtbl {
     pub TranslateNumerals: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INumeralSystemTranslatorFactory, INumeralSystemTranslatorFactory_Vtbl, 0x9630c8da_36ef_4d88_a85c_6f0d98d620a6);
+impl windows_core::RuntimeType for INumeralSystemTranslatorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INumeralSystemTranslatorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -370,6 +391,9 @@ pub struct INumeralSystemTranslatorFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IPercentFormatterFactory, IPercentFormatterFactory_Vtbl, 0xb7828aef_fed4_4018_a6e2_e09961e03765);
+impl windows_core::RuntimeType for IPercentFormatterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPercentFormatterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -379,6 +403,9 @@ pub struct IPercentFormatterFactory_Vtbl {
     CreatePercentFormatter: usize,
 }
 windows_core::imp::define_interface!(IPermilleFormatterFactory, IPermilleFormatterFactory_Vtbl, 0x2b37b4ac_e638_4ed5_a998_62f6b06a49ae);
+impl windows_core::RuntimeType for IPermilleFormatterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPermilleFormatterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -412,6 +439,9 @@ pub struct ISignedZeroOption_Vtbl {
     pub SetIsZeroSigned: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISignificantDigitsNumberRounder, ISignificantDigitsNumberRounder_Vtbl, 0xf5941bca_6646_4913_8c76_1b191ff94dfd);
+impl windows_core::RuntimeType for ISignificantDigitsNumberRounder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISignificantDigitsNumberRounder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -683,7 +713,7 @@ impl CurrencyFormatter {
     }
 }
 impl windows_core::RuntimeType for CurrencyFormatter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICurrencyFormatter>();
 }
 unsafe impl windows_core::Interface for CurrencyFormatter {
     type Vtable = ICurrencyFormatter_Vtbl;
@@ -907,7 +937,7 @@ impl DecimalFormatter {
     }
 }
 impl windows_core::RuntimeType for DecimalFormatter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INumberFormatter>();
 }
 unsafe impl windows_core::Interface for DecimalFormatter {
     type Vtable = INumberFormatter_Vtbl;
@@ -997,7 +1027,7 @@ impl IncrementNumberRounder {
     }
 }
 impl windows_core::RuntimeType for IncrementNumberRounder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INumberRounder>();
 }
 unsafe impl windows_core::Interface for IncrementNumberRounder {
     type Vtable = INumberRounder_Vtbl;
@@ -1070,7 +1100,7 @@ impl NumeralSystemTranslator {
     }
 }
 impl windows_core::RuntimeType for NumeralSystemTranslator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INumeralSystemTranslator>();
 }
 unsafe impl windows_core::Interface for NumeralSystemTranslator {
     type Vtable = INumeralSystemTranslator_Vtbl;
@@ -1294,7 +1324,7 @@ impl PercentFormatter {
     }
 }
 impl windows_core::RuntimeType for PercentFormatter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INumberFormatter>();
 }
 unsafe impl windows_core::Interface for PercentFormatter {
     type Vtable = INumberFormatter_Vtbl;
@@ -1518,7 +1548,7 @@ impl PermilleFormatter {
     }
 }
 impl windows_core::RuntimeType for PermilleFormatter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INumberFormatter>();
 }
 unsafe impl windows_core::Interface for PermilleFormatter {
     type Vtable = INumberFormatter_Vtbl;
@@ -1608,7 +1638,7 @@ impl SignificantDigitsNumberRounder {
     }
 }
 impl windows_core::RuntimeType for SignificantDigitsNumberRounder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INumberRounder>();
 }
 unsafe impl windows_core::Interface for SignificantDigitsNumberRounder {
     type Vtable = INumberRounder_Vtbl;

--- a/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPhoneNumberFormatter, IPhoneNumberFormatter_Vtbl, 0x1556b49e_bad4_4b4a_900d_4407adb7c981);
+impl windows_core::RuntimeType for IPhoneNumberFormatter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneNumberFormatter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IPhoneNumberFormatter_Vtbl {
     pub FormatStringWithLeftToRightMarkers: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneNumberFormatterStatics, IPhoneNumberFormatterStatics_Vtbl, 0x5ca6f931_84d9_414b_ab4e_a0552c878602);
+impl windows_core::RuntimeType for IPhoneNumberFormatterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneNumberFormatterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +24,9 @@ pub struct IPhoneNumberFormatterStatics_Vtbl {
     pub WrapWithLeftToRightMarkers: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneNumberInfo, IPhoneNumberInfo_Vtbl, 0x1c7ce4dd_c8b4_4ea3_9aef_b342e2c5b417);
+impl windows_core::RuntimeType for IPhoneNumberInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneNumberInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,12 +40,18 @@ pub struct IPhoneNumberInfo_Vtbl {
     pub CheckNumberMatch: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut PhoneNumberMatchResult) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneNumberInfoFactory, IPhoneNumberInfoFactory_Vtbl, 0x8202b964_adaa_4cff_8fcf_17e7516a28ff);
+impl windows_core::RuntimeType for IPhoneNumberInfoFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneNumberInfoFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneNumberInfoStatics, IPhoneNumberInfoStatics_Vtbl, 0x5b3f4f6a_86a9_40e9_8649_6d61161928d4);
+impl windows_core::RuntimeType for IPhoneNumberInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneNumberInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,7 +139,7 @@ impl PhoneNumberFormatter {
     }
 }
 impl windows_core::RuntimeType for PhoneNumberFormatter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneNumberFormatter>();
 }
 unsafe impl windows_core::Interface for PhoneNumberFormatter {
     type Vtable = IPhoneNumberFormatter_Vtbl;
@@ -237,7 +252,7 @@ impl PhoneNumberInfo {
     }
 }
 impl windows_core::RuntimeType for PhoneNumberInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneNumberInfo>();
 }
 unsafe impl windows_core::Interface for PhoneNumberInfo {
     type Vtable = IPhoneNumberInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/mod.rs
@@ -9,6 +9,9 @@ pub mod NumberFormatting;
 #[cfg(feature = "Globalization_PhoneNumberFormatting")]
 pub mod PhoneNumberFormatting;
 windows_core::imp::define_interface!(IApplicationLanguagesStatics, IApplicationLanguagesStatics_Vtbl, 0x75b40847_0a4c_4a92_9565_fd63c95f7aed);
+impl windows_core::RuntimeType for IApplicationLanguagesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationLanguagesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +27,9 @@ pub struct IApplicationLanguagesStatics_Vtbl {
     ManifestLanguages: usize,
 }
 windows_core::imp::define_interface!(IApplicationLanguagesStatics2, IApplicationLanguagesStatics2_Vtbl, 0x1df0de4f_072b_4d7b_8f06_cb2db40f2bb5);
+impl windows_core::RuntimeType for IApplicationLanguagesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationLanguagesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +39,9 @@ pub struct IApplicationLanguagesStatics2_Vtbl {
     GetLanguagesForUser: usize,
 }
 windows_core::imp::define_interface!(ICalendar, ICalendar_Vtbl, 0xca30221d_86d9_40fb_a26b_d44eb7cf08ea);
+impl windows_core::RuntimeType for ICalendar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +148,9 @@ pub struct ICalendar_Vtbl {
     pub IsDaylightSavingTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICalendarFactory, ICalendarFactory_Vtbl, 0x83f58412_e56b_4c75_a66e_0f63d57758a6);
+impl windows_core::RuntimeType for ICalendarFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,6 +164,9 @@ pub struct ICalendarFactory_Vtbl {
     CreateCalendar: usize,
 }
 windows_core::imp::define_interface!(ICalendarFactory2, ICalendarFactory2_Vtbl, 0xb44b378c_ca7e_4590_9e72_ea2bec1a5115);
+impl windows_core::RuntimeType for ICalendarFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +176,9 @@ pub struct ICalendarFactory2_Vtbl {
     CreateCalendarWithTimeZone: usize,
 }
 windows_core::imp::define_interface!(ICalendarIdentifiersStatics, ICalendarIdentifiersStatics_Vtbl, 0x80653f68_2cb2_4c1f_b590_f0f52bf4fd1a);
+impl windows_core::RuntimeType for ICalendarIdentifiersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarIdentifiersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,12 +193,18 @@ pub struct ICalendarIdentifiersStatics_Vtbl {
     pub UmAlQura: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICalendarIdentifiersStatics2, ICalendarIdentifiersStatics2_Vtbl, 0x7df4d488_5fd0_42a7_95b5_7d98d823075f);
+impl windows_core::RuntimeType for ICalendarIdentifiersStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarIdentifiersStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Persian: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICalendarIdentifiersStatics3, ICalendarIdentifiersStatics3_Vtbl, 0x2c225423_1fad_40c0_9334_a8eb90db04f5);
+impl windows_core::RuntimeType for ICalendarIdentifiersStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarIdentifiersStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -191,6 +215,9 @@ pub struct ICalendarIdentifiersStatics3_Vtbl {
     pub VietnameseLunar: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClockIdentifiersStatics, IClockIdentifiersStatics_Vtbl, 0x523805bb_12ec_4f83_bc31_b1b4376b0808);
+impl windows_core::RuntimeType for IClockIdentifiersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClockIdentifiersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,6 +225,9 @@ pub struct IClockIdentifiersStatics_Vtbl {
     pub TwentyFourHour: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrencyAmount, ICurrencyAmount_Vtbl, 0x74b49942_eb75_443a_95b3_7d723f56f93c);
+impl windows_core::RuntimeType for ICurrencyAmount {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyAmount_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -205,12 +235,18 @@ pub struct ICurrencyAmount_Vtbl {
     pub Currency: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrencyAmountFactory, ICurrencyAmountFactory_Vtbl, 0x48d7168f_ef3b_4aee_a6a1_4b036fe03ff0);
+impl windows_core::RuntimeType for ICurrencyAmountFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyAmountFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrencyIdentifiersStatics, ICurrencyIdentifiersStatics_Vtbl, 0x9f1d091b_d586_4913_9b6a_a9bd2dc12874);
+impl windows_core::RuntimeType for ICurrencyIdentifiersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyIdentifiersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -373,12 +409,18 @@ pub struct ICurrencyIdentifiersStatics_Vtbl {
     pub ZWL: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrencyIdentifiersStatics2, ICurrencyIdentifiersStatics2_Vtbl, 0x1814797f_c3b2_4c33_9591_980011950d37);
+impl windows_core::RuntimeType for ICurrencyIdentifiersStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyIdentifiersStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BYN: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrencyIdentifiersStatics3, ICurrencyIdentifiersStatics3_Vtbl, 0x4fb23bfa_ed25_4f4d_857f_237f1748c21c);
+impl windows_core::RuntimeType for ICurrencyIdentifiersStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrencyIdentifiersStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -388,6 +430,9 @@ pub struct ICurrencyIdentifiersStatics3_Vtbl {
     pub VES: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeographicRegion, IGeographicRegion_Vtbl, 0x01e9a621_4a64_4ed9_954f_9edeb07bd903);
+impl windows_core::RuntimeType for IGeographicRegion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeographicRegion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -403,18 +448,27 @@ pub struct IGeographicRegion_Vtbl {
     CurrenciesInUse: usize,
 }
 windows_core::imp::define_interface!(IGeographicRegionFactory, IGeographicRegionFactory_Vtbl, 0x53425270_77b4_426b_859f_81e19d512546);
+impl windows_core::RuntimeType for IGeographicRegionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeographicRegionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateGeographicRegion: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeographicRegionStatics, IGeographicRegionStatics_Vtbl, 0x29e28974_7ad9_4ef4_8799_b3b44fadec08);
+impl windows_core::RuntimeType for IGeographicRegionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeographicRegionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJapanesePhoneme, IJapanesePhoneme_Vtbl, 0x2f6a9300_e85b_43e6_897d_5d82f862df21);
+impl windows_core::RuntimeType for IJapanesePhoneme {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJapanesePhoneme_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -423,6 +477,9 @@ pub struct IJapanesePhoneme_Vtbl {
     pub IsPhraseStart: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJapanesePhoneticAnalyzerStatics, IJapanesePhoneticAnalyzerStatics_Vtbl, 0x88ab9e90_93de_41b2_b4d5_8edb227fd1c2);
+impl windows_core::RuntimeType for IJapanesePhoneticAnalyzerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJapanesePhoneticAnalyzerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -436,6 +493,9 @@ pub struct IJapanesePhoneticAnalyzerStatics_Vtbl {
     GetWordsWithMonoRubyOption: usize,
 }
 windows_core::imp::define_interface!(ILanguage, ILanguage_Vtbl, 0xea79a752_f7c2_4265_b1bd_c4dec4e4f080);
+impl windows_core::RuntimeType for ILanguage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -445,18 +505,27 @@ pub struct ILanguage_Vtbl {
     pub Script: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguage2, ILanguage2_Vtbl, 0x6a47e5b5_d94d_4886_a404_a5a5b9d5b494);
+impl windows_core::RuntimeType for ILanguage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LayoutDirection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut LanguageLayoutDirection) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguage3, ILanguage3_Vtbl, 0xc6af3d10_641a_5ba4_bb43_5e12aed75954);
+impl windows_core::RuntimeType for ILanguage3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguage3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AbbreviatedName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguageExtensionSubtags, ILanguageExtensionSubtags_Vtbl, 0x7d7daf45_368d_4364_852b_dec927037b85);
+impl windows_core::RuntimeType for ILanguageExtensionSubtags {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageExtensionSubtags_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -466,12 +535,18 @@ pub struct ILanguageExtensionSubtags_Vtbl {
     GetExtensionSubtags: usize,
 }
 windows_core::imp::define_interface!(ILanguageFactory, ILanguageFactory_Vtbl, 0x9b0252ac_0c27_44f8_b792_9793fb66c63e);
+impl windows_core::RuntimeType for ILanguageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguageStatics, ILanguageStatics_Vtbl, 0xb23cd557_0865_46d4_89b8_d59be8990f0d);
+impl windows_core::RuntimeType for ILanguageStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -479,12 +554,18 @@ pub struct ILanguageStatics_Vtbl {
     pub CurrentInputMethodLanguageTag: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguageStatics2, ILanguageStatics2_Vtbl, 0x30199f6e_914b_4b2a_9d6e_e3b0e27dbe4f);
+impl windows_core::RuntimeType for ILanguageStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TrySetInputMethodLanguageTag: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanguageStatics3, ILanguageStatics3_Vtbl, 0xd15ecb5a_71de_5752_9542_fac5b4f27261);
+impl windows_core::RuntimeType for ILanguageStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanguageStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -494,6 +575,9 @@ pub struct ILanguageStatics3_Vtbl {
     GetMuiCompatibleLanguageListFromLanguageTags: usize,
 }
 windows_core::imp::define_interface!(INumeralSystemIdentifiersStatics, INumeralSystemIdentifiersStatics_Vtbl, 0xa5c662c3_68c9_4d3d_b765_972029e21dec);
+impl windows_core::RuntimeType for INumeralSystemIdentifiersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INumeralSystemIdentifiersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -535,6 +619,9 @@ pub struct INumeralSystemIdentifiersStatics_Vtbl {
     pub Vaii: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INumeralSystemIdentifiersStatics2, INumeralSystemIdentifiersStatics2_Vtbl, 0x7f003228_9ddb_4a34_9104_0260c091a7c7);
+impl windows_core::RuntimeType for INumeralSystemIdentifiersStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INumeralSystemIdentifiersStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -552,6 +639,9 @@ pub struct INumeralSystemIdentifiersStatics2_Vtbl {
     pub ZmthMono: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimeZoneOnCalendar, ITimeZoneOnCalendar_Vtbl, 0xbb3c25e5_46cf_4317_a3f5_02621ad54478);
+impl windows_core::RuntimeType for ITimeZoneOnCalendar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimeZoneOnCalendar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1300,7 +1390,7 @@ impl Calendar {
     }
 }
 impl windows_core::RuntimeType for Calendar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICalendar>();
 }
 unsafe impl windows_core::Interface for Calendar {
     type Vtable = ICalendar_Vtbl;
@@ -1477,7 +1567,7 @@ impl CurrencyAmount {
     }
 }
 impl windows_core::RuntimeType for CurrencyAmount {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICurrencyAmount>();
 }
 unsafe impl windows_core::Interface for CurrencyAmount {
     type Vtable = ICurrencyAmount_Vtbl;
@@ -2567,7 +2657,7 @@ impl GeographicRegion {
     }
 }
 impl windows_core::RuntimeType for GeographicRegion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGeographicRegion>();
 }
 unsafe impl windows_core::Interface for GeographicRegion {
     type Vtable = IGeographicRegion_Vtbl;
@@ -2606,7 +2696,7 @@ impl JapanesePhoneme {
     }
 }
 impl windows_core::RuntimeType for JapanesePhoneme {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IJapanesePhoneme>();
 }
 unsafe impl windows_core::Interface for JapanesePhoneme {
     type Vtable = IJapanesePhoneme_Vtbl;
@@ -2751,7 +2841,7 @@ impl Language {
     }
 }
 impl windows_core::RuntimeType for Language {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILanguage>();
 }
 unsafe impl windows_core::Interface for Language {
     type Vtable = ILanguage_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDirect3D11CaptureFrame, IDirect3D11CaptureFrame_Vtbl, 0xfa50c623_38da_4b32_acf3_fa9734ad800e);
+impl windows_core::RuntimeType for IDirect3D11CaptureFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDirect3D11CaptureFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IDirect3D11CaptureFrame_Vtbl {
     pub ContentSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::SizeInt32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDirect3D11CaptureFramePool, IDirect3D11CaptureFramePool_Vtbl, 0x24eb6d22_1975_422e_82e7_780dbd8ddf24);
+impl windows_core::RuntimeType for IDirect3D11CaptureFramePool {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDirect3D11CaptureFramePool_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +33,9 @@ pub struct IDirect3D11CaptureFramePool_Vtbl {
     DispatcherQueue: usize,
 }
 windows_core::imp::define_interface!(IDirect3D11CaptureFramePoolStatics, IDirect3D11CaptureFramePoolStatics_Vtbl, 0x7784056a_67aa_4d53_ae54_1088d5a8ca21);
+impl windows_core::RuntimeType for IDirect3D11CaptureFramePoolStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDirect3D11CaptureFramePoolStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +45,9 @@ pub struct IDirect3D11CaptureFramePoolStatics_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IDirect3D11CaptureFramePoolStatics2, IDirect3D11CaptureFramePoolStatics2_Vtbl, 0x589b103f_6bbc_5df5_a991_02e28b3b66d5);
+impl windows_core::RuntimeType for IDirect3D11CaptureFramePoolStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDirect3D11CaptureFramePoolStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +57,9 @@ pub struct IDirect3D11CaptureFramePoolStatics2_Vtbl {
     CreateFreeThreaded: usize,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureAccessStatics, IGraphicsCaptureAccessStatics_Vtbl, 0x743ed370_06ec_5040_a58a_901f0f757095);
+impl windows_core::RuntimeType for IGraphicsCaptureAccessStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureAccessStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +69,9 @@ pub struct IGraphicsCaptureAccessStatics_Vtbl {
     RequestAccessAsync: usize,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureItem, IGraphicsCaptureItem_Vtbl, 0x79c3f95b_31f7_4ec2_a464_632ef5d30760);
+impl windows_core::RuntimeType for IGraphicsCaptureItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +81,9 @@ pub struct IGraphicsCaptureItem_Vtbl {
     pub RemoveClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureItemStatics, IGraphicsCaptureItemStatics_Vtbl, 0xa87ebea5_457c_5788_ab47_0cf1d3637e74);
+impl windows_core::RuntimeType for IGraphicsCaptureItemStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureItemStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,6 +93,9 @@ pub struct IGraphicsCaptureItemStatics_Vtbl {
     CreateFromVisual: usize,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureItemStatics2, IGraphicsCaptureItemStatics2_Vtbl, 0x3b92acc9_e584_5862_bf5c_9c316c6d2dbb);
+impl windows_core::RuntimeType for IGraphicsCaptureItemStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureItemStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -82,18 +106,27 @@ pub struct IGraphicsCaptureItemStatics2_Vtbl {
     pub TryCreateFromDisplayId: unsafe extern "system" fn(*mut core::ffi::c_void, super::DisplayId, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGraphicsCapturePicker, IGraphicsCapturePicker_Vtbl, 0x5a1711b3_ad79_4b4a_9336_1318fdde3539);
+impl windows_core::RuntimeType for IGraphicsCapturePicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCapturePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PickSingleItemAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureSession, IGraphicsCaptureSession_Vtbl, 0x814e42a9_f70f_4ad7_939b_fddcc6eb880d);
+impl windows_core::RuntimeType for IGraphicsCaptureSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub StartCapture: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureSession2, IGraphicsCaptureSession2_Vtbl, 0x2c39ae40_7d2e_5044_804e_8b6799d4cf9e);
+impl windows_core::RuntimeType for IGraphicsCaptureSession2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureSession2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,6 +134,9 @@ pub struct IGraphicsCaptureSession2_Vtbl {
     pub SetIsCursorCaptureEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureSession3, IGraphicsCaptureSession3_Vtbl, 0xf2cdd966_22ae_5ea1_9596_3a289344c3be);
+impl windows_core::RuntimeType for IGraphicsCaptureSession3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureSession3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +144,9 @@ pub struct IGraphicsCaptureSession3_Vtbl {
     pub SetIsBorderRequired: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGraphicsCaptureSessionStatics, IGraphicsCaptureSessionStatics_Vtbl, 0x2224a540_5974_49aa_b232_0882536f4cb5);
+impl windows_core::RuntimeType for IGraphicsCaptureSessionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGraphicsCaptureSessionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,7 +186,7 @@ impl Direct3D11CaptureFrame {
     }
 }
 impl windows_core::RuntimeType for Direct3D11CaptureFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDirect3D11CaptureFrame>();
 }
 unsafe impl windows_core::Interface for Direct3D11CaptureFrame {
     type Vtable = IDirect3D11CaptureFrame_Vtbl;
@@ -247,7 +286,7 @@ impl Direct3D11CaptureFramePool {
     }
 }
 impl windows_core::RuntimeType for Direct3D11CaptureFramePool {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDirect3D11CaptureFramePool>();
 }
 unsafe impl windows_core::Interface for Direct3D11CaptureFramePool {
     type Vtable = IDirect3D11CaptureFramePool_Vtbl;
@@ -344,7 +383,7 @@ impl GraphicsCaptureItem {
     }
 }
 impl windows_core::RuntimeType for GraphicsCaptureItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGraphicsCaptureItem>();
 }
 unsafe impl windows_core::Interface for GraphicsCaptureItem {
     type Vtable = IGraphicsCaptureItem_Vtbl;
@@ -376,7 +415,7 @@ impl GraphicsCapturePicker {
     }
 }
 impl windows_core::RuntimeType for GraphicsCapturePicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGraphicsCapturePicker>();
 }
 unsafe impl windows_core::Interface for GraphicsCapturePicker {
     type Vtable = IGraphicsCapturePicker_Vtbl;
@@ -436,7 +475,7 @@ impl GraphicsCaptureSession {
     }
 }
 impl windows_core::RuntimeType for GraphicsCaptureSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGraphicsCaptureSession>();
 }
 unsafe impl windows_core::Interface for GraphicsCaptureSession {
     type Vtable = IGraphicsCaptureSession_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHdmiDisplayInformation, IHdmiDisplayInformation_Vtbl, 0x130b3c0a_f565_476e_abd5_ea05aee74c69);
+impl windows_core::RuntimeType for IHdmiDisplayInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHdmiDisplayInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,12 +18,18 @@ pub struct IHdmiDisplayInformation_Vtbl {
     pub RemoveDisplayModesChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHdmiDisplayInformationStatics, IHdmiDisplayInformationStatics_Vtbl, 0x6ce6b260_f42a_4a15_914c_7b8e2a5a65df);
+impl windows_core::RuntimeType for IHdmiDisplayInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHdmiDisplayInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHdmiDisplayMode, IHdmiDisplayMode_Vtbl, 0x0c06d5ad_1b90_4f51_9981_ef5a1c0ddf66);
+impl windows_core::RuntimeType for IHdmiDisplayMode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHdmiDisplayMode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +46,9 @@ pub struct IHdmiDisplayMode_Vtbl {
     pub Is2086MetadataSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHdmiDisplayMode2, IHdmiDisplayMode2_Vtbl, 0x07cd4e9f_4b3c_42b8_84e7_895368718af2);
+impl windows_core::RuntimeType for IHdmiDisplayMode2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHdmiDisplayMode2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,7 +138,7 @@ impl HdmiDisplayInformation {
     }
 }
 impl windows_core::RuntimeType for HdmiDisplayInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHdmiDisplayInformation>();
 }
 unsafe impl windows_core::Interface for HdmiDisplayInformation {
     type Vtable = IHdmiDisplayInformation_Vtbl;
@@ -231,7 +243,7 @@ impl HdmiDisplayMode {
     }
 }
 impl windows_core::RuntimeType for HdmiDisplayMode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHdmiDisplayMode>();
 }
 unsafe impl windows_core::Interface for HdmiDisplayMode {
     type Vtable = IHdmiDisplayMode_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Graphics_Display_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IAdvancedColorInfo, IAdvancedColorInfo_Vtbl, 0x8797dcfb_b229_4081_ae9a_2cc85e34ad6a);
+impl windows_core::RuntimeType for IAdvancedColorInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedColorInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +20,9 @@ pub struct IAdvancedColorInfo_Vtbl {
     pub IsAdvancedColorKindAvailable: unsafe extern "system" fn(*mut core::ffi::c_void, AdvancedColorKind, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBrightnessOverride, IBrightnessOverride_Vtbl, 0x96c9621a_c143_4392_bedd_4a7e9574c8fd);
+impl windows_core::RuntimeType for IBrightnessOverride {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBrightnessOverride_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +42,9 @@ pub struct IBrightnessOverride_Vtbl {
     pub RemoveBrightnessLevelChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBrightnessOverrideSettings, IBrightnessOverrideSettings_Vtbl, 0xd112ab2a_7604_4dba_bcf8_4b6f49502cb0);
+impl windows_core::RuntimeType for IBrightnessOverrideSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBrightnessOverrideSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,6 +52,9 @@ pub struct IBrightnessOverrideSettings_Vtbl {
     pub DesiredNits: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBrightnessOverrideSettingsStatics, IBrightnessOverrideSettingsStatics_Vtbl, 0xd487dc90_6f74_440b_b383_5fe96cf00b0f);
+impl windows_core::RuntimeType for IBrightnessOverrideSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBrightnessOverrideSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,6 +63,9 @@ pub struct IBrightnessOverrideSettingsStatics_Vtbl {
     pub CreateFromDisplayBrightnessOverrideScenario: unsafe extern "system" fn(*mut core::ffi::c_void, DisplayBrightnessOverrideScenario, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBrightnessOverrideStatics, IBrightnessOverrideStatics_Vtbl, 0x03a7b9ed_e1f1_4a68_a11f_946ad8ce5393);
+impl windows_core::RuntimeType for IBrightnessOverrideStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBrightnessOverrideStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,18 +74,27 @@ pub struct IBrightnessOverrideStatics_Vtbl {
     pub SaveForSystemAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IColorOverrideSettings, IColorOverrideSettings_Vtbl, 0xfbefa134_4a81_4c4d_a5b6_7d1b5c4bd00b);
+impl windows_core::RuntimeType for IColorOverrideSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColorOverrideSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DesiredDisplayColorOverrideScenario: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DisplayColorOverrideScenario) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IColorOverrideSettingsStatics, IColorOverrideSettingsStatics_Vtbl, 0xb068e05f_c41f_4ac9_afab_827ab6248f9a);
+impl windows_core::RuntimeType for IColorOverrideSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColorOverrideSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFromDisplayColorOverrideScenario: unsafe extern "system" fn(*mut core::ffi::c_void, DisplayColorOverrideScenario, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayEnhancementOverride, IDisplayEnhancementOverride_Vtbl, 0x429594cf_d97a_4b02_a428_5c4292f7f522);
+impl windows_core::RuntimeType for IDisplayEnhancementOverride {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayEnhancementOverride_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,6 +115,9 @@ pub struct IDisplayEnhancementOverride_Vtbl {
     pub RemoveDisplayEnhancementOverrideCapabilitiesChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayEnhancementOverrideCapabilities, IDisplayEnhancementOverrideCapabilities_Vtbl, 0x457060de_ee5a_47b7_9918_1e51e812ccc8);
+impl windows_core::RuntimeType for IDisplayEnhancementOverrideCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayEnhancementOverrideCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,18 +129,27 @@ pub struct IDisplayEnhancementOverrideCapabilities_Vtbl {
     GetSupportedNitRanges: usize,
 }
 windows_core::imp::define_interface!(IDisplayEnhancementOverrideCapabilitiesChangedEventArgs, IDisplayEnhancementOverrideCapabilitiesChangedEventArgs_Vtbl, 0xdb61e664_15fa_49da_8b77_07dbd2af585d);
+impl windows_core::RuntimeType for IDisplayEnhancementOverrideCapabilitiesChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayEnhancementOverrideCapabilitiesChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Capabilities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayEnhancementOverrideStatics, IDisplayEnhancementOverrideStatics_Vtbl, 0xcf5b7ec1_9791_4453_b013_29b6f778e519);
+impl windows_core::RuntimeType for IDisplayEnhancementOverrideStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayEnhancementOverrideStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayInformation, IDisplayInformation_Vtbl, 0xbed112ae_adc3_4dc9_ae65_851f4d7d4799);
+impl windows_core::RuntimeType for IDisplayInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -138,18 +174,27 @@ pub struct IDisplayInformation_Vtbl {
     pub RemoveColorProfileChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayInformation2, IDisplayInformation2_Vtbl, 0x4dcd0021_fad1_4b8e_8edf_775887b8bf19);
+impl windows_core::RuntimeType for IDisplayInformation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayInformation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RawPixelsPerViewPixel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayInformation3, IDisplayInformation3_Vtbl, 0xdb15011d_0f09_4466_8ff3_11de9a3c929a);
+impl windows_core::RuntimeType for IDisplayInformation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayInformation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DiagonalSizeInInches: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayInformation4, IDisplayInformation4_Vtbl, 0xc972ce2f_1242_46be_b536_e1aafe9e7acf);
+impl windows_core::RuntimeType for IDisplayInformation4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayInformation4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -157,6 +202,9 @@ pub struct IDisplayInformation4_Vtbl {
     pub ScreenHeightInRawPixels: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayInformation5, IDisplayInformation5_Vtbl, 0x3a5442dc_2cde_4a8d_80d1_21dc5adcc1aa);
+impl windows_core::RuntimeType for IDisplayInformation5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayInformation5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +213,9 @@ pub struct IDisplayInformation5_Vtbl {
     pub RemoveAdvancedColorInfoChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDisplayInformationStatics, IDisplayInformationStatics_Vtbl, 0xc6a02a6c_d452_44dc_ba07_96f3c6adf9d1);
+impl windows_core::RuntimeType for IDisplayInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -176,6 +227,10 @@ pub struct IDisplayInformationStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IDisplayPropertiesStatics, IDisplayPropertiesStatics_Vtbl, 0x6937ed8d_30ea_4ded_8271_4553ff02f68a);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IDisplayPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IDisplayPropertiesStatics_Vtbl {
@@ -254,11 +309,17 @@ pub struct IDisplayPropertiesStatics_Vtbl {
     RemoveDisplayContentsInvalidated: usize,
 }
 windows_core::imp::define_interface!(IDisplayServices, IDisplayServices_Vtbl, 0x1b54f32b_890d_5747_bd26_fdbdeb0c8a71);
+impl windows_core::RuntimeType for IDisplayServices {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayServices_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IDisplayServicesStatics, IDisplayServicesStatics_Vtbl, 0xdc2096bf_730a_5560_b461_91c13d692e0c);
+impl windows_core::RuntimeType for IDisplayServicesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayServicesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -348,7 +409,7 @@ impl AdvancedColorInfo {
     }
 }
 impl windows_core::RuntimeType for AdvancedColorInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdvancedColorInfo>();
 }
 unsafe impl windows_core::Interface for AdvancedColorInfo {
     type Vtable = IAdvancedColorInfo_Vtbl;
@@ -478,7 +539,7 @@ impl BrightnessOverride {
     }
 }
 impl windows_core::RuntimeType for BrightnessOverride {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBrightnessOverride>();
 }
 unsafe impl windows_core::Interface for BrightnessOverride {
     type Vtable = IBrightnessOverride_Vtbl;
@@ -533,7 +594,7 @@ impl BrightnessOverrideSettings {
     }
 }
 impl windows_core::RuntimeType for BrightnessOverrideSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBrightnessOverrideSettings>();
 }
 unsafe impl windows_core::Interface for BrightnessOverrideSettings {
     type Vtable = IBrightnessOverrideSettings_Vtbl;
@@ -569,7 +630,7 @@ impl ColorOverrideSettings {
     }
 }
 impl windows_core::RuntimeType for ColorOverrideSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IColorOverrideSettings>();
 }
 unsafe impl windows_core::Interface for ColorOverrideSettings {
     type Vtable = IColorOverrideSettings_Vtbl;
@@ -697,7 +758,7 @@ impl DisplayEnhancementOverride {
     }
 }
 impl windows_core::RuntimeType for DisplayEnhancementOverride {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayEnhancementOverride>();
 }
 unsafe impl windows_core::Interface for DisplayEnhancementOverride {
     type Vtable = IDisplayEnhancementOverride_Vtbl;
@@ -737,7 +798,7 @@ impl DisplayEnhancementOverrideCapabilities {
     }
 }
 impl windows_core::RuntimeType for DisplayEnhancementOverrideCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayEnhancementOverrideCapabilities>();
 }
 unsafe impl windows_core::Interface for DisplayEnhancementOverrideCapabilities {
     type Vtable = IDisplayEnhancementOverrideCapabilities_Vtbl;
@@ -762,7 +823,7 @@ impl DisplayEnhancementOverrideCapabilitiesChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DisplayEnhancementOverrideCapabilitiesChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayEnhancementOverrideCapabilitiesChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for DisplayEnhancementOverrideCapabilitiesChangedEventArgs {
     type Vtable = IDisplayEnhancementOverrideCapabilitiesChangedEventArgs_Vtbl;
@@ -974,7 +1035,7 @@ impl DisplayInformation {
     }
 }
 impl windows_core::RuntimeType for DisplayInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayInformation>();
 }
 unsafe impl windows_core::Interface for DisplayInformation {
     type Vtable = IDisplayInformation_Vtbl;
@@ -1141,7 +1202,7 @@ impl DisplayServices {
     }
 }
 impl windows_core::RuntimeType for DisplayServices {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayServices>();
 }
 unsafe impl windows_core::Interface for DisplayServices {
     type Vtable = IDisplayServices_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHolographicCamera, IHolographicCamera_Vtbl, 0xe4e98445_9bed_4980_9ba0_e87680d1cb74);
+impl windows_core::RuntimeType for IHolographicCamera {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCamera_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IHolographicCamera_Vtbl {
     pub SetFarPlaneDistance: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCamera2, IHolographicCamera2_Vtbl, 0xb55b9f1a_ba8c_4f84_ad79_2e7e1e2450f3);
+impl windows_core::RuntimeType for IHolographicCamera2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCamera2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +25,9 @@ pub struct IHolographicCamera2_Vtbl {
     pub Display: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCamera3, IHolographicCamera3_Vtbl, 0x45aa4fb3_7b59_524e_4a3f_4a6ad6650477);
+impl windows_core::RuntimeType for IHolographicCamera3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCamera3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,12 +40,18 @@ pub struct IHolographicCamera3_Vtbl {
     QuadLayers: usize,
 }
 windows_core::imp::define_interface!(IHolographicCamera4, IHolographicCamera4_Vtbl, 0x9a2531d6_4723_4f39_a9a5_9d05181d9b44);
+impl windows_core::RuntimeType for IHolographicCamera4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCamera4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CanOverrideViewport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCamera5, IHolographicCamera5_Vtbl, 0x229706f2_628d_4ef5_9c08_a63fdd7787c6);
+impl windows_core::RuntimeType for IHolographicCamera5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCamera5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,12 +60,18 @@ pub struct IHolographicCamera5_Vtbl {
     pub SetIsHardwareContentProtectionEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCamera6, IHolographicCamera6_Vtbl, 0x0209194f_632d_5154_ab52_0b5d15b12505);
+impl windows_core::RuntimeType for IHolographicCamera6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCamera6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ViewConfiguration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCameraPose, IHolographicCameraPose_Vtbl, 0x0d7d7e30_12de_45bd_912b_c7f6561599d1);
+impl windows_core::RuntimeType for IHolographicCameraPose {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCameraPose_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +97,9 @@ pub struct IHolographicCameraPose_Vtbl {
     pub FarPlaneDistance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCameraPose2, IHolographicCameraPose2_Vtbl, 0x232be073_5d2d_4560_814e_2697c4fce16b);
+impl windows_core::RuntimeType for IHolographicCameraPose2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCameraPose2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +114,9 @@ pub struct IHolographicCameraPose2_Vtbl {
     pub OverrideViewport: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Rect, super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCameraRenderingParameters, IHolographicCameraRenderingParameters_Vtbl, 0x8eac2ed1_5bf4_4e16_8236_ae0800c11d0d);
+impl windows_core::RuntimeType for IHolographicCameraRenderingParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCameraRenderingParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,6 +142,9 @@ pub struct IHolographicCameraRenderingParameters_Vtbl {
     Direct3D11BackBuffer: usize,
 }
 windows_core::imp::define_interface!(IHolographicCameraRenderingParameters2, IHolographicCameraRenderingParameters2_Vtbl, 0x261270e3_b696_4634_94d6_be0681643599);
+impl windows_core::RuntimeType for IHolographicCameraRenderingParameters2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCameraRenderingParameters2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,6 +156,9 @@ pub struct IHolographicCameraRenderingParameters2_Vtbl {
     CommitDirect3D11DepthBuffer: usize,
 }
 windows_core::imp::define_interface!(IHolographicCameraRenderingParameters3, IHolographicCameraRenderingParameters3_Vtbl, 0xb1aa513f_136d_4b06_b9d4_e4b914cd0683);
+impl windows_core::RuntimeType for IHolographicCameraRenderingParameters3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCameraRenderingParameters3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,6 +166,9 @@ pub struct IHolographicCameraRenderingParameters3_Vtbl {
     pub SetIsContentProtectionEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCameraRenderingParameters4, IHolographicCameraRenderingParameters4_Vtbl, 0x0878fa4c_e163_57dc_82b7_c406ab3e0537);
+impl windows_core::RuntimeType for IHolographicCameraRenderingParameters4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCameraRenderingParameters4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +176,9 @@ pub struct IHolographicCameraRenderingParameters4_Vtbl {
     pub SetDepthReprojectionMethod: unsafe extern "system" fn(*mut core::ffi::c_void, HolographicDepthReprojectionMethod) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicCameraViewportParameters, IHolographicCameraViewportParameters_Vtbl, 0x80cdf3f7_842a_41e1_93ed_5692ab1fbb10);
+impl windows_core::RuntimeType for IHolographicCameraViewportParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicCameraViewportParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -153,6 +192,9 @@ pub struct IHolographicCameraViewportParameters_Vtbl {
     VisibleAreaMesh: usize,
 }
 windows_core::imp::define_interface!(IHolographicDisplay, IHolographicDisplay_Vtbl, 0x9acea414_1d9f_4090_a388_90c06f6eae9c);
+impl windows_core::RuntimeType for IHolographicDisplay {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicDisplay_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -167,24 +209,36 @@ pub struct IHolographicDisplay_Vtbl {
     SpatialLocator: usize,
 }
 windows_core::imp::define_interface!(IHolographicDisplay2, IHolographicDisplay2_Vtbl, 0x75ac3f82_e755_436c_8d96_4d32d131473e);
+impl windows_core::RuntimeType for IHolographicDisplay2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicDisplay2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RefreshRate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicDisplay3, IHolographicDisplay3_Vtbl, 0xfc4c6ac6_6480_5008_b29e_157d77c843f7);
+impl windows_core::RuntimeType for IHolographicDisplay3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicDisplay3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryGetViewConfiguration: unsafe extern "system" fn(*mut core::ffi::c_void, HolographicViewConfigurationKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicDisplayStatics, IHolographicDisplayStatics_Vtbl, 0xcb374983_e7b0_4841_8355_3ae5b536e9a4);
+impl windows_core::RuntimeType for IHolographicDisplayStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicDisplayStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicFrame, IHolographicFrame_Vtbl, 0xc6988eb6_a8b9_3054_a6eb_d624b6536375);
+impl windows_core::RuntimeType for IHolographicFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -205,18 +259,27 @@ pub struct IHolographicFrame_Vtbl {
     pub WaitForFrameToFinish: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicFrame2, IHolographicFrame2_Vtbl, 0x283f37bf_3bf2_5e91_6633_870574e6f217);
+impl windows_core::RuntimeType for IHolographicFrame2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicFrame2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetQuadLayerUpdateParameters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicFrame3, IHolographicFrame3_Vtbl, 0xe5e964c9_8a27_55d3_9f98_94530d369052);
+impl windows_core::RuntimeType for IHolographicFrame3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicFrame3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut HolographicFrameId) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicFramePrediction, IHolographicFramePrediction_Vtbl, 0x520f4de1_5c0a_4e79_a81e_6abe02bb2739);
+impl windows_core::RuntimeType for IHolographicFramePrediction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicFramePrediction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -232,6 +295,10 @@ pub struct IHolographicFramePrediction_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IHolographicFramePresentationMonitor, IHolographicFramePresentationMonitor_Vtbl, 0xca87256c_6fae_428e_bb83_25dfee51136b);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IHolographicFramePresentationMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IHolographicFramePresentationMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -242,6 +309,10 @@ pub struct IHolographicFramePresentationMonitor_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IHolographicFramePresentationReport, IHolographicFramePresentationReport_Vtbl, 0x80baf614_f2f4_4c8a_8de3_065c78f6d5de);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IHolographicFramePresentationReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IHolographicFramePresentationReport_Vtbl {
@@ -268,6 +339,9 @@ pub struct IHolographicFramePresentationReport_Vtbl {
     PresentationCount: usize,
 }
 windows_core::imp::define_interface!(IHolographicFrameRenderingReport, IHolographicFrameRenderingReport_Vtbl, 0x05f32de4_e384_51b3_b934_f0d3a0f78606);
+impl windows_core::RuntimeType for IHolographicFrameRenderingReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicFrameRenderingReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -278,6 +352,9 @@ pub struct IHolographicFrameRenderingReport_Vtbl {
     pub SystemRelativeTargetLatchTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicFrameScanoutMonitor, IHolographicFrameScanoutMonitor_Vtbl, 0x7e83efa9_843c_5401_8095_9bc1b8b08638);
+impl windows_core::RuntimeType for IHolographicFrameScanoutMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicFrameScanoutMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -287,6 +364,9 @@ pub struct IHolographicFrameScanoutMonitor_Vtbl {
     ReadReports: usize,
 }
 windows_core::imp::define_interface!(IHolographicFrameScanoutReport, IHolographicFrameScanoutReport_Vtbl, 0x0ebbe606_03a0_5ca0_b46e_bba068d7233f);
+impl windows_core::RuntimeType for IHolographicFrameScanoutReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicFrameScanoutReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -297,6 +377,9 @@ pub struct IHolographicFrameScanoutReport_Vtbl {
     pub SystemRelativePhotonTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicQuadLayer, IHolographicQuadLayer_Vtbl, 0x903460c9_c9d9_5d5c_41ac_a2d5ab0fd331);
+impl windows_core::RuntimeType for IHolographicQuadLayer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicQuadLayer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -307,6 +390,9 @@ pub struct IHolographicQuadLayer_Vtbl {
     pub Size: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicQuadLayerFactory, IHolographicQuadLayerFactory_Vtbl, 0xa67538f3_5a14_5a10_489a_455065b37b76);
+impl windows_core::RuntimeType for IHolographicQuadLayerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicQuadLayerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -317,6 +403,9 @@ pub struct IHolographicQuadLayerFactory_Vtbl {
     CreateWithPixelFormat: usize,
 }
 windows_core::imp::define_interface!(IHolographicQuadLayerUpdateParameters, IHolographicQuadLayerUpdateParameters_Vtbl, 0x2b0ea3b0_798d_5bca_55c2_2c0c762ebb08);
+impl windows_core::RuntimeType for IHolographicQuadLayerUpdateParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicQuadLayerUpdateParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -340,6 +429,9 @@ pub struct IHolographicQuadLayerUpdateParameters_Vtbl {
     UpdateLocationWithDisplayRelativeMode: usize,
 }
 windows_core::imp::define_interface!(IHolographicQuadLayerUpdateParameters2, IHolographicQuadLayerUpdateParameters2_Vtbl, 0x4f33d32d_82c1_46c1_8980_3cb70d98182b);
+impl windows_core::RuntimeType for IHolographicQuadLayerUpdateParameters2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicQuadLayerUpdateParameters2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -350,6 +442,9 @@ pub struct IHolographicQuadLayerUpdateParameters2_Vtbl {
     AcquireBufferToUpdateContentWithHardwareProtection: usize,
 }
 windows_core::imp::define_interface!(IHolographicSpace, IHolographicSpace_Vtbl, 0x4380dba6_5e78_434f_807c_3433d1efe8b7);
+impl windows_core::RuntimeType for IHolographicSpace {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpace_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -365,6 +460,9 @@ pub struct IHolographicSpace_Vtbl {
     pub CreateNextFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicSpace2, IHolographicSpace2_Vtbl, 0x4f81a9a8_b7ff_4883_9827_7d677287ea70);
+impl windows_core::RuntimeType for IHolographicSpace2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpace2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -379,12 +477,18 @@ pub struct IHolographicSpace2_Vtbl {
     CreateFramePresentationMonitor: usize,
 }
 windows_core::imp::define_interface!(IHolographicSpace3, IHolographicSpace3_Vtbl, 0xdf1733d1_f224_587e_8d71_1e8fc8f07b1f);
+impl windows_core::RuntimeType for IHolographicSpace3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpace3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFrameScanoutMonitor: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicSpaceCameraAddedEventArgs, IHolographicSpaceCameraAddedEventArgs_Vtbl, 0x58f1da35_bbb3_3c8f_993d_6c80e7feb99f);
+impl windows_core::RuntimeType for IHolographicSpaceCameraAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpaceCameraAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -392,12 +496,18 @@ pub struct IHolographicSpaceCameraAddedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicSpaceCameraRemovedEventArgs, IHolographicSpaceCameraRemovedEventArgs_Vtbl, 0x805444a8_f2ae_322e_8da9_836a0a95a4c1);
+impl windows_core::RuntimeType for IHolographicSpaceCameraRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpaceCameraRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Camera: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicSpaceStatics, IHolographicSpaceStatics_Vtbl, 0x364e6064_c8f2_3ba1_8391_66b8489e67fd);
+impl windows_core::RuntimeType for IHolographicSpaceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpaceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -407,6 +517,9 @@ pub struct IHolographicSpaceStatics_Vtbl {
     CreateForCoreWindow: usize,
 }
 windows_core::imp::define_interface!(IHolographicSpaceStatics2, IHolographicSpaceStatics2_Vtbl, 0x0e777088_75fc_48af_8758_0652f6f07c59);
+impl windows_core::RuntimeType for IHolographicSpaceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpaceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -416,12 +529,18 @@ pub struct IHolographicSpaceStatics2_Vtbl {
     pub RemoveIsAvailableChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicSpaceStatics3, IHolographicSpaceStatics3_Vtbl, 0x3b00de3d_b1a3_4dfe_8e79_fec5909e6df8);
+impl windows_core::RuntimeType for IHolographicSpaceStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicSpaceStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsConfigured: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicViewConfiguration, IHolographicViewConfiguration_Vtbl, 0x5c1de6e6_67e9_5004_b02c_67a3a122b576);
+impl windows_core::RuntimeType for IHolographicViewConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicViewConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -448,6 +567,9 @@ pub struct IHolographicViewConfiguration_Vtbl {
     pub SetIsEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHolographicViewConfiguration2, IHolographicViewConfiguration2_Vtbl, 0xe241756e_e0d0_5019_9af5_1b165bc2f54e);
+impl windows_core::RuntimeType for IHolographicViewConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHolographicViewConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -582,7 +704,7 @@ impl HolographicCamera {
     }
 }
 impl windows_core::RuntimeType for HolographicCamera {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicCamera>();
 }
 unsafe impl windows_core::Interface for HolographicCamera {
     type Vtable = IHolographicCamera_Vtbl;
@@ -686,7 +808,7 @@ impl HolographicCameraPose {
     }
 }
 impl windows_core::RuntimeType for HolographicCameraPose {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicCameraPose>();
 }
 unsafe impl windows_core::Interface for HolographicCameraPose {
     type Vtable = IHolographicCameraPose_Vtbl;
@@ -785,7 +907,7 @@ impl HolographicCameraRenderingParameters {
     }
 }
 impl windows_core::RuntimeType for HolographicCameraRenderingParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicCameraRenderingParameters>();
 }
 unsafe impl windows_core::Interface for HolographicCameraRenderingParameters {
     type Vtable = IHolographicCameraRenderingParameters_Vtbl;
@@ -819,7 +941,7 @@ impl HolographicCameraViewportParameters {
     }
 }
 impl windows_core::RuntimeType for HolographicCameraViewportParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicCameraViewportParameters>();
 }
 unsafe impl windows_core::Interface for HolographicCameraViewportParameters {
     type Vtable = IHolographicCameraViewportParameters_Vtbl;
@@ -905,7 +1027,7 @@ impl HolographicDisplay {
     }
 }
 impl windows_core::RuntimeType for HolographicDisplay {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicDisplay>();
 }
 unsafe impl windows_core::Interface for HolographicDisplay {
     type Vtable = IHolographicDisplay_Vtbl;
@@ -1002,7 +1124,7 @@ impl HolographicFrame {
     }
 }
 impl windows_core::RuntimeType for HolographicFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicFrame>();
 }
 unsafe impl windows_core::Interface for HolographicFrame {
     type Vtable = IHolographicFrame_Vtbl;
@@ -1036,7 +1158,7 @@ impl HolographicFramePrediction {
     }
 }
 impl windows_core::RuntimeType for HolographicFramePrediction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicFramePrediction>();
 }
 unsafe impl windows_core::Interface for HolographicFramePrediction {
     type Vtable = IHolographicFramePrediction_Vtbl;
@@ -1072,7 +1194,7 @@ impl HolographicFramePresentationMonitor {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for HolographicFramePresentationMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicFramePresentationMonitor>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for HolographicFramePresentationMonitor {
@@ -1138,7 +1260,7 @@ impl HolographicFramePresentationReport {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for HolographicFramePresentationReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicFramePresentationReport>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for HolographicFramePresentationReport {
@@ -1195,7 +1317,7 @@ impl HolographicFrameRenderingReport {
     }
 }
 impl windows_core::RuntimeType for HolographicFrameRenderingReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicFrameRenderingReport>();
 }
 unsafe impl windows_core::Interface for HolographicFrameRenderingReport {
     type Vtable = IHolographicFrameRenderingReport_Vtbl;
@@ -1226,7 +1348,7 @@ impl HolographicFrameScanoutMonitor {
     }
 }
 impl windows_core::RuntimeType for HolographicFrameScanoutMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicFrameScanoutMonitor>();
 }
 unsafe impl windows_core::Interface for HolographicFrameScanoutMonitor {
     type Vtable = IHolographicFrameScanoutMonitor_Vtbl;
@@ -1279,7 +1401,7 @@ impl HolographicFrameScanoutReport {
     }
 }
 impl windows_core::RuntimeType for HolographicFrameScanoutReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicFrameScanoutReport>();
 }
 unsafe impl windows_core::Interface for HolographicFrameScanoutReport {
     type Vtable = IHolographicFrameScanoutReport_Vtbl;
@@ -1335,7 +1457,7 @@ impl HolographicQuadLayer {
     }
 }
 impl windows_core::RuntimeType for HolographicQuadLayer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicQuadLayer>();
 }
 unsafe impl windows_core::Interface for HolographicQuadLayer {
     type Vtable = IHolographicQuadLayer_Vtbl;
@@ -1402,7 +1524,7 @@ impl HolographicQuadLayerUpdateParameters {
     }
 }
 impl windows_core::RuntimeType for HolographicQuadLayerUpdateParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicQuadLayerUpdateParameters>();
 }
 unsafe impl windows_core::Interface for HolographicQuadLayerUpdateParameters {
     type Vtable = IHolographicQuadLayerUpdateParameters_Vtbl;
@@ -1569,7 +1691,7 @@ impl HolographicSpace {
     }
 }
 impl windows_core::RuntimeType for HolographicSpace {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicSpace>();
 }
 unsafe impl windows_core::Interface for HolographicSpace {
     type Vtable = IHolographicSpace_Vtbl;
@@ -1601,7 +1723,7 @@ impl HolographicSpaceCameraAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HolographicSpaceCameraAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicSpaceCameraAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for HolographicSpaceCameraAddedEventArgs {
     type Vtable = IHolographicSpaceCameraAddedEventArgs_Vtbl;
@@ -1626,7 +1748,7 @@ impl HolographicSpaceCameraRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HolographicSpaceCameraRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicSpaceCameraRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for HolographicSpaceCameraRemovedEventArgs {
     type Vtable = IHolographicSpaceCameraRemovedEventArgs_Vtbl;
@@ -1733,7 +1855,7 @@ impl HolographicViewConfiguration {
     }
 }
 impl windows_core::RuntimeType for HolographicViewConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHolographicViewConfiguration>();
 }
 unsafe impl windows_core::Interface for HolographicViewConfiguration {
     type Vtable = IHolographicViewConfiguration_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBitmapBuffer, IBitmapBuffer_Vtbl, 0xa53e04c4_399c_438c_b28f_a63a6b83d1a1);
+impl windows_core::RuntimeType for IBitmapBuffer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapBuffer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IBitmapBuffer_Vtbl {
     pub GetPlaneDescription: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut BitmapPlaneDescription) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapCodecInformation, IBitmapCodecInformation_Vtbl, 0x400caaf2_c4b0_4392_a3b0_6f6f9ba95cb4);
+impl windows_core::RuntimeType for IBitmapCodecInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapCodecInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +27,9 @@ pub struct IBitmapCodecInformation_Vtbl {
     MimeTypes: usize,
 }
 windows_core::imp::define_interface!(IBitmapDecoder, IBitmapDecoder_Vtbl, 0xacef22ba_1d74_4c91_9dfc_9620745233e6);
+impl windows_core::RuntimeType for IBitmapDecoder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapDecoder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +43,9 @@ pub struct IBitmapDecoder_Vtbl {
     pub GetFrameAsync: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapDecoderStatics, IBitmapDecoderStatics_Vtbl, 0x438ccb26_bcef_4e95_bad6_23a822e58d01);
+impl windows_core::RuntimeType for IBitmapDecoderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapDecoderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +70,9 @@ pub struct IBitmapDecoderStatics_Vtbl {
     CreateWithIdAsync: usize,
 }
 windows_core::imp::define_interface!(IBitmapDecoderStatics2, IBitmapDecoderStatics2_Vtbl, 0x50ba68ea_99a1_40c4_80d9_aef0dafa6c3f);
+impl windows_core::RuntimeType for IBitmapDecoderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapDecoderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -65,6 +80,9 @@ pub struct IBitmapDecoderStatics2_Vtbl {
     pub WebpDecoderId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapEncoder, IBitmapEncoder_Vtbl, 0x2bc468e3_e1f8_4b54_95e8_32919551ce62);
+impl windows_core::RuntimeType for IBitmapEncoder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapEncoder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -87,6 +105,9 @@ pub struct IBitmapEncoder_Vtbl {
     pub FlushAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapEncoderStatics, IBitmapEncoderStatics_Vtbl, 0xa74356a7_a4e4_4eb9_8e40_564de7e1ccb2);
+impl windows_core::RuntimeType for IBitmapEncoderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapEncoderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,12 +136,18 @@ pub struct IBitmapEncoderStatics_Vtbl {
     pub CreateForInPlacePropertyEncodingAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapEncoderStatics2, IBitmapEncoderStatics2_Vtbl, 0x33cbc259_fe31_41b1_b812_086d21e87e16);
+impl windows_core::RuntimeType for IBitmapEncoderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapEncoderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub HeifEncoderId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapEncoderWithSoftwareBitmap, IBitmapEncoderWithSoftwareBitmap_Vtbl, 0x686cd241_4330_4c77_ace4_0334968b1768);
+impl windows_core::RuntimeType for IBitmapEncoderWithSoftwareBitmap {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapEncoderWithSoftwareBitmap_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -368,6 +395,9 @@ pub struct IBitmapFrameWithSoftwareBitmap_Vtbl {
     pub GetSoftwareBitmapTransformedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, BitmapPixelFormat, BitmapAlphaMode, *mut core::ffi::c_void, ExifOrientationMode, ColorManagementMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapProperties, IBitmapProperties_Vtbl, 0xea9f4f1b_b505_4450_a4d1_e8ca94529d8d);
+impl windows_core::RuntimeType for IBitmapProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -403,6 +433,9 @@ pub struct IBitmapPropertiesView_Vtbl {
     GetPropertiesAsync: usize,
 }
 windows_core::imp::define_interface!(IBitmapTransform, IBitmapTransform_Vtbl, 0xae755344_e268_4d35_adcf_e995d31a8d34);
+impl windows_core::RuntimeType for IBitmapTransform {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapTransform_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -420,6 +453,9 @@ pub struct IBitmapTransform_Vtbl {
     pub SetBounds: unsafe extern "system" fn(*mut core::ffi::c_void, BitmapBounds) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapTypedValue, IBitmapTypedValue_Vtbl, 0xcd8044a9_2443_4000_b0cd_79316c56f589);
+impl windows_core::RuntimeType for IBitmapTypedValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapTypedValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -427,18 +463,27 @@ pub struct IBitmapTypedValue_Vtbl {
     pub Type: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::PropertyType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBitmapTypedValueFactory, IBitmapTypedValueFactory_Vtbl, 0x92dbb599_ce13_46bb_9545_cb3a3f63eb8b);
+impl windows_core::RuntimeType for IBitmapTypedValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBitmapTypedValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, super::super::Foundation::PropertyType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPixelDataProvider, IPixelDataProvider_Vtbl, 0xdd831f25_185c_4595_9fb9_ccbe6ec18a6f);
+impl windows_core::RuntimeType for IPixelDataProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPixelDataProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DetachPixelData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISoftwareBitmap, ISoftwareBitmap_Vtbl, 0x689e0708_7eef_483f_963f_da938818e073);
+impl windows_core::RuntimeType for ISoftwareBitmap {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISoftwareBitmap_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -464,6 +509,9 @@ pub struct ISoftwareBitmap_Vtbl {
     pub GetReadOnlyView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISoftwareBitmapFactory, ISoftwareBitmapFactory_Vtbl, 0xc99feb69_2d62_4d47_a6b3_4fdb6a07fdf8);
+impl windows_core::RuntimeType for ISoftwareBitmapFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISoftwareBitmapFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -471,6 +519,9 @@ pub struct ISoftwareBitmapFactory_Vtbl {
     pub CreateWithAlpha: unsafe extern "system" fn(*mut core::ffi::c_void, BitmapPixelFormat, i32, i32, BitmapAlphaMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISoftwareBitmapStatics, ISoftwareBitmapStatics_Vtbl, 0xdf0385db_672f_4a9d_806e_c2442f343e86);
+impl windows_core::RuntimeType for ISoftwareBitmapStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISoftwareBitmapStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -527,7 +578,7 @@ impl BitmapBuffer {
     }
 }
 impl windows_core::RuntimeType for BitmapBuffer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapBuffer>();
 }
 unsafe impl windows_core::Interface for BitmapBuffer {
     type Vtable = IBitmapBuffer_Vtbl;
@@ -575,7 +626,7 @@ impl BitmapCodecInformation {
     }
 }
 impl windows_core::RuntimeType for BitmapCodecInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapCodecInformation>();
 }
 unsafe impl windows_core::Interface for BitmapCodecInformation {
     type Vtable = IBitmapCodecInformation_Vtbl;
@@ -833,7 +884,7 @@ impl BitmapDecoder {
     }
 }
 impl windows_core::RuntimeType for BitmapDecoder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapDecoder>();
 }
 unsafe impl windows_core::Interface for BitmapDecoder {
     type Vtable = IBitmapDecoder_Vtbl;
@@ -1048,7 +1099,7 @@ impl BitmapEncoder {
     }
 }
 impl windows_core::RuntimeType for BitmapEncoder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapEncoder>();
 }
 unsafe impl windows_core::Interface for BitmapEncoder {
     type Vtable = IBitmapEncoder_Vtbl;
@@ -1179,7 +1230,7 @@ impl BitmapFrame {
     }
 }
 impl windows_core::RuntimeType for BitmapFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapFrame>();
 }
 unsafe impl windows_core::Interface for BitmapFrame {
     type Vtable = IBitmapFrame_Vtbl;
@@ -1220,7 +1271,7 @@ impl BitmapProperties {
     }
 }
 impl windows_core::RuntimeType for BitmapProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapProperties>();
 }
 unsafe impl windows_core::Interface for BitmapProperties {
     type Vtable = IBitmapProperties_Vtbl;
@@ -1250,7 +1301,7 @@ impl BitmapPropertiesView {
     }
 }
 impl windows_core::RuntimeType for BitmapPropertiesView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapPropertiesView>();
 }
 unsafe impl windows_core::Interface for BitmapPropertiesView {
     type Vtable = IBitmapPropertiesView_Vtbl;
@@ -1342,7 +1393,7 @@ impl BitmapPropertySet {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for BitmapPropertySet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IMap<windows_core::HSTRING, BitmapTypedValue>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for BitmapPropertySet {
@@ -1453,7 +1504,7 @@ impl BitmapTransform {
     }
 }
 impl windows_core::RuntimeType for BitmapTransform {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapTransform>();
 }
 unsafe impl windows_core::Interface for BitmapTransform {
     type Vtable = IBitmapTransform_Vtbl;
@@ -1499,7 +1550,7 @@ impl BitmapTypedValue {
     }
 }
 impl windows_core::RuntimeType for BitmapTypedValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBitmapTypedValue>();
 }
 unsafe impl windows_core::Interface for BitmapTypedValue {
     type Vtable = IBitmapTypedValue_Vtbl;
@@ -1631,7 +1682,7 @@ impl ImageStream {
 }
 #[cfg(feature = "Storage_Streams")]
 impl windows_core::RuntimeType for ImageStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Storage::Streams::IRandomAccessStreamWithContentType>();
 }
 #[cfg(feature = "Storage_Streams")]
 unsafe impl windows_core::Interface for ImageStream {
@@ -1660,7 +1711,7 @@ impl PixelDataProvider {
     }
 }
 impl windows_core::RuntimeType for PixelDataProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPixelDataProvider>();
 }
 unsafe impl windows_core::Interface for PixelDataProvider {
     type Vtable = IPixelDataProvider_Vtbl;
@@ -1866,7 +1917,7 @@ impl SoftwareBitmap {
     }
 }
 impl windows_core::RuntimeType for SoftwareBitmap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISoftwareBitmap>();
 }
 unsafe impl windows_core::Interface for SoftwareBitmap {
     type Vtable = ISoftwareBitmap_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPrintBindingOptionDetails, IPrintBindingOptionDetails_Vtbl, 0xc3f4cc98_9564_4f16_a055_a98b9a49e9d3);
+impl windows_core::RuntimeType for IPrintBindingOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintBindingOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IPrintBindingOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintBorderingOptionDetails, IPrintBorderingOptionDetails_Vtbl, 0x4d73bc8f_fb53_4eb2_985f_1d91de0b7639);
+impl windows_core::RuntimeType for IPrintBorderingOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintBorderingOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IPrintBorderingOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCollationOptionDetails, IPrintCollationOptionDetails_Vtbl, 0xd6abb166_a5a6_40dc_acc3_739f28f1e5d3);
+impl windows_core::RuntimeType for IPrintCollationOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCollationOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +35,9 @@ pub struct IPrintCollationOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintColorModeOptionDetails, IPrintColorModeOptionDetails_Vtbl, 0xdba97704_f1d6_4843_a484_9b447cdcf3b6);
+impl windows_core::RuntimeType for IPrintColorModeOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintColorModeOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,6 +47,9 @@ pub struct IPrintColorModeOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCopiesOptionDetails, IPrintCopiesOptionDetails_Vtbl, 0x42053099_4339_4343_898d_2c47b5e0c341);
+impl windows_core::RuntimeType for IPrintCopiesOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCopiesOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +59,9 @@ pub struct IPrintCopiesOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCustomItemDetails, IPrintCustomItemDetails_Vtbl, 0x5704b637_5c3a_449a_aa36_b3291b1192fd);
+impl windows_core::RuntimeType for IPrintCustomItemDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCustomItemDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,12 +70,18 @@ pub struct IPrintCustomItemDetails_Vtbl {
     pub ItemDisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCustomItemListOptionDetails, IPrintCustomItemListOptionDetails_Vtbl, 0xa5fafd88_58f2_4ebd_b90f_51e4f2944c5d);
+impl windows_core::RuntimeType for IPrintCustomItemListOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCustomItemListOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AddItem: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCustomItemListOptionDetails2, IPrintCustomItemListOptionDetails2_Vtbl, 0xc9d6353d_651c_4a39_906e_1091a1801bf1);
+impl windows_core::RuntimeType for IPrintCustomItemListOptionDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCustomItemListOptionDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +91,9 @@ pub struct IPrintCustomItemListOptionDetails2_Vtbl {
     AddItem: usize,
 }
 windows_core::imp::define_interface!(IPrintCustomItemListOptionDetails3, IPrintCustomItemListOptionDetails3_Vtbl, 0x4fa1b53f_3c34_4868_a407_fc5eab259b21);
+impl windows_core::RuntimeType for IPrintCustomItemListOptionDetails3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCustomItemListOptionDetails3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,6 +181,9 @@ pub struct IPrintCustomOptionDetails_Vtbl {
     pub DisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCustomTextOptionDetails, IPrintCustomTextOptionDetails_Vtbl, 0x2ad171f8_c8bd_4905_9192_0d75136e8b31);
+impl windows_core::RuntimeType for IPrintCustomTextOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCustomTextOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +191,9 @@ pub struct IPrintCustomTextOptionDetails_Vtbl {
     pub MaxCharacters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCustomTextOptionDetails2, IPrintCustomTextOptionDetails2_Vtbl, 0xcea70b54_b977_4718_8338_7ed2b0d86fe3);
+impl windows_core::RuntimeType for IPrintCustomTextOptionDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCustomTextOptionDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -170,6 +203,9 @@ pub struct IPrintCustomTextOptionDetails2_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintCustomToggleOptionDetails, IPrintCustomToggleOptionDetails_Vtbl, 0x9db4d514_e461_4608_8ee9_db6f5ed073c6);
+impl windows_core::RuntimeType for IPrintCustomToggleOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintCustomToggleOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,6 +215,9 @@ pub struct IPrintCustomToggleOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintDuplexOptionDetails, IPrintDuplexOptionDetails_Vtbl, 0xfcd94591_d4a4_44fa_b3fe_42e0ba28d5ad);
+impl windows_core::RuntimeType for IPrintDuplexOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintDuplexOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +227,9 @@ pub struct IPrintDuplexOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintHolePunchOptionDetails, IPrintHolePunchOptionDetails_Vtbl, 0xa6de1f18_482c_4657_9d71_8ddddbea1e1e);
+impl windows_core::RuntimeType for IPrintHolePunchOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintHolePunchOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +316,9 @@ pub struct IPrintItemListOptionDetails_Vtbl {
     Items: usize,
 }
 windows_core::imp::define_interface!(IPrintMediaSizeOptionDetails, IPrintMediaSizeOptionDetails_Vtbl, 0x6c8d5bcf_c0bf_47c8_b84a_628e7d0d1a1d);
+impl windows_core::RuntimeType for IPrintMediaSizeOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintMediaSizeOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -283,6 +328,9 @@ pub struct IPrintMediaSizeOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintMediaTypeOptionDetails, IPrintMediaTypeOptionDetails_Vtbl, 0xf8c7000b_abf3_4abc_8e86_22abc5744a43);
+impl windows_core::RuntimeType for IPrintMediaTypeOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintMediaTypeOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -445,6 +493,9 @@ pub struct IPrintOptionDetails_Vtbl {
     pub TrySetValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintOrientationOptionDetails, IPrintOrientationOptionDetails_Vtbl, 0x46c38879_66e0_4da0_87b4_d25457824eb7);
+impl windows_core::RuntimeType for IPrintOrientationOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintOrientationOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -454,6 +505,9 @@ pub struct IPrintOrientationOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintPageRangeOptionDetails, IPrintPageRangeOptionDetails_Vtbl, 0x5a19e4b7_2be8_4aa7_9ea5_defbe8713b4e);
+impl windows_core::RuntimeType for IPrintPageRangeOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintPageRangeOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -463,6 +517,9 @@ pub struct IPrintPageRangeOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintQualityOptionDetails, IPrintQualityOptionDetails_Vtbl, 0x2dd06ba1_ce1a_44e6_84f9_3a92ea1e3044);
+impl windows_core::RuntimeType for IPrintQualityOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintQualityOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -472,6 +529,9 @@ pub struct IPrintQualityOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintStapleOptionDetails, IPrintStapleOptionDetails_Vtbl, 0xd43175bd_9c0b_44e0_84f6_ceebce653800);
+impl windows_core::RuntimeType for IPrintStapleOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintStapleOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -481,12 +541,18 @@ pub struct IPrintStapleOptionDetails_Vtbl {
     pub Description: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskOptionChangedEventArgs, IPrintTaskOptionChangedEventArgs_Vtbl, 0x65197d05_a5ee_4307_9407_9acad147679c);
+impl windows_core::RuntimeType for IPrintTaskOptionChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskOptionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OptionId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskOptionDetails, IPrintTaskOptionDetails_Vtbl, 0xf5720af1_a89e_42a6_81af_f8e010b38a68);
+impl windows_core::RuntimeType for IPrintTaskOptionDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskOptionDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -502,12 +568,18 @@ pub struct IPrintTaskOptionDetails_Vtbl {
     pub RemoveBeginValidation: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskOptionDetails2, IPrintTaskOptionDetails2_Vtbl, 0x53730a09_f968_4692_a177_c074597186db);
+impl windows_core::RuntimeType for IPrintTaskOptionDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskOptionDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateToggleOption: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskOptionDetailsStatic, IPrintTaskOptionDetailsStatic_Vtbl, 0x135da193_0961_4b6e_8766_f13b7fbccd58);
+impl windows_core::RuntimeType for IPrintTaskOptionDetailsStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskOptionDetailsStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -677,7 +749,7 @@ impl PrintBindingOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintBindingOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintBindingOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -779,7 +851,7 @@ impl PrintBorderingOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintBorderingOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintBorderingOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -881,7 +953,7 @@ impl PrintCollationOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintCollationOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintCollationOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -983,7 +1055,7 @@ impl PrintColorModeOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintColorModeOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintColorModeOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1091,7 +1163,7 @@ impl PrintCopiesOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintCopiesOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintCopiesOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1127,7 +1199,7 @@ impl PrintCustomItemDetails {
     }
 }
 impl windows_core::RuntimeType for PrintCustomItemDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintCustomItemDetails>();
 }
 unsafe impl windows_core::Interface for PrintCustomItemDetails {
     type Vtable = IPrintCustomItemDetails_Vtbl;
@@ -1252,7 +1324,7 @@ impl PrintCustomItemListOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintCustomItemListOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintCustomItemListOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1368,7 +1440,7 @@ impl PrintCustomTextOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintCustomTextOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintCustomTextOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1473,7 +1545,7 @@ impl PrintCustomToggleOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintCustomToggleOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintCustomToggleOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1575,7 +1647,7 @@ impl PrintDuplexOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintDuplexOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintDuplexOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1677,7 +1749,7 @@ impl PrintHolePunchOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintHolePunchOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintHolePunchOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1779,7 +1851,7 @@ impl PrintMediaSizeOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintMediaSizeOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintMediaSizeOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1881,7 +1953,7 @@ impl PrintMediaTypeOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintMediaTypeOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintMediaTypeOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -1983,7 +2055,7 @@ impl PrintOrientationOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintOrientationOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintOrientationOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -2077,7 +2149,7 @@ impl PrintPageRangeOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintPageRangeOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintPageRangeOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -2179,7 +2251,7 @@ impl PrintQualityOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintQualityOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintQualityOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -2281,7 +2353,7 @@ impl PrintStapleOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintStapleOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintStapleOptionDetails {
     type Vtable = IPrintOptionDetails_Vtbl;
@@ -2306,7 +2378,7 @@ impl PrintTaskOptionChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintTaskOptionChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskOptionChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintTaskOptionChangedEventArgs {
     type Vtable = IPrintTaskOptionChangedEventArgs_Vtbl;
@@ -2411,7 +2483,7 @@ impl PrintTaskOptionDetails {
     }
 }
 impl windows_core::RuntimeType for PrintTaskOptionDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskOptionDetails>();
 }
 unsafe impl windows_core::Interface for PrintTaskOptionDetails {
     type Vtable = IPrintTaskOptionDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPrintSupportExtensionSession, IPrintSupportExtensionSession_Vtbl, 0xeea45f1a_f4c6_54b3_a0b8_a559839aa4c3);
+impl windows_core::RuntimeType for IPrintSupportExtensionSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportExtensionSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +16,9 @@ pub struct IPrintSupportExtensionSession_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportExtensionSession2, IPrintSupportExtensionSession2_Vtbl, 0x10fa8c11_6de8_5765_8fcf_e716e0f27ed1);
+impl windows_core::RuntimeType for IPrintSupportExtensionSession2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportExtensionSession2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,12 +26,18 @@ pub struct IPrintSupportExtensionSession2_Vtbl {
     pub RemovePrinterSelected: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportExtensionTriggerDetails, IPrintSupportExtensionTriggerDetails_Vtbl, 0xae083711_9b09_55d1_a0ae_2a14c5f83d6a);
+impl windows_core::RuntimeType for IPrintSupportExtensionTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportExtensionTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Session: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportPrintDeviceCapabilitiesChangedEventArgs, IPrintSupportPrintDeviceCapabilitiesChangedEventArgs_Vtbl, 0x15969bf0_9028_5722_8a37_7d7c34b41dd6);
+impl windows_core::RuntimeType for IPrintSupportPrintDeviceCapabilitiesChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportPrintDeviceCapabilitiesChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +52,9 @@ pub struct IPrintSupportPrintDeviceCapabilitiesChangedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportPrintDeviceCapabilitiesChangedEventArgs2, IPrintSupportPrintDeviceCapabilitiesChangedEventArgs2_Vtbl, 0x469df9e7_fd07_5eeb_a07d_9fcc67f089ba);
+impl windows_core::RuntimeType for IPrintSupportPrintDeviceCapabilitiesChangedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportPrintDeviceCapabilitiesChangedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,11 +74,17 @@ pub struct IPrintSupportPrintDeviceCapabilitiesChangedEventArgs2_Vtbl {
     pub SetPrintDeviceCapabilitiesUpdatePolicy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportPrintDeviceCapabilitiesUpdatePolicy, IPrintSupportPrintDeviceCapabilitiesUpdatePolicy_Vtbl, 0x5f5fc025_8c35_5529_8038_8cdc3634bbcd);
+impl windows_core::RuntimeType for IPrintSupportPrintDeviceCapabilitiesUpdatePolicy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportPrintDeviceCapabilitiesUpdatePolicy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPrintSupportPrintDeviceCapabilitiesUpdatePolicyStatics, IPrintSupportPrintDeviceCapabilitiesUpdatePolicyStatics_Vtbl, 0x3d9e1a70_7c39_551f_aa1f_f8ca35b3119e);
+impl windows_core::RuntimeType for IPrintSupportPrintDeviceCapabilitiesUpdatePolicyStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportPrintDeviceCapabilitiesUpdatePolicyStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +92,9 @@ pub struct IPrintSupportPrintDeviceCapabilitiesUpdatePolicyStatics_Vtbl {
     pub CreatePrintJobRefresh: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportPrintTicketElement, IPrintSupportPrintTicketElement_Vtbl, 0x4b2a4489_730d_5be7_80e6_8332941abf13);
+impl windows_core::RuntimeType for IPrintSupportPrintTicketElement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportPrintTicketElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +104,9 @@ pub struct IPrintSupportPrintTicketElement_Vtbl {
     pub SetNamespaceUri: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportPrintTicketValidationRequestedEventArgs, IPrintSupportPrintTicketValidationRequestedEventArgs_Vtbl, 0x338e4e69_db55_55c7_8338_ef64680a8f90);
+impl windows_core::RuntimeType for IPrintSupportPrintTicketValidationRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportPrintTicketValidationRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,6 +118,9 @@ pub struct IPrintSupportPrintTicketValidationRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportPrinterSelectedEventArgs, IPrintSupportPrinterSelectedEventArgs_Vtbl, 0x7b1cb7d9_a8a4_5c09_adb2_66165f817977);
+impl windows_core::RuntimeType for IPrintSupportPrinterSelectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportPrinterSelectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,6 +152,9 @@ pub struct IPrintSupportPrinterSelectedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportSessionInfo, IPrintSupportSessionInfo_Vtbl, 0x852149af_777d_53e9_9ee9_45d3f4b5be9c);
+impl windows_core::RuntimeType for IPrintSupportSessionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportSessionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,6 +168,9 @@ pub struct IPrintSupportSessionInfo_Vtbl {
     Printer: usize,
 }
 windows_core::imp::define_interface!(IPrintSupportSettingsActivatedEventArgs, IPrintSupportSettingsActivatedEventArgs_Vtbl, 0x1e1b565e_a013_55ea_9b8c_eea39d9fb6c1);
+impl windows_core::RuntimeType for IPrintSupportSettingsActivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportSettingsActivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -142,6 +178,9 @@ pub struct IPrintSupportSettingsActivatedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintSupportSettingsUISession, IPrintSupportSettingsUISession_Vtbl, 0xc6da2251_83c3_55e4_a0f8_5de8b062adbf);
+impl windows_core::RuntimeType for IPrintSupportSettingsUISession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintSupportSettingsUISession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -218,7 +257,7 @@ impl PrintSupportExtensionSession {
     }
 }
 impl windows_core::RuntimeType for PrintSupportExtensionSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportExtensionSession>();
 }
 unsafe impl windows_core::Interface for PrintSupportExtensionSession {
     type Vtable = IPrintSupportExtensionSession_Vtbl;
@@ -243,7 +282,7 @@ impl PrintSupportExtensionTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PrintSupportExtensionTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportExtensionTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PrintSupportExtensionTriggerDetails {
     type Vtable = IPrintSupportExtensionTriggerDetails_Vtbl;
@@ -322,7 +361,7 @@ impl PrintSupportPrintDeviceCapabilitiesChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintSupportPrintDeviceCapabilitiesChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportPrintDeviceCapabilitiesChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintSupportPrintDeviceCapabilitiesChangedEventArgs {
     type Vtable = IPrintSupportPrintDeviceCapabilitiesChangedEventArgs_Vtbl;
@@ -357,7 +396,7 @@ impl PrintSupportPrintDeviceCapabilitiesUpdatePolicy {
     }
 }
 impl windows_core::RuntimeType for PrintSupportPrintDeviceCapabilitiesUpdatePolicy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportPrintDeviceCapabilitiesUpdatePolicy>();
 }
 unsafe impl windows_core::Interface for PrintSupportPrintDeviceCapabilitiesUpdatePolicy {
     type Vtable = IPrintSupportPrintDeviceCapabilitiesUpdatePolicy_Vtbl;
@@ -404,7 +443,7 @@ impl PrintSupportPrintTicketElement {
     }
 }
 impl windows_core::RuntimeType for PrintSupportPrintTicketElement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportPrintTicketElement>();
 }
 unsafe impl windows_core::Interface for PrintSupportPrintTicketElement {
     type Vtable = IPrintSupportPrintTicketElement_Vtbl;
@@ -441,7 +480,7 @@ impl PrintSupportPrintTicketValidationRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintSupportPrintTicketValidationRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportPrintTicketValidationRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintSupportPrintTicketValidationRequestedEventArgs {
     type Vtable = IPrintSupportPrintTicketValidationRequestedEventArgs_Vtbl;
@@ -521,7 +560,7 @@ impl PrintSupportPrinterSelectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintSupportPrinterSelectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportPrinterSelectedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintSupportPrinterSelectedEventArgs {
     type Vtable = IPrintSupportPrinterSelectedEventArgs_Vtbl;
@@ -555,7 +594,7 @@ impl PrintSupportSessionInfo {
     }
 }
 impl windows_core::RuntimeType for PrintSupportSessionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportSessionInfo>();
 }
 unsafe impl windows_core::Interface for PrintSupportSessionInfo {
     type Vtable = IPrintSupportSessionInfo_Vtbl;
@@ -621,7 +660,7 @@ impl PrintSupportSettingsActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintSupportSettingsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportSettingsActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintSupportSettingsActivatedEventArgs {
     type Vtable = IPrintSupportSettingsActivatedEventArgs_Vtbl;
@@ -676,7 +715,7 @@ impl PrintSupportSettingsUISession {
     }
 }
 impl windows_core::RuntimeType for PrintSupportSettingsUISession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintSupportSettingsUISession>();
 }
 unsafe impl windows_core::Interface for PrintSupportSettingsUISession {
     type Vtable = IPrintSupportSettingsUISession_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPrintTicketCapabilities, IPrintTicketCapabilities_Vtbl, 0x8c45508b_bbdc_4256_a142_2fd615ecb416);
+impl windows_core::RuntimeType for IPrintTicketCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTicketCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +30,9 @@ pub struct IPrintTicketCapabilities_Vtbl {
     pub GetParameterDefinition: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTicketFeature, IPrintTicketFeature_Vtbl, 0xe7607d6a_59f5_4103_8858_b97710963d39);
+impl windows_core::RuntimeType for IPrintTicketFeature {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTicketFeature_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +53,9 @@ pub struct IPrintTicketFeature_Vtbl {
     pub SelectionType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PrintTicketFeatureSelectionType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTicketOption, IPrintTicketOption_Vtbl, 0xb086cf90_b367_4e4b_bd48_9c78a0bb31ce);
+impl windows_core::RuntimeType for IPrintTicketOption {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTicketOption_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +78,9 @@ pub struct IPrintTicketOption_Vtbl {
     pub GetScoredPropertyValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTicketParameterDefinition, IPrintTicketParameterDefinition_Vtbl, 0xd6bab4e4_2962_4c01_b7f3_9a9294eb8335);
+impl windows_core::RuntimeType for IPrintTicketParameterDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTicketParameterDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +96,9 @@ pub struct IPrintTicketParameterDefinition_Vtbl {
     pub RangeMax: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTicketParameterInitializer, IPrintTicketParameterInitializer_Vtbl, 0x5e3335bb_a0a5_48b1_9d5c_07116ddc597a);
+impl windows_core::RuntimeType for IPrintTicketParameterInitializer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTicketParameterInitializer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -97,6 +112,9 @@ pub struct IPrintTicketParameterInitializer_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTicketValue, IPrintTicketValue_Vtbl, 0x66b30a32_244d_4e22_a98b_bb3cf1f2dd91);
+impl windows_core::RuntimeType for IPrintTicketValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTicketValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,6 +123,9 @@ pub struct IPrintTicketValue_Vtbl {
     pub GetValueAsString: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWorkflowPrintTicket, IWorkflowPrintTicket_Vtbl, 0x41d52285_35e8_448e_a8c5_e4b6a2cf826c);
+impl windows_core::RuntimeType for IWorkflowPrintTicket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWorkflowPrintTicket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +160,9 @@ pub struct IWorkflowPrintTicket_Vtbl {
     pub MergeAndValidateTicket: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWorkflowPrintTicketValidationResult, IWorkflowPrintTicketValidationResult_Vtbl, 0x0ad1f392_da7b_4a36_bf36_6a99a62e2059);
+impl windows_core::RuntimeType for IWorkflowPrintTicketValidationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWorkflowPrintTicketValidationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -293,7 +317,7 @@ impl PrintTicketCapabilities {
     }
 }
 impl windows_core::RuntimeType for PrintTicketCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTicketCapabilities>();
 }
 unsafe impl windows_core::Interface for PrintTicketCapabilities {
     type Vtable = IPrintTicketCapabilities_Vtbl;
@@ -376,7 +400,7 @@ impl PrintTicketFeature {
     }
 }
 impl windows_core::RuntimeType for PrintTicketFeature {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTicketFeature>();
 }
 unsafe impl windows_core::Interface for PrintTicketFeature {
     type Vtable = IPrintTicketFeature_Vtbl;
@@ -453,7 +477,7 @@ impl PrintTicketOption {
     }
 }
 impl windows_core::RuntimeType for PrintTicketOption {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTicketOption>();
 }
 unsafe impl windows_core::Interface for PrintTicketOption {
     type Vtable = IPrintTicketOption_Vtbl;
@@ -521,7 +545,7 @@ impl PrintTicketParameterDefinition {
     }
 }
 impl windows_core::RuntimeType for PrintTicketParameterDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTicketParameterDefinition>();
 }
 unsafe impl windows_core::Interface for PrintTicketParameterDefinition {
     type Vtable = IPrintTicketParameterDefinition_Vtbl;
@@ -575,7 +599,7 @@ impl PrintTicketParameterInitializer {
     }
 }
 impl windows_core::RuntimeType for PrintTicketParameterInitializer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTicketParameterInitializer>();
 }
 unsafe impl windows_core::Interface for PrintTicketParameterInitializer {
     type Vtable = IPrintTicketParameterInitializer_Vtbl;
@@ -614,7 +638,7 @@ impl PrintTicketValue {
     }
 }
 impl windows_core::RuntimeType for PrintTicketValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTicketValue>();
 }
 unsafe impl windows_core::Interface for PrintTicketValue {
     type Vtable = IPrintTicketValue_Vtbl;
@@ -818,7 +842,7 @@ impl WorkflowPrintTicket {
     }
 }
 impl windows_core::RuntimeType for WorkflowPrintTicket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWorkflowPrintTicket>();
 }
 unsafe impl windows_core::Interface for WorkflowPrintTicket {
     type Vtable = IWorkflowPrintTicket_Vtbl;
@@ -850,7 +874,7 @@ impl WorkflowPrintTicketValidationResult {
     }
 }
 impl windows_core::RuntimeType for WorkflowPrintTicketValidationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWorkflowPrintTicketValidationResult>();
 }
 unsafe impl windows_core::Interface for WorkflowPrintTicketValidationResult {
     type Vtable = IWorkflowPrintTicketValidationResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPrintWorkflowBackgroundSession, IPrintWorkflowBackgroundSession_Vtbl, 0x5b7913ba_0c5e_528a_7458_86a46cbddc45);
+impl windows_core::RuntimeType for IPrintWorkflowBackgroundSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowBackgroundSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IPrintWorkflowBackgroundSession_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowBackgroundSetupRequestedEventArgs, IPrintWorkflowBackgroundSetupRequestedEventArgs_Vtbl, 0x43e97342_1750_59c9_61fb_383748a20362);
+impl windows_core::RuntimeType for IPrintWorkflowBackgroundSetupRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowBackgroundSetupRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +28,9 @@ pub struct IPrintWorkflowBackgroundSetupRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowConfiguration, IPrintWorkflowConfiguration_Vtbl, 0xd0aac4ed_fd4b_5df5_4bb6_8d0d159ebe3f);
+impl windows_core::RuntimeType for IPrintWorkflowConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,12 +39,18 @@ pub struct IPrintWorkflowConfiguration_Vtbl {
     pub SessionId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowConfiguration2, IPrintWorkflowConfiguration2_Vtbl, 0xde350a50_a6d4_5be2_8b9a_09d3d39ea780);
+impl windows_core::RuntimeType for IPrintWorkflowConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AbortPrintFlow: unsafe extern "system" fn(*mut core::ffi::c_void, PrintWorkflowJobAbortReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowForegroundSession, IPrintWorkflowForegroundSession_Vtbl, 0xc79b63d0_f8ec_4ceb_953a_c8876157dd33);
+impl windows_core::RuntimeType for IPrintWorkflowForegroundSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowForegroundSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +62,9 @@ pub struct IPrintWorkflowForegroundSession_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowForegroundSetupRequestedEventArgs, IPrintWorkflowForegroundSetupRequestedEventArgs_Vtbl, 0xbbe38247_9c1b_4dd3_9b2b_c80468d941b3);
+impl windows_core::RuntimeType for IPrintWorkflowForegroundSetupRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowForegroundSetupRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,12 +76,18 @@ pub struct IPrintWorkflowForegroundSetupRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowJobActivatedEventArgs, IPrintWorkflowJobActivatedEventArgs_Vtbl, 0xd4bd5e6d_034e_5e00_a616_f961a033dcc8);
+impl windows_core::RuntimeType for IPrintWorkflowJobActivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowJobActivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Session: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowJobBackgroundSession, IPrintWorkflowJobBackgroundSession_Vtbl, 0xc5ec6ad8_20c9_5d51_8507_2734b46f96c5);
+impl windows_core::RuntimeType for IPrintWorkflowJobBackgroundSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowJobBackgroundSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +99,9 @@ pub struct IPrintWorkflowJobBackgroundSession_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowJobNotificationEventArgs, IPrintWorkflowJobNotificationEventArgs_Vtbl, 0x0ae16fba_5398_5eba_b472_978650186a9a);
+impl windows_core::RuntimeType for IPrintWorkflowJobNotificationEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowJobNotificationEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,6 +110,9 @@ pub struct IPrintWorkflowJobNotificationEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowJobStartingEventArgs, IPrintWorkflowJobStartingEventArgs_Vtbl, 0xe3d99ba8_31ad_5e09_b0d7_601b97f161ad);
+impl windows_core::RuntimeType for IPrintWorkflowJobStartingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowJobStartingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,12 +125,18 @@ pub struct IPrintWorkflowJobStartingEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowJobTriggerDetails, IPrintWorkflowJobTriggerDetails_Vtbl, 0xff296129_60e2_51db_ba8c_e2ccddb516b9);
+impl windows_core::RuntimeType for IPrintWorkflowJobTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowJobTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PrintWorkflowJobSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowJobUISession, IPrintWorkflowJobUISession_Vtbl, 0x00c8736b_7637_5687_a302_0f664d2aac65);
+impl windows_core::RuntimeType for IPrintWorkflowJobUISession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowJobUISession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -112,11 +148,17 @@ pub struct IPrintWorkflowJobUISession_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowObjectModelSourceFileContent, IPrintWorkflowObjectModelSourceFileContent_Vtbl, 0xc36c8a6a_8a2a_419a_b3c3_2090e6bfab2f);
+impl windows_core::RuntimeType for IPrintWorkflowObjectModelSourceFileContent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowObjectModelSourceFileContent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPrintWorkflowObjectModelSourceFileContentFactory, IPrintWorkflowObjectModelSourceFileContentFactory_Vtbl, 0x93b1b903_f013_56d6_b708_99ac2ccb12ee);
+impl windows_core::RuntimeType for IPrintWorkflowObjectModelSourceFileContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowObjectModelSourceFileContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,11 +168,17 @@ pub struct IPrintWorkflowObjectModelSourceFileContentFactory_Vtbl {
     CreateInstance: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowObjectModelTargetPackage, IPrintWorkflowObjectModelTargetPackage_Vtbl, 0x7d96bc74_9b54_4ca1_ad3a_979c3d44ddac);
+impl windows_core::RuntimeType for IPrintWorkflowObjectModelTargetPackage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowObjectModelTargetPackage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPdlConverter, IPrintWorkflowPdlConverter_Vtbl, 0x40604b62_0ae4_51f1_818f_731dc0b005ab);
+impl windows_core::RuntimeType for IPrintWorkflowPdlConverter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPdlConverter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +188,9 @@ pub struct IPrintWorkflowPdlConverter_Vtbl {
     ConvertPdlAsync: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPdlConverter2, IPrintWorkflowPdlConverter2_Vtbl, 0x854ceec1_7837_5b93_b7af_57a6998c2f71);
+impl windows_core::RuntimeType for IPrintWorkflowPdlConverter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPdlConverter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -149,6 +200,9 @@ pub struct IPrintWorkflowPdlConverter2_Vtbl {
     ConvertPdlAsync: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPdlDataAvailableEventArgs, IPrintWorkflowPdlDataAvailableEventArgs_Vtbl, 0xd4ad6b50_1547_5991_a0ef_e2ee20211518);
+impl windows_core::RuntimeType for IPrintWorkflowPdlDataAvailableEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPdlDataAvailableEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +212,9 @@ pub struct IPrintWorkflowPdlDataAvailableEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPdlModificationRequestedEventArgs, IPrintWorkflowPdlModificationRequestedEventArgs_Vtbl, 0x1a339a61_2e13_5edd_a707_ceec61d7333b);
+impl windows_core::RuntimeType for IPrintWorkflowPdlModificationRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPdlModificationRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +235,9 @@ pub struct IPrintWorkflowPdlModificationRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPdlModificationRequestedEventArgs2, IPrintWorkflowPdlModificationRequestedEventArgs2_Vtbl, 0x8d692147_6c62_5e31_a0e7_d49f92c111c0);
+impl windows_core::RuntimeType for IPrintWorkflowPdlModificationRequestedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPdlModificationRequestedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -191,6 +251,9 @@ pub struct IPrintWorkflowPdlModificationRequestedEventArgs2_Vtbl {
     CreateJobOnPrinterWithAttributesBuffer: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPdlSourceContent, IPrintWorkflowPdlSourceContent_Vtbl, 0x92f7fc41_32b8_56ab_845e_b1e68b3aedd5);
+impl windows_core::RuntimeType for IPrintWorkflowPdlSourceContent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPdlSourceContent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -205,6 +268,9 @@ pub struct IPrintWorkflowPdlSourceContent_Vtbl {
     GetContentFileAsync: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPdlTargetStream, IPrintWorkflowPdlTargetStream_Vtbl, 0xa742dfe5_1ee3_52a9_9f9f_2e2043180fd1);
+impl windows_core::RuntimeType for IPrintWorkflowPdlTargetStream {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPdlTargetStream_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,6 +281,9 @@ pub struct IPrintWorkflowPdlTargetStream_Vtbl {
     pub CompleteStreamSubmission: unsafe extern "system" fn(*mut core::ffi::c_void, PrintWorkflowSubmittedStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowPrinterJob, IPrintWorkflowPrinterJob_Vtbl, 0x12009f94_0d14_5443_bc09_250311ce570b);
+impl windows_core::RuntimeType for IPrintWorkflowPrinterJob {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowPrinterJob_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -246,6 +315,9 @@ pub struct IPrintWorkflowPrinterJob_Vtbl {
     SetJobAttributes: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowSourceContent, IPrintWorkflowSourceContent_Vtbl, 0x1a28c641_ceb1_4533_bb73_fbe63eefdb18);
+impl windows_core::RuntimeType for IPrintWorkflowSourceContent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowSourceContent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -257,6 +329,9 @@ pub struct IPrintWorkflowSourceContent_Vtbl {
     pub GetSourceSpoolDataAsXpsObjectModel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowSpoolStreamContent, IPrintWorkflowSpoolStreamContent_Vtbl, 0x72e55ece_e406_4b74_84e1_3ff3fdcdaf70);
+impl windows_core::RuntimeType for IPrintWorkflowSpoolStreamContent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowSpoolStreamContent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -266,6 +341,9 @@ pub struct IPrintWorkflowSpoolStreamContent_Vtbl {
     GetInputStream: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowStreamTarget, IPrintWorkflowStreamTarget_Vtbl, 0xb23bba84_8565_488b_9839_1c9e7c7aa916);
+impl windows_core::RuntimeType for IPrintWorkflowStreamTarget {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowStreamTarget_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -275,6 +353,9 @@ pub struct IPrintWorkflowStreamTarget_Vtbl {
     GetOutputStream: usize,
 }
 windows_core::imp::define_interface!(IPrintWorkflowSubmittedEventArgs, IPrintWorkflowSubmittedEventArgs_Vtbl, 0x3add0a41_3794_5569_5c87_40e8ff720f83);
+impl windows_core::RuntimeType for IPrintWorkflowSubmittedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowSubmittedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -286,6 +367,9 @@ pub struct IPrintWorkflowSubmittedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowSubmittedOperation, IPrintWorkflowSubmittedOperation_Vtbl, 0x2e4e6216_3be1_5f0f_5c81_a5a2bd4eab0e);
+impl windows_core::RuntimeType for IPrintWorkflowSubmittedOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowSubmittedOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,6 +378,9 @@ pub struct IPrintWorkflowSubmittedOperation_Vtbl {
     pub XpsContent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowTarget, IPrintWorkflowTarget_Vtbl, 0x29da276c_0a73_5aed_4f3d_970d3251f057);
+impl windows_core::RuntimeType for IPrintWorkflowTarget {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowTarget_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -301,18 +388,27 @@ pub struct IPrintWorkflowTarget_Vtbl {
     pub TargetAsXpsObjectModelPackage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowTriggerDetails, IPrintWorkflowTriggerDetails_Vtbl, 0x5739d868_9d86_4052_b0cb_f310becd59bb);
+impl windows_core::RuntimeType for IPrintWorkflowTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PrintWorkflowSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowUIActivatedEventArgs, IPrintWorkflowUIActivatedEventArgs_Vtbl, 0xbc8a844d_09eb_5746_72a6_8dc8b5edbe9b);
+impl windows_core::RuntimeType for IPrintWorkflowUIActivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowUIActivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PrintWorkflowSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowUILauncher, IPrintWorkflowUILauncher_Vtbl, 0x64e9e22f_14cc_5828_96fb_39163fb6c378);
+impl windows_core::RuntimeType for IPrintWorkflowUILauncher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowUILauncher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -320,6 +416,9 @@ pub struct IPrintWorkflowUILauncher_Vtbl {
     pub LaunchAndCompleteUIAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintWorkflowXpsDataAvailableEventArgs, IPrintWorkflowXpsDataAvailableEventArgs_Vtbl, 0x4d11c331_54d1_434e_be0e_82c5fa58e5b2);
+impl windows_core::RuntimeType for IPrintWorkflowXpsDataAvailableEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintWorkflowXpsDataAvailableEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -372,7 +471,7 @@ impl PrintWorkflowBackgroundSession {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowBackgroundSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowBackgroundSession>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowBackgroundSession {
     type Vtable = IPrintWorkflowBackgroundSession_Vtbl;
@@ -416,7 +515,7 @@ impl PrintWorkflowBackgroundSetupRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowBackgroundSetupRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowBackgroundSetupRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowBackgroundSetupRequestedEventArgs {
     type Vtable = IPrintWorkflowBackgroundSetupRequestedEventArgs_Vtbl;
@@ -459,7 +558,7 @@ impl PrintWorkflowConfiguration {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowConfiguration>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowConfiguration {
     type Vtable = IPrintWorkflowConfiguration_Vtbl;
@@ -516,7 +615,7 @@ impl PrintWorkflowForegroundSession {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowForegroundSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowForegroundSession>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowForegroundSession {
     type Vtable = IPrintWorkflowForegroundSession_Vtbl;
@@ -556,7 +655,7 @@ impl PrintWorkflowForegroundSetupRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowForegroundSetupRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowForegroundSetupRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowForegroundSetupRequestedEventArgs {
     type Vtable = IPrintWorkflowForegroundSetupRequestedEventArgs_Vtbl;
@@ -615,7 +714,7 @@ impl PrintWorkflowJobActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowJobActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowJobActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowJobActivatedEventArgs {
     type Vtable = IPrintWorkflowJobActivatedEventArgs_Vtbl;
@@ -672,7 +771,7 @@ impl PrintWorkflowJobBackgroundSession {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowJobBackgroundSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowJobBackgroundSession>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowJobBackgroundSession {
     type Vtable = IPrintWorkflowJobBackgroundSession_Vtbl;
@@ -711,7 +810,7 @@ impl PrintWorkflowJobNotificationEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowJobNotificationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowJobNotificationEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowJobNotificationEventArgs {
     type Vtable = IPrintWorkflowJobNotificationEventArgs_Vtbl;
@@ -755,7 +854,7 @@ impl PrintWorkflowJobStartingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowJobStartingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowJobStartingEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowJobStartingEventArgs {
     type Vtable = IPrintWorkflowJobStartingEventArgs_Vtbl;
@@ -780,7 +879,7 @@ impl PrintWorkflowJobTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowJobTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowJobTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowJobTriggerDetails {
     type Vtable = IPrintWorkflowJobTriggerDetails_Vtbl;
@@ -837,7 +936,7 @@ impl PrintWorkflowJobUISession {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowJobUISession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowJobUISession>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowJobUISession {
     type Vtable = IPrintWorkflowJobUISession_Vtbl;
@@ -870,7 +969,7 @@ impl PrintWorkflowObjectModelSourceFileContent {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowObjectModelSourceFileContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowObjectModelSourceFileContent>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowObjectModelSourceFileContent {
     type Vtable = IPrintWorkflowObjectModelSourceFileContent_Vtbl;
@@ -887,7 +986,7 @@ pub struct PrintWorkflowObjectModelTargetPackage(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PrintWorkflowObjectModelTargetPackage, windows_core::IUnknown, windows_core::IInspectable);
 impl PrintWorkflowObjectModelTargetPackage {}
 impl windows_core::RuntimeType for PrintWorkflowObjectModelTargetPackage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowObjectModelTargetPackage>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowObjectModelTargetPackage {
     type Vtable = IPrintWorkflowObjectModelTargetPackage_Vtbl;
@@ -931,7 +1030,7 @@ impl PrintWorkflowPdlConverter {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowPdlConverter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowPdlConverter>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowPdlConverter {
     type Vtable = IPrintWorkflowPdlConverter_Vtbl;
@@ -977,7 +1076,7 @@ impl PrintWorkflowPdlDataAvailableEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowPdlDataAvailableEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowPdlDataAvailableEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowPdlDataAvailableEventArgs {
     type Vtable = IPrintWorkflowPdlDataAvailableEventArgs_Vtbl;
@@ -1090,7 +1189,7 @@ impl PrintWorkflowPdlModificationRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowPdlModificationRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowPdlModificationRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowPdlModificationRequestedEventArgs {
     type Vtable = IPrintWorkflowPdlModificationRequestedEventArgs_Vtbl;
@@ -1131,7 +1230,7 @@ impl PrintWorkflowPdlSourceContent {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowPdlSourceContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowPdlSourceContent>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowPdlSourceContent {
     type Vtable = IPrintWorkflowPdlSourceContent_Vtbl;
@@ -1161,7 +1260,7 @@ impl PrintWorkflowPdlTargetStream {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowPdlTargetStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowPdlTargetStream>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowPdlTargetStream {
     type Vtable = IPrintWorkflowPdlTargetStream_Vtbl;
@@ -1253,7 +1352,7 @@ impl PrintWorkflowPrinterJob {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowPrinterJob {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowPrinterJob>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowPrinterJob {
     type Vtable = IPrintWorkflowPrinterJob_Vtbl;
@@ -1293,7 +1392,7 @@ impl PrintWorkflowSourceContent {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowSourceContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowSourceContent>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowSourceContent {
     type Vtable = IPrintWorkflowSourceContent_Vtbl;
@@ -1319,7 +1418,7 @@ impl PrintWorkflowSpoolStreamContent {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowSpoolStreamContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowSpoolStreamContent>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowSpoolStreamContent {
     type Vtable = IPrintWorkflowSpoolStreamContent_Vtbl;
@@ -1345,7 +1444,7 @@ impl PrintWorkflowStreamTarget {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowStreamTarget {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowStreamTarget>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowStreamTarget {
     type Vtable = IPrintWorkflowStreamTarget_Vtbl;
@@ -1388,7 +1487,7 @@ impl PrintWorkflowSubmittedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowSubmittedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowSubmittedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowSubmittedEventArgs {
     type Vtable = IPrintWorkflowSubmittedEventArgs_Vtbl;
@@ -1424,7 +1523,7 @@ impl PrintWorkflowSubmittedOperation {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowSubmittedOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowSubmittedOperation>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowSubmittedOperation {
     type Vtable = IPrintWorkflowSubmittedOperation_Vtbl;
@@ -1456,7 +1555,7 @@ impl PrintWorkflowTarget {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowTarget {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowTarget>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowTarget {
     type Vtable = IPrintWorkflowTarget_Vtbl;
@@ -1481,7 +1580,7 @@ impl PrintWorkflowTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowTriggerDetails {
     type Vtable = IPrintWorkflowTriggerDetails_Vtbl;
@@ -1540,7 +1639,7 @@ impl PrintWorkflowUIActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowUIActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowUIActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowUIActivatedEventArgs {
     type Vtable = IPrintWorkflowUIActivatedEventArgs_Vtbl;
@@ -1572,7 +1671,7 @@ impl PrintWorkflowUILauncher {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowUILauncher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowUILauncher>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowUILauncher {
     type Vtable = IPrintWorkflowUILauncher_Vtbl;
@@ -1604,7 +1703,7 @@ impl PrintWorkflowXpsDataAvailableEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintWorkflowXpsDataAvailableEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintWorkflowXpsDataAvailableEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintWorkflowXpsDataAvailableEventArgs {
     type Vtable = IPrintWorkflowXpsDataAvailableEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
@@ -17,6 +17,9 @@ pub struct IPrintDocumentSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPrintManager, IPrintManager_Vtbl, 0xff2a9694_8c99_44fd_ae4a_19d9aa9a0f0a);
+impl windows_core::RuntimeType for IPrintManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +27,9 @@ pub struct IPrintManager_Vtbl {
     pub RemovePrintTaskRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintManagerStatic, IPrintManagerStatic_Vtbl, 0x58185dcd_e634_4654_84f0_e0152a8217ac);
+impl windows_core::RuntimeType for IPrintManagerStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintManagerStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,12 +37,18 @@ pub struct IPrintManagerStatic_Vtbl {
     pub ShowPrintUIAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintManagerStatic2, IPrintManagerStatic2_Vtbl, 0x35a99955_e6ab_4139_9abd_b86a729b3598);
+impl windows_core::RuntimeType for IPrintManagerStatic2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintManagerStatic2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintPageInfo, IPrintPageInfo_Vtbl, 0xdd4be9c9_a6a1_4ada_930e_da872a4f23d3);
+impl windows_core::RuntimeType for IPrintPageInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintPageInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,6 +64,9 @@ pub struct IPrintPageInfo_Vtbl {
     pub Orientation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PrintOrientation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintPageRange, IPrintPageRange_Vtbl, 0xf8a06c54_6e7c_51c5_57fd_0660c2d71513);
+impl windows_core::RuntimeType for IPrintPageRange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintPageRange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +74,9 @@ pub struct IPrintPageRange_Vtbl {
     pub LastPageNumber: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintPageRangeFactory, IPrintPageRangeFactory_Vtbl, 0x408fd45f_e047_5f85_7129_fb085a4fad14);
+impl windows_core::RuntimeType for IPrintPageRangeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintPageRangeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +84,9 @@ pub struct IPrintPageRangeFactory_Vtbl {
     pub CreateWithSinglePage: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintPageRangeOptions, IPrintPageRangeOptions_Vtbl, 0xce6db728_1357_46b2_a923_79f995f448fc);
+impl windows_core::RuntimeType for IPrintPageRangeOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintPageRangeOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +98,9 @@ pub struct IPrintPageRangeOptions_Vtbl {
     pub AllowCustomSetOfPages: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTask, IPrintTask_Vtbl, 0x61d80247_6cf6_4fad_84e2_a5e82e2d4ceb);
+impl windows_core::RuntimeType for IPrintTask {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTask_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,6 +120,9 @@ pub struct IPrintTask_Vtbl {
     pub RemoveCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTask2, IPrintTask2_Vtbl, 0x36234877_3e53_4d9d_8f5e_316ac8dedae1);
+impl windows_core::RuntimeType for IPrintTask2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTask2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,12 +130,18 @@ pub struct IPrintTask2_Vtbl {
     pub IsPreviewEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskCompletedEventArgs, IPrintTaskCompletedEventArgs_Vtbl, 0x5bcd34af_24e9_4c10_8d07_14c346ba3fce);
+impl windows_core::RuntimeType for IPrintTaskCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Completion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PrintTaskCompletion) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskOptions, IPrintTaskOptions_Vtbl, 0x5a0a66bb_d289_41bb_96dd_57e28338ae3f);
+impl windows_core::RuntimeType for IPrintTaskOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,6 +153,9 @@ pub struct IPrintTaskOptions_Vtbl {
     GetPagePrintTicket: usize,
 }
 windows_core::imp::define_interface!(IPrintTaskOptions2, IPrintTaskOptions2_Vtbl, 0xeb9b1606_9a36_4b59_8617_b217849262e1);
+impl windows_core::RuntimeType for IPrintTaskOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -342,12 +378,18 @@ pub struct IPrintTaskOptionsCoreUIConfiguration_Vtbl {
     DisplayedOptions: usize,
 }
 windows_core::imp::define_interface!(IPrintTaskProgressingEventArgs, IPrintTaskProgressingEventArgs_Vtbl, 0x810cd3cb_b410_4282_a073_5ac378234174);
+impl windows_core::RuntimeType for IPrintTaskProgressingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskProgressingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DocumentPageCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskRequest, IPrintTaskRequest_Vtbl, 0x6ff61e2e_2722_4240_a67c_f364849a17f3);
+impl windows_core::RuntimeType for IPrintTaskRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -356,18 +398,27 @@ pub struct IPrintTaskRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskRequestedDeferral, IPrintTaskRequestedDeferral_Vtbl, 0xcfefb3f0_ce3e_42c7_9496_64800c622c44);
+impl windows_core::RuntimeType for IPrintTaskRequestedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskRequestedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskRequestedEventArgs, IPrintTaskRequestedEventArgs_Vtbl, 0xd0aff924_a31b_454c_a7b6_5d0cc522fc16);
+impl windows_core::RuntimeType for IPrintTaskRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskSourceRequestedArgs, IPrintTaskSourceRequestedArgs_Vtbl, 0xf9f067be_f456_41f0_9c98_5ce73e851410);
+impl windows_core::RuntimeType for IPrintTaskSourceRequestedArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskSourceRequestedArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -376,12 +427,18 @@ pub struct IPrintTaskSourceRequestedArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskSourceRequestedDeferral, IPrintTaskSourceRequestedDeferral_Vtbl, 0x4a1560d1_6992_4d9d_8555_4ca4563fb166);
+impl windows_core::RuntimeType for IPrintTaskSourceRequestedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskSourceRequestedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrintTaskTargetDeviceSupport, IPrintTaskTargetDeviceSupport_Vtbl, 0x295d70c0_c2cb_4b7d_b0ea_93095091a220);
+impl windows_core::RuntimeType for IPrintTaskTargetDeviceSupport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrintTaskTargetDeviceSupport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -391,6 +448,9 @@ pub struct IPrintTaskTargetDeviceSupport_Vtbl {
     pub Is3DManufacturingTargetEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStandardPrintTaskOptionsStatic, IStandardPrintTaskOptionsStatic_Vtbl, 0xb4483d26_0dd0_4cd4_baff_930fc7d6a574);
+impl windows_core::RuntimeType for IStandardPrintTaskOptionsStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStandardPrintTaskOptionsStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -409,12 +469,18 @@ pub struct IStandardPrintTaskOptionsStatic_Vtbl {
     pub InputBin: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStandardPrintTaskOptionsStatic2, IStandardPrintTaskOptionsStatic2_Vtbl, 0x3be38bf4_7a44_4269_9a52_81261e289ee9);
+impl windows_core::RuntimeType for IStandardPrintTaskOptionsStatic2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStandardPrintTaskOptionsStatic2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Bordering: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStandardPrintTaskOptionsStatic3, IStandardPrintTaskOptionsStatic3_Vtbl, 0xbbf68e86_3858_41b3_a799_55dd9888d475);
+impl windows_core::RuntimeType for IStandardPrintTaskOptionsStatic3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStandardPrintTaskOptionsStatic3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -469,7 +535,7 @@ impl PrintManager {
     }
 }
 impl windows_core::RuntimeType for PrintManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintManager>();
 }
 unsafe impl windows_core::Interface for PrintManager {
     type Vtable = IPrintManager_Vtbl;
@@ -549,7 +615,7 @@ impl PrintPageInfo {
     }
 }
 impl windows_core::RuntimeType for PrintPageInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintPageInfo>();
 }
 unsafe impl windows_core::Interface for PrintPageInfo {
     type Vtable = IPrintPageInfo_Vtbl;
@@ -598,7 +664,7 @@ impl PrintPageRange {
     }
 }
 impl windows_core::RuntimeType for PrintPageRange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintPageRange>();
 }
 unsafe impl windows_core::Interface for PrintPageRange {
     type Vtable = IPrintPageRange_Vtbl;
@@ -649,7 +715,7 @@ impl PrintPageRangeOptions {
     }
 }
 impl windows_core::RuntimeType for PrintPageRangeOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintPageRangeOptions>();
 }
 unsafe impl windows_core::Interface for PrintPageRangeOptions {
     type Vtable = IPrintPageRangeOptions_Vtbl;
@@ -778,7 +844,7 @@ impl PrintTask {
     }
 }
 impl windows_core::RuntimeType for PrintTask {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTask>();
 }
 unsafe impl windows_core::Interface for PrintTask {
     type Vtable = IPrintTask_Vtbl;
@@ -803,7 +869,7 @@ impl PrintTaskCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintTaskCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintTaskCompletedEventArgs {
     type Vtable = IPrintTaskCompletedEventArgs_Vtbl;
@@ -1009,7 +1075,7 @@ impl PrintTaskOptions {
     }
 }
 impl windows_core::RuntimeType for PrintTaskOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskOptionsCore>();
 }
 unsafe impl windows_core::Interface for PrintTaskOptions {
     type Vtable = IPrintTaskOptionsCore_Vtbl;
@@ -1034,7 +1100,7 @@ impl PrintTaskProgressingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintTaskProgressingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskProgressingEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintTaskProgressingEventArgs {
     type Vtable = IPrintTaskProgressingEventArgs_Vtbl;
@@ -1076,7 +1142,7 @@ impl PrintTaskRequest {
     }
 }
 impl windows_core::RuntimeType for PrintTaskRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskRequest>();
 }
 unsafe impl windows_core::Interface for PrintTaskRequest {
     type Vtable = IPrintTaskRequest_Vtbl;
@@ -1098,7 +1164,7 @@ impl PrintTaskRequestedDeferral {
     }
 }
 impl windows_core::RuntimeType for PrintTaskRequestedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskRequestedDeferral>();
 }
 unsafe impl windows_core::Interface for PrintTaskRequestedDeferral {
     type Vtable = IPrintTaskRequestedDeferral_Vtbl;
@@ -1123,7 +1189,7 @@ impl PrintTaskRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PrintTaskRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PrintTaskRequestedEventArgs {
     type Vtable = IPrintTaskRequestedEventArgs_Vtbl;
@@ -1162,7 +1228,7 @@ impl PrintTaskSourceRequestedArgs {
     }
 }
 impl windows_core::RuntimeType for PrintTaskSourceRequestedArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskSourceRequestedArgs>();
 }
 unsafe impl windows_core::Interface for PrintTaskSourceRequestedArgs {
     type Vtable = IPrintTaskSourceRequestedArgs_Vtbl;
@@ -1184,7 +1250,7 @@ impl PrintTaskSourceRequestedDeferral {
     }
 }
 impl windows_core::RuntimeType for PrintTaskSourceRequestedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrintTaskSourceRequestedDeferral>();
 }
 unsafe impl windows_core::Interface for PrintTaskSourceRequestedDeferral {
     type Vtable = IPrintTaskSourceRequestedDeferral_Vtbl;

--- a/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPrint3DManager, IPrint3DManager_Vtbl, 0x4d2fcb0a_7366_4971_8bd5_17c4e3e8c6c0);
+impl windows_core::RuntimeType for IPrint3DManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IPrint3DManager_Vtbl {
     pub RemoveTaskRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DManagerStatics, IPrint3DManagerStatics_Vtbl, 0x0ef1cafe_a9ad_4c08_a917_1d1f863eabcb);
+impl windows_core::RuntimeType for IPrint3DManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +19,9 @@ pub struct IPrint3DManagerStatics_Vtbl {
     pub ShowPrintUIAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DTask, IPrint3DTask_Vtbl, 0x8ce3d080_2118_4c28_80de_f426d70191ae);
+impl windows_core::RuntimeType for IPrint3DTask {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DTask_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +34,9 @@ pub struct IPrint3DTask_Vtbl {
     pub RemoveSourceChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DTaskCompletedEventArgs, IPrint3DTaskCompletedEventArgs_Vtbl, 0xcc1914af_2614_4f1d_accc_d6fc4fda5455);
+impl windows_core::RuntimeType for IPrint3DTaskCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DTaskCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,30 +44,45 @@ pub struct IPrint3DTaskCompletedEventArgs_Vtbl {
     pub ExtendedStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut Print3DTaskDetail) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DTaskRequest, IPrint3DTaskRequest_Vtbl, 0x2595c46f_2245_4c5a_8731_0d604dc6bc3c);
+impl windows_core::RuntimeType for IPrint3DTaskRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DTaskRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateTask: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DTaskRequestedEventArgs, IPrint3DTaskRequestedEventArgs_Vtbl, 0x150cb77f_18c5_40d7_9f40_fab3096e05a9);
+impl windows_core::RuntimeType for IPrint3DTaskRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DTaskRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DTaskSourceChangedEventArgs, IPrint3DTaskSourceChangedEventArgs_Vtbl, 0x5bcd34af_24e9_4c10_8d07_14c346ba3fcf);
+impl windows_core::RuntimeType for IPrint3DTaskSourceChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DTaskSourceChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Source: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrint3DTaskSourceRequestedArgs, IPrint3DTaskSourceRequestedArgs_Vtbl, 0xc77c9aba_24af_424d_a3bf_92250c355602);
+impl windows_core::RuntimeType for IPrint3DTaskSourceRequestedArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrint3DTaskSourceRequestedArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3D3MFPackage, IPrinting3D3MFPackage_Vtbl, 0xf64dd5c8_2ab7_45a9_a1b7_267e948d5b18);
+impl windows_core::RuntimeType for IPrinting3D3MFPackage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3D3MFPackage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +119,9 @@ pub struct IPrinting3D3MFPackage_Vtbl {
     pub SaveModelToPackageAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3D3MFPackage2, IPrinting3D3MFPackage2_Vtbl, 0x965c7ac4_93cb_4430_92b8_789cd454f883);
+impl windows_core::RuntimeType for IPrinting3D3MFPackage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3D3MFPackage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +129,9 @@ pub struct IPrinting3D3MFPackage2_Vtbl {
     pub SetCompression: unsafe extern "system" fn(*mut core::ffi::c_void, Printing3DPackageCompression) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3D3MFPackageStatics, IPrinting3D3MFPackageStatics_Vtbl, 0x7058d9af_7a9a_4787_b817_f6f459214823);
+impl windows_core::RuntimeType for IPrinting3D3MFPackageStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3D3MFPackageStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +141,9 @@ pub struct IPrinting3D3MFPackageStatics_Vtbl {
     LoadAsync: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DBaseMaterial, IPrinting3DBaseMaterial_Vtbl, 0xd0f0e743_c50c_4bcb_9d04_fc16adcea2c9);
+impl windows_core::RuntimeType for IPrinting3DBaseMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DBaseMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +153,9 @@ pub struct IPrinting3DBaseMaterial_Vtbl {
     pub SetColor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DBaseMaterialGroup, IPrinting3DBaseMaterialGroup_Vtbl, 0x94f070b8_2515_4a8d_a1f0_d0fc13d06021);
+impl windows_core::RuntimeType for IPrinting3DBaseMaterialGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DBaseMaterialGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,12 +166,18 @@ pub struct IPrinting3DBaseMaterialGroup_Vtbl {
     pub MaterialGroupId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DBaseMaterialGroupFactory, IPrinting3DBaseMaterialGroupFactory_Vtbl, 0x5c1546dc_8697_4193_976b_84bb4116e5bf);
+impl windows_core::RuntimeType for IPrinting3DBaseMaterialGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DBaseMaterialGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DBaseMaterialStatics, IPrinting3DBaseMaterialStatics_Vtbl, 0x815a47bc_374a_476d_be92_3ecfd1cb9776);
+impl windows_core::RuntimeType for IPrinting3DBaseMaterialStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DBaseMaterialStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +185,9 @@ pub struct IPrinting3DBaseMaterialStatics_Vtbl {
     pub Pla: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DColorMaterial, IPrinting3DColorMaterial_Vtbl, 0xe1899928_7ce7_4285_a35d_f145c9510c7b);
+impl windows_core::RuntimeType for IPrinting3DColorMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DColorMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,6 +195,9 @@ pub struct IPrinting3DColorMaterial_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DColorMaterial2, IPrinting3DColorMaterial2_Vtbl, 0xfab0e852_0aef_44e9_9ddd_36eeea5acd44);
+impl windows_core::RuntimeType for IPrinting3DColorMaterial2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DColorMaterial2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -160,6 +211,9 @@ pub struct IPrinting3DColorMaterial2_Vtbl {
     SetColor: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DColorMaterialGroup, IPrinting3DColorMaterialGroup_Vtbl, 0x001a6bd0_aadf_4226_afe9_f369a0b45004);
+impl windows_core::RuntimeType for IPrinting3DColorMaterialGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DColorMaterialGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -170,12 +224,18 @@ pub struct IPrinting3DColorMaterialGroup_Vtbl {
     pub MaterialGroupId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DColorMaterialGroupFactory, IPrinting3DColorMaterialGroupFactory_Vtbl, 0x71d38d6d_b1ea_4a5b_bc54_19c65f3df044);
+impl windows_core::RuntimeType for IPrinting3DColorMaterialGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DColorMaterialGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DComponent, IPrinting3DComponent_Vtbl, 0x7e287845_bf7f_4cdb_a27f_30a01437fede);
+impl windows_core::RuntimeType for IPrinting3DComponent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DComponent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -195,6 +255,9 @@ pub struct IPrinting3DComponent_Vtbl {
     pub SetPartNumber: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DComponentWithMatrix, IPrinting3DComponentWithMatrix_Vtbl, 0x3279f335_0ef0_456b_9a21_49bebe8b51c2);
+impl windows_core::RuntimeType for IPrinting3DComponentWithMatrix {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DComponentWithMatrix_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -210,6 +273,9 @@ pub struct IPrinting3DComponentWithMatrix_Vtbl {
     SetMatrix: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DCompositeMaterial, IPrinting3DCompositeMaterial_Vtbl, 0x462238dd_562e_4f6c_882d_f4d841fd63c7);
+impl windows_core::RuntimeType for IPrinting3DCompositeMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DCompositeMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -219,6 +285,9 @@ pub struct IPrinting3DCompositeMaterial_Vtbl {
     Values: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DCompositeMaterialGroup, IPrinting3DCompositeMaterialGroup_Vtbl, 0x8d946a5b_40f1_496d_a5fb_340a5a678e30);
+impl windows_core::RuntimeType for IPrinting3DCompositeMaterialGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DCompositeMaterialGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -233,6 +302,9 @@ pub struct IPrinting3DCompositeMaterialGroup_Vtbl {
     MaterialIndices: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DCompositeMaterialGroup2, IPrinting3DCompositeMaterialGroup2_Vtbl, 0x06e86d62_7d3b_41e1_944c_bafde4555483);
+impl windows_core::RuntimeType for IPrinting3DCompositeMaterialGroup2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DCompositeMaterialGroup2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,12 +312,18 @@ pub struct IPrinting3DCompositeMaterialGroup2_Vtbl {
     pub SetBaseMaterialGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DCompositeMaterialGroupFactory, IPrinting3DCompositeMaterialGroupFactory_Vtbl, 0xd08ecd13_92ff_43aa_a627_8d43c22c817e);
+impl windows_core::RuntimeType for IPrinting3DCompositeMaterialGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DCompositeMaterialGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DFaceReductionOptions, IPrinting3DFaceReductionOptions_Vtbl, 0xbbfed397_2d74_46f7_be85_99a67bbb6629);
+impl windows_core::RuntimeType for IPrinting3DFaceReductionOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DFaceReductionOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -257,6 +335,9 @@ pub struct IPrinting3DFaceReductionOptions_Vtbl {
     pub SetMaxEdgeLength: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DMaterial, IPrinting3DMaterial_Vtbl, 0x378db256_ed62_4952_b85b_03567d7c465e);
+impl windows_core::RuntimeType for IPrinting3DMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -282,6 +363,9 @@ pub struct IPrinting3DMaterial_Vtbl {
     MultiplePropertyGroups: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DMesh, IPrinting3DMesh_Vtbl, 0x192e90dc_0228_2e01_bc20_c5290cbf32c4);
+impl windows_core::RuntimeType for IPrinting3DMesh {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DMesh_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -328,6 +412,9 @@ pub struct IPrinting3DMesh_Vtbl {
     pub VerifyAsync: unsafe extern "system" fn(*mut core::ffi::c_void, Printing3DMeshVerificationMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DMeshVerificationResult, IPrinting3DMeshVerificationResult_Vtbl, 0x195671ba_e93a_4e8a_a46f_dea8e852197e);
+impl windows_core::RuntimeType for IPrinting3DMeshVerificationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DMeshVerificationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -342,6 +429,9 @@ pub struct IPrinting3DMeshVerificationResult_Vtbl {
     ReversedNormalTriangles: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DModel, IPrinting3DModel_Vtbl, 0x2d012ef0_52fb_919a_77b0_4b1a3b80324f);
+impl windows_core::RuntimeType for IPrinting3DModel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DModel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -377,6 +467,9 @@ pub struct IPrinting3DModel_Vtbl {
     pub Clone: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DModel2, IPrinting3DModel2_Vtbl, 0xc92069c7_c841_47f3_a84e_a149fd08b657);
+impl windows_core::RuntimeType for IPrinting3DModel2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DModel2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -388,6 +481,9 @@ pub struct IPrinting3DModel2_Vtbl {
     pub RepairWithProgressAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DModelTexture, IPrinting3DModelTexture_Vtbl, 0x5dafcf01_b59d_483c_97bb_a4d546d1c75c);
+impl windows_core::RuntimeType for IPrinting3DModelTexture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DModelTexture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -399,6 +495,9 @@ pub struct IPrinting3DModelTexture_Vtbl {
     pub SetTileStyleV: unsafe extern "system" fn(*mut core::ffi::c_void, Printing3DTextureEdgeBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DMultiplePropertyMaterial, IPrinting3DMultiplePropertyMaterial_Vtbl, 0x25a6254b_c6e9_484d_a214_a25e5776ba62);
+impl windows_core::RuntimeType for IPrinting3DMultiplePropertyMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DMultiplePropertyMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -408,6 +507,9 @@ pub struct IPrinting3DMultiplePropertyMaterial_Vtbl {
     MaterialIndices: usize,
 }
 windows_core::imp::define_interface!(IPrinting3DMultiplePropertyMaterialGroup, IPrinting3DMultiplePropertyMaterialGroup_Vtbl, 0xf0950519_aeb9_4515_a39b_a088fbbb277c);
+impl windows_core::RuntimeType for IPrinting3DMultiplePropertyMaterialGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DMultiplePropertyMaterialGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -422,12 +524,18 @@ pub struct IPrinting3DMultiplePropertyMaterialGroup_Vtbl {
     pub MaterialGroupId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DMultiplePropertyMaterialGroupFactory, IPrinting3DMultiplePropertyMaterialGroupFactory_Vtbl, 0x323e196e_d4c6_451e_a814_4d78a210fe53);
+impl windows_core::RuntimeType for IPrinting3DMultiplePropertyMaterialGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DMultiplePropertyMaterialGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DTexture2CoordMaterial, IPrinting3DTexture2CoordMaterial_Vtbl, 0x8d844bfb_07e9_4986_9833_8dd3d48c6859);
+impl windows_core::RuntimeType for IPrinting3DTexture2CoordMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DTexture2CoordMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -439,6 +547,9 @@ pub struct IPrinting3DTexture2CoordMaterial_Vtbl {
     pub SetV: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DTexture2CoordMaterialGroup, IPrinting3DTexture2CoordMaterialGroup_Vtbl, 0x627d7ca7_6d90_4fb9_9fc4_9feff3dfa892);
+impl windows_core::RuntimeType for IPrinting3DTexture2CoordMaterialGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DTexture2CoordMaterialGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -449,6 +560,9 @@ pub struct IPrinting3DTexture2CoordMaterialGroup_Vtbl {
     pub MaterialGroupId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DTexture2CoordMaterialGroup2, IPrinting3DTexture2CoordMaterialGroup2_Vtbl, 0x69fbdbba_b12e_429b_8386_df5284f6e80f);
+impl windows_core::RuntimeType for IPrinting3DTexture2CoordMaterialGroup2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DTexture2CoordMaterialGroup2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -456,12 +570,18 @@ pub struct IPrinting3DTexture2CoordMaterialGroup2_Vtbl {
     pub SetTexture: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DTexture2CoordMaterialGroupFactory, IPrinting3DTexture2CoordMaterialGroupFactory_Vtbl, 0xcbb049b0_468a_4c6f_b2a2_8eb8ba8dea48);
+impl windows_core::RuntimeType for IPrinting3DTexture2CoordMaterialGroupFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DTexture2CoordMaterialGroupFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrinting3DTextureResource, IPrinting3DTextureResource_Vtbl, 0xa70df32d_6ab1_44ae_bc45_a27382c0d38c);
+impl windows_core::RuntimeType for IPrinting3DTextureResource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrinting3DTextureResource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -514,7 +634,7 @@ impl Print3DManager {
     }
 }
 impl windows_core::RuntimeType for Print3DManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DManager>();
 }
 unsafe impl windows_core::Interface for Print3DManager {
     type Vtable = IPrint3DManager_Vtbl;
@@ -581,7 +701,7 @@ impl Print3DTask {
     }
 }
 impl windows_core::RuntimeType for Print3DTask {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DTask>();
 }
 unsafe impl windows_core::Interface for Print3DTask {
     type Vtable = IPrint3DTask_Vtbl;
@@ -613,7 +733,7 @@ impl Print3DTaskCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for Print3DTaskCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DTaskCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for Print3DTaskCompletedEventArgs {
     type Vtable = IPrint3DTaskCompletedEventArgs_Vtbl;
@@ -641,7 +761,7 @@ impl Print3DTaskRequest {
     }
 }
 impl windows_core::RuntimeType for Print3DTaskRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DTaskRequest>();
 }
 unsafe impl windows_core::Interface for Print3DTaskRequest {
     type Vtable = IPrint3DTaskRequest_Vtbl;
@@ -666,7 +786,7 @@ impl Print3DTaskRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for Print3DTaskRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DTaskRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for Print3DTaskRequestedEventArgs {
     type Vtable = IPrint3DTaskRequestedEventArgs_Vtbl;
@@ -691,7 +811,7 @@ impl Print3DTaskSourceChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for Print3DTaskSourceChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DTaskSourceChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for Print3DTaskSourceChangedEventArgs {
     type Vtable = IPrint3DTaskSourceChangedEventArgs_Vtbl;
@@ -716,7 +836,7 @@ impl Print3DTaskSourceRequestedArgs {
     }
 }
 impl windows_core::RuntimeType for Print3DTaskSourceRequestedArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrint3DTaskSourceRequestedArgs>();
 }
 unsafe impl windows_core::Interface for Print3DTaskSourceRequestedArgs {
     type Vtable = IPrint3DTaskSourceRequestedArgs_Vtbl;
@@ -850,7 +970,7 @@ impl Printing3D3MFPackage {
     }
 }
 impl windows_core::RuntimeType for Printing3D3MFPackage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3D3MFPackage>();
 }
 unsafe impl windows_core::Interface for Printing3D3MFPackage {
     type Vtable = IPrinting3D3MFPackage_Vtbl;
@@ -917,7 +1037,7 @@ impl Printing3DBaseMaterial {
     }
 }
 impl windows_core::RuntimeType for Printing3DBaseMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DBaseMaterial>();
 }
 unsafe impl windows_core::Interface for Printing3DBaseMaterial {
     type Vtable = IPrinting3DBaseMaterial_Vtbl;
@@ -961,7 +1081,7 @@ impl Printing3DBaseMaterialGroup {
     }
 }
 impl windows_core::RuntimeType for Printing3DBaseMaterialGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DBaseMaterialGroup>();
 }
 unsafe impl windows_core::Interface for Printing3DBaseMaterialGroup {
     type Vtable = IPrinting3DBaseMaterialGroup_Vtbl;
@@ -1010,7 +1130,7 @@ impl Printing3DColorMaterial {
     }
 }
 impl windows_core::RuntimeType for Printing3DColorMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DColorMaterial>();
 }
 unsafe impl windows_core::Interface for Printing3DColorMaterial {
     type Vtable = IPrinting3DColorMaterial_Vtbl;
@@ -1054,7 +1174,7 @@ impl Printing3DColorMaterialGroup {
     }
 }
 impl windows_core::RuntimeType for Printing3DColorMaterialGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DColorMaterialGroup>();
 }
 unsafe impl windows_core::Interface for Printing3DColorMaterialGroup {
     type Vtable = IPrinting3DColorMaterialGroup_Vtbl;
@@ -1148,7 +1268,7 @@ impl Printing3DComponent {
     }
 }
 impl windows_core::RuntimeType for Printing3DComponent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DComponent>();
 }
 unsafe impl windows_core::Interface for Printing3DComponent {
     type Vtable = IPrinting3DComponent_Vtbl;
@@ -1200,7 +1320,7 @@ impl Printing3DComponentWithMatrix {
     }
 }
 impl windows_core::RuntimeType for Printing3DComponentWithMatrix {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DComponentWithMatrix>();
 }
 unsafe impl windows_core::Interface for Printing3DComponentWithMatrix {
     type Vtable = IPrinting3DComponentWithMatrix_Vtbl;
@@ -1233,7 +1353,7 @@ impl Printing3DCompositeMaterial {
     }
 }
 impl windows_core::RuntimeType for Printing3DCompositeMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DCompositeMaterial>();
 }
 unsafe impl windows_core::Interface for Printing3DCompositeMaterial {
     type Vtable = IPrinting3DCompositeMaterial_Vtbl;
@@ -1299,7 +1419,7 @@ impl Printing3DCompositeMaterialGroup {
     }
 }
 impl windows_core::RuntimeType for Printing3DCompositeMaterialGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DCompositeMaterialGroup>();
 }
 unsafe impl windows_core::Interface for Printing3DCompositeMaterialGroup {
     type Vtable = IPrinting3DCompositeMaterialGroup_Vtbl;
@@ -1357,7 +1477,7 @@ impl Printing3DFaceReductionOptions {
     }
 }
 impl windows_core::RuntimeType for Printing3DFaceReductionOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DFaceReductionOptions>();
 }
 unsafe impl windows_core::Interface for Printing3DFaceReductionOptions {
     type Vtable = IPrinting3DFaceReductionOptions_Vtbl;
@@ -1422,7 +1542,7 @@ impl Printing3DMaterial {
     }
 }
 impl windows_core::RuntimeType for Printing3DMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DMaterial>();
 }
 unsafe impl windows_core::Interface for Printing3DMaterial {
     type Vtable = IPrinting3DMaterial_Vtbl;
@@ -1584,7 +1704,7 @@ impl Printing3DMesh {
     }
 }
 impl windows_core::RuntimeType for Printing3DMesh {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DMesh>();
 }
 unsafe impl windows_core::Interface for Printing3DMesh {
     type Vtable = IPrinting3DMesh_Vtbl;
@@ -1625,7 +1745,7 @@ impl Printing3DMeshVerificationResult {
     }
 }
 impl windows_core::RuntimeType for Printing3DMeshVerificationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DMeshVerificationResult>();
 }
 unsafe impl windows_core::Interface for Printing3DMeshVerificationResult {
     type Vtable = IPrinting3DMeshVerificationResult_Vtbl;
@@ -1802,7 +1922,7 @@ impl Printing3DModel {
     }
 }
 impl windows_core::RuntimeType for Printing3DModel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DModel>();
 }
 unsafe impl windows_core::Interface for Printing3DModel {
     type Vtable = IPrinting3DModel_Vtbl;
@@ -1863,7 +1983,7 @@ impl Printing3DModelTexture {
     }
 }
 impl windows_core::RuntimeType for Printing3DModelTexture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DModelTexture>();
 }
 unsafe impl windows_core::Interface for Printing3DModelTexture {
     type Vtable = IPrinting3DModelTexture_Vtbl;
@@ -1896,7 +2016,7 @@ impl Printing3DMultiplePropertyMaterial {
     }
 }
 impl windows_core::RuntimeType for Printing3DMultiplePropertyMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DMultiplePropertyMaterial>();
 }
 unsafe impl windows_core::Interface for Printing3DMultiplePropertyMaterial {
     type Vtable = IPrinting3DMultiplePropertyMaterial_Vtbl;
@@ -1948,7 +2068,7 @@ impl Printing3DMultiplePropertyMaterialGroup {
     }
 }
 impl windows_core::RuntimeType for Printing3DMultiplePropertyMaterialGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DMultiplePropertyMaterialGroup>();
 }
 unsafe impl windows_core::Interface for Printing3DMultiplePropertyMaterialGroup {
     type Vtable = IPrinting3DMultiplePropertyMaterialGroup_Vtbl;
@@ -2009,7 +2129,7 @@ impl Printing3DTexture2CoordMaterial {
     }
 }
 impl windows_core::RuntimeType for Printing3DTexture2CoordMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DTexture2CoordMaterial>();
 }
 unsafe impl windows_core::Interface for Printing3DTexture2CoordMaterial {
     type Vtable = IPrinting3DTexture2CoordMaterial_Vtbl;
@@ -2067,7 +2187,7 @@ impl Printing3DTexture2CoordMaterialGroup {
     }
 }
 impl windows_core::RuntimeType for Printing3DTexture2CoordMaterialGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DTexture2CoordMaterialGroup>();
 }
 unsafe impl windows_core::Interface for Printing3DTexture2CoordMaterialGroup {
     type Vtable = IPrinting3DTexture2CoordMaterialGroup_Vtbl;
@@ -2119,7 +2239,7 @@ impl Printing3DTextureResource {
     }
 }
 impl windows_core::RuntimeType for Printing3DTextureResource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrinting3DTextureResource>();
 }
 unsafe impl windows_core::Interface for Printing3DTextureResource {
     type Vtable = IPrinting3DTextureResource_Vtbl;

--- a/crates/libs/windows/src/Windows/Management/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Core/mod.rs
@@ -1,9 +1,15 @@
 windows_core::imp::define_interface!(IApplicationDataManager, IApplicationDataManager_Vtbl, 0x74d10432_2e99_4000_9a3a_64307e858129);
+impl windows_core::RuntimeType for IApplicationDataManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationDataManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IApplicationDataManagerStatics, IApplicationDataManagerStatics_Vtbl, 0x1e1862e3_698e_49a1_9752_dee94925b9b3);
+impl windows_core::RuntimeType for IApplicationDataManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationDataManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,7 +37,7 @@ impl ApplicationDataManager {
     }
 }
 impl windows_core::RuntimeType for ApplicationDataManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationDataManager>();
 }
 unsafe impl windows_core::Interface for ApplicationDataManager {
     type Vtable = IApplicationDataManager_Vtbl;

--- a/crates/libs/windows/src/Windows/Management/Deployment/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/Preview/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IClassicAppManagerStatics, IClassicAppManagerStatics_Vtbl, 0xe2fad668_882c_4f33_b035_0df7b90d67e6);
+impl windows_core::RuntimeType for IClassicAppManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClassicAppManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FindInstalledApp: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInstalledClassicAppInfo, IInstalledClassicAppInfo_Vtbl, 0x0a7d3da3_65d0_4086_80d6_0610d760207d);
+impl windows_core::RuntimeType for IInstalledClassicAppInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInstalledClassicAppInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,7 +55,7 @@ impl InstalledClassicAppInfo {
     }
 }
 impl windows_core::RuntimeType for InstalledClassicAppInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInstalledClassicAppInfo>();
 }
 unsafe impl windows_core::Interface for InstalledClassicAppInfo {
     type Vtable = IInstalledClassicAppInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Management_Deployment_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(IAddPackageOptions, IAddPackageOptions_Vtbl, 0x05cee018_f68f_422b_95a4_66679ec77fc0);
+impl windows_core::RuntimeType for IAddPackageOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAddPackageOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +51,9 @@ pub struct IAddPackageOptions_Vtbl {
     pub SetDeferRegistrationWhenPackagesAreInUse: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAddPackageOptions2, IAddPackageOptions2_Vtbl, 0xee515828_bf33_40f7_84af_1b6fad2919d7);
+impl windows_core::RuntimeType for IAddPackageOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAddPackageOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +65,9 @@ pub struct IAddPackageOptions2_Vtbl {
     pub SetLimitToExistingPackages: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallerManager, IAppInstallerManager_Vtbl, 0xe7ee21c3_2103_53ee_9b18_68afeab0033d);
+impl windows_core::RuntimeType for IAppInstallerManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallerManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +76,9 @@ pub struct IAppInstallerManager_Vtbl {
     pub PauseAutoUpdatesUntil: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppInstallerManagerStatics, IAppInstallerManagerStatics_Vtbl, 0xc95a6ed5_fc59_5336_9b2e_2b07c5e61434);
+impl windows_core::RuntimeType for IAppInstallerManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppInstallerManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -74,6 +86,9 @@ pub struct IAppInstallerManagerStatics_Vtbl {
     pub GetForSystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAutoUpdateSettingsOptions, IAutoUpdateSettingsOptions_Vtbl, 0x67491d87_35e1_512a_8968_1ae88d1be6d3);
+impl windows_core::RuntimeType for IAutoUpdateSettingsOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutoUpdateSettingsOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -119,6 +134,9 @@ pub struct IAutoUpdateSettingsOptions_Vtbl {
     OptionalPackageUris: usize,
 }
 windows_core::imp::define_interface!(IAutoUpdateSettingsOptionsStatics, IAutoUpdateSettingsOptionsStatics_Vtbl, 0x887b337d_0c05_54d0_bd49_3bb7a2c084cb);
+impl windows_core::RuntimeType for IAutoUpdateSettingsOptionsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutoUpdateSettingsOptionsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -128,6 +146,9 @@ pub struct IAutoUpdateSettingsOptionsStatics_Vtbl {
     CreateFromAppInstallerInfo: usize,
 }
 windows_core::imp::define_interface!(ICreateSharedPackageContainerOptions, ICreateSharedPackageContainerOptions_Vtbl, 0xc2ab6ece_f664_5c8e_a4b3_2a33276d3dde);
+impl windows_core::RuntimeType for ICreateSharedPackageContainerOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateSharedPackageContainerOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,6 +162,9 @@ pub struct ICreateSharedPackageContainerOptions_Vtbl {
     pub SetCreateCollisionOption: unsafe extern "system" fn(*mut core::ffi::c_void, SharedPackageContainerCreationCollisionOptions) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateSharedPackageContainerResult, ICreateSharedPackageContainerResult_Vtbl, 0xce8810bf_151c_5707_b936_497e564afc7a);
+impl windows_core::RuntimeType for ICreateSharedPackageContainerResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateSharedPackageContainerResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -149,6 +173,9 @@ pub struct ICreateSharedPackageContainerResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeleteSharedPackageContainerOptions, IDeleteSharedPackageContainerOptions_Vtbl, 0x9d81865f_986e_5138_8b5d_384d8e66ed6c);
+impl windows_core::RuntimeType for IDeleteSharedPackageContainerOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeleteSharedPackageContainerOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +185,9 @@ pub struct IDeleteSharedPackageContainerOptions_Vtbl {
     pub SetAllUsers: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeleteSharedPackageContainerResult, IDeleteSharedPackageContainerResult_Vtbl, 0x35398884_5736_517b_85bc_e598c81ab284);
+impl windows_core::RuntimeType for IDeleteSharedPackageContainerResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeleteSharedPackageContainerResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +195,9 @@ pub struct IDeleteSharedPackageContainerResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeploymentResult, IDeploymentResult_Vtbl, 0x2563b9ae_b77d_4c1f_8a7b_20e6ad515ef3);
+impl windows_core::RuntimeType for IDeploymentResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeploymentResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,12 +206,18 @@ pub struct IDeploymentResult_Vtbl {
     pub ExtendedErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDeploymentResult2, IDeploymentResult2_Vtbl, 0xfc0e715c_5a01_4bd7_bcf1_381c8c82e04a);
+impl windows_core::RuntimeType for IDeploymentResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDeploymentResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsRegistered: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFindSharedPackageContainerOptions, IFindSharedPackageContainerOptions_Vtbl, 0xb40fc8fe_8384_54cc_817d_ae09d3b6a606);
+impl windows_core::RuntimeType for IFindSharedPackageContainerOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFindSharedPackageContainerOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +227,9 @@ pub struct IFindSharedPackageContainerOptions_Vtbl {
     pub SetPackageFamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageAllUserProvisioningOptions, IPackageAllUserProvisioningOptions_Vtbl, 0xda35aa22_1de0_5d3e_99ff_d24f3118bf5e);
+impl windows_core::RuntimeType for IPackageAllUserProvisioningOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageAllUserProvisioningOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -201,6 +243,9 @@ pub struct IPackageAllUserProvisioningOptions_Vtbl {
     ProjectionOrderPackageFamilyNames: usize,
 }
 windows_core::imp::define_interface!(IPackageManager, IPackageManager_Vtbl, 0x9a7d4b65_5e8f_4fc7_a2e5_7f6925cb8b53);
+impl windows_core::RuntimeType for IPackageManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -261,12 +306,18 @@ pub struct IPackageManager_Vtbl {
     FindPackageByUserSecurityIdPackageFullName: usize,
 }
 windows_core::imp::define_interface!(IPackageManager10, IPackageManager10_Vtbl, 0xa7d7d07e_2e66_4093_aed5_e093ed87b3bb);
+impl windows_core::RuntimeType for IPackageManager10 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager10_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ProvisionPackageForAllUsersWithOptionsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageManager2, IPackageManager2_Vtbl, 0xf7aad08d_0840_46f2_b5d8_cad47693a095);
+impl windows_core::RuntimeType for IPackageManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -306,6 +357,9 @@ pub struct IPackageManager2_Vtbl {
     pub StageUserDataAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageManager3, IPackageManager3_Vtbl, 0xdaad9948_36f1_41a7_9188_bc263e0dcb72);
+impl windows_core::RuntimeType for IPackageManager3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -338,6 +392,9 @@ pub struct IPackageManager3_Vtbl {
     pub StageUserDataWithOptionsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, DeploymentOptions, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageManager4, IPackageManager4_Vtbl, 0x3c719963_bab6_46bf_8ff7_da4719230ae6);
+impl windows_core::RuntimeType for IPackageManager4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -347,6 +404,9 @@ pub struct IPackageManager4_Vtbl {
     GetPackageVolumesAsync: usize,
 }
 windows_core::imp::define_interface!(IPackageManager5, IPackageManager5_Vtbl, 0x711f3117_1afd_4313_978c_9bb6e1b864a7);
+impl windows_core::RuntimeType for IPackageManager5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -365,6 +425,9 @@ pub struct IPackageManager5_Vtbl {
     pub DebugSettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageManager6, IPackageManager6_Vtbl, 0x0847e909_53cd_4e4f_832e_57d180f6e447);
+impl windows_core::RuntimeType for IPackageManager6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -385,6 +448,9 @@ pub struct IPackageManager6_Vtbl {
     RequestAddPackageAsync: usize,
 }
 windows_core::imp::define_interface!(IPackageManager7, IPackageManager7_Vtbl, 0xf28654f4_2ba7_4b80_88d6_be15f9a23fba);
+impl windows_core::RuntimeType for IPackageManager7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -394,12 +460,18 @@ pub struct IPackageManager7_Vtbl {
     RequestAddPackageAndRelatedSetAsync: usize,
 }
 windows_core::imp::define_interface!(IPackageManager8, IPackageManager8_Vtbl, 0xb8575330_1298_4ee2_80ee_7f659c5d2782);
+impl windows_core::RuntimeType for IPackageManager8 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager8_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeprovisionPackageForAllUsersAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageManager9, IPackageManager9_Vtbl, 0x1aa79035_cc71_4b2e_80a6_c7041d8579a7);
+impl windows_core::RuntimeType for IPackageManager9 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManager9_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -418,6 +490,9 @@ pub struct IPackageManager9_Vtbl {
     pub GetPackageStubPreference: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut PackageStubPreference) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageManagerDebugSettings, IPackageManagerDebugSettings_Vtbl, 0x1a611683_a988_4fcf_8f0f_ce175898e8eb);
+impl windows_core::RuntimeType for IPackageManagerDebugSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageManagerDebugSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -431,6 +506,9 @@ pub struct IPackageManagerDebugSettings_Vtbl {
     SetContentGroupStateWithPercentageAsync: usize,
 }
 windows_core::imp::define_interface!(IPackageUserInformation, IPackageUserInformation_Vtbl, 0xf6383423_fa09_4cbc_9055_15ca275e2e7e);
+impl windows_core::RuntimeType for IPackageUserInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageUserInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -438,6 +516,9 @@ pub struct IPackageUserInformation_Vtbl {
     pub InstallState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PackageInstallState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPackageVolume, IPackageVolume_Vtbl, 0xcf2672c3_1a40_4450_9739_2ace2e898853);
+impl windows_core::RuntimeType for IPackageVolume {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageVolume_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -505,6 +586,9 @@ pub struct IPackageVolume_Vtbl {
     FindPackageByUserSecurityIdPackageFullName: usize,
 }
 windows_core::imp::define_interface!(IPackageVolume2, IPackageVolume2_Vtbl, 0x46abcf2e_9dd4_47a2_ab8c_c6408349bcd8);
+impl windows_core::RuntimeType for IPackageVolume2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageVolume2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -513,6 +597,9 @@ pub struct IPackageVolume2_Vtbl {
     pub GetAvailableSpaceAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRegisterPackageOptions, IRegisterPackageOptions_Vtbl, 0x677112a7_50d4_496c_8415_0602b4c6d3bf);
+impl windows_core::RuntimeType for IRegisterPackageOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRegisterPackageOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -546,6 +633,9 @@ pub struct IRegisterPackageOptions_Vtbl {
     pub SetDeferRegistrationWhenPackagesAreInUse: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRegisterPackageOptions2, IRegisterPackageOptions2_Vtbl, 0x3dfa9743_86ff_4a11_bc93_434eb6be3a0b);
+impl windows_core::RuntimeType for IRegisterPackageOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRegisterPackageOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -555,6 +645,9 @@ pub struct IRegisterPackageOptions2_Vtbl {
     ExpectedDigests: usize,
 }
 windows_core::imp::define_interface!(ISharedPackageContainer, ISharedPackageContainer_Vtbl, 0x177f1aa9_151e_5ef7_b1d9_2fba0b4b0d17);
+impl windows_core::RuntimeType for ISharedPackageContainer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedPackageContainer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -568,6 +661,9 @@ pub struct ISharedPackageContainer_Vtbl {
     pub ResetData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISharedPackageContainerManager, ISharedPackageContainerManager_Vtbl, 0xbe353068_1ef7_5ac8_ab3f_0b9f612f0274);
+impl windows_core::RuntimeType for ISharedPackageContainerManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedPackageContainerManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -584,6 +680,9 @@ pub struct ISharedPackageContainerManager_Vtbl {
     FindContainersWithOptions: usize,
 }
 windows_core::imp::define_interface!(ISharedPackageContainerManagerStatics, ISharedPackageContainerManagerStatics_Vtbl, 0x2ef56348_838a_5f55_a89e_1198a2c627e6);
+impl windows_core::RuntimeType for ISharedPackageContainerManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedPackageContainerManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -592,18 +691,27 @@ pub struct ISharedPackageContainerManagerStatics_Vtbl {
     pub GetForProvisioning: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISharedPackageContainerMember, ISharedPackageContainerMember_Vtbl, 0xfe0d0438_43c9_5426_b89c_f79bf85ddff4);
+impl windows_core::RuntimeType for ISharedPackageContainerMember {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedPackageContainerMember_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PackageFamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISharedPackageContainerMemberFactory, ISharedPackageContainerMemberFactory_Vtbl, 0x49b0ceeb_498f_5a62_b738_b3ca0d436704);
+impl windows_core::RuntimeType for ISharedPackageContainerMemberFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedPackageContainerMemberFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStagePackageOptions, IStagePackageOptions_Vtbl, 0x0b110c9c_b95d_4c56_bd36_6d656800d06b);
+impl windows_core::RuntimeType for IStagePackageOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStagePackageOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -643,6 +751,9 @@ pub struct IStagePackageOptions_Vtbl {
     pub SetAllowUnsigned: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStagePackageOptions2, IStagePackageOptions2_Vtbl, 0x990c4ccc_6226_4192_ba92_79875fce0d9c);
+impl windows_core::RuntimeType for IStagePackageOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStagePackageOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -652,6 +763,9 @@ pub struct IStagePackageOptions2_Vtbl {
     ExpectedDigests: usize,
 }
 windows_core::imp::define_interface!(IUpdateSharedPackageContainerOptions, IUpdateSharedPackageContainerOptions_Vtbl, 0x80672e83_7194_59f9_b5b9_daa5375f130a);
+impl windows_core::RuntimeType for IUpdateSharedPackageContainerOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUpdateSharedPackageContainerOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -661,6 +775,9 @@ pub struct IUpdateSharedPackageContainerOptions_Vtbl {
     pub SetRequirePackagesPresent: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUpdateSharedPackageContainerResult, IUpdateSharedPackageContainerResult_Vtbl, 0xaa407df7_c72d_5458_aea3_4645b6a8ee99);
+impl windows_core::RuntimeType for IUpdateSharedPackageContainerResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUpdateSharedPackageContainerResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -881,7 +998,7 @@ impl AddPackageOptions {
     }
 }
 impl windows_core::RuntimeType for AddPackageOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAddPackageOptions>();
 }
 unsafe impl windows_core::Interface for AddPackageOptions {
     type Vtable = IAddPackageOptions_Vtbl;
@@ -931,7 +1048,7 @@ impl AppInstallerManager {
     }
 }
 impl windows_core::RuntimeType for AppInstallerManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppInstallerManager>();
 }
 unsafe impl windows_core::Interface for AppInstallerManager {
     type Vtable = IAppInstallerManager_Vtbl;
@@ -1107,7 +1224,7 @@ impl AutoUpdateSettingsOptions {
     }
 }
 impl windows_core::RuntimeType for AutoUpdateSettingsOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutoUpdateSettingsOptions>();
 }
 unsafe impl windows_core::Interface for AutoUpdateSettingsOptions {
     type Vtable = IAutoUpdateSettingsOptions_Vtbl;
@@ -1162,7 +1279,7 @@ impl CreateSharedPackageContainerOptions {
     }
 }
 impl windows_core::RuntimeType for CreateSharedPackageContainerOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateSharedPackageContainerOptions>();
 }
 unsafe impl windows_core::Interface for CreateSharedPackageContainerOptions {
     type Vtable = ICreateSharedPackageContainerOptions_Vtbl;
@@ -1201,7 +1318,7 @@ impl CreateSharedPackageContainerResult {
     }
 }
 impl windows_core::RuntimeType for CreateSharedPackageContainerResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateSharedPackageContainerResult>();
 }
 unsafe impl windows_core::Interface for CreateSharedPackageContainerResult {
     type Vtable = ICreateSharedPackageContainerResult_Vtbl;
@@ -1248,7 +1365,7 @@ impl DeleteSharedPackageContainerOptions {
     }
 }
 impl windows_core::RuntimeType for DeleteSharedPackageContainerOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeleteSharedPackageContainerOptions>();
 }
 unsafe impl windows_core::Interface for DeleteSharedPackageContainerOptions {
     type Vtable = IDeleteSharedPackageContainerOptions_Vtbl;
@@ -1280,7 +1397,7 @@ impl DeleteSharedPackageContainerResult {
     }
 }
 impl windows_core::RuntimeType for DeleteSharedPackageContainerResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeleteSharedPackageContainerResult>();
 }
 unsafe impl windows_core::Interface for DeleteSharedPackageContainerResult {
     type Vtable = IDeleteSharedPackageContainerResult_Vtbl;
@@ -1326,7 +1443,7 @@ impl DeploymentResult {
     }
 }
 impl windows_core::RuntimeType for DeploymentResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDeploymentResult>();
 }
 unsafe impl windows_core::Interface for DeploymentResult {
     type Vtable = IDeploymentResult_Vtbl;
@@ -1373,7 +1490,7 @@ impl FindSharedPackageContainerOptions {
     }
 }
 impl windows_core::RuntimeType for FindSharedPackageContainerOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFindSharedPackageContainerOptions>();
 }
 unsafe impl windows_core::Interface for FindSharedPackageContainerOptions {
     type Vtable = IFindSharedPackageContainerOptions_Vtbl;
@@ -1414,7 +1531,7 @@ impl PackageAllUserProvisioningOptions {
     }
 }
 impl windows_core::RuntimeType for PackageAllUserProvisioningOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageAllUserProvisioningOptions>();
 }
 unsafe impl windows_core::Interface for PackageAllUserProvisioningOptions {
     type Vtable = IPackageAllUserProvisioningOptions_Vtbl;
@@ -2023,7 +2140,7 @@ impl PackageManager {
     }
 }
 impl windows_core::RuntimeType for PackageManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageManager>();
 }
 unsafe impl windows_core::Interface for PackageManager {
     type Vtable = IPackageManager_Vtbl;
@@ -2063,7 +2180,7 @@ impl PackageManagerDebugSettings {
     }
 }
 impl windows_core::RuntimeType for PackageManagerDebugSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageManagerDebugSettings>();
 }
 unsafe impl windows_core::Interface for PackageManagerDebugSettings {
     type Vtable = IPackageManagerDebugSettings_Vtbl;
@@ -2095,7 +2212,7 @@ impl PackageUserInformation {
     }
 }
 impl windows_core::RuntimeType for PackageUserInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageUserInformation>();
 }
 unsafe impl windows_core::Interface for PackageUserInformation {
     type Vtable = IPackageUserInformation_Vtbl;
@@ -2288,7 +2405,7 @@ impl PackageVolume {
     }
 }
 impl windows_core::RuntimeType for PackageVolume {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageVolume>();
 }
 unsafe impl windows_core::Interface for PackageVolume {
     type Vtable = IPackageVolume_Vtbl;
@@ -2453,7 +2570,7 @@ impl RegisterPackageOptions {
     }
 }
 impl windows_core::RuntimeType for RegisterPackageOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRegisterPackageOptions>();
 }
 unsafe impl windows_core::Interface for RegisterPackageOptions {
     type Vtable = IRegisterPackageOptions_Vtbl;
@@ -2510,7 +2627,7 @@ impl SharedPackageContainer {
     }
 }
 impl windows_core::RuntimeType for SharedPackageContainer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISharedPackageContainer>();
 }
 unsafe impl windows_core::Interface for SharedPackageContainer {
     type Vtable = ISharedPackageContainer_Vtbl;
@@ -2597,7 +2714,7 @@ impl SharedPackageContainerManager {
     }
 }
 impl windows_core::RuntimeType for SharedPackageContainerManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISharedPackageContainerManager>();
 }
 unsafe impl windows_core::Interface for SharedPackageContainerManager {
     type Vtable = ISharedPackageContainerManager_Vtbl;
@@ -2633,7 +2750,7 @@ impl SharedPackageContainerMember {
     }
 }
 impl windows_core::RuntimeType for SharedPackageContainerMember {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISharedPackageContainerMember>();
 }
 unsafe impl windows_core::Interface for SharedPackageContainerMember {
     type Vtable = ISharedPackageContainerMember_Vtbl;
@@ -2803,7 +2920,7 @@ impl StagePackageOptions {
     }
 }
 impl windows_core::RuntimeType for StagePackageOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStagePackageOptions>();
 }
 unsafe impl windows_core::Interface for StagePackageOptions {
     type Vtable = IStagePackageOptions_Vtbl;
@@ -2850,7 +2967,7 @@ impl UpdateSharedPackageContainerOptions {
     }
 }
 impl windows_core::RuntimeType for UpdateSharedPackageContainerOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUpdateSharedPackageContainerOptions>();
 }
 unsafe impl windows_core::Interface for UpdateSharedPackageContainerOptions {
     type Vtable = IUpdateSharedPackageContainerOptions_Vtbl;
@@ -2882,7 +2999,7 @@ impl UpdateSharedPackageContainerResult {
     }
 }
 impl windows_core::RuntimeType for UpdateSharedPackageContainerResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUpdateSharedPackageContainerResult>();
 }
 unsafe impl windows_core::Interface for UpdateSharedPackageContainerResult {
     type Vtable = IUpdateSharedPackageContainerResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Management/Policies/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Policies/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(INamedPolicyData, INamedPolicyData_Vtbl, 0x38dcb198_95ac_4077_a643_8078cae26400);
+impl windows_core::RuntimeType for INamedPolicyData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INamedPolicyData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +26,9 @@ pub struct INamedPolicyData_Vtbl {
     pub RemoveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INamedPolicyStatics, INamedPolicyStatics_Vtbl, 0x7f793be7_76c4_4058_8cad_67662cd05f0d);
+impl windows_core::RuntimeType for INamedPolicyStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INamedPolicyStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -159,7 +165,7 @@ impl NamedPolicyData {
     }
 }
 impl windows_core::RuntimeType for NamedPolicyData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INamedPolicyData>();
 }
 unsafe impl windows_core::Interface for NamedPolicyData {
     type Vtable = INamedPolicyData_Vtbl;

--- a/crates/libs/windows/src/Windows/Management/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Update/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPreviewBuildsManager, IPreviewBuildsManager_Vtbl, 0xfa07dd61_7e4f_59f7_7c9f_def9051c5f62);
+impl windows_core::RuntimeType for IPreviewBuildsManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPreviewBuildsManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IPreviewBuildsManager_Vtbl {
     pub SyncAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPreviewBuildsManagerStatics, IPreviewBuildsManagerStatics_Vtbl, 0x3e422887_b112_5a70_7da1_97d78d32aa29);
+impl windows_core::RuntimeType for IPreviewBuildsManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPreviewBuildsManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +21,9 @@ pub struct IPreviewBuildsManagerStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPreviewBuildsState, IPreviewBuildsState_Vtbl, 0xa2f2903e_b223_5f63_7546_3e8eac070a2e);
+impl windows_core::RuntimeType for IPreviewBuildsState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPreviewBuildsState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +33,9 @@ pub struct IPreviewBuildsState_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IWindowsUpdate, IWindowsUpdate_Vtbl, 0xc3c88dd7_0ef3_52b2_a9ad_66bfc6bd9582);
+impl windows_core::RuntimeType for IWindowsUpdate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +65,9 @@ pub struct IWindowsUpdate_Vtbl {
     pub AcceptEula: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateActionCompletedEventArgs, IWindowsUpdateActionCompletedEventArgs_Vtbl, 0x2c44b950_a655_5321_aec1_aee762922131);
+impl windows_core::RuntimeType for IWindowsUpdateActionCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateActionCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +77,9 @@ pub struct IWindowsUpdateActionCompletedEventArgs_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateActionProgress, IWindowsUpdateActionProgress_Vtbl, 0x83b22d8a_4bb0_549f_ba39_59724882d137);
+impl windows_core::RuntimeType for IWindowsUpdateActionProgress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateActionProgress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +87,9 @@ pub struct IWindowsUpdateActionProgress_Vtbl {
     pub Progress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateActionResult, IWindowsUpdateActionResult_Vtbl, 0xe6692c62_f697_51b7_ab7f_e73e5e688f12);
+impl windows_core::RuntimeType for IWindowsUpdateActionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateActionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +99,9 @@ pub struct IWindowsUpdateActionResult_Vtbl {
     pub Action: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateAdministrator, IWindowsUpdateAdministrator_Vtbl, 0x7a60181c_ba1e_5cf9_aa65_304120b73d72);
+impl windows_core::RuntimeType for IWindowsUpdateAdministrator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateAdministrator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +116,9 @@ pub struct IWindowsUpdateAdministrator_Vtbl {
     GetUpdates: usize,
 }
 windows_core::imp::define_interface!(IWindowsUpdateAdministratorStatics, IWindowsUpdateAdministratorStatics_Vtbl, 0x013e6d36_ef69_53bc_8db8_c403bca550ed);
+impl windows_core::RuntimeType for IWindowsUpdateAdministratorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateAdministratorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,6 +130,9 @@ pub struct IWindowsUpdateAdministratorStatics_Vtbl {
     pub CancelRestartRequest: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateApprovalData, IWindowsUpdateApprovalData_Vtbl, 0xaadf5bfd_84db_59bc_85e2_ad4fc1f62f7c);
+impl windows_core::RuntimeType for IWindowsUpdateApprovalData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateApprovalData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,6 +148,9 @@ pub struct IWindowsUpdateApprovalData_Vtbl {
     pub SetOptOutOfAutoReboot: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateAttentionRequiredInfo, IWindowsUpdateAttentionRequiredInfo_Vtbl, 0x44df2579_74d3_5ffa_b6ce_09e187e1e0ed);
+impl windows_core::RuntimeType for IWindowsUpdateAttentionRequiredInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateAttentionRequiredInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -125,6 +158,9 @@ pub struct IWindowsUpdateAttentionRequiredInfo_Vtbl {
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateAttentionRequiredReasonChangedEventArgs, IWindowsUpdateAttentionRequiredReasonChangedEventArgs_Vtbl, 0x0627abca_dbb8_524a_b1d2_d9df004eeb31);
+impl windows_core::RuntimeType for IWindowsUpdateAttentionRequiredReasonChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateAttentionRequiredReasonChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -132,6 +168,9 @@ pub struct IWindowsUpdateAttentionRequiredReasonChangedEventArgs_Vtbl {
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WindowsUpdateAttentionRequiredReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateGetAdministratorResult, IWindowsUpdateGetAdministratorResult_Vtbl, 0xbb39ffc4_2c42_5b1c_8995_343341c92c50);
+impl windows_core::RuntimeType for IWindowsUpdateGetAdministratorResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateGetAdministratorResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +178,9 @@ pub struct IWindowsUpdateGetAdministratorResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WindowsUpdateAdministratorStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateItem, IWindowsUpdateItem_Vtbl, 0xb222e44a_49b6_59bf_a033_ef617cd73a98);
+impl windows_core::RuntimeType for IWindowsUpdateItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,6 +194,9 @@ pub struct IWindowsUpdateItem_Vtbl {
     pub Operation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateManager, IWindowsUpdateManager_Vtbl, 0x5dd966c0_a71a_5602_bbd0_09a70e4573fa);
+impl windows_core::RuntimeType for IWindowsUpdateManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -185,12 +230,18 @@ pub struct IWindowsUpdateManager_Vtbl {
     pub StartScan: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateManagerFactory, IWindowsUpdateManagerFactory_Vtbl, 0x1b394df8_decb_5f44_b47c_6ccf3bcfdb37);
+impl windows_core::RuntimeType for IWindowsUpdateManagerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateManagerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateProgressChangedEventArgs, IWindowsUpdateProgressChangedEventArgs_Vtbl, 0xbbfbdeeb_94c8_5aa7_b0fb_66c67c233b0a);
+impl windows_core::RuntimeType for IWindowsUpdateProgressChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateProgressChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,6 +249,9 @@ pub struct IWindowsUpdateProgressChangedEventArgs_Vtbl {
     pub ActionProgress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateRestartRequestOptions, IWindowsUpdateRestartRequestOptions_Vtbl, 0x38cfb7d3_4188_5222_905c_6c4443c951ee);
+impl windows_core::RuntimeType for IWindowsUpdateRestartRequestOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateRestartRequestOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -217,12 +271,18 @@ pub struct IWindowsUpdateRestartRequestOptions_Vtbl {
     pub SetOptOutOfAutoReboot: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateRestartRequestOptionsFactory, IWindowsUpdateRestartRequestOptionsFactory_Vtbl, 0x75f41d04_0e17_50d0_8c15_6b9d0539b3a9);
+impl windows_core::RuntimeType for IWindowsUpdateRestartRequestOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateRestartRequestOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, i32, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsUpdateScanCompletedEventArgs, IWindowsUpdateScanCompletedEventArgs_Vtbl, 0x95b6953e_ba5c_5fe8_b115_12de184a6bb0);
+impl windows_core::RuntimeType for IWindowsUpdateScanCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsUpdateScanCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -283,7 +343,7 @@ impl PreviewBuildsManager {
     }
 }
 impl windows_core::RuntimeType for PreviewBuildsManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPreviewBuildsManager>();
 }
 unsafe impl windows_core::Interface for PreviewBuildsManager {
     type Vtable = IPreviewBuildsManager_Vtbl;
@@ -309,7 +369,7 @@ impl PreviewBuildsState {
     }
 }
 impl windows_core::RuntimeType for PreviewBuildsState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPreviewBuildsState>();
 }
 unsafe impl windows_core::Interface for PreviewBuildsState {
     type Vtable = IPreviewBuildsState_Vtbl;
@@ -492,7 +552,7 @@ impl WindowsUpdate {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdate>();
 }
 unsafe impl windows_core::Interface for WindowsUpdate {
     type Vtable = IWindowsUpdate_Vtbl;
@@ -538,7 +598,7 @@ impl WindowsUpdateActionCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateActionCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateActionCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateActionCompletedEventArgs {
     type Vtable = IWindowsUpdateActionCompletedEventArgs_Vtbl;
@@ -570,7 +630,7 @@ impl WindowsUpdateActionProgress {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateActionProgress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateActionProgress>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateActionProgress {
     type Vtable = IWindowsUpdateActionProgress_Vtbl;
@@ -616,7 +676,7 @@ impl WindowsUpdateActionResult {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateActionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateActionResult>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateActionResult {
     type Vtable = IWindowsUpdateActionResult_Vtbl;
@@ -706,7 +766,7 @@ impl WindowsUpdateAdministrator {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateAdministrator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateAdministrator>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateAdministrator {
     type Vtable = IWindowsUpdateAdministrator_Vtbl;
@@ -801,7 +861,7 @@ impl WindowsUpdateApprovalData {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateApprovalData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateApprovalData>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateApprovalData {
     type Vtable = IWindowsUpdateApprovalData_Vtbl;
@@ -833,7 +893,7 @@ impl WindowsUpdateAttentionRequiredInfo {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateAttentionRequiredInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateAttentionRequiredInfo>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateAttentionRequiredInfo {
     type Vtable = IWindowsUpdateAttentionRequiredInfo_Vtbl;
@@ -865,7 +925,7 @@ impl WindowsUpdateAttentionRequiredReasonChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateAttentionRequiredReasonChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateAttentionRequiredReasonChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateAttentionRequiredReasonChangedEventArgs {
     type Vtable = IWindowsUpdateAttentionRequiredReasonChangedEventArgs_Vtbl;
@@ -897,7 +957,7 @@ impl WindowsUpdateGetAdministratorResult {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateGetAdministratorResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateGetAdministratorResult>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateGetAdministratorResult {
     type Vtable = IWindowsUpdateGetAdministratorResult_Vtbl;
@@ -971,7 +1031,7 @@ impl WindowsUpdateItem {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateItem>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateItem {
     type Vtable = IWindowsUpdateItem_Vtbl;
@@ -1133,7 +1193,7 @@ impl WindowsUpdateManager {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateManager>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateManager {
     type Vtable = IWindowsUpdateManager_Vtbl;
@@ -1165,7 +1225,7 @@ impl WindowsUpdateProgressChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateProgressChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateProgressChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateProgressChangedEventArgs {
     type Vtable = IWindowsUpdateProgressChangedEventArgs_Vtbl;
@@ -1284,7 +1344,7 @@ impl WindowsUpdateRestartRequestOptions {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateRestartRequestOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateRestartRequestOptions>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateRestartRequestOptions {
     type Vtable = IWindowsUpdateRestartRequestOptions_Vtbl;
@@ -1331,7 +1391,7 @@ impl WindowsUpdateScanCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowsUpdateScanCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowsUpdateScanCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowsUpdateScanCompletedEventArgs {
     type Vtable = IWindowsUpdateScanCompletedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Management/Workplace/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Workplace/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IMdmAllowPolicyStatics, IMdmAllowPolicyStatics_Vtbl, 0xc39709e7_741c_41f2_a4b6_314c31502586);
+impl windows_core::RuntimeType for IMdmAllowPolicyStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMdmAllowPolicyStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct IMdmAllowPolicyStatics_Vtbl {
     pub IsStoreAllowed: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMdmPolicyStatics2, IMdmPolicyStatics2_Vtbl, 0xc99c7526_03d4_49f9_a993_43efccd265c4);
+impl windows_core::RuntimeType for IMdmPolicyStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMdmPolicyStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetMessagingSyncPolicy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MessagingSyncPolicy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWorkplaceSettingsStatics, IWorkplaceSettingsStatics_Vtbl, 0xe4676ffd_2d92_4c08_bad4_f6590b54a6d3);
+impl windows_core::RuntimeType for IWorkplaceSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWorkplaceSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/mod.rs
@@ -9,6 +9,9 @@ pub mod Update;
 #[cfg(feature = "Management_Workplace")]
 pub mod Workplace;
 windows_core::imp::define_interface!(IMdmAlert, IMdmAlert_Vtbl, 0xb0fbc327_28c1_4b52_a548_c5807caf70b6);
+impl windows_core::RuntimeType for IMdmAlert {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMdmAlert_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +30,9 @@ pub struct IMdmAlert_Vtbl {
     pub SetType: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMdmSession, IMdmSession_Vtbl, 0xfe89314c_8f64_4797_a9d7_9d88f86ae166);
+impl windows_core::RuntimeType for IMdmSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMdmSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +52,9 @@ pub struct IMdmSession_Vtbl {
     StartWithAlertsAsync: usize,
 }
 windows_core::imp::define_interface!(IMdmSessionManagerStatics, IMdmSessionManagerStatics_Vtbl, 0xcf4ad959_f745_4b79_9b5c_de0bf8efe44b);
+impl windows_core::RuntimeType for IMdmSessionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMdmSessionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -144,7 +153,7 @@ impl MdmAlert {
     }
 }
 impl windows_core::RuntimeType for MdmAlert {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMdmAlert>();
 }
 unsafe impl windows_core::Interface for MdmAlert {
     type Vtable = IMdmAlert_Vtbl;
@@ -218,7 +227,7 @@ impl MdmSession {
     }
 }
 impl windows_core::RuntimeType for MdmSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMdmSession>();
 }
 unsafe impl windows_core::Interface for MdmSession {
     type Vtable = IMdmSession_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/AppBroadcasting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/AppBroadcasting/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppBroadcastingMonitor, IAppBroadcastingMonitor_Vtbl, 0x00f95a68_8907_48a0_b8ef_24d208137542);
+impl windows_core::RuntimeType for IAppBroadcastingMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastingMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IAppBroadcastingMonitor_Vtbl {
     pub RemoveIsCurrentAppBroadcastingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastingStatus, IAppBroadcastingStatus_Vtbl, 0x1225e4df_03a1_42f8_8b80_c9228cd9cf2e);
+impl windows_core::RuntimeType for IAppBroadcastingStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastingStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +20,9 @@ pub struct IAppBroadcastingStatus_Vtbl {
     pub Details: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastingStatusDetails, IAppBroadcastingStatusDetails_Vtbl, 0x069dada4_b573_4e3c_8e19_1bafacd09713);
+impl windows_core::RuntimeType for IAppBroadcastingStatusDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastingStatusDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +36,9 @@ pub struct IAppBroadcastingStatusDetails_Vtbl {
     pub IsDisabledBySystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastingUI, IAppBroadcastingUI_Vtbl, 0xe56f9f8f_ee99_4dca_a3c3_70af3db44f5f);
+impl windows_core::RuntimeType for IAppBroadcastingUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastingUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +46,9 @@ pub struct IAppBroadcastingUI_Vtbl {
     pub ShowBroadcastUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastingUIStatics, IAppBroadcastingUIStatics_Vtbl, 0x55a8a79d_23cb_4579_9c34_886fe02c045a);
+impl windows_core::RuntimeType for IAppBroadcastingUIStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastingUIStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,7 +93,7 @@ impl AppBroadcastingMonitor {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastingMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastingMonitor>();
 }
 unsafe impl windows_core::Interface for AppBroadcastingMonitor {
     type Vtable = IAppBroadcastingMonitor_Vtbl;
@@ -110,7 +125,7 @@ impl AppBroadcastingStatus {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastingStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastingStatus>();
 }
 unsafe impl windows_core::Interface for AppBroadcastingStatus {
     type Vtable = IAppBroadcastingStatus_Vtbl;
@@ -184,7 +199,7 @@ impl AppBroadcastingStatusDetails {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastingStatusDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastingStatusDetails>();
 }
 unsafe impl windows_core::Interface for AppBroadcastingStatusDetails {
     type Vtable = IAppBroadcastingStatusDetails_Vtbl;
@@ -234,7 +249,7 @@ impl AppBroadcastingUI {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastingUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastingUI>();
 }
 unsafe impl windows_core::Interface for AppBroadcastingUI {
     type Vtable = IAppBroadcastingUI_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppRecordingManager, IAppRecordingManager_Vtbl, 0xe7e26076_a044_48e2_a512_3094d574c7cc);
+impl windows_core::RuntimeType for IAppRecordingManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppRecordingManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,12 +24,18 @@ pub struct IAppRecordingManager_Vtbl {
     SaveScreenshotToFilesAsync: usize,
 }
 windows_core::imp::define_interface!(IAppRecordingManagerStatics, IAppRecordingManagerStatics_Vtbl, 0x50e709f7_38ce_4bd3_9db2_e72bbe9de11d);
+impl windows_core::RuntimeType for IAppRecordingManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppRecordingManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppRecordingResult, IAppRecordingResult_Vtbl, 0x3a900864_c66d_46f9_b2d9_5bc2dad070d7);
+impl windows_core::RuntimeType for IAppRecordingResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppRecordingResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +45,9 @@ pub struct IAppRecordingResult_Vtbl {
     pub IsFileTruncated: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppRecordingSaveScreenshotResult, IAppRecordingSaveScreenshotResult_Vtbl, 0x9c5b8d0a_0abb_4457_aaee_24f9c12ec778);
+impl windows_core::RuntimeType for IAppRecordingSaveScreenshotResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppRecordingSaveScreenshotResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +59,9 @@ pub struct IAppRecordingSaveScreenshotResult_Vtbl {
     SavedScreenshotInfos: usize,
 }
 windows_core::imp::define_interface!(IAppRecordingSavedScreenshotInfo, IAppRecordingSavedScreenshotInfo_Vtbl, 0x9b642d0a_189a_4d00_bf25_e1bb1249d594);
+impl windows_core::RuntimeType for IAppRecordingSavedScreenshotInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppRecordingSavedScreenshotInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +72,9 @@ pub struct IAppRecordingSavedScreenshotInfo_Vtbl {
     pub MediaEncodingSubtype: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppRecordingStatus, IAppRecordingStatus_Vtbl, 0x1d0cc82c_bc18_4b8a_a6ef_127efab3b5d9);
+impl windows_core::RuntimeType for IAppRecordingStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppRecordingStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +84,9 @@ pub struct IAppRecordingStatus_Vtbl {
     pub Details: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppRecordingStatusDetails, IAppRecordingStatusDetails_Vtbl, 0xb538a9b0_14ed_4412_ac45_6d672c9c9949);
+impl windows_core::RuntimeType for IAppRecordingStatusDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppRecordingStatusDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -146,7 +167,7 @@ impl AppRecordingManager {
     }
 }
 impl windows_core::RuntimeType for AppRecordingManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppRecordingManager>();
 }
 unsafe impl windows_core::Interface for AppRecordingManager {
     type Vtable = IAppRecordingManager_Vtbl;
@@ -192,7 +213,7 @@ impl AppRecordingResult {
     }
 }
 impl windows_core::RuntimeType for AppRecordingResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppRecordingResult>();
 }
 unsafe impl windows_core::Interface for AppRecordingResult {
     type Vtable = IAppRecordingResult_Vtbl;
@@ -232,7 +253,7 @@ impl AppRecordingSaveScreenshotResult {
     }
 }
 impl windows_core::RuntimeType for AppRecordingSaveScreenshotResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppRecordingSaveScreenshotResult>();
 }
 unsafe impl windows_core::Interface for AppRecordingSaveScreenshotResult {
     type Vtable = IAppRecordingSaveScreenshotResult_Vtbl;
@@ -265,7 +286,7 @@ impl AppRecordingSavedScreenshotInfo {
     }
 }
 impl windows_core::RuntimeType for AppRecordingSavedScreenshotInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppRecordingSavedScreenshotInfo>();
 }
 unsafe impl windows_core::Interface for AppRecordingSavedScreenshotInfo {
     type Vtable = IAppRecordingSavedScreenshotInfo_Vtbl;
@@ -311,7 +332,7 @@ impl AppRecordingStatus {
     }
 }
 impl windows_core::RuntimeType for AppRecordingStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppRecordingStatus>();
 }
 unsafe impl windows_core::Interface for AppRecordingStatus {
     type Vtable = IAppRecordingStatus_Vtbl;
@@ -392,7 +413,7 @@ impl AppRecordingStatusDetails {
     }
 }
 impl windows_core::RuntimeType for AppRecordingStatusDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppRecordingStatusDetails>();
 }
 unsafe impl windows_core::Interface for AppRecordingStatusDetails {
     type Vtable = IAppRecordingStatusDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAudioDeviceInputNode, IAudioDeviceInputNode_Vtbl, 0xb01b6be1_6f4e_49e2_ac01_559d62beb3a9);
+impl windows_core::RuntimeType for IAudioDeviceInputNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioDeviceInputNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IAudioDeviceInputNode_Vtbl {
     Device: usize,
 }
 windows_core::imp::define_interface!(IAudioDeviceOutputNode, IAudioDeviceOutputNode_Vtbl, 0x362edbff_ff1c_4434_9e0f_bd2ef522ac82);
+impl windows_core::RuntimeType for IAudioDeviceOutputNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioDeviceOutputNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IAudioDeviceOutputNode_Vtbl {
     Device: usize,
 }
 windows_core::imp::define_interface!(IAudioFileInputNode, IAudioFileInputNode_Vtbl, 0x905b67c8_6f65_4cd4_8890_4694843c276d);
+impl windows_core::RuntimeType for IAudioFileInputNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioFileInputNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +48,9 @@ pub struct IAudioFileInputNode_Vtbl {
     pub RemoveFileCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioFileOutputNode, IAudioFileOutputNode_Vtbl, 0x50e01980_5166_4093_80f8_ada00089e9cf);
+impl windows_core::RuntimeType for IAudioFileOutputNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioFileOutputNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,12 +68,18 @@ pub struct IAudioFileOutputNode_Vtbl {
     FinalizeAsync: usize,
 }
 windows_core::imp::define_interface!(IAudioFrameCompletedEventArgs, IAudioFrameCompletedEventArgs_Vtbl, 0xdc7c829e_0208_4504_a5a8_f0f268920a65);
+impl windows_core::RuntimeType for IAudioFrameCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioFrameCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Frame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioFrameInputNode, IAudioFrameInputNode_Vtbl, 0x01b266c7_fd96_4ff5_a3c5_d27a9bf44237);
+impl windows_core::RuntimeType for IAudioFrameInputNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioFrameInputNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,12 +94,18 @@ pub struct IAudioFrameInputNode_Vtbl {
     pub RemoveQuantumStarted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioFrameOutputNode, IAudioFrameOutputNode_Vtbl, 0xb847371b_3299_45f5_88b3_c9d12a3f1cc8);
+impl windows_core::RuntimeType for IAudioFrameOutputNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioFrameOutputNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioGraph, IAudioGraph_Vtbl, 0x1ad46eed_e48c_4e14_9660_2c4f83e9cdd8);
+impl windows_core::RuntimeType for IAudioGraph {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraph_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,6 +172,9 @@ pub struct IAudioGraph_Vtbl {
     pub SamplesPerQuantum: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioGraph2, IAudioGraph2_Vtbl, 0x4e4c3bd5_4fc1_45f6_a947_3cd38f4fd839);
+impl windows_core::RuntimeType for IAudioGraph2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraph2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -170,6 +197,9 @@ pub struct IAudioGraph2_Vtbl {
     pub CreateBatchUpdater: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioGraph3, IAudioGraph3_Vtbl, 0xddcd25ae_1185_42a7_831d_6a9b0fc86820);
+impl windows_core::RuntimeType for IAudioGraph3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraph3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +213,9 @@ pub struct IAudioGraph3_Vtbl {
     CreateMediaSourceAudioInputNodeWithEmitterAsync: usize,
 }
 windows_core::imp::define_interface!(IAudioGraphConnection, IAudioGraphConnection_Vtbl, 0x763070ed_d04e_4fac_b233_600b42edd469);
+impl windows_core::RuntimeType for IAudioGraphConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraphConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -191,6 +224,9 @@ pub struct IAudioGraphConnection_Vtbl {
     pub Gain: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioGraphSettings, IAudioGraphSettings_Vtbl, 0x1d59647f_e6fe_4628_84f8_9d8bdba25785);
+impl windows_core::RuntimeType for IAudioGraphSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraphSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -226,6 +262,9 @@ pub struct IAudioGraphSettings_Vtbl {
     pub SetDesiredRenderDeviceAudioProcessing: unsafe extern "system" fn(*mut core::ffi::c_void, super::AudioProcessing) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioGraphSettings2, IAudioGraphSettings2_Vtbl, 0x72919787_4dab_46e3_b4c9_d8e1a2636062);
+impl windows_core::RuntimeType for IAudioGraphSettings2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraphSettings2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -233,6 +272,9 @@ pub struct IAudioGraphSettings2_Vtbl {
     pub MaxPlaybackSpeedFactor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioGraphSettingsFactory, IAudioGraphSettingsFactory_Vtbl, 0xa5d91cc6_c2eb_4a61_a214_1d66d75f83da);
+impl windows_core::RuntimeType for IAudioGraphSettingsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraphSettingsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -242,12 +284,18 @@ pub struct IAudioGraphSettingsFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IAudioGraphStatics, IAudioGraphStatics_Vtbl, 0x76ec3132_e159_4ab7_a82a_17beb4b31e94);
+impl windows_core::RuntimeType for IAudioGraphStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraphStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioGraphUnrecoverableErrorOccurredEventArgs, IAudioGraphUnrecoverableErrorOccurredEventArgs_Vtbl, 0xc3d9cbe0_3ff6_4fb3_b262_50d435c55423);
+impl windows_core::RuntimeType for IAudioGraphUnrecoverableErrorOccurredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioGraphUnrecoverableErrorOccurredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -596,6 +644,9 @@ pub struct IAudioNode_Vtbl {
     EnableEffectsByDefinition: usize,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitter, IAudioNodeEmitter_Vtbl, 0x3676971d_880a_47b8_adf7_1323a9d965be);
+impl windows_core::RuntimeType for IAudioNodeEmitter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -634,6 +685,9 @@ pub struct IAudioNodeEmitter_Vtbl {
     pub IsDopplerDisabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitter2, IAudioNodeEmitter2_Vtbl, 0x4ab6eecb_ec29_47f8_818c_b6b660a5aeb1);
+impl windows_core::RuntimeType for IAudioNodeEmitter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -641,6 +695,9 @@ pub struct IAudioNodeEmitter2_Vtbl {
     pub SetSpatialAudioModel: unsafe extern "system" fn(*mut core::ffi::c_void, SpatialAudioModel) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitterConeProperties, IAudioNodeEmitterConeProperties_Vtbl, 0xe99b2cee_02ca_4375_9326_0c6ae4bcdfb5);
+impl windows_core::RuntimeType for IAudioNodeEmitterConeProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitterConeProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -649,6 +706,9 @@ pub struct IAudioNodeEmitterConeProperties_Vtbl {
     pub OuterAngleGain: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitterDecayModel, IAudioNodeEmitterDecayModel_Vtbl, 0x1d1d5af7_0d53_4fa9_bd84_d5816a86f3ff);
+impl windows_core::RuntimeType for IAudioNodeEmitterDecayModel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitterDecayModel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -658,6 +718,9 @@ pub struct IAudioNodeEmitterDecayModel_Vtbl {
     pub NaturalProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitterDecayModelStatics, IAudioNodeEmitterDecayModelStatics_Vtbl, 0xc7787ca8_f178_462f_bc81_8dd5cbe5dae8);
+impl windows_core::RuntimeType for IAudioNodeEmitterDecayModelStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitterDecayModelStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -665,12 +728,18 @@ pub struct IAudioNodeEmitterDecayModelStatics_Vtbl {
     pub CreateCustom: unsafe extern "system" fn(*mut core::ffi::c_void, f64, f64, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitterFactory, IAudioNodeEmitterFactory_Vtbl, 0xfdc8489a_6ad6_4ce4_b7f7_a99370df7ee9);
+impl windows_core::RuntimeType for IAudioNodeEmitterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateAudioNodeEmitter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, AudioNodeEmitterSettings, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitterNaturalDecayModelProperties, IAudioNodeEmitterNaturalDecayModelProperties_Vtbl, 0x48934bcf_cf2c_4efc_9331_75bd22df1f0c);
+impl windows_core::RuntimeType for IAudioNodeEmitterNaturalDecayModelProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitterNaturalDecayModelProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -678,6 +747,9 @@ pub struct IAudioNodeEmitterNaturalDecayModelProperties_Vtbl {
     pub CutoffDistance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitterShape, IAudioNodeEmitterShape_Vtbl, 0xea0311c5_e73d_44bc_859c_45553bbc4828);
+impl windows_core::RuntimeType for IAudioNodeEmitterShape {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitterShape_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -685,6 +757,9 @@ pub struct IAudioNodeEmitterShape_Vtbl {
     pub ConeProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeEmitterShapeStatics, IAudioNodeEmitterShapeStatics_Vtbl, 0x57bb2771_ffa5_4b86_a779_e264aeb9145f);
+impl windows_core::RuntimeType for IAudioNodeEmitterShapeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeEmitterShapeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -692,6 +767,9 @@ pub struct IAudioNodeEmitterShapeStatics_Vtbl {
     pub CreateOmnidirectional: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioNodeListener, IAudioNodeListener_Vtbl, 0xd9722e16_0c0a_41da_b755_6c77835fb1eb);
+impl windows_core::RuntimeType for IAudioNodeListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioNodeListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -821,6 +899,9 @@ pub struct IAudioNodeWithListener_Vtbl {
     pub Listener: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioPlaybackConnection, IAudioPlaybackConnection_Vtbl, 0x1a4c1dea_cafc_50e7_8718_ea3f81cbfa51);
+impl windows_core::RuntimeType for IAudioPlaybackConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioPlaybackConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -834,6 +915,9 @@ pub struct IAudioPlaybackConnection_Vtbl {
     pub RemoveStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioPlaybackConnectionOpenResult, IAudioPlaybackConnectionOpenResult_Vtbl, 0x4e656aef_39f9_5fc9_a519_a5bbfd9fe921);
+impl windows_core::RuntimeType for IAudioPlaybackConnectionOpenResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioPlaybackConnectionOpenResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -841,6 +925,9 @@ pub struct IAudioPlaybackConnectionOpenResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioPlaybackConnectionStatics, IAudioPlaybackConnectionStatics_Vtbl, 0xe60963a2_69e6_5ffc_9e13_824a85213daf);
+impl windows_core::RuntimeType for IAudioPlaybackConnectionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioPlaybackConnectionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -848,6 +935,9 @@ pub struct IAudioPlaybackConnectionStatics_Vtbl {
     pub TryCreateFromId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioStateMonitor, IAudioStateMonitor_Vtbl, 0x1d13d136_0199_4cdc_b84e_e72c2b581ece);
+impl windows_core::RuntimeType for IAudioStateMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioStateMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -856,6 +946,9 @@ pub struct IAudioStateMonitor_Vtbl {
     pub SoundLevel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::SoundLevel) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioStateMonitorStatics, IAudioStateMonitorStatics_Vtbl, 0x6374ea4c_1b3b_4001_94d9_dd225330fa40);
+impl windows_core::RuntimeType for IAudioStateMonitorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioStateMonitorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -887,6 +980,9 @@ pub struct IAudioStateMonitorStatics_Vtbl {
     CreateForCaptureMonitoringWithCategoryAndDeviceId: usize,
 }
 windows_core::imp::define_interface!(ICreateAudioDeviceInputNodeResult, ICreateAudioDeviceInputNodeResult_Vtbl, 0x16eec7a8_1ca7_40ef_91a4_d346e0aa1bba);
+impl windows_core::RuntimeType for ICreateAudioDeviceInputNodeResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioDeviceInputNodeResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -894,12 +990,18 @@ pub struct ICreateAudioDeviceInputNodeResult_Vtbl {
     pub DeviceInputNode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioDeviceInputNodeResult2, ICreateAudioDeviceInputNodeResult2_Vtbl, 0x921c69ce_3f35_41c7_9622_79f608baedc2);
+impl windows_core::RuntimeType for ICreateAudioDeviceInputNodeResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioDeviceInputNodeResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioDeviceOutputNodeResult, ICreateAudioDeviceOutputNodeResult_Vtbl, 0xf7776d27_1d9a_47f7_9cd4_2859cc1b7bff);
+impl windows_core::RuntimeType for ICreateAudioDeviceOutputNodeResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioDeviceOutputNodeResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -907,12 +1009,18 @@ pub struct ICreateAudioDeviceOutputNodeResult_Vtbl {
     pub DeviceOutputNode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioDeviceOutputNodeResult2, ICreateAudioDeviceOutputNodeResult2_Vtbl, 0x4864269f_bdce_4ab1_bd38_fbae93aedaca);
+impl windows_core::RuntimeType for ICreateAudioDeviceOutputNodeResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioDeviceOutputNodeResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioFileInputNodeResult, ICreateAudioFileInputNodeResult_Vtbl, 0xce83d61c_e297_4c50_9ce7_1c7a69d6bd09);
+impl windows_core::RuntimeType for ICreateAudioFileInputNodeResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioFileInputNodeResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -920,12 +1028,18 @@ pub struct ICreateAudioFileInputNodeResult_Vtbl {
     pub FileInputNode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioFileInputNodeResult2, ICreateAudioFileInputNodeResult2_Vtbl, 0xf9082020_3d80_4fe0_81c1_768fea7ca7e0);
+impl windows_core::RuntimeType for ICreateAudioFileInputNodeResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioFileInputNodeResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioFileOutputNodeResult, ICreateAudioFileOutputNodeResult_Vtbl, 0x47d6ba7b_e909_453f_866e_5540cda734ff);
+impl windows_core::RuntimeType for ICreateAudioFileOutputNodeResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioFileOutputNodeResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -933,12 +1047,18 @@ pub struct ICreateAudioFileOutputNodeResult_Vtbl {
     pub FileOutputNode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioFileOutputNodeResult2, ICreateAudioFileOutputNodeResult2_Vtbl, 0x9f01b50d_3318_47b3_a60a_1b492be7fc0d);
+impl windows_core::RuntimeType for ICreateAudioFileOutputNodeResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioFileOutputNodeResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioGraphResult, ICreateAudioGraphResult_Vtbl, 0x5453ef7e_7bde_4b76_bb5d_48f79cfc8c0b);
+impl windows_core::RuntimeType for ICreateAudioGraphResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioGraphResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -946,12 +1066,18 @@ pub struct ICreateAudioGraphResult_Vtbl {
     pub Graph: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateAudioGraphResult2, ICreateAudioGraphResult2_Vtbl, 0x6d738dfc_88c6_4fcb_a534_85cedd4050a1);
+impl windows_core::RuntimeType for ICreateAudioGraphResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateAudioGraphResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateMediaSourceAudioInputNodeResult, ICreateMediaSourceAudioInputNodeResult_Vtbl, 0x46a658a3_53c0_4d59_9e51_cc1d1044a4c4);
+impl windows_core::RuntimeType for ICreateMediaSourceAudioInputNodeResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateMediaSourceAudioInputNodeResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -959,12 +1085,18 @@ pub struct ICreateMediaSourceAudioInputNodeResult_Vtbl {
     pub Node: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICreateMediaSourceAudioInputNodeResult2, ICreateMediaSourceAudioInputNodeResult2_Vtbl, 0x63514ce8_6a1a_49e3_97ec_28fd5be114e5);
+impl windows_core::RuntimeType for ICreateMediaSourceAudioInputNodeResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICreateMediaSourceAudioInputNodeResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEchoEffectDefinition, IEchoEffectDefinition_Vtbl, 0x0e4d3faa_36b8_4c91_b9da_11f44a8a6610);
+impl windows_core::RuntimeType for IEchoEffectDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEchoEffectDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -976,12 +1108,18 @@ pub struct IEchoEffectDefinition_Vtbl {
     pub Delay: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEchoEffectDefinitionFactory, IEchoEffectDefinitionFactory_Vtbl, 0x0d4e2257_aaf2_4e86_a54c_fb79db8f6c12);
+impl windows_core::RuntimeType for IEchoEffectDefinitionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEchoEffectDefinitionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEqualizerBand, IEqualizerBand_Vtbl, 0xc00a5a6a_262d_4b85_9bb7_43280b62ed0c);
+impl windows_core::RuntimeType for IEqualizerBand {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEqualizerBand_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -993,6 +1131,9 @@ pub struct IEqualizerBand_Vtbl {
     pub SetGain: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEqualizerEffectDefinition, IEqualizerEffectDefinition_Vtbl, 0x023f6f1f_83fe_449a_a822_c696442d16b0);
+impl windows_core::RuntimeType for IEqualizerEffectDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEqualizerEffectDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1002,18 +1143,27 @@ pub struct IEqualizerEffectDefinition_Vtbl {
     Bands: usize,
 }
 windows_core::imp::define_interface!(IEqualizerEffectDefinitionFactory, IEqualizerEffectDefinitionFactory_Vtbl, 0xd2876fc4_d410_4eb5_9e69_c9aa1277eaf0);
+impl windows_core::RuntimeType for IEqualizerEffectDefinitionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEqualizerEffectDefinitionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameInputNodeQuantumStartedEventArgs, IFrameInputNodeQuantumStartedEventArgs_Vtbl, 0x3d9bd498_a306_4f06_bd9f_e9efc8226304);
+impl windows_core::RuntimeType for IFrameInputNodeQuantumStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameInputNodeQuantumStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequiredSamples: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILimiterEffectDefinition, ILimiterEffectDefinition_Vtbl, 0x6b755d19_2603_47ba_bdeb_39055e3486dc);
+impl windows_core::RuntimeType for ILimiterEffectDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILimiterEffectDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1023,12 +1173,18 @@ pub struct ILimiterEffectDefinition_Vtbl {
     pub Loudness: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILimiterEffectDefinitionFactory, ILimiterEffectDefinitionFactory_Vtbl, 0xecbae6f1_61ff_45ef_b8f5_48659a57c72d);
+impl windows_core::RuntimeType for ILimiterEffectDefinitionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILimiterEffectDefinitionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSourceAudioInputNode, IMediaSourceAudioInputNode_Vtbl, 0x99d8983b_a88a_4041_8e4f_ddbac0c91fd3);
+impl windows_core::RuntimeType for IMediaSourceAudioInputNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceAudioInputNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1051,6 +1207,9 @@ pub struct IMediaSourceAudioInputNode_Vtbl {
     pub RemoveMediaSourceCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReverbEffectDefinition, IReverbEffectDefinition_Vtbl, 0x4606aa89_f563_4d0a_8f6e_f0cddff35d84);
+impl windows_core::RuntimeType for IReverbEffectDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReverbEffectDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1102,18 +1261,27 @@ pub struct IReverbEffectDefinition_Vtbl {
     pub DisableLateField: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReverbEffectDefinitionFactory, IReverbEffectDefinitionFactory_Vtbl, 0xa7d5cbfe_100b_4ff0_9da6_dc4e05a759f0);
+impl windows_core::RuntimeType for IReverbEffectDefinitionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReverbEffectDefinitionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISetDefaultSpatialAudioFormatResult, ISetDefaultSpatialAudioFormatResult_Vtbl, 0x1c2aa511_1400_5e70_9ea9_ae151241e8ea);
+impl windows_core::RuntimeType for ISetDefaultSpatialAudioFormatResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISetDefaultSpatialAudioFormatResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SetDefaultSpatialAudioFormatStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAudioDeviceConfiguration, ISpatialAudioDeviceConfiguration_Vtbl, 0xee830034_61cf_5749_9da4_10f0fe028199);
+impl windows_core::RuntimeType for ISpatialAudioDeviceConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAudioDeviceConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1127,12 +1295,18 @@ pub struct ISpatialAudioDeviceConfiguration_Vtbl {
     pub RemoveConfigurationChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAudioDeviceConfigurationStatics, ISpatialAudioDeviceConfigurationStatics_Vtbl, 0x3ec37f7b_936d_4e04_9728_2827d9f758c4);
+impl windows_core::RuntimeType for ISpatialAudioDeviceConfigurationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAudioDeviceConfigurationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAudioFormatConfiguration, ISpatialAudioFormatConfiguration_Vtbl, 0x32df09a8_50f0_5395_9923_7d44ca71ed6d);
+impl windows_core::RuntimeType for ISpatialAudioFormatConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAudioFormatConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1142,12 +1316,18 @@ pub struct ISpatialAudioFormatConfiguration_Vtbl {
     pub SetMixedRealityExclusiveModePolicy: unsafe extern "system" fn(*mut core::ffi::c_void, MixedRealitySpatialAudioFormatPolicy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAudioFormatConfigurationStatics, ISpatialAudioFormatConfigurationStatics_Vtbl, 0x2b5fef71_67c9_4e5f_a35b_41680711f8c7);
+impl windows_core::RuntimeType for ISpatialAudioFormatConfigurationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAudioFormatConfigurationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAudioFormatSubtypeStatics, ISpatialAudioFormatSubtypeStatics_Vtbl, 0xb3de8a47_83ee_4266_a945_bedf507afeed);
+impl windows_core::RuntimeType for ISpatialAudioFormatSubtypeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAudioFormatSubtypeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1159,6 +1339,9 @@ pub struct ISpatialAudioFormatSubtypeStatics_Vtbl {
     pub DTSXUltra: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAudioFormatSubtypeStatics2, ISpatialAudioFormatSubtypeStatics2_Vtbl, 0x4565e6cb_d95b_5621_b6af_0e8849c57c80);
+impl windows_core::RuntimeType for ISpatialAudioFormatSubtypeStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAudioFormatSubtypeStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1286,7 +1469,7 @@ impl AudioDeviceInputNode {
     }
 }
 impl windows_core::RuntimeType for AudioDeviceInputNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioDeviceInputNode>();
 }
 unsafe impl windows_core::Interface for AudioDeviceInputNode {
     type Vtable = IAudioDeviceInputNode_Vtbl;
@@ -1397,7 +1580,7 @@ impl AudioDeviceOutputNode {
     }
 }
 impl windows_core::RuntimeType for AudioDeviceOutputNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioDeviceOutputNode>();
 }
 unsafe impl windows_core::Interface for AudioDeviceOutputNode {
     type Vtable = IAudioDeviceOutputNode_Vtbl;
@@ -1615,7 +1798,7 @@ impl AudioFileInputNode {
     }
 }
 impl windows_core::RuntimeType for AudioFileInputNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioFileInputNode>();
 }
 unsafe impl windows_core::Interface for AudioFileInputNode {
     type Vtable = IAudioFileInputNode_Vtbl;
@@ -1728,7 +1911,7 @@ impl AudioFileOutputNode {
     }
 }
 impl windows_core::RuntimeType for AudioFileOutputNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioFileOutputNode>();
 }
 unsafe impl windows_core::Interface for AudioFileOutputNode {
     type Vtable = IAudioFileOutputNode_Vtbl;
@@ -1753,7 +1936,7 @@ impl AudioFrameCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AudioFrameCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioFrameCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for AudioFrameCompletedEventArgs {
     type Vtable = IAudioFrameCompletedEventArgs_Vtbl;
@@ -1935,7 +2118,7 @@ impl AudioFrameInputNode {
     }
 }
 impl windows_core::RuntimeType for AudioFrameInputNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioFrameInputNode>();
 }
 unsafe impl windows_core::Interface for AudioFrameInputNode {
     type Vtable = IAudioFrameInputNode_Vtbl;
@@ -2031,7 +2214,7 @@ impl AudioFrameOutputNode {
     }
 }
 impl windows_core::RuntimeType for AudioFrameOutputNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioFrameOutputNode>();
 }
 unsafe impl windows_core::Interface for AudioFrameOutputNode {
     type Vtable = IAudioFrameOutputNode_Vtbl;
@@ -2371,7 +2554,7 @@ impl AudioGraph {
     }
 }
 impl windows_core::RuntimeType for AudioGraph {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioGraph>();
 }
 unsafe impl windows_core::Interface for AudioGraph {
     type Vtable = IAudioGraph_Vtbl;
@@ -2394,7 +2577,7 @@ impl AudioGraphBatchUpdater {
     }
 }
 impl windows_core::RuntimeType for AudioGraphBatchUpdater {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IClosable>();
 }
 unsafe impl windows_core::Interface for AudioGraphBatchUpdater {
     type Vtable = super::super::Foundation::IClosable_Vtbl;
@@ -2430,7 +2613,7 @@ impl AudioGraphConnection {
     }
 }
 impl windows_core::RuntimeType for AudioGraphConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioGraphConnection>();
 }
 unsafe impl windows_core::Interface for AudioGraphConnection {
     type Vtable = IAudioGraphConnection_Vtbl;
@@ -2549,7 +2732,7 @@ impl AudioGraphSettings {
     }
 }
 impl windows_core::RuntimeType for AudioGraphSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioGraphSettings>();
 }
 unsafe impl windows_core::Interface for AudioGraphSettings {
     type Vtable = IAudioGraphSettings_Vtbl;
@@ -2574,7 +2757,7 @@ impl AudioGraphUnrecoverableErrorOccurredEventArgs {
     }
 }
 impl windows_core::RuntimeType for AudioGraphUnrecoverableErrorOccurredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioGraphUnrecoverableErrorOccurredEventArgs>();
 }
 unsafe impl windows_core::Interface for AudioGraphUnrecoverableErrorOccurredEventArgs {
     type Vtable = IAudioGraphUnrecoverableErrorOccurredEventArgs_Vtbl;
@@ -2718,7 +2901,7 @@ impl AudioNodeEmitter {
     }
 }
 impl windows_core::RuntimeType for AudioNodeEmitter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioNodeEmitter>();
 }
 unsafe impl windows_core::Interface for AudioNodeEmitter {
     type Vtable = IAudioNodeEmitter_Vtbl;
@@ -2757,7 +2940,7 @@ impl AudioNodeEmitterConeProperties {
     }
 }
 impl windows_core::RuntimeType for AudioNodeEmitterConeProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioNodeEmitterConeProperties>();
 }
 unsafe impl windows_core::Interface for AudioNodeEmitterConeProperties {
     type Vtable = IAudioNodeEmitterConeProperties_Vtbl;
@@ -2820,7 +3003,7 @@ impl AudioNodeEmitterDecayModel {
     }
 }
 impl windows_core::RuntimeType for AudioNodeEmitterDecayModel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioNodeEmitterDecayModel>();
 }
 unsafe impl windows_core::Interface for AudioNodeEmitterDecayModel {
     type Vtable = IAudioNodeEmitterDecayModel_Vtbl;
@@ -2852,7 +3035,7 @@ impl AudioNodeEmitterNaturalDecayModelProperties {
     }
 }
 impl windows_core::RuntimeType for AudioNodeEmitterNaturalDecayModelProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioNodeEmitterNaturalDecayModelProperties>();
 }
 unsafe impl windows_core::Interface for AudioNodeEmitterNaturalDecayModelProperties {
     type Vtable = IAudioNodeEmitterNaturalDecayModelProperties_Vtbl;
@@ -2901,7 +3084,7 @@ impl AudioNodeEmitterShape {
     }
 }
 impl windows_core::RuntimeType for AudioNodeEmitterShape {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioNodeEmitterShape>();
 }
 unsafe impl windows_core::Interface for AudioNodeEmitterShape {
     type Vtable = IAudioNodeEmitterShape_Vtbl;
@@ -2976,7 +3159,7 @@ impl AudioNodeListener {
     }
 }
 impl windows_core::RuntimeType for AudioNodeListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioNodeListener>();
 }
 unsafe impl windows_core::Interface for AudioNodeListener {
     type Vtable = IAudioNodeListener_Vtbl;
@@ -3069,7 +3252,7 @@ impl AudioPlaybackConnection {
     }
 }
 impl windows_core::RuntimeType for AudioPlaybackConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioPlaybackConnection>();
 }
 unsafe impl windows_core::Interface for AudioPlaybackConnection {
     type Vtable = IAudioPlaybackConnection_Vtbl;
@@ -3101,7 +3284,7 @@ impl AudioPlaybackConnectionOpenResult {
     }
 }
 impl windows_core::RuntimeType for AudioPlaybackConnectionOpenResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioPlaybackConnectionOpenResult>();
 }
 unsafe impl windows_core::Interface for AudioPlaybackConnectionOpenResult {
     type Vtable = IAudioPlaybackConnectionOpenResult_Vtbl;
@@ -3199,7 +3382,7 @@ impl AudioStateMonitor {
     }
 }
 impl windows_core::RuntimeType for AudioStateMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioStateMonitor>();
 }
 unsafe impl windows_core::Interface for AudioStateMonitor {
     type Vtable = IAudioStateMonitor_Vtbl;
@@ -3324,7 +3507,7 @@ impl AudioSubmixNode {
     }
 }
 impl windows_core::RuntimeType for AudioSubmixNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioInputNode>();
 }
 unsafe impl windows_core::Interface for AudioSubmixNode {
     type Vtable = IAudioInputNode_Vtbl;
@@ -3363,7 +3546,7 @@ impl CreateAudioDeviceInputNodeResult {
     }
 }
 impl windows_core::RuntimeType for CreateAudioDeviceInputNodeResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateAudioDeviceInputNodeResult>();
 }
 unsafe impl windows_core::Interface for CreateAudioDeviceInputNodeResult {
     type Vtable = ICreateAudioDeviceInputNodeResult_Vtbl;
@@ -3402,7 +3585,7 @@ impl CreateAudioDeviceOutputNodeResult {
     }
 }
 impl windows_core::RuntimeType for CreateAudioDeviceOutputNodeResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateAudioDeviceOutputNodeResult>();
 }
 unsafe impl windows_core::Interface for CreateAudioDeviceOutputNodeResult {
     type Vtable = ICreateAudioDeviceOutputNodeResult_Vtbl;
@@ -3441,7 +3624,7 @@ impl CreateAudioFileInputNodeResult {
     }
 }
 impl windows_core::RuntimeType for CreateAudioFileInputNodeResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateAudioFileInputNodeResult>();
 }
 unsafe impl windows_core::Interface for CreateAudioFileInputNodeResult {
     type Vtable = ICreateAudioFileInputNodeResult_Vtbl;
@@ -3480,7 +3663,7 @@ impl CreateAudioFileOutputNodeResult {
     }
 }
 impl windows_core::RuntimeType for CreateAudioFileOutputNodeResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateAudioFileOutputNodeResult>();
 }
 unsafe impl windows_core::Interface for CreateAudioFileOutputNodeResult {
     type Vtable = ICreateAudioFileOutputNodeResult_Vtbl;
@@ -3519,7 +3702,7 @@ impl CreateAudioGraphResult {
     }
 }
 impl windows_core::RuntimeType for CreateAudioGraphResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateAudioGraphResult>();
 }
 unsafe impl windows_core::Interface for CreateAudioGraphResult {
     type Vtable = ICreateAudioGraphResult_Vtbl;
@@ -3558,7 +3741,7 @@ impl CreateMediaSourceAudioInputNodeResult {
     }
 }
 impl windows_core::RuntimeType for CreateMediaSourceAudioInputNodeResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICreateMediaSourceAudioInputNodeResult>();
 }
 unsafe impl windows_core::Interface for CreateMediaSourceAudioInputNodeResult {
     type Vtable = ICreateMediaSourceAudioInputNodeResult_Vtbl;
@@ -3641,7 +3824,7 @@ impl EchoEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for EchoEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEchoEffectDefinition>();
 }
 unsafe impl windows_core::Interface for EchoEffectDefinition {
     type Vtable = IEchoEffectDefinition_Vtbl;
@@ -3692,7 +3875,7 @@ impl EqualizerBand {
     }
 }
 impl windows_core::RuntimeType for EqualizerBand {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEqualizerBand>();
 }
 unsafe impl windows_core::Interface for EqualizerBand {
     type Vtable = IEqualizerBand_Vtbl;
@@ -3750,7 +3933,7 @@ impl EqualizerEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for EqualizerEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEqualizerEffectDefinition>();
 }
 unsafe impl windows_core::Interface for EqualizerEffectDefinition {
     type Vtable = IEqualizerEffectDefinition_Vtbl;
@@ -3775,7 +3958,7 @@ impl FrameInputNodeQuantumStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for FrameInputNodeQuantumStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameInputNodeQuantumStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for FrameInputNodeQuantumStartedEventArgs {
     type Vtable = IFrameInputNodeQuantumStartedEventArgs_Vtbl;
@@ -3847,7 +4030,7 @@ impl LimiterEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for LimiterEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILimiterEffectDefinition>();
 }
 unsafe impl windows_core::Interface for LimiterEffectDefinition {
     type Vtable = ILimiterEffectDefinition_Vtbl;
@@ -4065,7 +4248,7 @@ impl MediaSourceAudioInputNode {
     }
 }
 impl windows_core::RuntimeType for MediaSourceAudioInputNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaSourceAudioInputNode>();
 }
 unsafe impl windows_core::Interface for MediaSourceAudioInputNode {
     type Vtable = IMediaSourceAudioInputNode_Vtbl;
@@ -4368,7 +4551,7 @@ impl ReverbEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for ReverbEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IReverbEffectDefinition>();
 }
 unsafe impl windows_core::Interface for ReverbEffectDefinition {
     type Vtable = IReverbEffectDefinition_Vtbl;
@@ -4393,7 +4576,7 @@ impl SetDefaultSpatialAudioFormatResult {
     }
 }
 impl windows_core::RuntimeType for SetDefaultSpatialAudioFormatResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISetDefaultSpatialAudioFormatResult>();
 }
 unsafe impl windows_core::Interface for SetDefaultSpatialAudioFormatResult {
     type Vtable = ISetDefaultSpatialAudioFormatResult_Vtbl;
@@ -4478,7 +4661,7 @@ impl SpatialAudioDeviceConfiguration {
     }
 }
 impl windows_core::RuntimeType for SpatialAudioDeviceConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialAudioDeviceConfiguration>();
 }
 unsafe impl windows_core::Interface for SpatialAudioDeviceConfiguration {
     type Vtable = ISpatialAudioDeviceConfiguration_Vtbl;
@@ -4532,7 +4715,7 @@ impl SpatialAudioFormatConfiguration {
     }
 }
 impl windows_core::RuntimeType for SpatialAudioFormatConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialAudioFormatConfiguration>();
 }
 unsafe impl windows_core::Interface for SpatialAudioFormatConfiguration {
     type Vtable = ISpatialAudioFormatConfiguration_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Capture/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IVariablePhotoCapturedEventArgs, IVariablePhotoCapturedEventArgs_Vtbl, 0xd1eb4c5c_1b53_4e4a_8b5c_db7887ac949b);
+impl windows_core::RuntimeType for IVariablePhotoCapturedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVariablePhotoCapturedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IVariablePhotoCapturedEventArgs_Vtbl {
     pub CapturedFrameControlValues: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVariablePhotoSequenceCapture, IVariablePhotoSequenceCapture_Vtbl, 0xd0112d1d_031e_4041_a6d6_bd742476a8ee);
+impl windows_core::RuntimeType for IVariablePhotoSequenceCapture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVariablePhotoSequenceCapture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct IVariablePhotoSequenceCapture_Vtbl {
     pub RemoveStopped: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVariablePhotoSequenceCapture2, IVariablePhotoSequenceCapture2_Vtbl, 0xfe2c62bc_50b0_43e3_917c_e3b92798942f);
+impl windows_core::RuntimeType for IVariablePhotoSequenceCapture2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVariablePhotoSequenceCapture2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,7 +69,7 @@ impl VariablePhotoCapturedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VariablePhotoCapturedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVariablePhotoCapturedEventArgs>();
 }
 unsafe impl windows_core::Interface for VariablePhotoCapturedEventArgs {
     type Vtable = IVariablePhotoCapturedEventArgs_Vtbl;
@@ -134,7 +143,7 @@ impl VariablePhotoSequenceCapture {
     }
 }
 impl windows_core::RuntimeType for VariablePhotoSequenceCapture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVariablePhotoSequenceCapture>();
 }
 unsafe impl windows_core::Interface for VariablePhotoSequenceCapture {
     type Vtable = IVariablePhotoSequenceCapture_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAudioMediaFrame, IAudioMediaFrame_Vtbl, 0xa3a9feff_8021_441b_9a46_e7f0137b7981);
+impl windows_core::RuntimeType for IAudioMediaFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioMediaFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IAudioMediaFrame_Vtbl {
     pub GetAudioFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBufferMediaFrame, IBufferMediaFrame_Vtbl, 0xb5b153c7_9b84_4062_b79c_a365b2596854);
+impl windows_core::RuntimeType for IBufferMediaFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBufferMediaFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct IBufferMediaFrame_Vtbl {
     Buffer: usize,
 }
 windows_core::imp::define_interface!(IDepthMediaFrame, IDepthMediaFrame_Vtbl, 0x47135e4f_8549_45c0_925b_80d35efdb10a);
+impl windows_core::RuntimeType for IDepthMediaFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDepthMediaFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +41,9 @@ pub struct IDepthMediaFrame_Vtbl {
     TryCreateCoordinateMapper: usize,
 }
 windows_core::imp::define_interface!(IDepthMediaFrame2, IDepthMediaFrame2_Vtbl, 0x6cca473d_c4a4_4176_b0cd_33eae3b35aa3);
+impl windows_core::RuntimeType for IDepthMediaFrame2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDepthMediaFrame2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +51,9 @@ pub struct IDepthMediaFrame2_Vtbl {
     pub MinReliableDepth: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDepthMediaFrameFormat, IDepthMediaFrameFormat_Vtbl, 0xc312cf40_d729_453e_8780_2e04f140d28e);
+impl windows_core::RuntimeType for IDepthMediaFrameFormat {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDepthMediaFrameFormat_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +61,9 @@ pub struct IDepthMediaFrameFormat_Vtbl {
     pub DepthScaleInMeters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInfraredMediaFrame, IInfraredMediaFrame_Vtbl, 0x3fd13503_004b_4f0e_91ac_465299b41658);
+impl windows_core::RuntimeType for IInfraredMediaFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInfraredMediaFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,11 +72,17 @@ pub struct IInfraredMediaFrame_Vtbl {
     pub IsIlluminated: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameArrivedEventArgs, IMediaFrameArrivedEventArgs_Vtbl, 0x0b430add_a490_4435_ada1_9affd55239f7);
+impl windows_core::RuntimeType for IMediaFrameArrivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameArrivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IMediaFrameFormat, IMediaFrameFormat_Vtbl, 0x71902b4e_b279_4a97_a9db_bd5a2fb78f39);
+impl windows_core::RuntimeType for IMediaFrameFormat {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameFormat_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +99,9 @@ pub struct IMediaFrameFormat_Vtbl {
     pub VideoFormat: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameFormat2, IMediaFrameFormat2_Vtbl, 0x63856340_5e87_4c10_86d1_6df097a6c6a8);
+impl windows_core::RuntimeType for IMediaFrameFormat2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameFormat2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +111,9 @@ pub struct IMediaFrameFormat2_Vtbl {
     AudioEncodingProperties: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameReader, IMediaFrameReader_Vtbl, 0xe4c94395_2028_48ed_90b0_d1c1b162e24c);
+impl windows_core::RuntimeType for IMediaFrameReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +124,9 @@ pub struct IMediaFrameReader_Vtbl {
     pub StopAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameReader2, IMediaFrameReader2_Vtbl, 0x871127b3_8531_4050_87cc_a13733cf3e9b);
+impl windows_core::RuntimeType for IMediaFrameReader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameReader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,6 +134,9 @@ pub struct IMediaFrameReader2_Vtbl {
     pub AcquisitionMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaFrameReaderAcquisitionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameReference, IMediaFrameReference_Vtbl, 0xf6b88641_f0dc_4044_8dc9_961cedd05bad);
+impl windows_core::RuntimeType for IMediaFrameReference {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameReference_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,12 +156,18 @@ pub struct IMediaFrameReference_Vtbl {
     CoordinateSystem: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameReference2, IMediaFrameReference2_Vtbl, 0xddbc3ecc_d5b2_49ef_836a_947d989b80c1);
+impl windows_core::RuntimeType for IMediaFrameReference2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameReference2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AudioMediaFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameSource, IMediaFrameSource_Vtbl, 0xd6782953_90db_46a8_8add_2aa884a8d253);
+impl windows_core::RuntimeType for IMediaFrameSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +187,9 @@ pub struct IMediaFrameSource_Vtbl {
     TryGetCameraIntrinsics: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceController, IMediaFrameSourceController_Vtbl, 0x6d076635_316d_4b8f_b7b6_eeb04a8c6525);
+impl windows_core::RuntimeType for IMediaFrameSourceController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +201,9 @@ pub struct IMediaFrameSourceController_Vtbl {
     VideoDeviceController: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceController2, IMediaFrameSourceController2_Vtbl, 0xefc49fd4_fcf2_4a03_b4e4_ac9628739bee);
+impl windows_core::RuntimeType for IMediaFrameSourceController2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceController2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -163,6 +211,9 @@ pub struct IMediaFrameSourceController2_Vtbl {
     pub SetPropertyByExtendedIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceController3, IMediaFrameSourceController3_Vtbl, 0x1f0cf815_2464_4651_b1e8_4a82dbdb54de);
+impl windows_core::RuntimeType for IMediaFrameSourceController3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceController3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,6 +223,9 @@ pub struct IMediaFrameSourceController3_Vtbl {
     AudioDeviceController: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceGetPropertyResult, IMediaFrameSourceGetPropertyResult_Vtbl, 0x088616c2_3a64_4bd5_bd2b_e7c898d2f37a);
+impl windows_core::RuntimeType for IMediaFrameSourceGetPropertyResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceGetPropertyResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,6 +233,9 @@ pub struct IMediaFrameSourceGetPropertyResult_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceGroup, IMediaFrameSourceGroup_Vtbl, 0x7f605b87_4832_4b5f_ae3d_412faab37d34);
+impl windows_core::RuntimeType for IMediaFrameSourceGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -190,6 +247,9 @@ pub struct IMediaFrameSourceGroup_Vtbl {
     SourceInfos: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceGroupStatics, IMediaFrameSourceGroupStatics_Vtbl, 0x1c48bfc5_436f_4508_94cf_d5d8b7326445);
+impl windows_core::RuntimeType for IMediaFrameSourceGroupStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceGroupStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -201,6 +261,9 @@ pub struct IMediaFrameSourceGroupStatics_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceInfo, IMediaFrameSourceInfo_Vtbl, 0x87bdc9cd_4601_408f_91cf_038318cd0af3);
+impl windows_core::RuntimeType for IMediaFrameSourceInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,6 +285,9 @@ pub struct IMediaFrameSourceInfo_Vtbl {
     CoordinateSystem: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceInfo2, IMediaFrameSourceInfo2_Vtbl, 0x195a7855_6457_42c6_a769_19b65bd32e6e);
+impl windows_core::RuntimeType for IMediaFrameSourceInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -232,6 +298,9 @@ pub struct IMediaFrameSourceInfo2_Vtbl {
     VideoProfileMediaDescription: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceInfo3, IMediaFrameSourceInfo3_Vtbl, 0xca824ab6_66ea_5885_a2b6_26c0eeec3c7b);
+impl windows_core::RuntimeType for IMediaFrameSourceInfo3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceInfo3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -241,17 +310,26 @@ pub struct IMediaFrameSourceInfo3_Vtbl {
     GetRelativePanel: usize,
 }
 windows_core::imp::define_interface!(IMediaFrameSourceInfo4, IMediaFrameSourceInfo4_Vtbl, 0x4817d721_85eb_470c_8f37_43ca5498e41d);
+impl windows_core::RuntimeType for IMediaFrameSourceInfo4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaFrameSourceInfo4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsShareable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMultiSourceMediaFrameArrivedEventArgs, IMultiSourceMediaFrameArrivedEventArgs_Vtbl, 0x63115e01_cf51_48fd_aab0_6d693eb48127);
+impl windows_core::RuntimeType for IMultiSourceMediaFrameArrivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMultiSourceMediaFrameArrivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IMultiSourceMediaFrameReader, IMultiSourceMediaFrameReader_Vtbl, 0x8d144402_f763_488d_98f2_b437bcf075e7);
+impl windows_core::RuntimeType for IMultiSourceMediaFrameReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMultiSourceMediaFrameReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -262,6 +340,9 @@ pub struct IMultiSourceMediaFrameReader_Vtbl {
     pub StopAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMultiSourceMediaFrameReader2, IMultiSourceMediaFrameReader2_Vtbl, 0xef5c8abd_fc5c_4c6b_9d81_3cb9cc637c26);
+impl windows_core::RuntimeType for IMultiSourceMediaFrameReader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMultiSourceMediaFrameReader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -269,12 +350,18 @@ pub struct IMultiSourceMediaFrameReader2_Vtbl {
     pub AcquisitionMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaFrameReaderAcquisitionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMultiSourceMediaFrameReference, IMultiSourceMediaFrameReference_Vtbl, 0x21964b1a_7fe2_44d6_92e5_298e6d2810e9);
+impl windows_core::RuntimeType for IMultiSourceMediaFrameReference {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMultiSourceMediaFrameReference_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryGetFrameReferenceBySourceId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoMediaFrame, IVideoMediaFrame_Vtbl, 0x00dd4ccb_32bd_4fe1_a013_7cc13cf5dbcf);
+impl windows_core::RuntimeType for IVideoMediaFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoMediaFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -297,6 +384,9 @@ pub struct IVideoMediaFrame_Vtbl {
     pub GetVideoFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoMediaFrameFormat, IVideoMediaFrameFormat_Vtbl, 0x46027fc0_d71b_45c7_8f14_6d9a0ae604e4);
+impl windows_core::RuntimeType for IVideoMediaFrameFormat {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoMediaFrameFormat_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -334,7 +424,7 @@ impl AudioMediaFrame {
     }
 }
 impl windows_core::RuntimeType for AudioMediaFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioMediaFrame>();
 }
 unsafe impl windows_core::Interface for AudioMediaFrame {
     type Vtable = IAudioMediaFrame_Vtbl;
@@ -367,7 +457,7 @@ impl BufferMediaFrame {
     }
 }
 impl windows_core::RuntimeType for BufferMediaFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBufferMediaFrame>();
 }
 unsafe impl windows_core::Interface for BufferMediaFrame {
     type Vtable = IBufferMediaFrame_Vtbl;
@@ -432,7 +522,7 @@ impl DepthMediaFrame {
     }
 }
 impl windows_core::RuntimeType for DepthMediaFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDepthMediaFrame>();
 }
 unsafe impl windows_core::Interface for DepthMediaFrame {
     type Vtable = IDepthMediaFrame_Vtbl;
@@ -464,7 +554,7 @@ impl DepthMediaFrameFormat {
     }
 }
 impl windows_core::RuntimeType for DepthMediaFrameFormat {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDepthMediaFrameFormat>();
 }
 unsafe impl windows_core::Interface for DepthMediaFrameFormat {
     type Vtable = IDepthMediaFrameFormat_Vtbl;
@@ -503,7 +593,7 @@ impl InfraredMediaFrame {
     }
 }
 impl windows_core::RuntimeType for InfraredMediaFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInfraredMediaFrame>();
 }
 unsafe impl windows_core::Interface for InfraredMediaFrame {
     type Vtable = IInfraredMediaFrame_Vtbl;
@@ -520,7 +610,7 @@ pub struct MediaFrameArrivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaFrameArrivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaFrameArrivedEventArgs {}
 impl windows_core::RuntimeType for MediaFrameArrivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameArrivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaFrameArrivedEventArgs {
     type Vtable = IMediaFrameArrivedEventArgs_Vtbl;
@@ -583,7 +673,7 @@ impl MediaFrameFormat {
     }
 }
 impl windows_core::RuntimeType for MediaFrameFormat {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameFormat>();
 }
 unsafe impl windows_core::Interface for MediaFrameFormat {
     type Vtable = IMediaFrameFormat_Vtbl;
@@ -652,7 +742,7 @@ impl MediaFrameReader {
     }
 }
 impl windows_core::RuntimeType for MediaFrameReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameReader>();
 }
 unsafe impl windows_core::Interface for MediaFrameReader {
     type Vtable = IMediaFrameReader_Vtbl;
@@ -740,7 +830,7 @@ impl MediaFrameReference {
     }
 }
 impl windows_core::RuntimeType for MediaFrameReference {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameReference>();
 }
 unsafe impl windows_core::Interface for MediaFrameReference {
     type Vtable = IMediaFrameReference_Vtbl;
@@ -822,7 +912,7 @@ impl MediaFrameSource {
     }
 }
 impl windows_core::RuntimeType for MediaFrameSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameSource>();
 }
 unsafe impl windows_core::Interface for MediaFrameSource {
     type Vtable = IMediaFrameSource_Vtbl;
@@ -890,7 +980,7 @@ impl MediaFrameSourceController {
     }
 }
 impl windows_core::RuntimeType for MediaFrameSourceController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameSourceController>();
 }
 unsafe impl windows_core::Interface for MediaFrameSourceController {
     type Vtable = IMediaFrameSourceController_Vtbl;
@@ -922,7 +1012,7 @@ impl MediaFrameSourceGetPropertyResult {
     }
 }
 impl windows_core::RuntimeType for MediaFrameSourceGetPropertyResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameSourceGetPropertyResult>();
 }
 unsafe impl windows_core::Interface for MediaFrameSourceGetPropertyResult {
     type Vtable = IMediaFrameSourceGetPropertyResult_Vtbl;
@@ -986,7 +1076,7 @@ impl MediaFrameSourceGroup {
     }
 }
 impl windows_core::RuntimeType for MediaFrameSourceGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameSourceGroup>();
 }
 unsafe impl windows_core::Interface for MediaFrameSourceGroup {
     type Vtable = IMediaFrameSourceGroup_Vtbl;
@@ -1089,7 +1179,7 @@ impl MediaFrameSourceInfo {
     }
 }
 impl windows_core::RuntimeType for MediaFrameSourceInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaFrameSourceInfo>();
 }
 unsafe impl windows_core::Interface for MediaFrameSourceInfo {
     type Vtable = IMediaFrameSourceInfo_Vtbl;
@@ -1106,7 +1196,7 @@ pub struct MultiSourceMediaFrameArrivedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MultiSourceMediaFrameArrivedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MultiSourceMediaFrameArrivedEventArgs {}
 impl windows_core::RuntimeType for MultiSourceMediaFrameArrivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMultiSourceMediaFrameArrivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MultiSourceMediaFrameArrivedEventArgs {
     type Vtable = IMultiSourceMediaFrameArrivedEventArgs_Vtbl;
@@ -1175,7 +1265,7 @@ impl MultiSourceMediaFrameReader {
     }
 }
 impl windows_core::RuntimeType for MultiSourceMediaFrameReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMultiSourceMediaFrameReader>();
 }
 unsafe impl windows_core::Interface for MultiSourceMediaFrameReader {
     type Vtable = IMultiSourceMediaFrameReader_Vtbl;
@@ -1205,7 +1295,7 @@ impl MultiSourceMediaFrameReference {
     }
 }
 impl windows_core::RuntimeType for MultiSourceMediaFrameReference {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMultiSourceMediaFrameReference>();
 }
 unsafe impl windows_core::Interface for MultiSourceMediaFrameReference {
     type Vtable = IMultiSourceMediaFrameReference_Vtbl;
@@ -1282,7 +1372,7 @@ impl VideoMediaFrame {
     }
 }
 impl windows_core::RuntimeType for VideoMediaFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoMediaFrame>();
 }
 unsafe impl windows_core::Interface for VideoMediaFrame {
     type Vtable = IVideoMediaFrame_Vtbl;
@@ -1328,7 +1418,7 @@ impl VideoMediaFrameFormat {
     }
 }
 impl windows_core::RuntimeType for VideoMediaFrameFormat {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoMediaFrameFormat>();
 }
 unsafe impl windows_core::Interface for VideoMediaFrameFormat {
     type Vtable = IVideoMediaFrameFormat_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/mod.rs
@@ -3,6 +3,9 @@ pub mod Core;
 #[cfg(feature = "Media_Capture_Frames")]
 pub mod Frames;
 windows_core::imp::define_interface!(IAdvancedCapturedPhoto, IAdvancedCapturedPhoto_Vtbl, 0xf072728b_b292_4491_9d41_99807a550bbf);
+impl windows_core::RuntimeType for IAdvancedCapturedPhoto {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedCapturedPhoto_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,12 +17,18 @@ pub struct IAdvancedCapturedPhoto_Vtbl {
     pub Context: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedCapturedPhoto2, IAdvancedCapturedPhoto2_Vtbl, 0x18cf6cd8_cffe_42d8_8104_017bb318f4a1);
+impl windows_core::RuntimeType for IAdvancedCapturedPhoto2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedCapturedPhoto2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FrameBoundsRelativeToReferencePhoto: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedPhotoCapture, IAdvancedPhotoCapture_Vtbl, 0x83ffaafa_6667_44dc_973c_a6bce596aa0f);
+impl windows_core::RuntimeType for IAdvancedPhotoCapture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedPhotoCapture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +41,9 @@ pub struct IAdvancedPhotoCapture_Vtbl {
     pub FinishAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastBackgroundService, IAppBroadcastBackgroundService_Vtbl, 0xbad1e72a_fa94_46f9_95fc_d71511cda70b);
+impl windows_core::RuntimeType for IAppBroadcastBackgroundService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastBackgroundService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,6 +63,9 @@ pub struct IAppBroadcastBackgroundService_Vtbl {
     pub TitleId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastBackgroundService2, IAppBroadcastBackgroundService2_Vtbl, 0xfc8ccbbf_5549_4b87_959f_23ca401fd473);
+impl windows_core::RuntimeType for IAppBroadcastBackgroundService2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastBackgroundService2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +82,9 @@ pub struct IAppBroadcastBackgroundService2_Vtbl {
     pub RemoveBroadcastChannelChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastBackgroundServiceSignInInfo, IAppBroadcastBackgroundServiceSignInInfo_Vtbl, 0x5e735275_88c8_4eca_89ba_4825985db880);
+impl windows_core::RuntimeType for IAppBroadcastBackgroundServiceSignInInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastBackgroundServiceSignInInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,6 +103,9 @@ pub struct IAppBroadcastBackgroundServiceSignInInfo_Vtbl {
     pub RemoveSignInStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastBackgroundServiceSignInInfo2, IAppBroadcastBackgroundServiceSignInInfo2_Vtbl, 0x9104285c_62cf_4a3c_a7ee_aeb507404645);
+impl windows_core::RuntimeType for IAppBroadcastBackgroundServiceSignInInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastBackgroundServiceSignInInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +113,9 @@ pub struct IAppBroadcastBackgroundServiceSignInInfo2_Vtbl {
     pub RemoveUserNameChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastBackgroundServiceStreamInfo, IAppBroadcastBackgroundServiceStreamInfo_Vtbl, 0x31dc02bc_990a_4904_aa96_fe364381f136);
+impl windows_core::RuntimeType for IAppBroadcastBackgroundServiceStreamInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastBackgroundServiceStreamInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -111,12 +135,18 @@ pub struct IAppBroadcastBackgroundServiceStreamInfo_Vtbl {
     pub RemoveVideoEncodingBitrateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastBackgroundServiceStreamInfo2, IAppBroadcastBackgroundServiceStreamInfo2_Vtbl, 0xbd1e9f6d_94dc_4fce_9541_a9f129596334);
+impl windows_core::RuntimeType for IAppBroadcastBackgroundServiceStreamInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastBackgroundServiceStreamInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportProblemWithStream: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastCameraCaptureStateChangedEventArgs, IAppBroadcastCameraCaptureStateChangedEventArgs_Vtbl, 0x1e334cd0_b882_4b88_8692_05999aceb70f);
+impl windows_core::RuntimeType for IAppBroadcastCameraCaptureStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastCameraCaptureStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +154,9 @@ pub struct IAppBroadcastCameraCaptureStateChangedEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastGlobalSettings, IAppBroadcastGlobalSettings_Vtbl, 0xb2cb27a5_70fc_4e17_80bd_6ba0fd3ff3a0);
+impl windows_core::RuntimeType for IAppBroadcastGlobalSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastGlobalSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -153,6 +186,9 @@ pub struct IAppBroadcastGlobalSettings_Vtbl {
     pub IsCursorImageCaptureEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastHeartbeatRequestedEventArgs, IAppBroadcastHeartbeatRequestedEventArgs_Vtbl, 0xcea54283_ee51_4dbf_9472_79a9ed4e2165);
+impl windows_core::RuntimeType for IAppBroadcastHeartbeatRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastHeartbeatRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -160,6 +196,9 @@ pub struct IAppBroadcastHeartbeatRequestedEventArgs_Vtbl {
     pub Handled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastManagerStatics, IAppBroadcastManagerStatics_Vtbl, 0x364e018b_1e4e_411f_ab3e_92959844c156);
+impl windows_core::RuntimeType for IAppBroadcastManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +208,9 @@ pub struct IAppBroadcastManagerStatics_Vtbl {
     pub ApplyProviderSettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastMicrophoneCaptureStateChangedEventArgs, IAppBroadcastMicrophoneCaptureStateChangedEventArgs_Vtbl, 0xa86ad5e9_9440_4908_9d09_65b7e315d795);
+impl windows_core::RuntimeType for IAppBroadcastMicrophoneCaptureStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastMicrophoneCaptureStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -176,6 +218,9 @@ pub struct IAppBroadcastMicrophoneCaptureStateChangedEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastPlugIn, IAppBroadcastPlugIn_Vtbl, 0x520c1e66_6513_4574_ac54_23b79729615b);
+impl windows_core::RuntimeType for IAppBroadcastPlugIn {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPlugIn_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +233,9 @@ pub struct IAppBroadcastPlugIn_Vtbl {
     pub DisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastPlugInManager, IAppBroadcastPlugInManager_Vtbl, 0xe550d979_27a1_49a7_bbf4_d7a9e9d07668);
+impl windows_core::RuntimeType for IAppBroadcastPlugInManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPlugInManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -200,6 +248,9 @@ pub struct IAppBroadcastPlugInManager_Vtbl {
     pub SetDefaultPlugIn: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastPlugInManagerStatics, IAppBroadcastPlugInManagerStatics_Vtbl, 0xf2645c20_5c76_4cdc_9364_82fe9eb6534d);
+impl windows_core::RuntimeType for IAppBroadcastPlugInManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPlugInManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -210,12 +261,18 @@ pub struct IAppBroadcastPlugInManagerStatics_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IAppBroadcastPlugInStateChangedEventArgs, IAppBroadcastPlugInStateChangedEventArgs_Vtbl, 0x4881d0f2_abc5_4fc6_84b0_89370bb47212);
+impl windows_core::RuntimeType for IAppBroadcastPlugInStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPlugInStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PlugInState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppBroadcastPlugInState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastPreview, IAppBroadcastPreview_Vtbl, 0x14b60f5a_6e4a_4b80_a14f_67ee77d153e7);
+impl windows_core::RuntimeType for IAppBroadcastPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -227,6 +284,9 @@ pub struct IAppBroadcastPreview_Vtbl {
     pub PreviewStreamReader: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastPreviewStateChangedEventArgs, IAppBroadcastPreviewStateChangedEventArgs_Vtbl, 0x5a57f2de_8dea_4e86_90ad_03fc26b9653c);
+impl windows_core::RuntimeType for IAppBroadcastPreviewStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPreviewStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -234,6 +294,9 @@ pub struct IAppBroadcastPreviewStateChangedEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastPreviewStreamReader, IAppBroadcastPreviewStreamReader_Vtbl, 0x92228d50_db3f_40a8_8cd4_f4e371ddab37);
+impl windows_core::RuntimeType for IAppBroadcastPreviewStreamReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPreviewStreamReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -253,6 +316,9 @@ pub struct IAppBroadcastPreviewStreamReader_Vtbl {
     pub RemoveVideoFrameArrived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastPreviewStreamVideoFrame, IAppBroadcastPreviewStreamVideoFrame_Vtbl, 0x010fbea1_94fe_4499_b8c0_8d244279fb12);
+impl windows_core::RuntimeType for IAppBroadcastPreviewStreamVideoFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPreviewStreamVideoFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -263,6 +329,9 @@ pub struct IAppBroadcastPreviewStreamVideoFrame_Vtbl {
     VideoBuffer: usize,
 }
 windows_core::imp::define_interface!(IAppBroadcastPreviewStreamVideoHeader, IAppBroadcastPreviewStreamVideoHeader_Vtbl, 0x8bef6113_da84_4499_a7ab_87118cb4a157);
+impl windows_core::RuntimeType for IAppBroadcastPreviewStreamVideoHeader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastPreviewStreamVideoHeader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +341,9 @@ pub struct IAppBroadcastPreviewStreamVideoHeader_Vtbl {
     pub FrameId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastProviderSettings, IAppBroadcastProviderSettings_Vtbl, 0xc30bdf62_9948_458f_ad50_aa06ec03da08);
+impl windows_core::RuntimeType for IAppBroadcastProviderSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastProviderSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -291,6 +363,9 @@ pub struct IAppBroadcastProviderSettings_Vtbl {
     pub VideoEncodingResolutionMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppBroadcastVideoEncodingResolutionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastServices, IAppBroadcastServices_Vtbl, 0x8660b4d6_969b_4e3c_ac3a_8b042ee4ee63);
+impl windows_core::RuntimeType for IAppBroadcastServices {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastServices_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -311,6 +386,9 @@ pub struct IAppBroadcastServices_Vtbl {
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastSignInStateChangedEventArgs, IAppBroadcastSignInStateChangedEventArgs_Vtbl, 0x02b692a4_5919_4a9e_8d5e_c9bb0dd3377a);
+impl windows_core::RuntimeType for IAppBroadcastSignInStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastSignInStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -318,6 +396,9 @@ pub struct IAppBroadcastSignInStateChangedEventArgs_Vtbl {
     pub Result: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppBroadcastSignInResult) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastState, IAppBroadcastState_Vtbl, 0xee08056d_8099_4ddd_922e_c56dac58abfb);
+impl windows_core::RuntimeType for IAppBroadcastState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -364,6 +445,9 @@ pub struct IAppBroadcastState_Vtbl {
     pub RemoveCaptureTargetClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastStreamAudioFrame, IAppBroadcastStreamAudioFrame_Vtbl, 0xefab4ac8_21ba_453f_8bb7_5e938a2e9a74);
+impl windows_core::RuntimeType for IAppBroadcastStreamAudioFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastStreamAudioFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -374,6 +458,9 @@ pub struct IAppBroadcastStreamAudioFrame_Vtbl {
     AudioBuffer: usize,
 }
 windows_core::imp::define_interface!(IAppBroadcastStreamAudioHeader, IAppBroadcastStreamAudioHeader_Vtbl, 0xbf21a570_6b78_4216_9f07_5aff5256f1b7);
+impl windows_core::RuntimeType for IAppBroadcastStreamAudioHeader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastStreamAudioHeader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -384,6 +471,9 @@ pub struct IAppBroadcastStreamAudioHeader_Vtbl {
     pub FrameId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastStreamReader, IAppBroadcastStreamReader_Vtbl, 0xb338bcf9_3364_4460_b5f1_3cc2796a8aa2);
+impl windows_core::RuntimeType for IAppBroadcastStreamReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastStreamReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -405,12 +495,18 @@ pub struct IAppBroadcastStreamReader_Vtbl {
     pub RemoveVideoFrameArrived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastStreamStateChangedEventArgs, IAppBroadcastStreamStateChangedEventArgs_Vtbl, 0x5108a733_d008_4a89_93be_58aed961374e);
+impl windows_core::RuntimeType for IAppBroadcastStreamStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastStreamStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub StreamState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppBroadcastStreamState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastStreamVideoFrame, IAppBroadcastStreamVideoFrame_Vtbl, 0x0f97cf2b_c9e4_4e88_8194_d814cbd585d8);
+impl windows_core::RuntimeType for IAppBroadcastStreamVideoFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastStreamVideoFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -421,6 +517,9 @@ pub struct IAppBroadcastStreamVideoFrame_Vtbl {
     VideoBuffer: usize,
 }
 windows_core::imp::define_interface!(IAppBroadcastStreamVideoHeader, IAppBroadcastStreamVideoHeader_Vtbl, 0x0b9ebece_7e32_432d_8ca2_36bf10b9f462);
+impl windows_core::RuntimeType for IAppBroadcastStreamVideoHeader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastStreamVideoHeader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -432,18 +531,27 @@ pub struct IAppBroadcastStreamVideoHeader_Vtbl {
     pub FrameId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastTriggerDetails, IAppBroadcastTriggerDetails_Vtbl, 0xdeebab35_ec5e_4d8f_b1c0_5da6e8c75638);
+impl windows_core::RuntimeType for IAppBroadcastTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BackgroundService: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppBroadcastViewerCountChangedEventArgs, IAppBroadcastViewerCountChangedEventArgs_Vtbl, 0xe6e11825_5401_4ade_8bd2_c14ecee6807d);
+impl windows_core::RuntimeType for IAppBroadcastViewerCountChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppBroadcastViewerCountChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ViewerCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCapture, IAppCapture_Vtbl, 0x9749d453_a29a_45ed_8f29_22d09942cff7);
+impl windows_core::RuntimeType for IAppCapture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCapture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -453,6 +561,9 @@ pub struct IAppCapture_Vtbl {
     pub RemoveCapturingChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureAlternateShortcutKeys, IAppCaptureAlternateShortcutKeys_Vtbl, 0x19e8e0ef_236c_40f9_b38f_9b7dd65d1ccc);
+impl windows_core::RuntimeType for IAppCaptureAlternateShortcutKeys {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureAlternateShortcutKeys_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -538,6 +649,9 @@ pub struct IAppCaptureAlternateShortcutKeys_Vtbl {
     ToggleRecordingIndicatorKeyModifiers: usize,
 }
 windows_core::imp::define_interface!(IAppCaptureAlternateShortcutKeys2, IAppCaptureAlternateShortcutKeys2_Vtbl, 0xc3669090_dd17_47f0_95e5_ce42286cf338);
+impl windows_core::RuntimeType for IAppCaptureAlternateShortcutKeys2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureAlternateShortcutKeys2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -559,6 +673,9 @@ pub struct IAppCaptureAlternateShortcutKeys2_Vtbl {
     ToggleMicrophoneCaptureKeyModifiers: usize,
 }
 windows_core::imp::define_interface!(IAppCaptureAlternateShortcutKeys3, IAppCaptureAlternateShortcutKeys3_Vtbl, 0x7b81448c_418e_469c_a49a_45b597c826b6);
+impl windows_core::RuntimeType for IAppCaptureAlternateShortcutKeys3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureAlternateShortcutKeys3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -596,12 +713,18 @@ pub struct IAppCaptureAlternateShortcutKeys3_Vtbl {
     ToggleBroadcastKeyModifiers: usize,
 }
 windows_core::imp::define_interface!(IAppCaptureDurationGeneratedEventArgs, IAppCaptureDurationGeneratedEventArgs_Vtbl, 0xc1f5563b_ffa1_44c9_975f_27fbeb553b35);
+impl windows_core::RuntimeType for IAppCaptureDurationGeneratedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureDurationGeneratedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Duration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureFileGeneratedEventArgs, IAppCaptureFileGeneratedEventArgs_Vtbl, 0x4189fbf4_465e_45bf_907f_165b3fb23758);
+impl windows_core::RuntimeType for IAppCaptureFileGeneratedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureFileGeneratedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -611,6 +734,9 @@ pub struct IAppCaptureFileGeneratedEventArgs_Vtbl {
     File: usize,
 }
 windows_core::imp::define_interface!(IAppCaptureManagerStatics, IAppCaptureManagerStatics_Vtbl, 0x7d9e3ea7_6282_4735_8d4e_aa45f90f6723);
+impl windows_core::RuntimeType for IAppCaptureManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -618,6 +744,9 @@ pub struct IAppCaptureManagerStatics_Vtbl {
     pub ApplySettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureMetadataWriter, IAppCaptureMetadataWriter_Vtbl, 0xe0ce4877_9aaf_46b4_ad31_6a60b441c780);
+impl windows_core::RuntimeType for IAppCaptureMetadataWriter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureMetadataWriter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -634,6 +763,9 @@ pub struct IAppCaptureMetadataWriter_Vtbl {
     pub RemoveMetadataPurged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureMicrophoneCaptureStateChangedEventArgs, IAppCaptureMicrophoneCaptureStateChangedEventArgs_Vtbl, 0x324d249e_45bc_4c35_bc35_e469fc7a69e0);
+impl windows_core::RuntimeType for IAppCaptureMicrophoneCaptureStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureMicrophoneCaptureStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -641,6 +773,9 @@ pub struct IAppCaptureMicrophoneCaptureStateChangedEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureRecordOperation, IAppCaptureRecordOperation_Vtbl, 0xc66020a9_1538_495c_9bbb_2ba870ec5861);
+impl windows_core::RuntimeType for IAppCaptureRecordOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureRecordOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -661,6 +796,9 @@ pub struct IAppCaptureRecordOperation_Vtbl {
     pub RemoveFileGenerated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureRecordingStateChangedEventArgs, IAppCaptureRecordingStateChangedEventArgs_Vtbl, 0x24fc8712_e305_490d_b415_6b1c9049736b);
+impl windows_core::RuntimeType for IAppCaptureRecordingStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureRecordingStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -668,6 +806,9 @@ pub struct IAppCaptureRecordingStateChangedEventArgs_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureServices, IAppCaptureServices_Vtbl, 0x44fec0b5_34f5_4f18_ae8c_b9123abbfc0d);
+impl windows_core::RuntimeType for IAppCaptureServices {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureServices_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -677,6 +818,9 @@ pub struct IAppCaptureServices_Vtbl {
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureSettings, IAppCaptureSettings_Vtbl, 0x14683a86_8807_48d3_883a_970ee4532a39);
+impl windows_core::RuntimeType for IAppCaptureSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -730,6 +874,9 @@ pub struct IAppCaptureSettings_Vtbl {
     pub HasHardwareEncoder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureSettings2, IAppCaptureSettings2_Vtbl, 0xfcb8cee7_e26b_476f_9b1a_ec342d2a8fde);
+impl windows_core::RuntimeType for IAppCaptureSettings2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureSettings2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -737,6 +884,9 @@ pub struct IAppCaptureSettings2_Vtbl {
     pub AlternateShortcutKeys: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureSettings3, IAppCaptureSettings3_Vtbl, 0xa93502fe_88c2_42d6_aaaa_40feffd75aec);
+impl windows_core::RuntimeType for IAppCaptureSettings3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureSettings3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -744,6 +894,9 @@ pub struct IAppCaptureSettings3_Vtbl {
     pub IsMicrophoneCaptureEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureSettings4, IAppCaptureSettings4_Vtbl, 0x07c2774c_1a81_482f_a244_049d95f25b0b);
+impl windows_core::RuntimeType for IAppCaptureSettings4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureSettings4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -757,6 +910,9 @@ pub struct IAppCaptureSettings4_Vtbl {
     pub VideoEncodingFrameRateMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppCaptureVideoEncodingFrameRateMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureSettings5, IAppCaptureSettings5_Vtbl, 0x18894522_b0e8_4ba0_8f13_3eaa5fa4013b);
+impl windows_core::RuntimeType for IAppCaptureSettings5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureSettings5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -766,6 +922,9 @@ pub struct IAppCaptureSettings5_Vtbl {
     pub IsCursorImageCaptureEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureState, IAppCaptureState_Vtbl, 0x73134372_d4eb_44ce_9538_465f506ac4ea);
+impl windows_core::RuntimeType for IAppCaptureState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -782,18 +941,27 @@ pub struct IAppCaptureState_Vtbl {
     pub RemoveCaptureTargetClosed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureStatics, IAppCaptureStatics_Vtbl, 0xf922dd6c_0a7e_4e74_8b20_9c1f902d08a1);
+impl windows_core::RuntimeType for IAppCaptureStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCaptureStatics2, IAppCaptureStatics2_Vtbl, 0xb2d881d4_836c_4da4_afd7_facc041e1cf3);
+impl windows_core::RuntimeType for IAppCaptureStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCaptureStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetAllowedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraCaptureUI, ICameraCaptureUI_Vtbl, 0x48587540_6f93_4bb4_b8f3_e89e48948c91);
+impl windows_core::RuntimeType for ICameraCaptureUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraCaptureUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -805,6 +973,9 @@ pub struct ICameraCaptureUI_Vtbl {
     CaptureFileAsync: usize,
 }
 windows_core::imp::define_interface!(ICameraCaptureUIPhotoCaptureSettings, ICameraCaptureUIPhotoCaptureSettings_Vtbl, 0xb9f5be97_3472_46a8_8a9e_04ce42ccc97d);
+impl windows_core::RuntimeType for ICameraCaptureUIPhotoCaptureSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraCaptureUIPhotoCaptureSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -820,6 +991,9 @@ pub struct ICameraCaptureUIPhotoCaptureSettings_Vtbl {
     pub SetAllowCropping: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraCaptureUIVideoCaptureSettings, ICameraCaptureUIVideoCaptureSettings_Vtbl, 0x64e92d1f_a28d_425a_b84f_e568335ff24e);
+impl windows_core::RuntimeType for ICameraCaptureUIVideoCaptureSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraCaptureUIVideoCaptureSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -833,12 +1007,18 @@ pub struct ICameraCaptureUIVideoCaptureSettings_Vtbl {
     pub SetAllowTrimming: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraOptionsUIStatics, ICameraOptionsUIStatics_Vtbl, 0x3b0d5e34_3906_4b7d_946c_7bde844499ae);
+impl windows_core::RuntimeType for ICameraOptionsUIStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraOptionsUIStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Show: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICapturedFrame, ICapturedFrame_Vtbl, 0x1dd2de1f_571b_44d8_8e80_a08a1578766e);
+impl windows_core::RuntimeType for ICapturedFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICapturedFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -846,6 +1026,9 @@ pub struct ICapturedFrame_Vtbl {
     pub Height: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICapturedFrame2, ICapturedFrame2_Vtbl, 0x543fa6d1_bd78_4866_adda_24314bc65dea);
+impl windows_core::RuntimeType for ICapturedFrame2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICapturedFrame2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -856,6 +1039,9 @@ pub struct ICapturedFrame2_Vtbl {
     BitmapProperties: usize,
 }
 windows_core::imp::define_interface!(ICapturedFrameControlValues, ICapturedFrameControlValues_Vtbl, 0x90c65b7f_4e0d_4ca4_882d_7a144fed0a90);
+impl windows_core::RuntimeType for ICapturedFrameControlValues {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICapturedFrameControlValues_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -873,6 +1059,9 @@ pub struct ICapturedFrameControlValues_Vtbl {
     pub ZoomFactor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICapturedFrameControlValues2, ICapturedFrameControlValues2_Vtbl, 0x500b2b88_06d2_4aa7_a7db_d37af73321d8);
+impl windows_core::RuntimeType for ICapturedFrameControlValues2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICapturedFrameControlValues2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -889,6 +1078,9 @@ pub struct ICapturedFrameControlValues2_Vtbl {
     pub WhiteBalanceGain: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICapturedFrameWithSoftwareBitmap, ICapturedFrameWithSoftwareBitmap_Vtbl, 0xb58e8b6e_8503_49b5_9e86_897d26a3ff3d);
+impl windows_core::RuntimeType for ICapturedFrameWithSoftwareBitmap {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICapturedFrameWithSoftwareBitmap_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -898,6 +1090,9 @@ pub struct ICapturedFrameWithSoftwareBitmap_Vtbl {
     SoftwareBitmap: usize,
 }
 windows_core::imp::define_interface!(ICapturedPhoto, ICapturedPhoto_Vtbl, 0xb0ce7e5a_cfcc_4d6c_8ad1_0869208aca16);
+impl windows_core::RuntimeType for ICapturedPhoto {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICapturedPhoto_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -905,6 +1100,9 @@ pub struct ICapturedPhoto_Vtbl {
     pub Thumbnail: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameBarServices, IGameBarServices_Vtbl, 0x2dbead57_50a6_499e_8c6c_d330a7311796);
+impl windows_core::RuntimeType for IGameBarServices {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameBarServices_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -919,6 +1117,9 @@ pub struct IGameBarServices_Vtbl {
     pub RemoveCommandReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameBarServicesCommandEventArgs, IGameBarServicesCommandEventArgs_Vtbl, 0xa74226b2_f176_4fcf_8fbb_cf698b2eb8e0);
+impl windows_core::RuntimeType for IGameBarServicesCommandEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameBarServicesCommandEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -926,6 +1127,9 @@ pub struct IGameBarServicesCommandEventArgs_Vtbl {
     pub Origin: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GameBarCommandOrigin) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameBarServicesManager, IGameBarServicesManager_Vtbl, 0x3a4b9cfa_7f8b_4c60_9dbb_0bcd262dffc6);
+impl windows_core::RuntimeType for IGameBarServicesManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameBarServicesManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -933,18 +1137,27 @@ pub struct IGameBarServicesManager_Vtbl {
     pub RemoveGameBarServicesCreated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameBarServicesManagerGameBarServicesCreatedEventArgs, IGameBarServicesManagerGameBarServicesCreatedEventArgs_Vtbl, 0xededbd9c_143e_49a3_a5ea_0b1995c8d46e);
+impl windows_core::RuntimeType for IGameBarServicesManagerGameBarServicesCreatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameBarServicesManagerGameBarServicesCreatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GameBarServices: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameBarServicesManagerStatics, IGameBarServicesManagerStatics_Vtbl, 0x34c1b616_ff25_4792_98f2_d3753f15ac13);
+impl windows_core::RuntimeType for IGameBarServicesManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameBarServicesManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameBarServicesTargetInfo, IGameBarServicesTargetInfo_Vtbl, 0xb4202f92_1611_4e05_b6ef_dfd737ae33b0);
+impl windows_core::RuntimeType for IGameBarServicesTargetInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameBarServicesTargetInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -954,6 +1167,9 @@ pub struct IGameBarServicesTargetInfo_Vtbl {
     pub DisplayMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut GameBarServicesDisplayMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLagMediaRecording, ILowLagMediaRecording_Vtbl, 0x41c8baf7_ff3f_49f0_a477_f195e3ce5108);
+impl windows_core::RuntimeType for ILowLagMediaRecording {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLagMediaRecording_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -962,6 +1178,9 @@ pub struct ILowLagMediaRecording_Vtbl {
     pub FinishAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLagMediaRecording2, ILowLagMediaRecording2_Vtbl, 0x6369c758_5644_41e2_97af_8ef56a25e225);
+impl windows_core::RuntimeType for ILowLagMediaRecording2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLagMediaRecording2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -972,6 +1191,9 @@ pub struct ILowLagMediaRecording2_Vtbl {
     pub ResumeAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLagMediaRecording3, ILowLagMediaRecording3_Vtbl, 0x5c33ab12_48f7_47da_b41e_90880a5fe0ec);
+impl windows_core::RuntimeType for ILowLagMediaRecording3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLagMediaRecording3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -982,6 +1204,9 @@ pub struct ILowLagMediaRecording3_Vtbl {
     pub StopWithResultAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLagPhotoCapture, ILowLagPhotoCapture_Vtbl, 0xa37251b7_6b44_473d_8f24_f703d6c0ec44);
+impl windows_core::RuntimeType for ILowLagPhotoCapture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLagPhotoCapture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -989,6 +1214,9 @@ pub struct ILowLagPhotoCapture_Vtbl {
     pub FinishAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLagPhotoSequenceCapture, ILowLagPhotoSequenceCapture_Vtbl, 0x7cc346bb_b9a9_4c91_8ffa_287e9c668669);
+impl windows_core::RuntimeType for ILowLagPhotoSequenceCapture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLagPhotoSequenceCapture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -999,6 +1227,9 @@ pub struct ILowLagPhotoSequenceCapture_Vtbl {
     pub RemovePhotoCaptured: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCapture, IMediaCapture_Vtbl, 0xc61afbb4_fb10_4a34_ac18_ca80d9c8e7ee);
+impl windows_core::RuntimeType for IMediaCapture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1057,6 +1288,9 @@ pub struct IMediaCapture_Vtbl {
     pub GetRecordRotation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VideoRotation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCapture2, IMediaCapture2_Vtbl, 0x9cc68260_7da1_4043_b652_21b8878daff9);
+impl windows_core::RuntimeType for IMediaCapture2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapture2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1090,6 +1324,9 @@ pub struct IMediaCapture2_Vtbl {
     SetEncodingPropertiesAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaCapture3, IMediaCapture3_Vtbl, 0xd4136f30_1564_466e_bc0a_af94e02ab016);
+impl windows_core::RuntimeType for IMediaCapture3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapture3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1103,6 +1340,9 @@ pub struct IMediaCapture3_Vtbl {
     pub RemovePhotoConfirmationCaptured: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCapture4, IMediaCapture4_Vtbl, 0xbacd6fd6_fb08_4947_aea2_ce14eff0ce13);
+impl windows_core::RuntimeType for IMediaCapture4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapture4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1136,6 +1376,9 @@ pub struct IMediaCapture4_Vtbl {
     PrepareAdvancedPhotoCaptureAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaCapture5, IMediaCapture5_Vtbl, 0xda787c22_3a9b_4720_a71e_97900a316e5a);
+impl windows_core::RuntimeType for IMediaCapture5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapture5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1163,6 +1406,9 @@ pub struct IMediaCapture5_Vtbl {
     CreateFrameReaderWithSubtypeAndSizeAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaCapture6, IMediaCapture6_Vtbl, 0x228948bd_4b20_4bb1_9fd6_a583212a1012);
+impl windows_core::RuntimeType for IMediaCapture6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapture6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1174,6 +1420,9 @@ pub struct IMediaCapture6_Vtbl {
     CreateMultiSourceFrameReaderAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaCapture7, IMediaCapture7_Vtbl, 0x9169f102_8888_541a_95bc_24e4d462542a);
+impl windows_core::RuntimeType for IMediaCapture7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapture7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1183,6 +1432,9 @@ pub struct IMediaCapture7_Vtbl {
     CreateRelativePanelWatcher: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs, IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs_Vtbl, 0x9d2f920d_a588_43c6_89d6_5ad322af006a);
+impl windows_core::RuntimeType for IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1190,6 +1442,9 @@ pub struct IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaCaptureDeviceExclusiveControlStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureFailedEventArgs, IMediaCaptureFailedEventArgs_Vtbl, 0x80fde3f4_54c4_42c0_8d19_cea1a87ca18b);
+impl windows_core::RuntimeType for IMediaCaptureFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1197,6 +1452,9 @@ pub struct IMediaCaptureFailedEventArgs_Vtbl {
     pub Code: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureFocusChangedEventArgs, IMediaCaptureFocusChangedEventArgs_Vtbl, 0x81e1bc7f_2277_493e_abee_d3f44ff98c04);
+impl windows_core::RuntimeType for IMediaCaptureFocusChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureFocusChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1206,6 +1464,9 @@ pub struct IMediaCaptureFocusChangedEventArgs_Vtbl {
     FocusState: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureInitializationSettings, IMediaCaptureInitializationSettings_Vtbl, 0x9782ba70_ea65_4900_9356_8ca887726884);
+impl windows_core::RuntimeType for IMediaCaptureInitializationSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureInitializationSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1219,6 +1480,9 @@ pub struct IMediaCaptureInitializationSettings_Vtbl {
     pub PhotoCaptureSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PhotoCaptureSource) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureInitializationSettings2, IMediaCaptureInitializationSettings2_Vtbl, 0x404e0626_c9dc_43e9_aee4_e6bf1b57b44c);
+impl windows_core::RuntimeType for IMediaCaptureInitializationSettings2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureInitializationSettings2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1228,6 +1492,9 @@ pub struct IMediaCaptureInitializationSettings2_Vtbl {
     pub AudioProcessing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::AudioProcessing) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureInitializationSettings3, IMediaCaptureInitializationSettings3_Vtbl, 0x4160519d_be48_4730_8104_0cf6e9e97948);
+impl windows_core::RuntimeType for IMediaCaptureInitializationSettings3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureInitializationSettings3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1249,6 +1516,9 @@ pub struct IMediaCaptureInitializationSettings3_Vtbl {
     VideoSource: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureInitializationSettings4, IMediaCaptureInitializationSettings4_Vtbl, 0xf502a537_4cb7_4d28_95ed_4f9f012e0518);
+impl windows_core::RuntimeType for IMediaCaptureInitializationSettings4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureInitializationSettings4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1262,6 +1532,9 @@ pub struct IMediaCaptureInitializationSettings4_Vtbl {
     pub SetPhotoMediaDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureInitializationSettings5, IMediaCaptureInitializationSettings5_Vtbl, 0xd5a2e3b8_2626_4e94_b7b3_5308a0f64b1a);
+impl windows_core::RuntimeType for IMediaCaptureInitializationSettings5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureInitializationSettings5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1279,6 +1552,9 @@ pub struct IMediaCaptureInitializationSettings5_Vtbl {
     pub SetMemoryPreference: unsafe extern "system" fn(*mut core::ffi::c_void, MediaCaptureMemoryPreference) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureInitializationSettings6, IMediaCaptureInitializationSettings6_Vtbl, 0xb2e26b47_3db1_4d33_ab63_0ffa09056585);
+impl windows_core::RuntimeType for IMediaCaptureInitializationSettings6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureInitializationSettings6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1286,6 +1562,9 @@ pub struct IMediaCaptureInitializationSettings6_Vtbl {
     pub SetAlwaysPlaySystemShutterSound: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureInitializationSettings7, IMediaCaptureInitializationSettings7_Vtbl, 0x41546967_f58a_5d82_9ef4_ed572fb5e34e);
+impl windows_core::RuntimeType for IMediaCaptureInitializationSettings7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureInitializationSettings7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1301,6 +1580,9 @@ pub struct IMediaCaptureInitializationSettings7_Vtbl {
     pub SetDeviceUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCapturePauseResult, IMediaCapturePauseResult_Vtbl, 0xaec47ca3_4477_4b04_a06f_2c1c5182fe9d);
+impl windows_core::RuntimeType for IMediaCapturePauseResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCapturePauseResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1308,6 +1590,9 @@ pub struct IMediaCapturePauseResult_Vtbl {
     pub RecordDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureRelativePanelWatcher, IMediaCaptureRelativePanelWatcher_Vtbl, 0x7d896566_04be_5b89_b30e_bd34a9f12db0);
+impl windows_core::RuntimeType for IMediaCaptureRelativePanelWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureRelativePanelWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1321,6 +1606,9 @@ pub struct IMediaCaptureRelativePanelWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureSettings, IMediaCaptureSettings_Vtbl, 0x1d83aafe_6d45_4477_8dc4_ac5bc01c4091);
+impl windows_core::RuntimeType for IMediaCaptureSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1331,6 +1619,9 @@ pub struct IMediaCaptureSettings_Vtbl {
     pub VideoDeviceCharacteristic: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VideoDeviceCharacteristic) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureSettings2, IMediaCaptureSettings2_Vtbl, 0x6f9e7cfb_fa9f_4b13_9cbe_5ab94f1f3493);
+impl windows_core::RuntimeType for IMediaCaptureSettings2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureSettings2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1344,6 +1635,9 @@ pub struct IMediaCaptureSettings2_Vtbl {
     pub AudioProcessing: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::AudioProcessing) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureSettings3, IMediaCaptureSettings3_Vtbl, 0x303c67c2_8058_4b1b_b877_8c2ef3528440);
+impl windows_core::RuntimeType for IMediaCaptureSettings3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureSettings3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1353,6 +1647,9 @@ pub struct IMediaCaptureSettings3_Vtbl {
     Direct3D11Device: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureStatics, IMediaCaptureStatics_Vtbl, 0xacef81ff_99ed_4645_965e_1925cfc63834);
+impl windows_core::RuntimeType for IMediaCaptureStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1371,6 +1668,9 @@ pub struct IMediaCaptureStatics_Vtbl {
     FindKnownVideoProfiles: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureStopResult, IMediaCaptureStopResult_Vtbl, 0xf9db6a2a_a092_4ad1_97d4_f201f9d082db);
+impl windows_core::RuntimeType for IMediaCaptureStopResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureStopResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1378,6 +1678,9 @@ pub struct IMediaCaptureStopResult_Vtbl {
     pub RecordDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureVideoPreview, IMediaCaptureVideoPreview_Vtbl, 0x27727073_549e_447f_a20a_4f03c479d8c0);
+impl windows_core::RuntimeType for IMediaCaptureVideoPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureVideoPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1393,6 +1696,9 @@ pub struct IMediaCaptureVideoPreview_Vtbl {
     pub StopPreviewAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCaptureVideoProfile, IMediaCaptureVideoProfile_Vtbl, 0x21a073bf_a3ee_4ecf_9ef6_50b0bc4e1305);
+impl windows_core::RuntimeType for IMediaCaptureVideoProfile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureVideoProfile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1416,6 +1722,9 @@ pub struct IMediaCaptureVideoProfile_Vtbl {
     GetConcurrency: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureVideoProfile2, IMediaCaptureVideoProfile2_Vtbl, 0x97ddc95f_94ce_468f_9316_fc5bc2638f6b);
+impl windows_core::RuntimeType for IMediaCaptureVideoProfile2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureVideoProfile2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1429,6 +1738,9 @@ pub struct IMediaCaptureVideoProfile2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureVideoProfileMediaDescription, IMediaCaptureVideoProfileMediaDescription_Vtbl, 0x8012afef_b691_49ff_83f2_c1e76eaaea1b);
+impl windows_core::RuntimeType for IMediaCaptureVideoProfileMediaDescription {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureVideoProfileMediaDescription_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1445,6 +1757,9 @@ pub struct IMediaCaptureVideoProfileMediaDescription_Vtbl {
     IsHdrVideoSupported: usize,
 }
 windows_core::imp::define_interface!(IMediaCaptureVideoProfileMediaDescription2, IMediaCaptureVideoProfileMediaDescription2_Vtbl, 0xc6a6ef13_322d_413a_b85a_68a88e02f4e9);
+impl windows_core::RuntimeType for IMediaCaptureVideoProfileMediaDescription2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCaptureVideoProfileMediaDescription2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1455,6 +1770,9 @@ pub struct IMediaCaptureVideoProfileMediaDescription2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IOptionalReferencePhotoCapturedEventArgs, IOptionalReferencePhotoCapturedEventArgs_Vtbl, 0x470f88b3_1e6d_4051_9c8b_f1d85af047b7);
+impl windows_core::RuntimeType for IOptionalReferencePhotoCapturedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOptionalReferencePhotoCapturedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1462,6 +1780,9 @@ pub struct IOptionalReferencePhotoCapturedEventArgs_Vtbl {
     pub Context: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoCapturedEventArgs, IPhotoCapturedEventArgs_Vtbl, 0x373bfbc1_984e_4ff0_bf85_1c00aabc5a45);
+impl windows_core::RuntimeType for IPhotoCapturedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoCapturedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1470,6 +1791,9 @@ pub struct IPhotoCapturedEventArgs_Vtbl {
     pub CaptureTimeOffset: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoConfirmationCapturedEventArgs, IPhotoConfirmationCapturedEventArgs_Vtbl, 0xab473672_c28a_4827_8f8d_3636d3beb51e);
+impl windows_core::RuntimeType for IPhotoConfirmationCapturedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoConfirmationCapturedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1477,6 +1801,9 @@ pub struct IPhotoConfirmationCapturedEventArgs_Vtbl {
     pub CaptureTimeOffset: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScreenCapture, IScreenCapture_Vtbl, 0x89179ef7_cd12_4e0e_a6d4_5b3de98b2e9b);
+impl windows_core::RuntimeType for IScreenCapture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScreenCapture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1494,12 +1821,18 @@ pub struct IScreenCapture_Vtbl {
     pub RemoveSourceSuspensionChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScreenCaptureStatics, IScreenCaptureStatics_Vtbl, 0xc898c3b0_c8a5_11e2_8b8b_0800200c9a66);
+impl windows_core::RuntimeType for IScreenCaptureStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScreenCaptureStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISourceSuspensionChangedEventArgs, ISourceSuspensionChangedEventArgs_Vtbl, 0x2ece7b5e_d49b_4394_bc32_f97d6cedec1c);
+impl windows_core::RuntimeType for ISourceSuspensionChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISourceSuspensionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1507,6 +1840,9 @@ pub struct ISourceSuspensionChangedEventArgs_Vtbl {
     pub IsVideoSuspended: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoStreamConfiguration, IVideoStreamConfiguration_Vtbl, 0xd8770a6f_4390_4b5e_ad3e_0f8af0963490);
+impl windows_core::RuntimeType for IVideoStreamConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoStreamConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1555,7 +1891,7 @@ impl AdvancedCapturedPhoto {
     }
 }
 impl windows_core::RuntimeType for AdvancedCapturedPhoto {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdvancedCapturedPhoto>();
 }
 unsafe impl windows_core::Interface for AdvancedCapturedPhoto {
     type Vtable = IAdvancedCapturedPhoto_Vtbl;
@@ -1625,7 +1961,7 @@ impl AdvancedPhotoCapture {
     }
 }
 impl windows_core::RuntimeType for AdvancedPhotoCapture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdvancedPhotoCapture>();
 }
 unsafe impl windows_core::Interface for AdvancedPhotoCapture {
     type Vtable = IAdvancedPhotoCapture_Vtbl;
@@ -1800,7 +2136,7 @@ impl AppBroadcastBackgroundService {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastBackgroundService {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastBackgroundService>();
 }
 unsafe impl windows_core::Interface for AppBroadcastBackgroundService {
     type Vtable = IAppBroadcastBackgroundService_Vtbl;
@@ -1898,7 +2234,7 @@ impl AppBroadcastBackgroundServiceSignInInfo {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastBackgroundServiceSignInInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastBackgroundServiceSignInInfo>();
 }
 unsafe impl windows_core::Interface for AppBroadcastBackgroundServiceSignInInfo {
     type Vtable = IAppBroadcastBackgroundServiceSignInInfo_Vtbl;
@@ -2007,7 +2343,7 @@ impl AppBroadcastBackgroundServiceStreamInfo {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastBackgroundServiceStreamInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastBackgroundServiceStreamInfo>();
 }
 unsafe impl windows_core::Interface for AppBroadcastBackgroundServiceStreamInfo {
     type Vtable = IAppBroadcastBackgroundServiceStreamInfo_Vtbl;
@@ -2037,7 +2373,7 @@ impl AppBroadcastCameraCaptureStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastCameraCaptureStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastCameraCaptureStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastCameraCaptureStateChangedEventArgs {
     type Vtable = IAppBroadcastCameraCaptureStateChangedEventArgs_Vtbl;
@@ -2193,7 +2529,7 @@ impl AppBroadcastGlobalSettings {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastGlobalSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastGlobalSettings>();
 }
 unsafe impl windows_core::Interface for AppBroadcastGlobalSettings {
     type Vtable = IAppBroadcastGlobalSettings_Vtbl;
@@ -2220,7 +2556,7 @@ impl AppBroadcastHeartbeatRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastHeartbeatRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastHeartbeatRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastHeartbeatRequestedEventArgs {
     type Vtable = IAppBroadcastHeartbeatRequestedEventArgs_Vtbl;
@@ -2285,7 +2621,7 @@ impl AppBroadcastMicrophoneCaptureStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastMicrophoneCaptureStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastMicrophoneCaptureStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastMicrophoneCaptureStateChangedEventArgs {
     type Vtable = IAppBroadcastMicrophoneCaptureStateChangedEventArgs_Vtbl;
@@ -2332,7 +2668,7 @@ impl AppBroadcastPlugIn {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPlugIn {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPlugIn>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPlugIn {
     type Vtable = IAppBroadcastPlugIn_Vtbl;
@@ -2400,7 +2736,7 @@ impl AppBroadcastPlugInManager {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPlugInManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPlugInManager>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPlugInManager {
     type Vtable = IAppBroadcastPlugInManager_Vtbl;
@@ -2425,7 +2761,7 @@ impl AppBroadcastPlugInStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPlugInStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPlugInStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPlugInStateChangedEventArgs {
     type Vtable = IAppBroadcastPlugInStateChangedEventArgs_Vtbl;
@@ -2482,7 +2818,7 @@ impl AppBroadcastPreview {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPreview>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPreview {
     type Vtable = IAppBroadcastPreview_Vtbl;
@@ -2514,7 +2850,7 @@ impl AppBroadcastPreviewStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPreviewStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPreviewStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPreviewStateChangedEventArgs {
     type Vtable = IAppBroadcastPreviewStateChangedEventArgs_Vtbl;
@@ -2590,7 +2926,7 @@ impl AppBroadcastPreviewStreamReader {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPreviewStreamReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPreviewStreamReader>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPreviewStreamReader {
     type Vtable = IAppBroadcastPreviewStreamReader_Vtbl;
@@ -2623,7 +2959,7 @@ impl AppBroadcastPreviewStreamVideoFrame {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPreviewStreamVideoFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPreviewStreamVideoFrame>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPreviewStreamVideoFrame {
     type Vtable = IAppBroadcastPreviewStreamVideoFrame_Vtbl;
@@ -2669,7 +3005,7 @@ impl AppBroadcastPreviewStreamVideoHeader {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastPreviewStreamVideoHeader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastPreviewStreamVideoHeader>();
 }
 unsafe impl windows_core::Interface for AppBroadcastPreviewStreamVideoHeader {
     type Vtable = IAppBroadcastPreviewStreamVideoHeader_Vtbl;
@@ -2764,7 +3100,7 @@ impl AppBroadcastProviderSettings {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastProviderSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastProviderSettings>();
 }
 unsafe impl windows_core::Interface for AppBroadcastProviderSettings {
     type Vtable = IAppBroadcastProviderSettings_Vtbl;
@@ -2867,7 +3203,7 @@ impl AppBroadcastServices {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastServices {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastServices>();
 }
 unsafe impl windows_core::Interface for AppBroadcastServices {
     type Vtable = IAppBroadcastServices_Vtbl;
@@ -2899,7 +3235,7 @@ impl AppBroadcastSignInStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastSignInStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastSignInStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastSignInStateChangedEventArgs {
     type Vtable = IAppBroadcastSignInStateChangedEventArgs_Vtbl;
@@ -3147,7 +3483,7 @@ impl AppBroadcastState {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastState>();
 }
 unsafe impl windows_core::Interface for AppBroadcastState {
     type Vtable = IAppBroadcastState_Vtbl;
@@ -3180,7 +3516,7 @@ impl AppBroadcastStreamAudioFrame {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastStreamAudioFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastStreamAudioFrame>();
 }
 unsafe impl windows_core::Interface for AppBroadcastStreamAudioFrame {
     type Vtable = IAppBroadcastStreamAudioFrame_Vtbl;
@@ -3231,7 +3567,7 @@ impl AppBroadcastStreamAudioHeader {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastStreamAudioHeader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastStreamAudioHeader>();
 }
 unsafe impl windows_core::Interface for AppBroadcastStreamAudioHeader {
     type Vtable = IAppBroadcastStreamAudioHeader_Vtbl;
@@ -3339,7 +3675,7 @@ impl AppBroadcastStreamReader {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastStreamReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastStreamReader>();
 }
 unsafe impl windows_core::Interface for AppBroadcastStreamReader {
     type Vtable = IAppBroadcastStreamReader_Vtbl;
@@ -3362,7 +3698,7 @@ impl AppBroadcastStreamStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastStreamStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastStreamStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastStreamStateChangedEventArgs {
     type Vtable = IAppBroadcastStreamStateChangedEventArgs_Vtbl;
@@ -3393,7 +3729,7 @@ impl AppBroadcastStreamVideoFrame {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastStreamVideoFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastStreamVideoFrame>();
 }
 unsafe impl windows_core::Interface for AppBroadcastStreamVideoFrame {
     type Vtable = IAppBroadcastStreamVideoFrame_Vtbl;
@@ -3451,7 +3787,7 @@ impl AppBroadcastStreamVideoHeader {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastStreamVideoHeader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastStreamVideoHeader>();
 }
 unsafe impl windows_core::Interface for AppBroadcastStreamVideoHeader {
     type Vtable = IAppBroadcastStreamVideoHeader_Vtbl;
@@ -3474,7 +3810,7 @@ impl AppBroadcastTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastTriggerDetails>();
 }
 unsafe impl windows_core::Interface for AppBroadcastTriggerDetails {
     type Vtable = IAppBroadcastTriggerDetails_Vtbl;
@@ -3497,7 +3833,7 @@ impl AppBroadcastViewerCountChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppBroadcastViewerCountChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppBroadcastViewerCountChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppBroadcastViewerCountChangedEventArgs {
     type Vtable = IAppBroadcastViewerCountChangedEventArgs_Vtbl;
@@ -3565,7 +3901,7 @@ impl AppCapture {
     }
 }
 impl windows_core::RuntimeType for AppCapture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCapture>();
 }
 unsafe impl windows_core::Interface for AppCapture {
     type Vtable = IAppCapture_Vtbl;
@@ -3789,7 +4125,7 @@ impl AppCaptureAlternateShortcutKeys {
     }
 }
 impl windows_core::RuntimeType for AppCaptureAlternateShortcutKeys {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureAlternateShortcutKeys>();
 }
 unsafe impl windows_core::Interface for AppCaptureAlternateShortcutKeys {
     type Vtable = IAppCaptureAlternateShortcutKeys_Vtbl;
@@ -3812,7 +4148,7 @@ impl AppCaptureDurationGeneratedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppCaptureDurationGeneratedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureDurationGeneratedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppCaptureDurationGeneratedEventArgs {
     type Vtable = IAppCaptureDurationGeneratedEventArgs_Vtbl;
@@ -3838,7 +4174,7 @@ impl AppCaptureFileGeneratedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppCaptureFileGeneratedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureFileGeneratedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppCaptureFileGeneratedEventArgs {
     type Vtable = IAppCaptureFileGeneratedEventArgs_Vtbl;
@@ -3944,7 +4280,7 @@ impl AppCaptureMetadataWriter {
     }
 }
 impl windows_core::RuntimeType for AppCaptureMetadataWriter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureMetadataWriter>();
 }
 unsafe impl windows_core::Interface for AppCaptureMetadataWriter {
     type Vtable = IAppCaptureMetadataWriter_Vtbl;
@@ -3976,7 +4312,7 @@ impl AppCaptureMicrophoneCaptureStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppCaptureMicrophoneCaptureStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureMicrophoneCaptureStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppCaptureMicrophoneCaptureStateChangedEventArgs {
     type Vtable = IAppCaptureMicrophoneCaptureStateChangedEventArgs_Vtbl;
@@ -4076,7 +4412,7 @@ impl AppCaptureRecordOperation {
     }
 }
 impl windows_core::RuntimeType for AppCaptureRecordOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureRecordOperation>();
 }
 unsafe impl windows_core::Interface for AppCaptureRecordOperation {
     type Vtable = IAppCaptureRecordOperation_Vtbl;
@@ -4108,7 +4444,7 @@ impl AppCaptureRecordingStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppCaptureRecordingStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureRecordingStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppCaptureRecordingStateChangedEventArgs {
     type Vtable = IAppCaptureRecordingStateChangedEventArgs_Vtbl;
@@ -4154,7 +4490,7 @@ impl AppCaptureServices {
     }
 }
 impl windows_core::RuntimeType for AppCaptureServices {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureServices>();
 }
 unsafe impl windows_core::Interface for AppCaptureServices {
     type Vtable = IAppCaptureServices_Vtbl;
@@ -4477,7 +4813,7 @@ impl AppCaptureSettings {
     }
 }
 impl windows_core::RuntimeType for AppCaptureSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureSettings>();
 }
 unsafe impl windows_core::Interface for AppCaptureSettings {
     type Vtable = IAppCaptureSettings_Vtbl;
@@ -4564,7 +4900,7 @@ impl AppCaptureState {
     }
 }
 impl windows_core::RuntimeType for AppCaptureState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCaptureState>();
 }
 unsafe impl windows_core::Interface for AppCaptureState {
     type Vtable = IAppCaptureState_Vtbl;
@@ -4611,7 +4947,7 @@ impl CameraCaptureUI {
     }
 }
 impl windows_core::RuntimeType for CameraCaptureUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraCaptureUI>();
 }
 unsafe impl windows_core::Interface for CameraCaptureUI {
     type Vtable = ICameraCaptureUI_Vtbl;
@@ -4682,7 +5018,7 @@ impl CameraCaptureUIPhotoCaptureSettings {
     }
 }
 impl windows_core::RuntimeType for CameraCaptureUIPhotoCaptureSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraCaptureUIPhotoCaptureSettings>();
 }
 unsafe impl windows_core::Interface for CameraCaptureUIPhotoCaptureSettings {
     type Vtable = ICameraCaptureUIPhotoCaptureSettings_Vtbl;
@@ -4744,7 +5080,7 @@ impl CameraCaptureUIVideoCaptureSettings {
     }
 }
 impl windows_core::RuntimeType for CameraCaptureUIVideoCaptureSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraCaptureUIVideoCaptureSettings>();
 }
 unsafe impl windows_core::Interface for CameraCaptureUIVideoCaptureSettings {
     type Vtable = ICameraCaptureUIVideoCaptureSettings_Vtbl;
@@ -4926,7 +5262,7 @@ impl CapturedFrame {
     }
 }
 impl windows_core::RuntimeType for CapturedFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICapturedFrame>();
 }
 unsafe impl windows_core::Interface for CapturedFrame {
     type Vtable = ICapturedFrame_Vtbl;
@@ -5045,7 +5381,7 @@ impl CapturedFrameControlValues {
     }
 }
 impl windows_core::RuntimeType for CapturedFrameControlValues {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICapturedFrameControlValues>();
 }
 unsafe impl windows_core::Interface for CapturedFrameControlValues {
     type Vtable = ICapturedFrameControlValues_Vtbl;
@@ -5077,7 +5413,7 @@ impl CapturedPhoto {
     }
 }
 impl windows_core::RuntimeType for CapturedPhoto {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICapturedPhoto>();
 }
 unsafe impl windows_core::Interface for CapturedPhoto {
     type Vtable = ICapturedPhoto_Vtbl;
@@ -5152,7 +5488,7 @@ impl GameBarServices {
     }
 }
 impl windows_core::RuntimeType for GameBarServices {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameBarServices>();
 }
 unsafe impl windows_core::Interface for GameBarServices {
     type Vtable = IGameBarServices_Vtbl;
@@ -5184,7 +5520,7 @@ impl GameBarServicesCommandEventArgs {
     }
 }
 impl windows_core::RuntimeType for GameBarServicesCommandEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameBarServicesCommandEventArgs>();
 }
 unsafe impl windows_core::Interface for GameBarServicesCommandEventArgs {
     type Vtable = IGameBarServicesCommandEventArgs_Vtbl;
@@ -5227,7 +5563,7 @@ impl GameBarServicesManager {
     }
 }
 impl windows_core::RuntimeType for GameBarServicesManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameBarServicesManager>();
 }
 unsafe impl windows_core::Interface for GameBarServicesManager {
     type Vtable = IGameBarServicesManager_Vtbl;
@@ -5252,7 +5588,7 @@ impl GameBarServicesManagerGameBarServicesCreatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GameBarServicesManagerGameBarServicesCreatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameBarServicesManagerGameBarServicesCreatedEventArgs>();
 }
 unsafe impl windows_core::Interface for GameBarServicesManagerGameBarServicesCreatedEventArgs {
     type Vtable = IGameBarServicesManagerGameBarServicesCreatedEventArgs_Vtbl;
@@ -5298,7 +5634,7 @@ impl GameBarServicesTargetInfo {
     }
 }
 impl windows_core::RuntimeType for GameBarServicesTargetInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameBarServicesTargetInfo>();
 }
 unsafe impl windows_core::Interface for GameBarServicesTargetInfo {
     type Vtable = IGameBarServicesTargetInfo_Vtbl;
@@ -5367,7 +5703,7 @@ impl LowLagMediaRecording {
     }
 }
 impl windows_core::RuntimeType for LowLagMediaRecording {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLagMediaRecording>();
 }
 unsafe impl windows_core::Interface for LowLagMediaRecording {
     type Vtable = ILowLagMediaRecording_Vtbl;
@@ -5397,7 +5733,7 @@ impl LowLagPhotoCapture {
     }
 }
 impl windows_core::RuntimeType for LowLagPhotoCapture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLagPhotoCapture>();
 }
 unsafe impl windows_core::Interface for LowLagPhotoCapture {
     type Vtable = ILowLagPhotoCapture_Vtbl;
@@ -5448,7 +5784,7 @@ impl LowLagPhotoSequenceCapture {
     }
 }
 impl windows_core::RuntimeType for LowLagPhotoSequenceCapture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLagPhotoSequenceCapture>();
 }
 unsafe impl windows_core::Interface for LowLagPhotoSequenceCapture {
     type Vtable = ILowLagPhotoSequenceCapture_Vtbl;
@@ -6089,7 +6425,7 @@ impl MediaCapture {
     }
 }
 impl windows_core::RuntimeType for MediaCapture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCapture>();
 }
 unsafe impl windows_core::Interface for MediaCapture {
     type Vtable = IMediaCapture_Vtbl;
@@ -6119,7 +6455,7 @@ impl MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaCaptureDeviceExclusiveControlStatusChangedEventArgs {
     type Vtable = IMediaCaptureDeviceExclusiveControlStatusChangedEventArgs_Vtbl;
@@ -6151,7 +6487,7 @@ impl MediaCaptureFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaCaptureFailedEventArgs {
     type Vtable = IMediaCaptureFailedEventArgs_Vtbl;
@@ -6175,7 +6511,7 @@ impl MediaCaptureFocusChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureFocusChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureFocusChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaCaptureFocusChangedEventArgs {
     type Vtable = IMediaCaptureFocusChangedEventArgs_Vtbl;
@@ -6433,7 +6769,7 @@ impl MediaCaptureInitializationSettings {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureInitializationSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureInitializationSettings>();
 }
 unsafe impl windows_core::Interface for MediaCaptureInitializationSettings {
     type Vtable = IMediaCaptureInitializationSettings_Vtbl;
@@ -6470,7 +6806,7 @@ impl MediaCapturePauseResult {
     }
 }
 impl windows_core::RuntimeType for MediaCapturePauseResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCapturePauseResult>();
 }
 unsafe impl windows_core::Interface for MediaCapturePauseResult {
     type Vtable = IMediaCapturePauseResult_Vtbl;
@@ -6521,7 +6857,7 @@ impl MediaCaptureRelativePanelWatcher {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureRelativePanelWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureRelativePanelWatcher>();
 }
 unsafe impl windows_core::Interface for MediaCaptureRelativePanelWatcher {
     type Vtable = IMediaCaptureRelativePanelWatcher_Vtbl;
@@ -6638,7 +6974,7 @@ impl MediaCaptureSettings {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureSettings>();
 }
 unsafe impl windows_core::Interface for MediaCaptureSettings {
     type Vtable = IMediaCaptureSettings_Vtbl;
@@ -6673,7 +7009,7 @@ impl MediaCaptureStopResult {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureStopResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureStopResult>();
 }
 unsafe impl windows_core::Interface for MediaCaptureStopResult {
     type Vtable = IMediaCaptureStopResult_Vtbl;
@@ -6751,7 +7087,7 @@ impl MediaCaptureVideoProfile {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureVideoProfile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureVideoProfile>();
 }
 unsafe impl windows_core::Interface for MediaCaptureVideoProfile {
     type Vtable = IMediaCaptureVideoProfile_Vtbl;
@@ -6821,7 +7157,7 @@ impl MediaCaptureVideoProfileMediaDescription {
     }
 }
 impl windows_core::RuntimeType for MediaCaptureVideoProfileMediaDescription {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCaptureVideoProfileMediaDescription>();
 }
 unsafe impl windows_core::Interface for MediaCaptureVideoProfileMediaDescription {
     type Vtable = IMediaCaptureVideoProfileMediaDescription_Vtbl;
@@ -6853,7 +7189,7 @@ impl OptionalReferencePhotoCapturedEventArgs {
     }
 }
 impl windows_core::RuntimeType for OptionalReferencePhotoCapturedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOptionalReferencePhotoCapturedEventArgs>();
 }
 unsafe impl windows_core::Interface for OptionalReferencePhotoCapturedEventArgs {
     type Vtable = IOptionalReferencePhotoCapturedEventArgs_Vtbl;
@@ -6892,7 +7228,7 @@ impl PhotoCapturedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PhotoCapturedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoCapturedEventArgs>();
 }
 unsafe impl windows_core::Interface for PhotoCapturedEventArgs {
     type Vtable = IPhotoCapturedEventArgs_Vtbl;
@@ -6924,7 +7260,7 @@ impl PhotoConfirmationCapturedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PhotoConfirmationCapturedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoConfirmationCapturedEventArgs>();
 }
 unsafe impl windows_core::Interface for PhotoConfirmationCapturedEventArgs {
     type Vtable = IPhotoConfirmationCapturedEventArgs_Vtbl;
@@ -6997,7 +7333,7 @@ impl ScreenCapture {
     }
 }
 impl windows_core::RuntimeType for ScreenCapture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScreenCapture>();
 }
 unsafe impl windows_core::Interface for ScreenCapture {
     type Vtable = IScreenCapture_Vtbl;
@@ -7029,7 +7365,7 @@ impl SourceSuspensionChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SourceSuspensionChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISourceSuspensionChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for SourceSuspensionChangedEventArgs {
     type Vtable = ISourceSuspensionChangedEventArgs_Vtbl;
@@ -7063,7 +7399,7 @@ impl VideoStreamConfiguration {
     }
 }
 impl windows_core::RuntimeType for VideoStreamConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoStreamConfiguration>();
 }
 unsafe impl windows_core::Interface for VideoStreamConfiguration {
     type Vtable = IVideoStreamConfiguration_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Casting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Casting/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICastingConnection, ICastingConnection_Vtbl, 0xcd951653_c2f1_4498_8b78_5fb4cd3640dd);
+impl windows_core::RuntimeType for ICastingConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +17,9 @@ pub struct ICastingConnection_Vtbl {
     pub DisconnectAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICastingConnectionErrorOccurredEventArgs, ICastingConnectionErrorOccurredEventArgs_Vtbl, 0xa7fb3c69_8719_4f00_81fb_961863c79a32);
+impl windows_core::RuntimeType for ICastingConnectionErrorOccurredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingConnectionErrorOccurredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +27,9 @@ pub struct ICastingConnectionErrorOccurredEventArgs_Vtbl {
     pub Message: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICastingDevice, ICastingDevice_Vtbl, 0xde721c83_4a43_4ad1_a6d2_2492a796c3f2);
+impl windows_core::RuntimeType for ICastingDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +43,9 @@ pub struct ICastingDevice_Vtbl {
     pub CreateCastingConnection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICastingDevicePicker, ICastingDevicePicker_Vtbl, 0xdcd39924_0591_49be_aacb_4b82ee756a95);
+impl windows_core::RuntimeType for ICastingDevicePicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingDevicePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +66,9 @@ pub struct ICastingDevicePicker_Vtbl {
     pub Hide: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICastingDevicePickerFilter, ICastingDevicePickerFilter_Vtbl, 0xbe8c619c_b563_4354_ae33_9fdaad8c6291);
+impl windows_core::RuntimeType for ICastingDevicePickerFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingDevicePickerFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,12 +84,18 @@ pub struct ICastingDevicePickerFilter_Vtbl {
     SupportedCastingSources: usize,
 }
 windows_core::imp::define_interface!(ICastingDeviceSelectedEventArgs, ICastingDeviceSelectedEventArgs_Vtbl, 0xdc439e86_dd57_4d0d_9400_af45e4fb3663);
+impl windows_core::RuntimeType for ICastingDeviceSelectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingDeviceSelectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SelectedCastingDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICastingDeviceStatics, ICastingDeviceStatics_Vtbl, 0xe7d958d7_4d13_4237_a365_4c4f6a4cfd2f);
+impl windows_core::RuntimeType for ICastingDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -87,6 +108,9 @@ pub struct ICastingDeviceStatics_Vtbl {
     DeviceInfoSupportsCastingAsync: usize,
 }
 windows_core::imp::define_interface!(ICastingSource, ICastingSource_Vtbl, 0xf429ea72_3467_47e6_a027_522923e9d727);
+impl windows_core::RuntimeType for ICastingSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICastingSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,7 +202,7 @@ impl CastingConnection {
     }
 }
 impl windows_core::RuntimeType for CastingConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICastingConnection>();
 }
 unsafe impl windows_core::Interface for CastingConnection {
     type Vtable = ICastingConnection_Vtbl;
@@ -210,7 +234,7 @@ impl CastingConnectionErrorOccurredEventArgs {
     }
 }
 impl windows_core::RuntimeType for CastingConnectionErrorOccurredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICastingConnectionErrorOccurredEventArgs>();
 }
 unsafe impl windows_core::Interface for CastingConnectionErrorOccurredEventArgs {
     type Vtable = ICastingConnectionErrorOccurredEventArgs_Vtbl;
@@ -300,7 +324,7 @@ impl CastingDevice {
     }
 }
 impl windows_core::RuntimeType for CastingDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICastingDevice>();
 }
 unsafe impl windows_core::Interface for CastingDevice {
     type Vtable = ICastingDevice_Vtbl;
@@ -381,7 +405,7 @@ impl CastingDevicePicker {
     }
 }
 impl windows_core::RuntimeType for CastingDevicePicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICastingDevicePicker>();
 }
 unsafe impl windows_core::Interface for CastingDevicePicker {
     type Vtable = ICastingDevicePicker_Vtbl;
@@ -440,7 +464,7 @@ impl CastingDevicePickerFilter {
     }
 }
 impl windows_core::RuntimeType for CastingDevicePickerFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICastingDevicePickerFilter>();
 }
 unsafe impl windows_core::Interface for CastingDevicePickerFilter {
     type Vtable = ICastingDevicePickerFilter_Vtbl;
@@ -465,7 +489,7 @@ impl CastingDeviceSelectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CastingDeviceSelectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICastingDeviceSelectedEventArgs>();
 }
 unsafe impl windows_core::Interface for CastingDeviceSelectedEventArgs {
     type Vtable = ICastingDeviceSelectedEventArgs_Vtbl;
@@ -497,7 +521,7 @@ impl CastingSource {
     }
 }
 impl windows_core::RuntimeType for CastingSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICastingSource>();
 }
 unsafe impl windows_core::Interface for CastingSource {
     type Vtable = ICastingSource_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/ClosedCaptioning/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/ClosedCaptioning/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IClosedCaptionPropertiesStatics, IClosedCaptionPropertiesStatics_Vtbl, 0x10aa1f84_cc30_4141_b503_5272289e0c20);
+impl windows_core::RuntimeType for IClosedCaptionPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClosedCaptionPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +28,9 @@ pub struct IClosedCaptionPropertiesStatics_Vtbl {
     pub RegionOpacity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ClosedCaptionOpacity) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClosedCaptionPropertiesStatics2, IClosedCaptionPropertiesStatics2_Vtbl, 0x9de26870_37de_4197_8845_9a48dc5ac317);
+impl windows_core::RuntimeType for IClosedCaptionPropertiesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClosedCaptionPropertiesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IContentRestrictionsBrowsePolicy, IContentRestrictionsBrowsePolicy_Vtbl, 0x8c0133a4_442e_461a_8757_fad2f5bd37e4);
+impl windows_core::RuntimeType for IContentRestrictionsBrowsePolicy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentRestrictionsBrowsePolicy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IContentRestrictionsBrowsePolicy_Vtbl {
     pub PreferredAgeRating: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRatedContentDescription, IRatedContentDescription_Vtbl, 0x694866df_66b2_4dc3_96b1_f090eedee255);
+impl windows_core::RuntimeType for IRatedContentDescription {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRatedContentDescription_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,12 +40,18 @@ pub struct IRatedContentDescription_Vtbl {
     SetRatings: usize,
 }
 windows_core::imp::define_interface!(IRatedContentDescriptionFactory, IRatedContentDescriptionFactory_Vtbl, 0x2e38df62_9b90_4fa6_89c1_4b8d2ffb3573);
+impl windows_core::RuntimeType for IRatedContentDescriptionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRatedContentDescriptionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, RatedContentCategory, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRatedContentRestrictions, IRatedContentRestrictions_Vtbl, 0x3f7f23cb_ba07_4401_a49d_8b9222205723);
+impl windows_core::RuntimeType for IRatedContentRestrictions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRatedContentRestrictions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +62,9 @@ pub struct IRatedContentRestrictions_Vtbl {
     pub RemoveRestrictionsChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRatedContentRestrictionsFactory, IRatedContentRestrictionsFactory_Vtbl, 0xfb4b2996_c3bd_4910_9619_97cfd0694d56);
+impl windows_core::RuntimeType for IRatedContentRestrictionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRatedContentRestrictionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,7 +98,7 @@ impl ContentRestrictionsBrowsePolicy {
     }
 }
 impl windows_core::RuntimeType for ContentRestrictionsBrowsePolicy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContentRestrictionsBrowsePolicy>();
 }
 unsafe impl windows_core::Interface for ContentRestrictionsBrowsePolicy {
     type Vtable = IContentRestrictionsBrowsePolicy_Vtbl;
@@ -177,7 +192,7 @@ impl RatedContentDescription {
     }
 }
 impl windows_core::RuntimeType for RatedContentDescription {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRatedContentDescription>();
 }
 unsafe impl windows_core::Interface for RatedContentDescription {
     type Vtable = IRatedContentDescription_Vtbl;
@@ -254,7 +269,7 @@ impl RatedContentRestrictions {
     }
 }
 impl windows_core::RuntimeType for RatedContentRestrictions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRatedContentRestrictions>();
 }
 unsafe impl windows_core::Interface for RatedContentRestrictions {
     type Vtable = IRatedContentRestrictions_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Control/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Control/mod.rs
@@ -1,9 +1,15 @@
 windows_core::imp::define_interface!(ICurrentSessionChangedEventArgs, ICurrentSessionChangedEventArgs_Vtbl, 0x6969cb39_0bfa_5fe0_8d73_09cc5e5408e1);
+impl windows_core::RuntimeType for ICurrentSessionChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentSessionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IGlobalSystemMediaTransportControlsSession, IGlobalSystemMediaTransportControlsSession_Vtbl, 0x7148c835_9b14_5ae2_ab85_dc9b1c14e1a8);
+impl windows_core::RuntimeType for IGlobalSystemMediaTransportControlsSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalSystemMediaTransportControlsSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +40,9 @@ pub struct IGlobalSystemMediaTransportControlsSession_Vtbl {
     pub RemoveMediaPropertiesChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGlobalSystemMediaTransportControlsSessionManager, IGlobalSystemMediaTransportControlsSessionManager_Vtbl, 0xcace8eac_e86e_504a_ab31_5ff8ff1bce49);
+impl windows_core::RuntimeType for IGlobalSystemMediaTransportControlsSessionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalSystemMediaTransportControlsSessionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,12 +57,18 @@ pub struct IGlobalSystemMediaTransportControlsSessionManager_Vtbl {
     pub RemoveSessionsChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGlobalSystemMediaTransportControlsSessionManagerStatics, IGlobalSystemMediaTransportControlsSessionManagerStatics_Vtbl, 0x2050c4ee_11a0_57de_aed7_c97c70338245);
+impl windows_core::RuntimeType for IGlobalSystemMediaTransportControlsSessionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalSystemMediaTransportControlsSessionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGlobalSystemMediaTransportControlsSessionMediaProperties, IGlobalSystemMediaTransportControlsSessionMediaProperties_Vtbl, 0x68856cf6_adb4_54b2_ac16_05837907acb6);
+impl windows_core::RuntimeType for IGlobalSystemMediaTransportControlsSessionMediaProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalSystemMediaTransportControlsSessionMediaProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +90,9 @@ pub struct IGlobalSystemMediaTransportControlsSessionMediaProperties_Vtbl {
     Thumbnail: usize,
 }
 windows_core::imp::define_interface!(IGlobalSystemMediaTransportControlsSessionPlaybackControls, IGlobalSystemMediaTransportControlsSessionPlaybackControls_Vtbl, 0x6501a3e6_bc7a_503a_bb1b_68f158f3fb03);
+impl windows_core::RuntimeType for IGlobalSystemMediaTransportControlsSessionPlaybackControls {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalSystemMediaTransportControlsSessionPlaybackControls_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,6 +113,9 @@ pub struct IGlobalSystemMediaTransportControlsSessionPlaybackControls_Vtbl {
     pub IsPlaybackPositionEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGlobalSystemMediaTransportControlsSessionPlaybackInfo, IGlobalSystemMediaTransportControlsSessionPlaybackInfo_Vtbl, 0x94b4b6cf_e8ba_51ad_87a7_c10ade106127);
+impl windows_core::RuntimeType for IGlobalSystemMediaTransportControlsSessionPlaybackInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalSystemMediaTransportControlsSessionPlaybackInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,6 +127,9 @@ pub struct IGlobalSystemMediaTransportControlsSessionPlaybackInfo_Vtbl {
     pub IsShuffleActive: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGlobalSystemMediaTransportControlsSessionTimelineProperties, IGlobalSystemMediaTransportControlsSessionTimelineProperties_Vtbl, 0xede34136_6f25_588d_8ecf_ea5b6735aaa5);
+impl windows_core::RuntimeType for IGlobalSystemMediaTransportControlsSessionTimelineProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalSystemMediaTransportControlsSessionTimelineProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,21 +141,33 @@ pub struct IGlobalSystemMediaTransportControlsSessionTimelineProperties_Vtbl {
     pub LastUpdatedTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPropertiesChangedEventArgs, IMediaPropertiesChangedEventArgs_Vtbl, 0x7d3741cb_adf0_5cef_91ba_cfabcdd77678);
+impl windows_core::RuntimeType for IMediaPropertiesChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPropertiesChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPlaybackInfoChangedEventArgs, IPlaybackInfoChangedEventArgs_Vtbl, 0x786756c2_bc0d_50a5_8807_054291fef139);
+impl windows_core::RuntimeType for IPlaybackInfoChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackInfoChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISessionsChangedEventArgs, ISessionsChangedEventArgs_Vtbl, 0xbbf0cd32_42c4_5a58_b317_f34bbfbd26e0);
+impl windows_core::RuntimeType for ISessionsChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISessionsChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ITimelinePropertiesChangedEventArgs, ITimelinePropertiesChangedEventArgs_Vtbl, 0x29033a2f_c923_5a77_bcaf_055ff415ad32);
+impl windows_core::RuntimeType for ITimelinePropertiesChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimelinePropertiesChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -142,7 +178,7 @@ pub struct CurrentSessionChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CurrentSessionChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CurrentSessionChangedEventArgs {}
 impl windows_core::RuntimeType for CurrentSessionChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICurrentSessionChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for CurrentSessionChangedEventArgs {
     type Vtable = ICurrentSessionChangedEventArgs_Vtbl;
@@ -335,7 +371,7 @@ impl GlobalSystemMediaTransportControlsSession {
     }
 }
 impl windows_core::RuntimeType for GlobalSystemMediaTransportControlsSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGlobalSystemMediaTransportControlsSession>();
 }
 unsafe impl windows_core::Interface for GlobalSystemMediaTransportControlsSession {
     type Vtable = IGlobalSystemMediaTransportControlsSession_Vtbl;
@@ -407,7 +443,7 @@ impl GlobalSystemMediaTransportControlsSessionManager {
     }
 }
 impl windows_core::RuntimeType for GlobalSystemMediaTransportControlsSessionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGlobalSystemMediaTransportControlsSessionManager>();
 }
 unsafe impl windows_core::Interface for GlobalSystemMediaTransportControlsSessionManager {
     type Vtable = IGlobalSystemMediaTransportControlsSessionManager_Vtbl;
@@ -497,7 +533,7 @@ impl GlobalSystemMediaTransportControlsSessionMediaProperties {
     }
 }
 impl windows_core::RuntimeType for GlobalSystemMediaTransportControlsSessionMediaProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGlobalSystemMediaTransportControlsSessionMediaProperties>();
 }
 unsafe impl windows_core::Interface for GlobalSystemMediaTransportControlsSessionMediaProperties {
     type Vtable = IGlobalSystemMediaTransportControlsSessionMediaProperties_Vtbl;
@@ -620,7 +656,7 @@ impl GlobalSystemMediaTransportControlsSessionPlaybackControls {
     }
 }
 impl windows_core::RuntimeType for GlobalSystemMediaTransportControlsSessionPlaybackControls {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGlobalSystemMediaTransportControlsSessionPlaybackControls>();
 }
 unsafe impl windows_core::Interface for GlobalSystemMediaTransportControlsSessionPlaybackControls {
     type Vtable = IGlobalSystemMediaTransportControlsSessionPlaybackControls_Vtbl;
@@ -680,7 +716,7 @@ impl GlobalSystemMediaTransportControlsSessionPlaybackInfo {
     }
 }
 impl windows_core::RuntimeType for GlobalSystemMediaTransportControlsSessionPlaybackInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGlobalSystemMediaTransportControlsSessionPlaybackInfo>();
 }
 unsafe impl windows_core::Interface for GlobalSystemMediaTransportControlsSessionPlaybackInfo {
     type Vtable = IGlobalSystemMediaTransportControlsSessionPlaybackInfo_Vtbl;
@@ -740,7 +776,7 @@ impl GlobalSystemMediaTransportControlsSessionTimelineProperties {
     }
 }
 impl windows_core::RuntimeType for GlobalSystemMediaTransportControlsSessionTimelineProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGlobalSystemMediaTransportControlsSessionTimelineProperties>();
 }
 unsafe impl windows_core::Interface for GlobalSystemMediaTransportControlsSessionTimelineProperties {
     type Vtable = IGlobalSystemMediaTransportControlsSessionTimelineProperties_Vtbl;
@@ -757,7 +793,7 @@ pub struct MediaPropertiesChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(MediaPropertiesChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl MediaPropertiesChangedEventArgs {}
 impl windows_core::RuntimeType for MediaPropertiesChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPropertiesChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPropertiesChangedEventArgs {
     type Vtable = IMediaPropertiesChangedEventArgs_Vtbl;
@@ -774,7 +810,7 @@ pub struct PlaybackInfoChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PlaybackInfoChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PlaybackInfoChangedEventArgs {}
 impl windows_core::RuntimeType for PlaybackInfoChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaybackInfoChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PlaybackInfoChangedEventArgs {
     type Vtable = IPlaybackInfoChangedEventArgs_Vtbl;
@@ -791,7 +827,7 @@ pub struct SessionsChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(SessionsChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl SessionsChangedEventArgs {}
 impl windows_core::RuntimeType for SessionsChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISessionsChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for SessionsChangedEventArgs {
     type Vtable = ISessionsChangedEventArgs_Vtbl;
@@ -808,7 +844,7 @@ pub struct TimelinePropertiesChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(TimelinePropertiesChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl TimelinePropertiesChangedEventArgs {}
 impl windows_core::RuntimeType for TimelinePropertiesChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimelinePropertiesChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for TimelinePropertiesChangedEventArgs {
     type Vtable = ITimelinePropertiesChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Core/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/Preview/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISoundLevelBrokerStatics, ISoundLevelBrokerStatics_Vtbl, 0x6a633961_dbed_464c_a09a_33412f5caa3f);
+impl windows_core::RuntimeType for ISoundLevelBrokerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISoundLevelBrokerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Media/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Media_Core_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(IAudioStreamDescriptor, IAudioStreamDescriptor_Vtbl, 0x1e3692e4_4027_4847_a70b_df1d9a2a7b04);
+impl windows_core::RuntimeType for IAudioStreamDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioStreamDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IAudioStreamDescriptor_Vtbl {
     EncodingProperties: usize,
 }
 windows_core::imp::define_interface!(IAudioStreamDescriptor2, IAudioStreamDescriptor2_Vtbl, 0x2e68f1f6_a448_497b_8840_85082665acf9);
+impl windows_core::RuntimeType for IAudioStreamDescriptor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioStreamDescriptor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,12 +25,18 @@ pub struct IAudioStreamDescriptor2_Vtbl {
     pub TrailingEncoderPadding: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioStreamDescriptor3, IAudioStreamDescriptor3_Vtbl, 0x4d220da1_8e83_44ef_8973_2f63e993f36b);
+impl windows_core::RuntimeType for IAudioStreamDescriptor3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioStreamDescriptor3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioStreamDescriptorFactory, IAudioStreamDescriptorFactory_Vtbl, 0x4a86ce9e_4cb1_4380_8e0c_83504b7f5bf3);
+impl windows_core::RuntimeType for IAudioStreamDescriptorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioStreamDescriptorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +46,9 @@ pub struct IAudioStreamDescriptorFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IAudioTrack, IAudioTrack_Vtbl, 0xf23b6e77_3ef7_40de_b943_068b1321701d);
+impl windows_core::RuntimeType for IAudioTrack {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioTrack_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,12 +66,18 @@ pub struct IAudioTrack_Vtbl {
     pub SupportInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioTrackOpenFailedEventArgs, IAudioTrackOpenFailedEventArgs_Vtbl, 0xeeddb9b9_bb7c_4112_bf76_9384676f824b);
+impl windows_core::RuntimeType for IAudioTrackOpenFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioTrackOpenFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioTrackSupportInfo, IAudioTrackSupportInfo_Vtbl, 0x178beff7_cc39_44a6_b951_4a5653f073fa);
+impl windows_core::RuntimeType for IAudioTrackSupportInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioTrackSupportInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +87,9 @@ pub struct IAudioTrackSupportInfo_Vtbl {
     pub MediaSourceStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaSourceStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChapterCue, IChapterCue_Vtbl, 0x72a98001_d38a_4c0a_8fa6_75cddaf4664c);
+impl windows_core::RuntimeType for IChapterCue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChapterCue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +97,9 @@ pub struct IChapterCue_Vtbl {
     pub Title: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICodecInfo, ICodecInfo_Vtbl, 0x51e89f85_ea97_499c_86ac_4ce5e73f3a42);
+impl windows_core::RuntimeType for ICodecInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICodecInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +113,9 @@ pub struct ICodecInfo_Vtbl {
     pub IsTrusted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICodecQuery, ICodecQuery_Vtbl, 0x222a953a_af61_4e04_808a_a4634e2f3ac4);
+impl windows_core::RuntimeType for ICodecQuery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICodecQuery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,6 +125,9 @@ pub struct ICodecQuery_Vtbl {
     FindAllAsync: usize,
 }
 windows_core::imp::define_interface!(ICodecSubtypesStatics, ICodecSubtypesStatics_Vtbl, 0xa66ac4f2_888b_4224_8cf6_2a8d4eb02382);
+impl windows_core::RuntimeType for ICodecSubtypesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICodecSubtypesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,6 +184,9 @@ pub struct ICodecSubtypesStatics_Vtbl {
     pub AudioFormatWMAudioV9: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataCue, IDataCue_Vtbl, 0x7c7f676d_1fbc_4e2d_9a87_ee38bd1dc637);
+impl windows_core::RuntimeType for IDataCue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataCue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -164,6 +200,9 @@ pub struct IDataCue_Vtbl {
     Data: usize,
 }
 windows_core::imp::define_interface!(IDataCue2, IDataCue2_Vtbl, 0xbc561b15_95f2_49e8_96f1_8dd5dac68d93);
+impl windows_core::RuntimeType for IDataCue2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataCue2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,12 +212,18 @@ pub struct IDataCue2_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IFaceDetectedEventArgs, IFaceDetectedEventArgs_Vtbl, 0x19918426_c65b_46ba_85f8_13880576c90a);
+impl windows_core::RuntimeType for IFaceDetectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceDetectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ResultFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFaceDetectionEffect, IFaceDetectionEffect_Vtbl, 0xae15ebd2_0542_42a9_bc90_f283a29f46c1);
+impl windows_core::RuntimeType for IFaceDetectionEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceDetectionEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -190,6 +235,9 @@ pub struct IFaceDetectionEffect_Vtbl {
     pub RemoveFaceDetected: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFaceDetectionEffectDefinition, IFaceDetectionEffectDefinition_Vtbl, 0x43dca081_b848_4f33_b702_1fd2624fb016);
+impl windows_core::RuntimeType for IFaceDetectionEffectDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceDetectionEffectDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,6 +247,9 @@ pub struct IFaceDetectionEffectDefinition_Vtbl {
     pub SynchronousDetectionEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFaceDetectionEffectFrame, IFaceDetectionEffectFrame_Vtbl, 0x8ab08993_5dc8_447b_a247_5270bd802ece);
+impl windows_core::RuntimeType for IFaceDetectionEffectFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceDetectionEffectFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -208,6 +259,9 @@ pub struct IFaceDetectionEffectFrame_Vtbl {
     DetectedFaces: usize,
 }
 windows_core::imp::define_interface!(IHighDynamicRangeControl, IHighDynamicRangeControl_Vtbl, 0x55f1a7ae_d957_4dc9_9d1c_8553a82a7d99);
+impl windows_core::RuntimeType for IHighDynamicRangeControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHighDynamicRangeControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,6 +269,9 @@ pub struct IHighDynamicRangeControl_Vtbl {
     pub Enabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHighDynamicRangeOutput, IHighDynamicRangeOutput_Vtbl, 0x0f57806b_253b_4119_bb40_3a90e51384f7);
+impl windows_core::RuntimeType for IHighDynamicRangeOutput {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHighDynamicRangeOutput_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -225,6 +282,9 @@ pub struct IHighDynamicRangeOutput_Vtbl {
     FrameControllers: usize,
 }
 windows_core::imp::define_interface!(IImageCue, IImageCue_Vtbl, 0x52828282_367b_440b_9116_3c84570dd270);
+impl windows_core::RuntimeType for IImageCue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageCue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -242,6 +302,9 @@ pub struct IImageCue_Vtbl {
     SoftwareBitmap: usize,
 }
 windows_core::imp::define_interface!(IInitializeMediaStreamSourceRequestedEventArgs, IInitializeMediaStreamSourceRequestedEventArgs_Vtbl, 0x25bc45e1_9b08_4c2e_a855_4542f1a75deb);
+impl windows_core::RuntimeType for IInitializeMediaStreamSourceRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInitializeMediaStreamSourceRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -253,6 +316,9 @@ pub struct IInitializeMediaStreamSourceRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLightFusionResult, ILowLightFusionResult_Vtbl, 0x78edbe35_27a0_42e0_9cd3_738d2089de9c);
+impl windows_core::RuntimeType for ILowLightFusionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLightFusionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -262,6 +328,9 @@ pub struct ILowLightFusionResult_Vtbl {
     Frame: usize,
 }
 windows_core::imp::define_interface!(ILowLightFusionStatics, ILowLightFusionStatics_Vtbl, 0x5305016d_c29e_40e2_87a9_9e1fd2f192f5);
+impl windows_core::RuntimeType for ILowLightFusionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLightFusionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -276,6 +345,9 @@ pub struct ILowLightFusionStatics_Vtbl {
     FuseAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaBinder, IMediaBinder_Vtbl, 0x2b7e40aa_de07_424f_83f1_f1de46c4fa2e);
+impl windows_core::RuntimeType for IMediaBinder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBinder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -286,6 +358,9 @@ pub struct IMediaBinder_Vtbl {
     pub Source: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBindingEventArgs, IMediaBindingEventArgs_Vtbl, 0xb61cb25a_1b6d_4630_a86d_2f0837f712e5);
+impl windows_core::RuntimeType for IMediaBindingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBindingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -304,6 +379,9 @@ pub struct IMediaBindingEventArgs_Vtbl {
     SetStreamReference: usize,
 }
 windows_core::imp::define_interface!(IMediaBindingEventArgs2, IMediaBindingEventArgs2_Vtbl, 0x0464cceb_bb5a_482f_b8ba_f0284c696567);
+impl windows_core::RuntimeType for IMediaBindingEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBindingEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -317,6 +395,9 @@ pub struct IMediaBindingEventArgs2_Vtbl {
     SetStorageFile: usize,
 }
 windows_core::imp::define_interface!(IMediaBindingEventArgs3, IMediaBindingEventArgs3_Vtbl, 0xf8eb475e_19be_44fc_a5ed_7aba315037f9);
+impl windows_core::RuntimeType for IMediaBindingEventArgs3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBindingEventArgs3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -376,6 +457,9 @@ pub struct IMediaCue_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaCueEventArgs, IMediaCueEventArgs_Vtbl, 0xd12f47f7_5fa4_4e68_9fe5_32160dcee57e);
+impl windows_core::RuntimeType for IMediaCueEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCueEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -392,6 +476,9 @@ pub struct IMediaSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IMediaSource2, IMediaSource2_Vtbl, 0x2eb61048_655f_4c37_b813_b4e45dfa0abe);
+impl windows_core::RuntimeType for IMediaSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -413,6 +500,9 @@ pub struct IMediaSource2_Vtbl {
     ExternalTimedMetadataTracks: usize,
 }
 windows_core::imp::define_interface!(IMediaSource3, IMediaSource3_Vtbl, 0xb59f0d9b_4b6e_41ed_bbb4_7c7509a994ad);
+impl windows_core::RuntimeType for IMediaSource3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSource3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -422,6 +512,9 @@ pub struct IMediaSource3_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSource4, IMediaSource4_Vtbl, 0xbdafad57_8eff_4c63_85a6_84de0ae3e4f2);
+impl windows_core::RuntimeType for IMediaSource4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSource4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -435,6 +528,9 @@ pub struct IMediaSource4_Vtbl {
     pub OpenAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSource5, IMediaSource5_Vtbl, 0x331a22ae_ed2e_4a22_94c8_b743a92b3022);
+impl windows_core::RuntimeType for IMediaSource5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSource5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -444,6 +540,9 @@ pub struct IMediaSource5_Vtbl {
     DownloadOperation: usize,
 }
 windows_core::imp::define_interface!(IMediaSourceAppServiceConnection, IMediaSourceAppServiceConnection_Vtbl, 0x61e1ea97_1916_4810_b7f4_b642be829596);
+impl windows_core::RuntimeType for IMediaSourceAppServiceConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceAppServiceConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -452,6 +551,9 @@ pub struct IMediaSourceAppServiceConnection_Vtbl {
     pub Start: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSourceAppServiceConnectionFactory, IMediaSourceAppServiceConnectionFactory_Vtbl, 0x65b912eb_80b9_44f9_9c1e_e120f6d92838);
+impl windows_core::RuntimeType for IMediaSourceAppServiceConnectionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceAppServiceConnectionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -461,18 +563,27 @@ pub struct IMediaSourceAppServiceConnectionFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IMediaSourceError, IMediaSourceError_Vtbl, 0x5c0a8965_37c5_4e9d_8d21_1cdee90cecc6);
+impl windows_core::RuntimeType for IMediaSourceError {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceError_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSourceOpenOperationCompletedEventArgs, IMediaSourceOpenOperationCompletedEventArgs_Vtbl, 0xfc682ceb_e281_477c_a8e0_1acd654114c8);
+impl windows_core::RuntimeType for IMediaSourceOpenOperationCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceOpenOperationCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSourceStateChangedEventArgs, IMediaSourceStateChangedEventArgs_Vtbl, 0x0a30af82_9071_4bac_bc39_ca2a93b717a9);
+impl windows_core::RuntimeType for IMediaSourceStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -480,6 +591,9 @@ pub struct IMediaSourceStateChangedEventArgs_Vtbl {
     pub NewState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaSourceState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSourceStatics, IMediaSourceStatics_Vtbl, 0xf77d6fa4_4652_410e_b1d8_e9a5e245a45c);
+impl windows_core::RuntimeType for IMediaSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -505,12 +619,18 @@ pub struct IMediaSourceStatics_Vtbl {
     pub CreateFromUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSourceStatics2, IMediaSourceStatics2_Vtbl, 0xeee161a4_7f13_4896_b8cb_df0de5bcb9f1);
+impl windows_core::RuntimeType for IMediaSourceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFromMediaBinder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaSourceStatics3, IMediaSourceStatics3_Vtbl, 0x453a30d6_2bea_4122_9f73_eace04526e35);
+impl windows_core::RuntimeType for IMediaSourceStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -520,6 +640,9 @@ pub struct IMediaSourceStatics3_Vtbl {
     CreateFromMediaFrameSource: usize,
 }
 windows_core::imp::define_interface!(IMediaSourceStatics4, IMediaSourceStatics4_Vtbl, 0x281b3bfc_e50a_4428_a500_9c4ed918d3f0);
+impl windows_core::RuntimeType for IMediaSourceStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaSourceStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -628,6 +751,9 @@ pub struct IMediaStreamDescriptor2_Vtbl {
     pub Label: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSample, IMediaStreamSample_Vtbl, 0x5c8db627_4b80_4361_9837_6cb7481ad9d6);
+impl windows_core::RuntimeType for IMediaStreamSample {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSample_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -653,6 +779,9 @@ pub struct IMediaStreamSample_Vtbl {
     pub Discontinuous: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSample2, IMediaStreamSample2_Vtbl, 0x45078691_fce8_4746_a1c8_10c25d3d7cd3);
+impl windows_core::RuntimeType for IMediaStreamSample2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSample2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -662,6 +791,9 @@ pub struct IMediaStreamSample2_Vtbl {
     Direct3D11Surface: usize,
 }
 windows_core::imp::define_interface!(IMediaStreamSampleProtectionProperties, IMediaStreamSampleProtectionProperties_Vtbl, 0x4eb88292_ecdf_493e_841d_dd4add7caca2);
+impl windows_core::RuntimeType for IMediaStreamSampleProtectionProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSampleProtectionProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -673,6 +805,9 @@ pub struct IMediaStreamSampleProtectionProperties_Vtbl {
     pub GetSubSampleMapping: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSampleStatics, IMediaStreamSampleStatics_Vtbl, 0xdfdf218f_a6cf_4579_be41_73dd941ad972);
+impl windows_core::RuntimeType for IMediaStreamSampleStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSampleStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -686,6 +821,9 @@ pub struct IMediaStreamSampleStatics_Vtbl {
     CreateFromStreamAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaStreamSampleStatics2, IMediaStreamSampleStatics2_Vtbl, 0x9efe9521_6d46_494c_a2f8_d662922e2dd7);
+impl windows_core::RuntimeType for IMediaStreamSampleStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSampleStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -695,6 +833,9 @@ pub struct IMediaStreamSampleStatics2_Vtbl {
     CreateFromDirect3D11Surface: usize,
 }
 windows_core::imp::define_interface!(IMediaStreamSource, IMediaStreamSource_Vtbl, 0x3712d543_45eb_4138_aa62_c01e26f3843f);
+impl windows_core::RuntimeType for IMediaStreamSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -744,6 +885,9 @@ pub struct IMediaStreamSource_Vtbl {
     pub AddProtectionKey: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const u8, u32, *const u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSource2, IMediaStreamSource2_Vtbl, 0xec55d0ad_2e6a_4f74_adbb_b562d1533849);
+impl windows_core::RuntimeType for IMediaStreamSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -751,6 +895,9 @@ pub struct IMediaStreamSource2_Vtbl {
     pub RemoveSampleRendered: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSource3, IMediaStreamSource3_Vtbl, 0x6a2a2746_3ddd_4ddf_a121_94045ecf9440);
+impl windows_core::RuntimeType for IMediaStreamSource3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSource3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -758,6 +905,9 @@ pub struct IMediaStreamSource3_Vtbl {
     pub MaxSupportedPlaybackRate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSource4, IMediaStreamSource4_Vtbl, 0x1d0cfcab_830d_417c_a3a9_2454fd6415c7);
+impl windows_core::RuntimeType for IMediaStreamSource4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSource4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -765,18 +915,27 @@ pub struct IMediaStreamSource4_Vtbl {
     pub IsLive: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceClosedEventArgs, IMediaStreamSourceClosedEventArgs_Vtbl, 0xcd8c7eb2_4816_4e24_88f0_491ef7386406);
+impl windows_core::RuntimeType for IMediaStreamSourceClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceClosedRequest, IMediaStreamSourceClosedRequest_Vtbl, 0x907c00e9_18a3_4951_887a_2c1eebd5c69e);
+impl windows_core::RuntimeType for IMediaStreamSourceClosedRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceClosedRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaStreamSourceClosedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceFactory, IMediaStreamSourceFactory_Vtbl, 0xef77e0d9_d158_4b7a_863f_203342fbfd41);
+impl windows_core::RuntimeType for IMediaStreamSourceFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -784,12 +943,18 @@ pub struct IMediaStreamSourceFactory_Vtbl {
     pub CreateFromDescriptors: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceSampleRenderedEventArgs, IMediaStreamSourceSampleRenderedEventArgs_Vtbl, 0x9d697b05_d4f2_4c7a_9dfe_8d6cd0b3ee84);
+impl windows_core::RuntimeType for IMediaStreamSourceSampleRenderedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceSampleRenderedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SampleLag: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceSampleRequest, IMediaStreamSourceSampleRequest_Vtbl, 0x4db341a9_3501_4d9b_83f9_8f235c822532);
+impl windows_core::RuntimeType for IMediaStreamSourceSampleRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceSampleRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -800,24 +965,36 @@ pub struct IMediaStreamSourceSampleRequest_Vtbl {
     pub ReportSampleProgress: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceSampleRequestDeferral, IMediaStreamSourceSampleRequestDeferral_Vtbl, 0x7895cc02_f982_43c8_9d16_c62d999319be);
+impl windows_core::RuntimeType for IMediaStreamSourceSampleRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceSampleRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceSampleRequestedEventArgs, IMediaStreamSourceSampleRequestedEventArgs_Vtbl, 0x10f9bb9e_71c5_492f_847f_0da1f35e81f8);
+impl windows_core::RuntimeType for IMediaStreamSourceSampleRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceSampleRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceStartingEventArgs, IMediaStreamSourceStartingEventArgs_Vtbl, 0xf41468f2_c274_4940_a5bb_28a572452fa7);
+impl windows_core::RuntimeType for IMediaStreamSourceStartingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceStartingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceStartingRequest, IMediaStreamSourceStartingRequest_Vtbl, 0x2a9093e4_35c4_4b1b_a791_0d99db56dd1d);
+impl windows_core::RuntimeType for IMediaStreamSourceStartingRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceStartingRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -826,12 +1003,18 @@ pub struct IMediaStreamSourceStartingRequest_Vtbl {
     pub SetActualStartPosition: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceStartingRequestDeferral, IMediaStreamSourceStartingRequestDeferral_Vtbl, 0x3f1356a5_6340_4dc4_9910_068ed9f598f8);
+impl windows_core::RuntimeType for IMediaStreamSourceStartingRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceStartingRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceSwitchStreamsRequest, IMediaStreamSourceSwitchStreamsRequest_Vtbl, 0x41b8808e_38a9_4ec3_9ba0_b69b85501e90);
+impl windows_core::RuntimeType for IMediaStreamSourceSwitchStreamsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceSwitchStreamsRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -840,12 +1023,18 @@ pub struct IMediaStreamSourceSwitchStreamsRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceSwitchStreamsRequestDeferral, IMediaStreamSourceSwitchStreamsRequestDeferral_Vtbl, 0xbee3d835_a505_4f9a_b943_2b8cb1b4bbd9);
+impl windows_core::RuntimeType for IMediaStreamSourceSwitchStreamsRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceSwitchStreamsRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaStreamSourceSwitchStreamsRequestedEventArgs, IMediaStreamSourceSwitchStreamsRequestedEventArgs_Vtbl, 0x42202b72_6ea1_4677_981e_350a0da412aa);
+impl windows_core::RuntimeType for IMediaStreamSourceSwitchStreamsRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaStreamSourceSwitchStreamsRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -900,6 +1089,9 @@ pub struct IMediaTrack_Vtbl {
     pub Label: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMseSourceBuffer, IMseSourceBuffer_Vtbl, 0x0c1aa3e3_df8d_4079_a3fe_6849184b4e2f);
+impl windows_core::RuntimeType for IMseSourceBuffer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMseSourceBuffer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -942,6 +1134,9 @@ pub struct IMseSourceBuffer_Vtbl {
     pub Remove: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMseSourceBufferList, IMseSourceBufferList_Vtbl, 0x95fae8e7_a8e7_4ebf_8927_145e940ba511);
+impl windows_core::RuntimeType for IMseSourceBufferList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMseSourceBufferList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -955,6 +1150,9 @@ pub struct IMseSourceBufferList_Vtbl {
     Buffers: usize,
 }
 windows_core::imp::define_interface!(IMseStreamSource, IMseStreamSource_Vtbl, 0xb0b4198d_02f4_4923_88dd_81bc3f360ffa);
+impl windows_core::RuntimeType for IMseStreamSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMseStreamSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -974,6 +1172,9 @@ pub struct IMseStreamSource_Vtbl {
     pub EndOfStream: unsafe extern "system" fn(*mut core::ffi::c_void, MseEndOfStreamStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMseStreamSource2, IMseStreamSource2_Vtbl, 0x66f57d37_f9e7_418a_9cde_a020e956552b);
+impl windows_core::RuntimeType for IMseStreamSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMseStreamSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -981,12 +1182,18 @@ pub struct IMseStreamSource2_Vtbl {
     pub SetLiveSeekableRange: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMseStreamSourceStatics, IMseStreamSourceStatics_Vtbl, 0x465c679d_d570_43ce_ba21_0bff5f3fbd0a);
+impl windows_core::RuntimeType for IMseStreamSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMseStreamSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsContentTypeSupported: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneAnalysisEffect, ISceneAnalysisEffect_Vtbl, 0xc04ba319_ca41_4813_bffd_7b08b0ed2557);
+impl windows_core::RuntimeType for ISceneAnalysisEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneAnalysisEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -997,6 +1204,9 @@ pub struct ISceneAnalysisEffect_Vtbl {
     pub RemoveSceneAnalyzed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneAnalysisEffectFrame, ISceneAnalysisEffectFrame_Vtbl, 0xd8b10e4c_7fd9_42e1_85eb_6572c297c987);
+impl windows_core::RuntimeType for ISceneAnalysisEffectFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneAnalysisEffectFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1007,12 +1217,18 @@ pub struct ISceneAnalysisEffectFrame_Vtbl {
     pub HighDynamicRange: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneAnalysisEffectFrame2, ISceneAnalysisEffectFrame2_Vtbl, 0x2d4e29be_061f_47ae_9915_02524b5f9a5f);
+impl windows_core::RuntimeType for ISceneAnalysisEffectFrame2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneAnalysisEffectFrame2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AnalysisRecommendation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SceneAnalysisRecommendation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneAnalyzedEventArgs, ISceneAnalyzedEventArgs_Vtbl, 0x146b9588_2851_45e4_ad55_44cf8df8db4d);
+impl windows_core::RuntimeType for ISceneAnalyzedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneAnalyzedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1059,6 +1275,9 @@ pub struct ISingleSelectMediaTrackList_Vtbl {
     pub SelectedIndex: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechCue, ISpeechCue_Vtbl, 0xaee254dc_1725_4bad_8043_a98499b017a2);
+impl windows_core::RuntimeType for ISpeechCue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechCue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1070,6 +1289,9 @@ pub struct ISpeechCue_Vtbl {
     pub SetEndPositionInInput: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataStreamDescriptor, ITimedMetadataStreamDescriptor_Vtbl, 0x133336bf_296a_463e_9ff9_01cd25691408);
+impl windows_core::RuntimeType for ITimedMetadataStreamDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataStreamDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1080,6 +1302,9 @@ pub struct ITimedMetadataStreamDescriptor_Vtbl {
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataStreamDescriptorFactory, ITimedMetadataStreamDescriptorFactory_Vtbl, 0xc027de30_7362_4ff9_98b1_2dfd0b8d1cae);
+impl windows_core::RuntimeType for ITimedMetadataStreamDescriptorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataStreamDescriptorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1089,6 +1314,9 @@ pub struct ITimedMetadataStreamDescriptorFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ITimedMetadataTrack, ITimedMetadataTrack_Vtbl, 0x9e6aed9e_f67a_49a9_b330_cf03b0e9cf07);
+impl windows_core::RuntimeType for ITimedMetadataTrack {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataTrack_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1112,6 +1340,9 @@ pub struct ITimedMetadataTrack_Vtbl {
     pub RemoveCue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataTrack2, ITimedMetadataTrack2_Vtbl, 0x21b4b648_9f9d_40ba_a8f3_1a92753aef0b);
+impl windows_core::RuntimeType for ITimedMetadataTrack2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataTrack2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1122,6 +1353,9 @@ pub struct ITimedMetadataTrack2_Vtbl {
     pub Name: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataTrackError, ITimedMetadataTrackError_Vtbl, 0xb3767915_4114_4819_b9d9_dd76089e72f8);
+impl windows_core::RuntimeType for ITimedMetadataTrackError {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataTrackError_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1129,12 +1363,18 @@ pub struct ITimedMetadataTrackError_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataTrackFactory, ITimedMetadataTrackFactory_Vtbl, 0x8dd57611_97b3_4e1f_852c_0f482c81ad26);
+impl windows_core::RuntimeType for ITimedMetadataTrackFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataTrackFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, TimedMetadataKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataTrackFailedEventArgs, ITimedMetadataTrackFailedEventArgs_Vtbl, 0xa57fc9d1_6789_4d4d_b07f_84b4f31acb70);
+impl windows_core::RuntimeType for ITimedMetadataTrackFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataTrackFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1164,6 +1404,9 @@ pub struct ITimedMetadataTrackProvider_Vtbl {
     TimedMetadataTracks: usize,
 }
 windows_core::imp::define_interface!(ITimedTextBouten, ITimedTextBouten_Vtbl, 0xd9062783_5597_5092_820c_8f738e0f774a);
+impl windows_core::RuntimeType for ITimedTextBouten {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextBouten_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1181,6 +1424,9 @@ pub struct ITimedTextBouten_Vtbl {
     pub SetPosition: unsafe extern "system" fn(*mut core::ffi::c_void, TimedTextBoutenPosition) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextCue, ITimedTextCue_Vtbl, 0x51c79e51_3b86_494d_b359_bb2ea7aca9a9);
+impl windows_core::RuntimeType for ITimedTextCue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextCue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1194,6 +1440,9 @@ pub struct ITimedTextCue_Vtbl {
     Lines: usize,
 }
 windows_core::imp::define_interface!(ITimedTextLine, ITimedTextLine_Vtbl, 0x978d7ce2_7308_4c66_be50_65777289f5df);
+impl windows_core::RuntimeType for ITimedTextLine {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextLine_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1205,6 +1454,9 @@ pub struct ITimedTextLine_Vtbl {
     Subformats: usize,
 }
 windows_core::imp::define_interface!(ITimedTextRegion, ITimedTextRegion_Vtbl, 0x1ed0881f_8a06_4222_9f59_b21bf40124b4);
+impl windows_core::RuntimeType for ITimedTextRegion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextRegion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1240,6 +1492,9 @@ pub struct ITimedTextRegion_Vtbl {
     pub SetScrollMode: unsafe extern "system" fn(*mut core::ffi::c_void, TimedTextScrollMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextRuby, ITimedTextRuby_Vtbl, 0x10335c29_5b3c_5693_9959_d05a0bd24628);
+impl windows_core::RuntimeType for ITimedTextRuby {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextRuby_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1253,6 +1508,9 @@ pub struct ITimedTextRuby_Vtbl {
     pub SetReserve: unsafe extern "system" fn(*mut core::ffi::c_void, TimedTextRubyReserve) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextSource, ITimedTextSource_Vtbl, 0xc4ed9ba6_101f_404d_a949_82f33fcd93b7);
+impl windows_core::RuntimeType for ITimedTextSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1260,6 +1518,9 @@ pub struct ITimedTextSource_Vtbl {
     pub RemoveResolved: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextSourceResolveResultEventArgs, ITimedTextSourceResolveResultEventArgs_Vtbl, 0x48907c9c_dcd8_4c33_9ad3_6cdce7b1c566);
+impl windows_core::RuntimeType for ITimedTextSourceResolveResultEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextSourceResolveResultEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1270,6 +1531,9 @@ pub struct ITimedTextSourceResolveResultEventArgs_Vtbl {
     Tracks: usize,
 }
 windows_core::imp::define_interface!(ITimedTextSourceStatics, ITimedTextSourceStatics_Vtbl, 0x7e311853_9aba_4ac4_bb98_2fb176c3bfdd);
+impl windows_core::RuntimeType for ITimedTextSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1285,6 +1549,9 @@ pub struct ITimedTextSourceStatics_Vtbl {
     pub CreateFromUriWithLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextSourceStatics2, ITimedTextSourceStatics2_Vtbl, 0xb66b7602_923e_43fa_9633_587075812db5);
+impl windows_core::RuntimeType for ITimedTextSourceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextSourceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1300,6 +1567,9 @@ pub struct ITimedTextSourceStatics2_Vtbl {
     pub CreateFromUriWithIndexAndLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextStyle, ITimedTextStyle_Vtbl, 0x1bb2384d_a825_40c2_a7f5_281eaedf3b55);
+impl windows_core::RuntimeType for ITimedTextStyle {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextStyle_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1347,6 +1617,9 @@ pub struct ITimedTextStyle_Vtbl {
     pub SetOutlineRadius: unsafe extern "system" fn(*mut core::ffi::c_void, TimedTextDouble) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextStyle2, ITimedTextStyle2_Vtbl, 0x655f492d_6111_4787_89cc_686fece57e14);
+impl windows_core::RuntimeType for ITimedTextStyle2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextStyle2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1360,6 +1633,9 @@ pub struct ITimedTextStyle2_Vtbl {
     pub SetIsOverlineEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextStyle3, ITimedTextStyle3_Vtbl, 0xf803f93b_3e99_595e_bbb7_78a2fa13c270);
+impl windows_core::RuntimeType for ITimedTextStyle3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextStyle3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1371,6 +1647,9 @@ pub struct ITimedTextStyle3_Vtbl {
     pub SetFontAngleInDegrees: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedTextSubformat, ITimedTextSubformat_Vtbl, 0xd713502f_3261_4722_a0c2_b937b2390f14);
+impl windows_core::RuntimeType for ITimedTextSubformat {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedTextSubformat_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1382,6 +1661,9 @@ pub struct ITimedTextSubformat_Vtbl {
     pub SetSubformatStyle: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoStabilizationEffect, IVideoStabilizationEffect_Vtbl, 0x0808a650_9698_4e57_877b_bd7cb2ee0f8a);
+impl windows_core::RuntimeType for IVideoStabilizationEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoStabilizationEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1395,12 +1677,18 @@ pub struct IVideoStabilizationEffect_Vtbl {
     GetRecommendedStreamConfiguration: usize,
 }
 windows_core::imp::define_interface!(IVideoStabilizationEffectEnabledChangedEventArgs, IVideoStabilizationEffectEnabledChangedEventArgs_Vtbl, 0x187eff28_67bb_4713_b900_4168da164529);
+impl windows_core::RuntimeType for IVideoStabilizationEffectEnabledChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoStabilizationEffectEnabledChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VideoStabilizationEffectEnabledChangedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoStreamDescriptor, IVideoStreamDescriptor_Vtbl, 0x12ee0d55_9c2b_4440_8057_2c7a90f0cbec);
+impl windows_core::RuntimeType for IVideoStreamDescriptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoStreamDescriptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1410,12 +1698,18 @@ pub struct IVideoStreamDescriptor_Vtbl {
     EncodingProperties: usize,
 }
 windows_core::imp::define_interface!(IVideoStreamDescriptor2, IVideoStreamDescriptor2_Vtbl, 0x8b306e10_453e_4088_832d_c36fa4f94af3);
+impl windows_core::RuntimeType for IVideoStreamDescriptor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoStreamDescriptor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoStreamDescriptorFactory, IVideoStreamDescriptorFactory_Vtbl, 0x494ef6d1_bb75_43d2_9e5e_7b79a3afced4);
+impl windows_core::RuntimeType for IVideoStreamDescriptorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoStreamDescriptorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1425,6 +1719,9 @@ pub struct IVideoStreamDescriptorFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IVideoTrack, IVideoTrack_Vtbl, 0x99f3b7f3_e298_4396_bb6a_a51be6a2a20a);
+impl windows_core::RuntimeType for IVideoTrack {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoTrack_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1442,12 +1739,18 @@ pub struct IVideoTrack_Vtbl {
     pub SupportInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoTrackOpenFailedEventArgs, IVideoTrackOpenFailedEventArgs_Vtbl, 0x7679e231_04f9_4c82_a4ee_8602c8bb4754);
+impl windows_core::RuntimeType for IVideoTrackOpenFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoTrackOpenFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoTrackSupportInfo, IVideoTrackSupportInfo_Vtbl, 0x4bb534a0_fc5f_450d_8ff0_778d590486de);
+impl windows_core::RuntimeType for IVideoTrackSupportInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoTrackSupportInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1560,7 +1863,7 @@ impl AudioStreamDescriptor {
     }
 }
 impl windows_core::RuntimeType for AudioStreamDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioStreamDescriptor>();
 }
 unsafe impl windows_core::Interface for AudioStreamDescriptor {
     type Vtable = IAudioStreamDescriptor_Vtbl;
@@ -1655,7 +1958,7 @@ impl AudioTrack {
     }
 }
 impl windows_core::RuntimeType for AudioTrack {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaTrack>();
 }
 unsafe impl windows_core::Interface for AudioTrack {
     type Vtable = IMediaTrack_Vtbl;
@@ -1680,7 +1983,7 @@ impl AudioTrackOpenFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AudioTrackOpenFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioTrackOpenFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for AudioTrackOpenFailedEventArgs {
     type Vtable = IAudioTrackOpenFailedEventArgs_Vtbl;
@@ -1726,7 +2029,7 @@ impl AudioTrackSupportInfo {
     }
 }
 impl windows_core::RuntimeType for AudioTrackSupportInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioTrackSupportInfo>();
 }
 unsafe impl windows_core::Interface for AudioTrackSupportInfo {
     type Vtable = IAudioTrackSupportInfo_Vtbl;
@@ -1796,7 +2099,7 @@ impl ChapterCue {
     }
 }
 impl windows_core::RuntimeType for ChapterCue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChapterCue>();
 }
 unsafe impl windows_core::Interface for ChapterCue {
     type Vtable = IChapterCue_Vtbl;
@@ -1850,7 +2153,7 @@ impl CodecInfo {
     }
 }
 impl windows_core::RuntimeType for CodecInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICodecInfo>();
 }
 unsafe impl windows_core::Interface for CodecInfo {
     type Vtable = ICodecInfo_Vtbl;
@@ -1883,7 +2186,7 @@ impl CodecQuery {
     }
 }
 impl windows_core::RuntimeType for CodecQuery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICodecQuery>();
 }
 unsafe impl windows_core::Interface for CodecQuery {
     type Vtable = ICodecQuery_Vtbl;
@@ -2283,7 +2586,7 @@ impl DataCue {
     }
 }
 impl windows_core::RuntimeType for DataCue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataCue>();
 }
 unsafe impl windows_core::Interface for DataCue {
     type Vtable = IDataCue_Vtbl;
@@ -2308,7 +2611,7 @@ impl FaceDetectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for FaceDetectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFaceDetectedEventArgs>();
 }
 unsafe impl windows_core::Interface for FaceDetectedEventArgs {
     type Vtable = IFaceDetectedEventArgs_Vtbl;
@@ -2371,7 +2674,7 @@ impl FaceDetectionEffect {
     }
 }
 impl windows_core::RuntimeType for FaceDetectionEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFaceDetectionEffect>();
 }
 unsafe impl windows_core::Interface for FaceDetectionEffect {
     type Vtable = IFaceDetectionEffect_Vtbl;
@@ -2440,7 +2743,7 @@ impl FaceDetectionEffectDefinition {
 }
 #[cfg(feature = "Media_Effects")]
 impl windows_core::RuntimeType for FaceDetectionEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::Effects::IVideoEffectDefinition>();
 }
 #[cfg(feature = "Media_Effects")]
 unsafe impl windows_core::Interface for FaceDetectionEffectDefinition {
@@ -2550,7 +2853,7 @@ impl FaceDetectionEffectFrame {
     }
 }
 impl windows_core::RuntimeType for FaceDetectionEffectFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFaceDetectionEffectFrame>();
 }
 unsafe impl windows_core::Interface for FaceDetectionEffectFrame {
     type Vtable = IFaceDetectionEffectFrame_Vtbl;
@@ -2579,7 +2882,7 @@ impl HighDynamicRangeControl {
     }
 }
 impl windows_core::RuntimeType for HighDynamicRangeControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHighDynamicRangeControl>();
 }
 unsafe impl windows_core::Interface for HighDynamicRangeControl {
     type Vtable = IHighDynamicRangeControl_Vtbl;
@@ -2612,7 +2915,7 @@ impl HighDynamicRangeOutput {
     }
 }
 impl windows_core::RuntimeType for HighDynamicRangeOutput {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHighDynamicRangeOutput>();
 }
 unsafe impl windows_core::Interface for HighDynamicRangeOutput {
     type Vtable = IHighDynamicRangeOutput_Vtbl;
@@ -2709,7 +3012,7 @@ impl ImageCue {
     }
 }
 impl windows_core::RuntimeType for ImageCue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageCue>();
 }
 unsafe impl windows_core::Interface for ImageCue {
     type Vtable = IImageCue_Vtbl;
@@ -2749,7 +3052,7 @@ impl InitializeMediaStreamSourceRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for InitializeMediaStreamSourceRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInitializeMediaStreamSourceRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for InitializeMediaStreamSourceRequestedEventArgs {
     type Vtable = IInitializeMediaStreamSourceRequestedEventArgs_Vtbl;
@@ -2814,7 +3117,7 @@ impl LowLightFusionResult {
     }
 }
 impl windows_core::RuntimeType for LowLightFusionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLightFusionResult>();
 }
 unsafe impl windows_core::Interface for LowLightFusionResult {
     type Vtable = ILowLightFusionResult_Vtbl;
@@ -2871,7 +3174,7 @@ impl MediaBinder {
     }
 }
 impl windows_core::RuntimeType for MediaBinder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBinder>();
 }
 unsafe impl windows_core::Interface for MediaBinder {
     type Vtable = IMediaBinder_Vtbl;
@@ -2964,7 +3267,7 @@ impl MediaBindingEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaBindingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBindingEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaBindingEventArgs {
     type Vtable = IMediaBindingEventArgs_Vtbl;
@@ -2989,7 +3292,7 @@ impl MediaCueEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaCueEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaCueEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaCueEventArgs {
     type Vtable = IMediaCueEventArgs_Vtbl;
@@ -3259,7 +3562,7 @@ impl MediaSource {
     }
 }
 impl windows_core::RuntimeType for MediaSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaSource2>();
 }
 unsafe impl windows_core::Interface for MediaSource {
     type Vtable = IMediaSource2_Vtbl;
@@ -3310,7 +3613,7 @@ impl MediaSourceAppServiceConnection {
     }
 }
 impl windows_core::RuntimeType for MediaSourceAppServiceConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaSourceAppServiceConnection>();
 }
 unsafe impl windows_core::Interface for MediaSourceAppServiceConnection {
     type Vtable = IMediaSourceAppServiceConnection_Vtbl;
@@ -3333,7 +3636,7 @@ impl MediaSourceError {
     }
 }
 impl windows_core::RuntimeType for MediaSourceError {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaSourceError>();
 }
 unsafe impl windows_core::Interface for MediaSourceError {
     type Vtable = IMediaSourceError_Vtbl;
@@ -3358,7 +3661,7 @@ impl MediaSourceOpenOperationCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaSourceOpenOperationCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaSourceOpenOperationCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaSourceOpenOperationCompletedEventArgs {
     type Vtable = IMediaSourceOpenOperationCompletedEventArgs_Vtbl;
@@ -3390,7 +3693,7 @@ impl MediaSourceStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaSourceStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaSourceStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaSourceStateChangedEventArgs {
     type Vtable = IMediaSourceStateChangedEventArgs_Vtbl;
@@ -3544,7 +3847,7 @@ impl MediaStreamSample {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSample {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSample>();
 }
 unsafe impl windows_core::Interface for MediaStreamSample {
     type Vtable = IMediaStreamSample_Vtbl;
@@ -3629,7 +3932,7 @@ impl MediaStreamSamplePropertySet {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for MediaStreamSamplePropertySet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IMap<windows_core::GUID, windows_core::IInspectable>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for MediaStreamSamplePropertySet {
@@ -3691,7 +3994,7 @@ impl MediaStreamSampleProtectionProperties {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSampleProtectionProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSampleProtectionProperties>();
 }
 unsafe impl windows_core::Interface for MediaStreamSampleProtectionProperties {
     type Vtable = IMediaStreamSampleProtectionProperties_Vtbl;
@@ -3946,7 +4249,7 @@ impl MediaStreamSource {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSource>();
 }
 unsafe impl windows_core::Interface for MediaStreamSource {
     type Vtable = IMediaStreamSource_Vtbl;
@@ -3971,7 +4274,7 @@ impl MediaStreamSourceClosedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceClosedEventArgs {
     type Vtable = IMediaStreamSourceClosedEventArgs_Vtbl;
@@ -3996,7 +4299,7 @@ impl MediaStreamSourceClosedRequest {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceClosedRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceClosedRequest>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceClosedRequest {
     type Vtable = IMediaStreamSourceClosedRequest_Vtbl;
@@ -4021,7 +4324,7 @@ impl MediaStreamSourceSampleRenderedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceSampleRenderedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceSampleRenderedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceSampleRenderedEventArgs {
     type Vtable = IMediaStreamSourceSampleRenderedEventArgs_Vtbl;
@@ -4071,7 +4374,7 @@ impl MediaStreamSourceSampleRequest {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceSampleRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceSampleRequest>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceSampleRequest {
     type Vtable = IMediaStreamSourceSampleRequest_Vtbl;
@@ -4093,7 +4396,7 @@ impl MediaStreamSourceSampleRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceSampleRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceSampleRequestDeferral>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceSampleRequestDeferral {
     type Vtable = IMediaStreamSourceSampleRequestDeferral_Vtbl;
@@ -4118,7 +4421,7 @@ impl MediaStreamSourceSampleRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceSampleRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceSampleRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceSampleRequestedEventArgs {
     type Vtable = IMediaStreamSourceSampleRequestedEventArgs_Vtbl;
@@ -4143,7 +4446,7 @@ impl MediaStreamSourceStartingEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceStartingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceStartingEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceStartingEventArgs {
     type Vtable = IMediaStreamSourceStartingEventArgs_Vtbl;
@@ -4179,7 +4482,7 @@ impl MediaStreamSourceStartingRequest {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceStartingRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceStartingRequest>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceStartingRequest {
     type Vtable = IMediaStreamSourceStartingRequest_Vtbl;
@@ -4201,7 +4504,7 @@ impl MediaStreamSourceStartingRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceStartingRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceStartingRequestDeferral>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceStartingRequestDeferral {
     type Vtable = IMediaStreamSourceStartingRequestDeferral_Vtbl;
@@ -4240,7 +4543,7 @@ impl MediaStreamSourceSwitchStreamsRequest {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceSwitchStreamsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceSwitchStreamsRequest>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceSwitchStreamsRequest {
     type Vtable = IMediaStreamSourceSwitchStreamsRequest_Vtbl;
@@ -4262,7 +4565,7 @@ impl MediaStreamSourceSwitchStreamsRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceSwitchStreamsRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceSwitchStreamsRequestDeferral>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceSwitchStreamsRequestDeferral {
     type Vtable = IMediaStreamSourceSwitchStreamsRequestDeferral_Vtbl;
@@ -4287,7 +4590,7 @@ impl MediaStreamSourceSwitchStreamsRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaStreamSourceSwitchStreamsRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamSourceSwitchStreamsRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaStreamSourceSwitchStreamsRequestedEventArgs {
     type Vtable = IMediaStreamSourceSwitchStreamsRequestedEventArgs_Vtbl;
@@ -4472,7 +4775,7 @@ impl MseSourceBuffer {
     }
 }
 impl windows_core::RuntimeType for MseSourceBuffer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMseSourceBuffer>();
 }
 unsafe impl windows_core::Interface for MseSourceBuffer {
     type Vtable = IMseSourceBuffer_Vtbl;
@@ -4526,7 +4829,7 @@ impl MseSourceBufferList {
     }
 }
 impl windows_core::RuntimeType for MseSourceBufferList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMseSourceBufferList>();
 }
 unsafe impl windows_core::Interface for MseSourceBufferList {
     type Vtable = IMseSourceBufferList_Vtbl;
@@ -4672,7 +4975,7 @@ impl MseStreamSource {
     }
 }
 impl windows_core::RuntimeType for MseStreamSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMseStreamSource>();
 }
 unsafe impl windows_core::Interface for MseStreamSource {
     type Vtable = IMseStreamSource_Vtbl;
@@ -4731,7 +5034,7 @@ impl SceneAnalysisEffect {
     }
 }
 impl windows_core::RuntimeType for SceneAnalysisEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneAnalysisEffect>();
 }
 unsafe impl windows_core::Interface for SceneAnalysisEffect {
     type Vtable = ISceneAnalysisEffect_Vtbl;
@@ -4778,7 +5081,7 @@ impl SceneAnalysisEffectDefinition {
 }
 #[cfg(feature = "Media_Effects")]
 impl windows_core::RuntimeType for SceneAnalysisEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::Effects::IVideoEffectDefinition>();
 }
 #[cfg(feature = "Media_Effects")]
 unsafe impl windows_core::Interface for SceneAnalysisEffectDefinition {
@@ -4902,7 +5205,7 @@ impl SceneAnalysisEffectFrame {
     }
 }
 impl windows_core::RuntimeType for SceneAnalysisEffectFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneAnalysisEffectFrame>();
 }
 unsafe impl windows_core::Interface for SceneAnalysisEffectFrame {
     type Vtable = ISceneAnalysisEffectFrame_Vtbl;
@@ -4927,7 +5230,7 @@ impl SceneAnalyzedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SceneAnalyzedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneAnalyzedEventArgs>();
 }
 unsafe impl windows_core::Interface for SceneAnalyzedEventArgs {
     type Vtable = ISceneAnalyzedEventArgs_Vtbl;
@@ -5025,7 +5328,7 @@ impl SpeechCue {
     }
 }
 impl windows_core::RuntimeType for SpeechCue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechCue>();
 }
 unsafe impl windows_core::Interface for SpeechCue {
     type Vtable = ISpeechCue_Vtbl;
@@ -5114,7 +5417,7 @@ impl TimedMetadataStreamDescriptor {
     }
 }
 impl windows_core::RuntimeType for TimedMetadataStreamDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaStreamDescriptor>();
 }
 unsafe impl windows_core::Interface for TimedMetadataStreamDescriptor {
     type Vtable = IMediaStreamDescriptor_Vtbl;
@@ -5277,7 +5580,7 @@ impl TimedMetadataTrack {
     }
 }
 impl windows_core::RuntimeType for TimedMetadataTrack {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedMetadataTrack>();
 }
 unsafe impl windows_core::Interface for TimedMetadataTrack {
     type Vtable = ITimedMetadataTrack_Vtbl;
@@ -5309,7 +5612,7 @@ impl TimedMetadataTrackError {
     }
 }
 impl windows_core::RuntimeType for TimedMetadataTrackError {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedMetadataTrackError>();
 }
 unsafe impl windows_core::Interface for TimedMetadataTrackError {
     type Vtable = ITimedMetadataTrackError_Vtbl;
@@ -5334,7 +5637,7 @@ impl TimedMetadataTrackFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TimedMetadataTrackFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedMetadataTrackFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for TimedMetadataTrackFailedEventArgs {
     type Vtable = ITimedMetadataTrackFailedEventArgs_Vtbl;
@@ -5387,7 +5690,7 @@ impl TimedTextBouten {
     }
 }
 impl windows_core::RuntimeType for TimedTextBouten {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextBouten>();
 }
 unsafe impl windows_core::Interface for TimedTextBouten {
     type Vtable = ITimedTextBouten_Vtbl;
@@ -5482,7 +5785,7 @@ impl TimedTextCue {
     }
 }
 impl windows_core::RuntimeType for TimedTextCue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextCue>();
 }
 unsafe impl windows_core::Interface for TimedTextCue {
     type Vtable = ITimedTextCue_Vtbl;
@@ -5526,7 +5829,7 @@ impl TimedTextLine {
     }
 }
 impl windows_core::RuntimeType for TimedTextLine {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextLine>();
 }
 unsafe impl windows_core::Interface for TimedTextLine {
     type Vtable = ITimedTextLine_Vtbl;
@@ -5685,7 +5988,7 @@ impl TimedTextRegion {
     }
 }
 impl windows_core::RuntimeType for TimedTextRegion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextRegion>();
 }
 unsafe impl windows_core::Interface for TimedTextRegion {
     type Vtable = ITimedTextRegion_Vtbl;
@@ -5747,7 +6050,7 @@ impl TimedTextRuby {
     }
 }
 impl windows_core::RuntimeType for TimedTextRuby {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextRuby>();
 }
 unsafe impl windows_core::Interface for TimedTextRuby {
     type Vtable = ITimedTextRuby_Vtbl;
@@ -5869,7 +6172,7 @@ impl TimedTextSource {
     }
 }
 impl windows_core::RuntimeType for TimedTextSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextSource>();
 }
 unsafe impl windows_core::Interface for TimedTextSource {
     type Vtable = ITimedTextSource_Vtbl;
@@ -5902,7 +6205,7 @@ impl TimedTextSourceResolveResultEventArgs {
     }
 }
 impl windows_core::RuntimeType for TimedTextSourceResolveResultEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextSourceResolveResultEventArgs>();
 }
 unsafe impl windows_core::Interface for TimedTextSourceResolveResultEventArgs {
     type Vtable = ITimedTextSourceResolveResultEventArgs_Vtbl;
@@ -6145,7 +6448,7 @@ impl TimedTextStyle {
     }
 }
 impl windows_core::RuntimeType for TimedTextStyle {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextStyle>();
 }
 unsafe impl windows_core::Interface for TimedTextStyle {
     type Vtable = ITimedTextStyle_Vtbl;
@@ -6206,7 +6509,7 @@ impl TimedTextSubformat {
     }
 }
 impl windows_core::RuntimeType for TimedTextSubformat {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedTextSubformat>();
 }
 unsafe impl windows_core::Interface for TimedTextSubformat {
     type Vtable = ITimedTextSubformat_Vtbl;
@@ -6270,7 +6573,7 @@ impl VideoStabilizationEffect {
     }
 }
 impl windows_core::RuntimeType for VideoStabilizationEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoStabilizationEffect>();
 }
 unsafe impl windows_core::Interface for VideoStabilizationEffect {
     type Vtable = IVideoStabilizationEffect_Vtbl;
@@ -6317,7 +6620,7 @@ impl VideoStabilizationEffectDefinition {
 }
 #[cfg(feature = "Media_Effects")]
 impl windows_core::RuntimeType for VideoStabilizationEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::Effects::IVideoEffectDefinition>();
 }
 #[cfg(feature = "Media_Effects")]
 unsafe impl windows_core::Interface for VideoStabilizationEffectDefinition {
@@ -6346,7 +6649,7 @@ impl VideoStabilizationEffectEnabledChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VideoStabilizationEffectEnabledChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoStabilizationEffectEnabledChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for VideoStabilizationEffectEnabledChangedEventArgs {
     type Vtable = IVideoStabilizationEffectEnabledChangedEventArgs_Vtbl;
@@ -6435,7 +6738,7 @@ impl VideoStreamDescriptor {
     }
 }
 impl windows_core::RuntimeType for VideoStreamDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoStreamDescriptor>();
 }
 unsafe impl windows_core::Interface for VideoStreamDescriptor {
     type Vtable = IVideoStreamDescriptor_Vtbl;
@@ -6530,7 +6833,7 @@ impl VideoTrack {
     }
 }
 impl windows_core::RuntimeType for VideoTrack {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaTrack>();
 }
 unsafe impl windows_core::Interface for VideoTrack {
     type Vtable = IMediaTrack_Vtbl;
@@ -6555,7 +6858,7 @@ impl VideoTrackOpenFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VideoTrackOpenFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoTrackOpenFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for VideoTrackOpenFailedEventArgs {
     type Vtable = IVideoTrackOpenFailedEventArgs_Vtbl;
@@ -6587,7 +6890,7 @@ impl VideoTrackSupportInfo {
     }
 }
 impl windows_core::RuntimeType for VideoTrackSupportInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoTrackSupportInfo>();
 }
 unsafe impl windows_core::Interface for VideoTrackSupportInfo {
     type Vtable = IVideoTrackSupportInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICameraIntrinsics, ICameraIntrinsics_Vtbl, 0x0aa6ed32_6589_49da_afde_594270ca0aac);
+impl windows_core::RuntimeType for ICameraIntrinsics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraIntrinsics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,6 +41,9 @@ pub struct ICameraIntrinsics_Vtbl {
     UnprojectPixelsAtUnitDepth: usize,
 }
 windows_core::imp::define_interface!(ICameraIntrinsics2, ICameraIntrinsics2_Vtbl, 0x0cdaa447_0798_4b4d_839f_c5ec414db27a);
+impl windows_core::RuntimeType for ICameraIntrinsics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraIntrinsics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,6 +57,9 @@ pub struct ICameraIntrinsics2_Vtbl {
     pub UndistortPoints: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::super::Foundation::Point, u32, *mut super::super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraIntrinsicsFactory, ICameraIntrinsicsFactory_Vtbl, 0xc0ddc486_2132_4a34_a659_9bfe2a055712);
+impl windows_core::RuntimeType for ICameraIntrinsicsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraIntrinsicsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +69,9 @@ pub struct ICameraIntrinsicsFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IDepthCorrelatedCoordinateMapper, IDepthCorrelatedCoordinateMapper_Vtbl, 0xf95d89fb_8af0_4cb0_926d_696866e5046a);
+impl windows_core::RuntimeType for IDepthCorrelatedCoordinateMapper {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDepthCorrelatedCoordinateMapper_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -81,6 +93,9 @@ pub struct IDepthCorrelatedCoordinateMapper_Vtbl {
     MapPoints: usize,
 }
 windows_core::imp::define_interface!(IFrameControlCapabilities, IFrameControlCapabilities_Vtbl, 0xa8ffae60_4e9e_4377_a789_e24c4ae7e544);
+impl windows_core::RuntimeType for IFrameControlCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameControlCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,12 +106,18 @@ pub struct IFrameControlCapabilities_Vtbl {
     pub PhotoConfirmationSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameControlCapabilities2, IFrameControlCapabilities2_Vtbl, 0xce9b0464_4730_440f_bd3e_efe8a8f230a8);
+impl windows_core::RuntimeType for IFrameControlCapabilities2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameControlCapabilities2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Flash: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameController, IFrameController_Vtbl, 0xc16459d9_baef_4052_9177_48aff2af7522);
+impl windows_core::RuntimeType for IFrameController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,12 +129,18 @@ pub struct IFrameController_Vtbl {
     pub SetPhotoConfirmationEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameController2, IFrameController2_Vtbl, 0x00d3bc75_d87c_485b_8a09_5c358568b427);
+impl windows_core::RuntimeType for IFrameController2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameController2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FlashControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameExposureCapabilities, IFrameExposureCapabilities_Vtbl, 0xbdbe9ce3_3985_4e72_97c2_0590d61307a1);
+impl windows_core::RuntimeType for IFrameExposureCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameExposureCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -123,6 +150,9 @@ pub struct IFrameExposureCapabilities_Vtbl {
     pub Step: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameExposureCompensationCapabilities, IFrameExposureCompensationCapabilities_Vtbl, 0xb988a823_8065_41ee_b04f_722265954500);
+impl windows_core::RuntimeType for IFrameExposureCompensationCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameExposureCompensationCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -132,6 +162,9 @@ pub struct IFrameExposureCompensationCapabilities_Vtbl {
     pub Step: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameExposureCompensationControl, IFrameExposureCompensationControl_Vtbl, 0xe95896c9_f7f9_48ca_8591_a26531cb1578);
+impl windows_core::RuntimeType for IFrameExposureCompensationControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameExposureCompensationControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +172,9 @@ pub struct IFrameExposureCompensationControl_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameExposureControl, IFrameExposureControl_Vtbl, 0xb1605a61_ffaf_4752_b621_f5b6f117f432);
+impl windows_core::RuntimeType for IFrameExposureControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameExposureControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,6 +184,9 @@ pub struct IFrameExposureControl_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameFlashCapabilities, IFrameFlashCapabilities_Vtbl, 0xbb9341a2_5ebe_4f62_8223_0e2b05bfbbd0);
+impl windows_core::RuntimeType for IFrameFlashCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameFlashCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +195,9 @@ pub struct IFrameFlashCapabilities_Vtbl {
     pub PowerSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameFlashControl, IFrameFlashControl_Vtbl, 0x75d5f6c7_bd45_4fab_9375_45ac04b332c2);
+impl windows_core::RuntimeType for IFrameFlashControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameFlashControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +211,9 @@ pub struct IFrameFlashControl_Vtbl {
     pub SetPowerPercent: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameFocusCapabilities, IFrameFocusCapabilities_Vtbl, 0x7b25cd58_01c0_4065_9c40_c1a721425c1a);
+impl windows_core::RuntimeType for IFrameFocusCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameFocusCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +223,9 @@ pub struct IFrameFocusCapabilities_Vtbl {
     pub Step: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameFocusControl, IFrameFocusControl_Vtbl, 0x272df1d0_d912_4214_a67b_e38a8d48d8c6);
+impl windows_core::RuntimeType for IFrameFocusControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameFocusControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -185,6 +233,9 @@ pub struct IFrameFocusControl_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameIsoSpeedCapabilities, IFrameIsoSpeedCapabilities_Vtbl, 0x16bdff61_6df6_4ac9_b92a_9f6ecd1ad2fa);
+impl windows_core::RuntimeType for IFrameIsoSpeedCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameIsoSpeedCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -194,6 +245,9 @@ pub struct IFrameIsoSpeedCapabilities_Vtbl {
     pub Step: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFrameIsoSpeedControl, IFrameIsoSpeedControl_Vtbl, 0x1a03efed_786a_4c75_a557_7ab9a85f588c);
+impl windows_core::RuntimeType for IFrameIsoSpeedControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFrameIsoSpeedControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,6 +257,9 @@ pub struct IFrameIsoSpeedControl_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVariablePhotoSequenceController, IVariablePhotoSequenceController_Vtbl, 0x7fbff880_ed8c_43fd_a7c3_b35809e4229a);
+impl windows_core::RuntimeType for IVariablePhotoSequenceController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVariablePhotoSequenceController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -345,7 +402,7 @@ impl CameraIntrinsics {
     }
 }
 impl windows_core::RuntimeType for CameraIntrinsics {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraIntrinsics>();
 }
 unsafe impl windows_core::Interface for CameraIntrinsics {
     type Vtable = ICameraIntrinsics_Vtbl;
@@ -408,7 +465,7 @@ impl DepthCorrelatedCoordinateMapper {
     }
 }
 impl windows_core::RuntimeType for DepthCorrelatedCoordinateMapper {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDepthCorrelatedCoordinateMapper>();
 }
 unsafe impl windows_core::Interface for DepthCorrelatedCoordinateMapper {
     type Vtable = IDepthCorrelatedCoordinateMapper_Vtbl;
@@ -468,7 +525,7 @@ impl FrameControlCapabilities {
     }
 }
 impl windows_core::RuntimeType for FrameControlCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameControlCapabilities>();
 }
 unsafe impl windows_core::Interface for FrameControlCapabilities {
     type Vtable = IFrameControlCapabilities_Vtbl;
@@ -540,7 +597,7 @@ impl FrameController {
     }
 }
 impl windows_core::RuntimeType for FrameController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameController>();
 }
 unsafe impl windows_core::Interface for FrameController {
     type Vtable = IFrameController_Vtbl;
@@ -586,7 +643,7 @@ impl FrameExposureCapabilities {
     }
 }
 impl windows_core::RuntimeType for FrameExposureCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameExposureCapabilities>();
 }
 unsafe impl windows_core::Interface for FrameExposureCapabilities {
     type Vtable = IFrameExposureCapabilities_Vtbl;
@@ -630,7 +687,7 @@ impl FrameExposureCompensationCapabilities {
     }
 }
 impl windows_core::RuntimeType for FrameExposureCompensationCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameExposureCompensationCapabilities>();
 }
 unsafe impl windows_core::Interface for FrameExposureCompensationCapabilities {
     type Vtable = IFrameExposureCompensationCapabilities_Vtbl;
@@ -660,7 +717,7 @@ impl FrameExposureCompensationControl {
     }
 }
 impl windows_core::RuntimeType for FrameExposureCompensationControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameExposureCompensationControl>();
 }
 unsafe impl windows_core::Interface for FrameExposureCompensationControl {
     type Vtable = IFrameExposureCompensationControl_Vtbl;
@@ -701,7 +758,7 @@ impl FrameExposureControl {
     }
 }
 impl windows_core::RuntimeType for FrameExposureControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameExposureControl>();
 }
 unsafe impl windows_core::Interface for FrameExposureControl {
     type Vtable = IFrameExposureControl_Vtbl;
@@ -738,7 +795,7 @@ impl FrameFlashCapabilities {
     }
 }
 impl windows_core::RuntimeType for FrameFlashCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameFlashCapabilities>();
 }
 unsafe impl windows_core::Interface for FrameFlashCapabilities {
     type Vtable = IFrameFlashCapabilities_Vtbl;
@@ -798,7 +855,7 @@ impl FrameFlashControl {
     }
 }
 impl windows_core::RuntimeType for FrameFlashControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameFlashControl>();
 }
 unsafe impl windows_core::Interface for FrameFlashControl {
     type Vtable = IFrameFlashControl_Vtbl;
@@ -842,7 +899,7 @@ impl FrameFocusCapabilities {
     }
 }
 impl windows_core::RuntimeType for FrameFocusCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameFocusCapabilities>();
 }
 unsafe impl windows_core::Interface for FrameFocusCapabilities {
     type Vtable = IFrameFocusCapabilities_Vtbl;
@@ -872,7 +929,7 @@ impl FrameFocusControl {
     }
 }
 impl windows_core::RuntimeType for FrameFocusControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameFocusControl>();
 }
 unsafe impl windows_core::Interface for FrameFocusControl {
     type Vtable = IFrameFocusControl_Vtbl;
@@ -916,7 +973,7 @@ impl FrameIsoSpeedCapabilities {
     }
 }
 impl windows_core::RuntimeType for FrameIsoSpeedCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameIsoSpeedCapabilities>();
 }
 unsafe impl windows_core::Interface for FrameIsoSpeedCapabilities {
     type Vtable = IFrameIsoSpeedCapabilities_Vtbl;
@@ -957,7 +1014,7 @@ impl FrameIsoSpeedControl {
     }
 }
 impl windows_core::RuntimeType for FrameIsoSpeedControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFrameIsoSpeedControl>();
 }
 unsafe impl windows_core::Interface for FrameIsoSpeedControl {
     type Vtable = IFrameIsoSpeedControl_Vtbl;
@@ -1032,7 +1089,7 @@ impl VariablePhotoSequenceController {
     }
 }
 impl windows_core::RuntimeType for VariablePhotoSequenceController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVariablePhotoSequenceController>();
 }
 unsafe impl windows_core::Interface for VariablePhotoSequenceController {
     type Vtable = IVariablePhotoSequenceController_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Media_Devices_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IAdvancedPhotoCaptureSettings, IAdvancedPhotoCaptureSettings_Vtbl, 0x08f3863a_0018_445b_93d2_646d1c5ed05c);
+impl windows_core::RuntimeType for IAdvancedPhotoCaptureSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedPhotoCaptureSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IAdvancedPhotoCaptureSettings_Vtbl {
     pub SetMode: unsafe extern "system" fn(*mut core::ffi::c_void, AdvancedPhotoMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedPhotoControl, IAdvancedPhotoControl_Vtbl, 0xc5b15486_9001_4682_9309_68eae0080eec);
+impl windows_core::RuntimeType for IAdvancedPhotoControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedPhotoControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct IAdvancedPhotoControl_Vtbl {
     pub Configure: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController, IAdvancedVideoCaptureDeviceController_Vtbl, 0xde6ff4d3_2b96_4583_80ab_b5b01dc6a8d7);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,12 +36,18 @@ pub struct IAdvancedVideoCaptureDeviceController_Vtbl {
     pub GetDeviceProperty: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController10, IAdvancedVideoCaptureDeviceController10_Vtbl, 0xc621b82d_d6f0_5c1b_a388_a6e938407146);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController10 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController10_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CameraOcclusionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController11, IAdvancedVideoCaptureDeviceController11_Vtbl, 0xd5b65ae2_3772_580c_a630_e75de9106904);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController11 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController11_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +57,9 @@ pub struct IAdvancedVideoCaptureDeviceController11_Vtbl {
     TryAcquireExclusiveControl: usize,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController2, IAdvancedVideoCaptureDeviceController2_Vtbl, 0x8bb94f8f_f11a_43db_b402_11930b80ae56);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +78,9 @@ pub struct IAdvancedVideoCaptureDeviceController2_Vtbl {
     pub SetPrimaryUse: unsafe extern "system" fn(*mut core::ffi::c_void, CaptureUse) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController3, IAdvancedVideoCaptureDeviceController3_Vtbl, 0xa98b8f34_ee0d_470c_b9f0_4229c4bbd089);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +92,9 @@ pub struct IAdvancedVideoCaptureDeviceController3_Vtbl {
     pub ZoomControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController4, IAdvancedVideoCaptureDeviceController4_Vtbl, 0xea9fbfaf_d371_41c3_9a17_824a87ebdfd2);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -82,6 +106,9 @@ pub struct IAdvancedVideoCaptureDeviceController4_Vtbl {
     pub AdvancedPhotoControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController5, IAdvancedVideoCaptureDeviceController5_Vtbl, 0x33512b17_b9cb_4a23_b875_f9eaab535492);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,30 +119,45 @@ pub struct IAdvancedVideoCaptureDeviceController5_Vtbl {
     pub SetDevicePropertyByExtendedId: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, u32, *const u8, *mut VideoDeviceControllerSetDevicePropertyStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController6, IAdvancedVideoCaptureDeviceController6_Vtbl, 0xb6563a53_68a1_44b7_9f89_b5fa97ac0cbe);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub VideoTemporalDenoisingControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController7, IAdvancedVideoCaptureDeviceController7_Vtbl, 0x8d2927f0_a054_50e7_b7df_7c04234d10f0);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InfraredTorchControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController8, IAdvancedVideoCaptureDeviceController8_Vtbl, 0xd843f010_e7fb_595b_9a78_0e54c4532b43);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController8 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController8_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PanelBasedOptimizationControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvancedVideoCaptureDeviceController9, IAdvancedVideoCaptureDeviceController9_Vtbl, 0x8bdca95d_0255_51bc_a10d_5a169ec1625a);
+impl windows_core::RuntimeType for IAdvancedVideoCaptureDeviceController9 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvancedVideoCaptureDeviceController9_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DigitalWindowControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioDeviceController, IAudioDeviceController_Vtbl, 0xedd4a388_79c7_4f7c_90e8_ef934b21580a);
+impl windows_core::RuntimeType for IAudioDeviceController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioDeviceController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -125,6 +167,9 @@ pub struct IAudioDeviceController_Vtbl {
     pub VolumePercent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioDeviceModule, IAudioDeviceModule_Vtbl, 0x86cfac36_47c1_4b33_9852_8773ec4be123);
+impl windows_core::RuntimeType for IAudioDeviceModule {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioDeviceModule_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +184,9 @@ pub struct IAudioDeviceModule_Vtbl {
     SendCommandAsync: usize,
 }
 windows_core::imp::define_interface!(IAudioDeviceModuleNotificationEventArgs, IAudioDeviceModuleNotificationEventArgs_Vtbl, 0xe3e3ccaf_224c_48be_956b_9a13134e96e8);
+impl windows_core::RuntimeType for IAudioDeviceModuleNotificationEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioDeviceModuleNotificationEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -149,6 +197,9 @@ pub struct IAudioDeviceModuleNotificationEventArgs_Vtbl {
     NotificationData: usize,
 }
 windows_core::imp::define_interface!(IAudioDeviceModulesManager, IAudioDeviceModulesManager_Vtbl, 0x6aa40c4d_960a_4d1c_b318_0022604547ed);
+impl windows_core::RuntimeType for IAudioDeviceModulesManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioDeviceModulesManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -164,12 +215,18 @@ pub struct IAudioDeviceModulesManager_Vtbl {
     FindAll: usize,
 }
 windows_core::imp::define_interface!(IAudioDeviceModulesManagerFactory, IAudioDeviceModulesManagerFactory_Vtbl, 0x8db03670_e64d_4773_96c0_bc7ebf0e063f);
+impl windows_core::RuntimeType for IAudioDeviceModulesManagerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioDeviceModulesManagerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICallControl, ICallControl_Vtbl, 0xa520d0d6_ae8d_45db_8011_ca49d3b3e578);
+impl windows_core::RuntimeType for ICallControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICallControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -192,6 +249,9 @@ pub struct ICallControl_Vtbl {
     pub RemoveAudioTransferRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICallControlStatics, ICallControlStatics_Vtbl, 0x03945ad5_85ab_40e1_af19_56c94303b019);
+impl windows_core::RuntimeType for ICallControlStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICallControlStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,6 +259,9 @@ pub struct ICallControlStatics_Vtbl {
     pub FromId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraOcclusionInfo, ICameraOcclusionInfo_Vtbl, 0xaf6c4ad0_a84d_5db6_be58_a5da21cfe011);
+impl windows_core::RuntimeType for ICameraOcclusionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraOcclusionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -208,6 +271,9 @@ pub struct ICameraOcclusionInfo_Vtbl {
     pub RemoveStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraOcclusionState, ICameraOcclusionState_Vtbl, 0x430adeb8_6842_5e55_9bde_04b4ef3a8a57);
+impl windows_core::RuntimeType for ICameraOcclusionState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraOcclusionState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,6 +281,9 @@ pub struct ICameraOcclusionState_Vtbl {
     pub IsOcclusionKind: unsafe extern "system" fn(*mut core::ffi::c_void, CameraOcclusionKind, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraOcclusionStateChangedEventArgs, ICameraOcclusionStateChangedEventArgs_Vtbl, 0x8512d848_c0de_57ca_a1ca_fb2c3d23df55);
+impl windows_core::RuntimeType for ICameraOcclusionStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraOcclusionStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +317,9 @@ pub struct IDefaultAudioDeviceChangedEventArgs_Vtbl {
     pub Role: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AudioDeviceRole) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialRequestedEventArgs, IDialRequestedEventArgs_Vtbl, 0x037b929e_953c_4286_8866_4f0f376c855a);
+impl windows_core::RuntimeType for IDialRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -255,6 +327,9 @@ pub struct IDialRequestedEventArgs_Vtbl {
     pub Contact: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDigitalWindowBounds, IDigitalWindowBounds_Vtbl, 0xdd4f21dd_d173_5c6b_8c25_bdd26d5122b1);
+impl windows_core::RuntimeType for IDigitalWindowBounds {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDigitalWindowBounds_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -266,6 +341,9 @@ pub struct IDigitalWindowBounds_Vtbl {
     pub SetScale: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDigitalWindowCapability, IDigitalWindowCapability_Vtbl, 0xd78bad2c_f721_5244_a196_b56ccbec606c);
+impl windows_core::RuntimeType for IDigitalWindowCapability {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDigitalWindowCapability_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -277,6 +355,9 @@ pub struct IDigitalWindowCapability_Vtbl {
     pub NormalizedFieldOfViewLimit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDigitalWindowControl, IDigitalWindowControl_Vtbl, 0x23b69eff_65d2_53ea_8780_de582b48b544);
+impl windows_core::RuntimeType for IDigitalWindowControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDigitalWindowControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -293,6 +374,9 @@ pub struct IDigitalWindowControl_Vtbl {
     pub GetCapabilityForSize: unsafe extern "system" fn(*mut core::ffi::c_void, i32, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IExposureCompensationControl, IExposureCompensationControl_Vtbl, 0x81c8e834_dcec_4011_a610_1f3847e64aca);
+impl windows_core::RuntimeType for IExposureCompensationControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExposureCompensationControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -304,6 +388,9 @@ pub struct IExposureCompensationControl_Vtbl {
     pub SetValueAsync: unsafe extern "system" fn(*mut core::ffi::c_void, f32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IExposureControl, IExposureControl_Vtbl, 0x09e8cbe2_ad96_4f28_a0e0_96ed7e1b5fd2);
+impl windows_core::RuntimeType for IExposureControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExposureControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -317,6 +404,9 @@ pub struct IExposureControl_Vtbl {
     pub SetValueAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IExposurePriorityVideoControl, IExposurePriorityVideoControl_Vtbl, 0x2cb240a3_5168_4271_9ea5_47621a98a352);
+impl windows_core::RuntimeType for IExposurePriorityVideoControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExposurePriorityVideoControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -325,6 +415,9 @@ pub struct IExposurePriorityVideoControl_Vtbl {
     pub SetEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFlashControl, IFlashControl_Vtbl, 0xdef41dbe_7d68_45e3_8c0f_be7bb32837d0);
+impl windows_core::RuntimeType for IFlashControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFlashControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -341,6 +434,9 @@ pub struct IFlashControl_Vtbl {
     pub SetPowerPercent: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFlashControl2, IFlashControl2_Vtbl, 0x7d29cc9e_75e1_4af7_bd7d_4e38e1c06cd6);
+impl windows_core::RuntimeType for IFlashControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFlashControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -349,6 +445,9 @@ pub struct IFlashControl2_Vtbl {
     pub SetAssistantLightEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFocusControl, IFocusControl_Vtbl, 0xc0d889f6_5228_4453_b153_85606592b238);
+impl windows_core::RuntimeType for IFocusControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFocusControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -368,6 +467,9 @@ pub struct IFocusControl_Vtbl {
     pub FocusAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFocusControl2, IFocusControl2_Vtbl, 0x3f7cff48_c534_4e9e_94c3_52ef2afd5d07);
+impl windows_core::RuntimeType for IFocusControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFocusControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -392,6 +494,9 @@ pub struct IFocusControl2_Vtbl {
     pub Configure: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFocusSettings, IFocusSettings_Vtbl, 0x79958f6b_3263_4275_85d6_aeae891c96ee);
+impl windows_core::RuntimeType for IFocusSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFocusSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -409,6 +514,9 @@ pub struct IFocusSettings_Vtbl {
     pub SetDisableDriverFallback: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHdrVideoControl, IHdrVideoControl_Vtbl, 0x55d8e2d0_30c0_43bf_9b9a_9799d70ced94);
+impl windows_core::RuntimeType for IHdrVideoControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHdrVideoControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -421,6 +529,9 @@ pub struct IHdrVideoControl_Vtbl {
     pub SetMode: unsafe extern "system" fn(*mut core::ffi::c_void, HdrVideoMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInfraredTorchControl, IInfraredTorchControl_Vtbl, 0x1cba2c83_6cb6_5a04_a6fc_3be7b33ff056);
+impl windows_core::RuntimeType for IInfraredTorchControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInfraredTorchControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -438,6 +549,9 @@ pub struct IInfraredTorchControl_Vtbl {
     pub SetPower: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsoSpeedControl, IIsoSpeedControl_Vtbl, 0x27b6c322_25ad_4f1b_aaab_524ab376ca33);
+impl windows_core::RuntimeType for IIsoSpeedControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsoSpeedControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -456,6 +570,9 @@ pub struct IIsoSpeedControl_Vtbl {
     SetPresetAsync: usize,
 }
 windows_core::imp::define_interface!(IIsoSpeedControl2, IIsoSpeedControl2_Vtbl, 0x6f1578f2_6d77_4f8a_8c2f_6130b6395053);
+impl windows_core::RuntimeType for IIsoSpeedControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsoSpeedControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -468,12 +585,18 @@ pub struct IIsoSpeedControl2_Vtbl {
     pub SetAutoAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeypadPressedEventArgs, IKeypadPressedEventArgs_Vtbl, 0xd3a43900_b4fa_49cd_9442_89af6568f601);
+impl windows_core::RuntimeType for IKeypadPressedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeypadPressedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TelephonyKey: unsafe extern "system" fn(*mut core::ffi::c_void, *mut TelephonyKey) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLagPhotoControl, ILowLagPhotoControl_Vtbl, 0x6d5c4dd0_fadf_415d_aee6_3baa529300c9);
+impl windows_core::RuntimeType for ILowLagPhotoControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLagPhotoControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -500,6 +623,9 @@ pub struct ILowLagPhotoControl_Vtbl {
     pub HardwareAcceleratedThumbnailSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILowLagPhotoSequenceControl, ILowLagPhotoSequenceControl_Vtbl, 0x3dcf909d_6d16_409c_bafe_b9a594c6fde6);
+impl windows_core::RuntimeType for ILowLagPhotoSequenceControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILowLagPhotoSequenceControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -533,6 +659,9 @@ pub struct ILowLagPhotoSequenceControl_Vtbl {
     pub HardwareAcceleratedThumbnailSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaDeviceControl, IMediaDeviceControl_Vtbl, 0xefa8dfa9_6f75_4863_ba0b_583f3036b4de);
+impl windows_core::RuntimeType for IMediaDeviceControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaDeviceControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -543,6 +672,9 @@ pub struct IMediaDeviceControl_Vtbl {
     pub TrySetAuto: unsafe extern "system" fn(*mut core::ffi::c_void, bool, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaDeviceControlCapabilities, IMediaDeviceControlCapabilities_Vtbl, 0x23005816_eb85_43e2_b92b_8240d5ee70ec);
+impl windows_core::RuntimeType for IMediaDeviceControlCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaDeviceControlCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -604,6 +736,9 @@ pub struct IMediaDeviceController_Vtbl {
     SetMediaStreamPropertiesAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaDeviceStatics, IMediaDeviceStatics_Vtbl, 0xaa2d9a40_909f_4bba_bf8b_0c0d296f14f0);
+impl windows_core::RuntimeType for IMediaDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -618,6 +753,9 @@ pub struct IMediaDeviceStatics_Vtbl {
     pub RemoveDefaultAudioRenderDeviceChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IModuleCommandResult, IModuleCommandResult_Vtbl, 0x520d1eb4_1374_4c7d_b1e4_39dcdf3eae4e);
+impl windows_core::RuntimeType for IModuleCommandResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IModuleCommandResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -628,6 +766,9 @@ pub struct IModuleCommandResult_Vtbl {
     Result: usize,
 }
 windows_core::imp::define_interface!(IOpticalImageStabilizationControl, IOpticalImageStabilizationControl_Vtbl, 0xbfad9c1d_00bc_423b_8eb2_a0178ca94247);
+impl windows_core::RuntimeType for IOpticalImageStabilizationControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOpticalImageStabilizationControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -640,6 +781,9 @@ pub struct IOpticalImageStabilizationControl_Vtbl {
     pub SetMode: unsafe extern "system" fn(*mut core::ffi::c_void, OpticalImageStabilizationMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPanelBasedOptimizationControl, IPanelBasedOptimizationControl_Vtbl, 0x33323223_6247_5419_a5a4_3d808645d917);
+impl windows_core::RuntimeType for IPanelBasedOptimizationControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPanelBasedOptimizationControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -654,6 +798,9 @@ pub struct IPanelBasedOptimizationControl_Vtbl {
     SetPanel: usize,
 }
 windows_core::imp::define_interface!(IPhotoConfirmationControl, IPhotoConfirmationControl_Vtbl, 0xc8f3f363_ff5e_4582_a9a8_0550f85a4a76);
+impl windows_core::RuntimeType for IPhotoConfirmationControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoConfirmationControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -670,12 +817,18 @@ pub struct IPhotoConfirmationControl_Vtbl {
     SetPixelFormat: usize,
 }
 windows_core::imp::define_interface!(IRedialRequestedEventArgs, IRedialRequestedEventArgs_Vtbl, 0x7eb55209_76ab_4c31_b40e_4b58379d580c);
+impl windows_core::RuntimeType for IRedialRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRedialRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Handled: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRegionOfInterest, IRegionOfInterest_Vtbl, 0xe5ecc834_ce66_4e05_a78f_cf391a5ec2d1);
+impl windows_core::RuntimeType for IRegionOfInterest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRegionOfInterest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -689,6 +842,9 @@ pub struct IRegionOfInterest_Vtbl {
     pub SetBounds: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRegionOfInterest2, IRegionOfInterest2_Vtbl, 0x19fe2a91_73aa_4d51_8a9d_56ccf7db7f54);
+impl windows_core::RuntimeType for IRegionOfInterest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRegionOfInterest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -700,6 +856,9 @@ pub struct IRegionOfInterest2_Vtbl {
     pub SetWeight: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRegionsOfInterestControl, IRegionsOfInterestControl_Vtbl, 0xc323f527_ab0b_4558_8b5b_df5693db0378);
+impl windows_core::RuntimeType for IRegionsOfInterestControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRegionsOfInterestControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -718,6 +877,9 @@ pub struct IRegionsOfInterestControl_Vtbl {
     pub AutoExposureSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneModeControl, ISceneModeControl_Vtbl, 0xd48e5af7_8d59_4854_8c62_12c70ba89b7c);
+impl windows_core::RuntimeType for ISceneModeControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneModeControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -729,6 +891,9 @@ pub struct ISceneModeControl_Vtbl {
     pub SetValueAsync: unsafe extern "system" fn(*mut core::ffi::c_void, CaptureSceneMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITorchControl, ITorchControl_Vtbl, 0xa6053665_8250_416c_919a_724296afa306);
+impl windows_core::RuntimeType for ITorchControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITorchControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -740,6 +905,9 @@ pub struct ITorchControl_Vtbl {
     pub SetPowerPercent: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoDeviceController, IVideoDeviceController_Vtbl, 0x99555575_2e2e_40b8_b6c7_f82d10013210);
+impl windows_core::RuntimeType for IVideoDeviceController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoDeviceController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -764,6 +932,9 @@ pub struct IVideoDeviceController_Vtbl {
     TryGetPowerlineFrequency: usize,
 }
 windows_core::imp::define_interface!(IVideoDeviceControllerGetDevicePropertyResult, IVideoDeviceControllerGetDevicePropertyResult_Vtbl, 0xc5d88395_6ed5_4790_8b5d_0ef13935d0f8);
+impl windows_core::RuntimeType for IVideoDeviceControllerGetDevicePropertyResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoDeviceControllerGetDevicePropertyResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -771,6 +942,9 @@ pub struct IVideoDeviceControllerGetDevicePropertyResult_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoTemporalDenoisingControl, IVideoTemporalDenoisingControl_Vtbl, 0x7ab34735_3e2a_4a32_baff_4358c4fbdd57);
+impl windows_core::RuntimeType for IVideoTemporalDenoisingControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoTemporalDenoisingControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -783,6 +957,9 @@ pub struct IVideoTemporalDenoisingControl_Vtbl {
     pub SetMode: unsafe extern "system" fn(*mut core::ffi::c_void, VideoTemporalDenoisingMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWhiteBalanceControl, IWhiteBalanceControl_Vtbl, 0x781f047e_7162_49c8_a8f9_9481c565363e);
+impl windows_core::RuntimeType for IWhiteBalanceControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWhiteBalanceControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -796,6 +973,9 @@ pub struct IWhiteBalanceControl_Vtbl {
     pub SetValueAsync: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IZoomControl, IZoomControl_Vtbl, 0x3a1e0b12_32da_4c17_bfd7_8d0c73c8f5a5);
+impl windows_core::RuntimeType for IZoomControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IZoomControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -807,6 +987,9 @@ pub struct IZoomControl_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IZoomControl2, IZoomControl2_Vtbl, 0x69843db0_2e99_4641_8529_184f319d1671);
+impl windows_core::RuntimeType for IZoomControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IZoomControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -818,6 +1001,9 @@ pub struct IZoomControl2_Vtbl {
     pub Configure: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IZoomSettings, IZoomSettings_Vtbl, 0x6ad66b24_14b4_4bfd_b18f_88fe24463b52);
+impl windows_core::RuntimeType for IZoomSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IZoomSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -851,7 +1037,7 @@ impl AdvancedPhotoCaptureSettings {
     }
 }
 impl windows_core::RuntimeType for AdvancedPhotoCaptureSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdvancedPhotoCaptureSettings>();
 }
 unsafe impl windows_core::Interface for AdvancedPhotoCaptureSettings {
     type Vtable = IAdvancedPhotoCaptureSettings_Vtbl;
@@ -898,7 +1084,7 @@ impl AdvancedPhotoControl {
     }
 }
 impl windows_core::RuntimeType for AdvancedPhotoControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdvancedPhotoControl>();
 }
 unsafe impl windows_core::Interface for AdvancedPhotoControl {
     type Vtable = IAdvancedPhotoControl_Vtbl;
@@ -966,7 +1152,7 @@ impl AudioDeviceController {
     }
 }
 impl windows_core::RuntimeType for AudioDeviceController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioDeviceController>();
 }
 unsafe impl windows_core::Interface for AudioDeviceController {
     type Vtable = IAudioDeviceController_Vtbl;
@@ -1028,7 +1214,7 @@ impl AudioDeviceModule {
     }
 }
 impl windows_core::RuntimeType for AudioDeviceModule {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioDeviceModule>();
 }
 unsafe impl windows_core::Interface for AudioDeviceModule {
     type Vtable = IAudioDeviceModule_Vtbl;
@@ -1059,7 +1245,7 @@ impl AudioDeviceModuleNotificationEventArgs {
     }
 }
 impl windows_core::RuntimeType for AudioDeviceModuleNotificationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioDeviceModuleNotificationEventArgs>();
 }
 unsafe impl windows_core::Interface for AudioDeviceModuleNotificationEventArgs {
     type Vtable = IAudioDeviceModuleNotificationEventArgs_Vtbl;
@@ -1118,7 +1304,7 @@ impl AudioDeviceModulesManager {
     }
 }
 impl windows_core::RuntimeType for AudioDeviceModulesManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioDeviceModulesManager>();
 }
 unsafe impl windows_core::Interface for AudioDeviceModulesManager {
     type Vtable = IAudioDeviceModulesManager_Vtbl;
@@ -1266,7 +1452,7 @@ impl CallControl {
     }
 }
 impl windows_core::RuntimeType for CallControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICallControl>();
 }
 unsafe impl windows_core::Interface for CallControl {
     type Vtable = ICallControl_Vtbl;
@@ -1312,7 +1498,7 @@ impl CameraOcclusionInfo {
     }
 }
 impl windows_core::RuntimeType for CameraOcclusionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraOcclusionInfo>();
 }
 unsafe impl windows_core::Interface for CameraOcclusionInfo {
     type Vtable = ICameraOcclusionInfo_Vtbl;
@@ -1344,7 +1530,7 @@ impl CameraOcclusionState {
     }
 }
 impl windows_core::RuntimeType for CameraOcclusionState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraOcclusionState>();
 }
 unsafe impl windows_core::Interface for CameraOcclusionState {
     type Vtable = ICameraOcclusionState_Vtbl;
@@ -1369,7 +1555,7 @@ impl CameraOcclusionStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CameraOcclusionStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraOcclusionStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for CameraOcclusionStateChangedEventArgs {
     type Vtable = ICameraOcclusionStateChangedEventArgs_Vtbl;
@@ -1402,7 +1588,7 @@ impl DefaultAudioCaptureDeviceChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DefaultAudioCaptureDeviceChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDefaultAudioDeviceChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for DefaultAudioCaptureDeviceChangedEventArgs {
     type Vtable = IDefaultAudioDeviceChangedEventArgs_Vtbl;
@@ -1435,7 +1621,7 @@ impl DefaultAudioRenderDeviceChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DefaultAudioRenderDeviceChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDefaultAudioDeviceChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for DefaultAudioRenderDeviceChangedEventArgs {
     type Vtable = IDefaultAudioDeviceChangedEventArgs_Vtbl;
@@ -1464,7 +1650,7 @@ impl DialRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DialRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for DialRequestedEventArgs {
     type Vtable = IDialRequestedEventArgs_Vtbl;
@@ -1522,7 +1708,7 @@ impl DigitalWindowBounds {
     }
 }
 impl windows_core::RuntimeType for DigitalWindowBounds {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDigitalWindowBounds>();
 }
 unsafe impl windows_core::Interface for DigitalWindowBounds {
     type Vtable = IDigitalWindowBounds_Vtbl;
@@ -1582,7 +1768,7 @@ impl DigitalWindowCapability {
     }
 }
 impl windows_core::RuntimeType for DigitalWindowCapability {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDigitalWindowCapability>();
 }
 unsafe impl windows_core::Interface for DigitalWindowCapability {
     type Vtable = IDigitalWindowCapability_Vtbl;
@@ -1654,7 +1840,7 @@ impl DigitalWindowControl {
     }
 }
 impl windows_core::RuntimeType for DigitalWindowControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDigitalWindowControl>();
 }
 unsafe impl windows_core::Interface for DigitalWindowControl {
     type Vtable = IDigitalWindowControl_Vtbl;
@@ -1714,7 +1900,7 @@ impl ExposureCompensationControl {
     }
 }
 impl windows_core::RuntimeType for ExposureCompensationControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExposureCompensationControl>();
 }
 unsafe impl windows_core::Interface for ExposureCompensationControl {
     type Vtable = IExposureCompensationControl_Vtbl;
@@ -1786,7 +1972,7 @@ impl ExposureControl {
     }
 }
 impl windows_core::RuntimeType for ExposureControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExposureControl>();
 }
 unsafe impl windows_core::Interface for ExposureControl {
     type Vtable = IExposureControl_Vtbl;
@@ -1820,7 +2006,7 @@ impl ExposurePriorityVideoControl {
     }
 }
 impl windows_core::RuntimeType for ExposurePriorityVideoControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExposurePriorityVideoControl>();
 }
 unsafe impl windows_core::Interface for ExposurePriorityVideoControl {
     type Vtable = IExposurePriorityVideoControl_Vtbl;
@@ -1921,7 +2107,7 @@ impl FlashControl {
     }
 }
 impl windows_core::RuntimeType for FlashControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFlashControl>();
 }
 unsafe impl windows_core::Interface for FlashControl {
     type Vtable = IFlashControl_Vtbl;
@@ -2088,7 +2274,7 @@ impl FocusControl {
     }
 }
 impl windows_core::RuntimeType for FocusControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFocusControl>();
 }
 unsafe impl windows_core::Interface for FocusControl {
     type Vtable = IFocusControl_Vtbl;
@@ -2183,7 +2369,7 @@ impl FocusSettings {
     }
 }
 impl windows_core::RuntimeType for FocusSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFocusSettings>();
 }
 unsafe impl windows_core::Interface for FocusSettings {
     type Vtable = IFocusSettings_Vtbl;
@@ -2227,7 +2413,7 @@ impl HdrVideoControl {
     }
 }
 impl windows_core::RuntimeType for HdrVideoControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHdrVideoControl>();
 }
 unsafe impl windows_core::Interface for HdrVideoControl {
     type Vtable = IHdrVideoControl_Vtbl;
@@ -2303,7 +2489,7 @@ impl InfraredTorchControl {
     }
 }
 impl windows_core::RuntimeType for InfraredTorchControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInfraredTorchControl>();
 }
 unsafe impl windows_core::Interface for InfraredTorchControl {
     type Vtable = IInfraredTorchControl_Vtbl;
@@ -2401,7 +2587,7 @@ impl IsoSpeedControl {
     }
 }
 impl windows_core::RuntimeType for IsoSpeedControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsoSpeedControl>();
 }
 unsafe impl windows_core::Interface for IsoSpeedControl {
     type Vtable = IIsoSpeedControl_Vtbl;
@@ -2424,7 +2610,7 @@ impl KeypadPressedEventArgs {
     }
 }
 impl windows_core::RuntimeType for KeypadPressedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeypadPressedEventArgs>();
 }
 unsafe impl windows_core::Interface for KeypadPressedEventArgs {
     type Vtable = IKeypadPressedEventArgs_Vtbl;
@@ -2503,7 +2689,7 @@ impl LowLagPhotoControl {
     }
 }
 impl windows_core::RuntimeType for LowLagPhotoControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLagPhotoControl>();
 }
 unsafe impl windows_core::Interface for LowLagPhotoControl {
     type Vtable = ILowLagPhotoControl_Vtbl;
@@ -2623,7 +2809,7 @@ impl LowLagPhotoSequenceControl {
     }
 }
 impl windows_core::RuntimeType for LowLagPhotoSequenceControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILowLagPhotoSequenceControl>();
 }
 unsafe impl windows_core::Interface for LowLagPhotoSequenceControl {
     type Vtable = ILowLagPhotoSequenceControl_Vtbl;
@@ -2739,7 +2925,7 @@ impl MediaDeviceControl {
     }
 }
 impl windows_core::RuntimeType for MediaDeviceControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaDeviceControl>();
 }
 unsafe impl windows_core::Interface for MediaDeviceControl {
     type Vtable = IMediaDeviceControl_Vtbl;
@@ -2797,7 +2983,7 @@ impl MediaDeviceControlCapabilities {
     }
 }
 impl windows_core::RuntimeType for MediaDeviceControlCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaDeviceControlCapabilities>();
 }
 unsafe impl windows_core::Interface for MediaDeviceControlCapabilities {
     type Vtable = IMediaDeviceControlCapabilities_Vtbl;
@@ -2828,7 +3014,7 @@ impl ModuleCommandResult {
     }
 }
 impl windows_core::RuntimeType for ModuleCommandResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IModuleCommandResult>();
 }
 unsafe impl windows_core::Interface for ModuleCommandResult {
     type Vtable = IModuleCommandResult_Vtbl;
@@ -2870,7 +3056,7 @@ impl OpticalImageStabilizationControl {
     }
 }
 impl windows_core::RuntimeType for OpticalImageStabilizationControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOpticalImageStabilizationControl>();
 }
 unsafe impl windows_core::Interface for OpticalImageStabilizationControl {
     type Vtable = IOpticalImageStabilizationControl_Vtbl;
@@ -2908,7 +3094,7 @@ impl PanelBasedOptimizationControl {
     }
 }
 impl windows_core::RuntimeType for PanelBasedOptimizationControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPanelBasedOptimizationControl>();
 }
 unsafe impl windows_core::Interface for PanelBasedOptimizationControl {
     type Vtable = IPanelBasedOptimizationControl_Vtbl;
@@ -2957,7 +3143,7 @@ impl PhotoConfirmationControl {
     }
 }
 impl windows_core::RuntimeType for PhotoConfirmationControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoConfirmationControl>();
 }
 unsafe impl windows_core::Interface for PhotoConfirmationControl {
     type Vtable = IPhotoConfirmationControl_Vtbl;
@@ -2977,7 +3163,7 @@ impl RedialRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RedialRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRedialRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for RedialRequestedEventArgs {
     type Vtable = IRedialRequestedEventArgs_Vtbl;
@@ -3079,7 +3265,7 @@ impl RegionOfInterest {
     }
 }
 impl windows_core::RuntimeType for RegionOfInterest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRegionOfInterest>();
 }
 unsafe impl windows_core::Interface for RegionOfInterest {
     type Vtable = IRegionOfInterest_Vtbl;
@@ -3154,7 +3340,7 @@ impl RegionsOfInterestControl {
     }
 }
 impl windows_core::RuntimeType for RegionsOfInterestControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRegionsOfInterestControl>();
 }
 unsafe impl windows_core::Interface for RegionsOfInterestControl {
     type Vtable = IRegionsOfInterestControl_Vtbl;
@@ -3192,7 +3378,7 @@ impl SceneModeControl {
     }
 }
 impl windows_core::RuntimeType for SceneModeControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneModeControl>();
 }
 unsafe impl windows_core::Interface for SceneModeControl {
     type Vtable = ISceneModeControl_Vtbl;
@@ -3244,7 +3430,7 @@ impl TorchControl {
     }
 }
 impl windows_core::RuntimeType for TorchControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITorchControl>();
 }
 unsafe impl windows_core::Interface for TorchControl {
     type Vtable = ITorchControl_Vtbl;
@@ -3631,7 +3817,7 @@ impl VideoDeviceController {
     }
 }
 impl windows_core::RuntimeType for VideoDeviceController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoDeviceController>();
 }
 unsafe impl windows_core::Interface for VideoDeviceController {
     type Vtable = IVideoDeviceController_Vtbl;
@@ -3661,7 +3847,7 @@ impl VideoDeviceControllerGetDevicePropertyResult {
     }
 }
 impl windows_core::RuntimeType for VideoDeviceControllerGetDevicePropertyResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoDeviceControllerGetDevicePropertyResult>();
 }
 unsafe impl windows_core::Interface for VideoDeviceControllerGetDevicePropertyResult {
     type Vtable = IVideoDeviceControllerGetDevicePropertyResult_Vtbl;
@@ -3705,7 +3891,7 @@ impl VideoTemporalDenoisingControl {
     }
 }
 impl windows_core::RuntimeType for VideoTemporalDenoisingControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoTemporalDenoisingControl>();
 }
 unsafe impl windows_core::Interface for VideoTemporalDenoisingControl {
     type Vtable = IVideoTemporalDenoisingControl_Vtbl;
@@ -3779,7 +3965,7 @@ impl WhiteBalanceControl {
     }
 }
 impl windows_core::RuntimeType for WhiteBalanceControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWhiteBalanceControl>();
 }
 unsafe impl windows_core::Interface for WhiteBalanceControl {
     type Vtable = IWhiteBalanceControl_Vtbl;
@@ -3856,7 +4042,7 @@ impl ZoomControl {
     }
 }
 impl windows_core::RuntimeType for ZoomControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IZoomControl>();
 }
 unsafe impl windows_core::Interface for ZoomControl {
     type Vtable = IZoomControl_Vtbl;
@@ -3901,7 +4087,7 @@ impl ZoomSettings {
     }
 }
 impl windows_core::RuntimeType for ZoomSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IZoomSettings>();
 }
 unsafe impl windows_core::Interface for ZoomSettings {
     type Vtable = IZoomSettings_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDialApp, IDialApp_Vtbl, 0x555ffbd3_45b7_49f3_bbd7_302db6084646);
+impl windows_core::RuntimeType for IDialApp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialApp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IDialApp_Vtbl {
     pub GetAppStateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialAppStateDetails, IDialAppStateDetails_Vtbl, 0xddc4a4a1_f5de_400d_bea4_8c8466bb2961);
+impl windows_core::RuntimeType for IDialAppStateDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialAppStateDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +21,9 @@ pub struct IDialAppStateDetails_Vtbl {
     pub FullXml: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialDevice, IDialDevice_Vtbl, 0xfff0edaf_759f_41d2_a20a_7f29ce0b3784);
+impl windows_core::RuntimeType for IDialDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +31,9 @@ pub struct IDialDevice_Vtbl {
     pub GetDialApp: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialDevice2, IDialDevice2_Vtbl, 0xbab7f3d5_5bfb_4eba_8b32_b57c5c5ee5c9);
+impl windows_core::RuntimeType for IDialDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +44,9 @@ pub struct IDialDevice2_Vtbl {
     Thumbnail: usize,
 }
 windows_core::imp::define_interface!(IDialDevicePicker, IDialDevicePicker_Vtbl, 0xba7e520a_ff59_4f4b_bdac_d89f495ad6e1);
+impl windows_core::RuntimeType for IDialDevicePicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialDevicePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +75,9 @@ pub struct IDialDevicePicker_Vtbl {
     pub SetDisplayStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, DialDeviceDisplayStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialDevicePickerFilter, IDialDevicePickerFilter_Vtbl, 0xc17c93ba_86c0_485d_b8d6_0f9a8f641590);
+impl windows_core::RuntimeType for IDialDevicePickerFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialDevicePickerFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,12 +87,18 @@ pub struct IDialDevicePickerFilter_Vtbl {
     SupportedAppNames: usize,
 }
 windows_core::imp::define_interface!(IDialDeviceSelectedEventArgs, IDialDeviceSelectedEventArgs_Vtbl, 0x480b92ad_ac76_47eb_9c06_a19304da0247);
+impl windows_core::RuntimeType for IDialDeviceSelectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialDeviceSelectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SelectedDialDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialDeviceStatics, IDialDeviceStatics_Vtbl, 0xaa69cc95_01f8_4758_8461_2bbd1cdc3cf3);
+impl windows_core::RuntimeType for IDialDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,12 +110,18 @@ pub struct IDialDeviceStatics_Vtbl {
     DeviceInfoSupportsDialAsync: usize,
 }
 windows_core::imp::define_interface!(IDialDisconnectButtonClickedEventArgs, IDialDisconnectButtonClickedEventArgs_Vtbl, 0x52765152_9c81_4e55_adc2_0ebe99cde3b6);
+impl windows_core::RuntimeType for IDialDisconnectButtonClickedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialDisconnectButtonClickedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Device: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialReceiverApp, IDialReceiverApp_Vtbl, 0xfd3e7c57_5045_470e_b304_4dd9b13e7d11);
+impl windows_core::RuntimeType for IDialReceiverApp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialReceiverApp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,12 +135,18 @@ pub struct IDialReceiverApp_Vtbl {
     SetAdditionalDataAsync: usize,
 }
 windows_core::imp::define_interface!(IDialReceiverApp2, IDialReceiverApp2_Vtbl, 0x530c5805_9130_42ac_a504_1977dcb2ea8a);
+impl windows_core::RuntimeType for IDialReceiverApp2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialReceiverApp2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetUniqueDeviceNameAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDialReceiverAppStatics, IDialReceiverAppStatics_Vtbl, 0x53183a3c_4c36_4d02_b28a_f2a9da38ec52);
+impl windows_core::RuntimeType for IDialReceiverAppStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDialReceiverAppStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,7 +187,7 @@ impl DialApp {
     }
 }
 impl windows_core::RuntimeType for DialApp {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialApp>();
 }
 unsafe impl windows_core::Interface for DialApp {
     type Vtable = IDialApp_Vtbl;
@@ -183,7 +219,7 @@ impl DialAppStateDetails {
     }
 }
 impl windows_core::RuntimeType for DialAppStateDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialAppStateDetails>();
 }
 unsafe impl windows_core::Interface for DialAppStateDetails {
     type Vtable = IDialAppStateDetails_Vtbl;
@@ -257,7 +293,7 @@ impl DialDevice {
     }
 }
 impl windows_core::RuntimeType for DialDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialDevice>();
 }
 unsafe impl windows_core::Interface for DialDevice {
     type Vtable = IDialDevice_Vtbl;
@@ -374,7 +410,7 @@ impl DialDevicePicker {
     }
 }
 impl windows_core::RuntimeType for DialDevicePicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialDevicePicker>();
 }
 unsafe impl windows_core::Interface for DialDevicePicker {
     type Vtable = IDialDevicePicker_Vtbl;
@@ -400,7 +436,7 @@ impl DialDevicePickerFilter {
     }
 }
 impl windows_core::RuntimeType for DialDevicePickerFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialDevicePickerFilter>();
 }
 unsafe impl windows_core::Interface for DialDevicePickerFilter {
     type Vtable = IDialDevicePickerFilter_Vtbl;
@@ -425,7 +461,7 @@ impl DialDeviceSelectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DialDeviceSelectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialDeviceSelectedEventArgs>();
 }
 unsafe impl windows_core::Interface for DialDeviceSelectedEventArgs {
     type Vtable = IDialDeviceSelectedEventArgs_Vtbl;
@@ -450,7 +486,7 @@ impl DialDisconnectButtonClickedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DialDisconnectButtonClickedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialDisconnectButtonClickedEventArgs>();
 }
 unsafe impl windows_core::Interface for DialDisconnectButtonClickedEventArgs {
     type Vtable = IDialDisconnectButtonClickedEventArgs_Vtbl;
@@ -505,7 +541,7 @@ impl DialReceiverApp {
     }
 }
 impl windows_core::RuntimeType for DialReceiverApp {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDialReceiverApp>();
 }
 unsafe impl windows_core::Interface for DialReceiverApp {
     type Vtable = IDialReceiverApp_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Editing/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Editing/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBackgroundAudioTrack, IBackgroundAudioTrack_Vtbl, 0x4b91b3bd_9e21_4266_a9c2_67dd011a2357);
+impl windows_core::RuntimeType for IBackgroundAudioTrack {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundAudioTrack_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +30,9 @@ pub struct IBackgroundAudioTrack_Vtbl {
     AudioEffectDefinitions: usize,
 }
 windows_core::imp::define_interface!(IBackgroundAudioTrackStatics, IBackgroundAudioTrackStatics_Vtbl, 0xd9b1c0d7_d018_42a8_a559_cb4d9e97e664);
+impl windows_core::RuntimeType for IBackgroundAudioTrackStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundAudioTrackStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +43,9 @@ pub struct IBackgroundAudioTrackStatics_Vtbl {
     CreateFromFileAsync: usize,
 }
 windows_core::imp::define_interface!(IEmbeddedAudioTrack, IEmbeddedAudioTrack_Vtbl, 0x55ee5a7a_2d30_3fba_a190_4f1a6454f88f);
+impl windows_core::RuntimeType for IEmbeddedAudioTrack {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmbeddedAudioTrack_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +55,9 @@ pub struct IEmbeddedAudioTrack_Vtbl {
     GetAudioEncodingProperties: usize,
 }
 windows_core::imp::define_interface!(IMediaClip, IMediaClip_Vtbl, 0x53f25366_5fba_3ea4_8693_24761811140a);
+impl windows_core::RuntimeType for IMediaClip {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaClip_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +96,9 @@ pub struct IMediaClip_Vtbl {
     VideoEffectDefinitions: usize,
 }
 windows_core::imp::define_interface!(IMediaClipStatics, IMediaClipStatics_Vtbl, 0xfa402b68_928f_43c4_bc6e_783a1a359656);
+impl windows_core::RuntimeType for IMediaClipStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaClipStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,6 +116,9 @@ pub struct IMediaClipStatics_Vtbl {
     CreateFromImageFileAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaClipStatics2, IMediaClipStatics2_Vtbl, 0x5b1dd7b3_854e_4d9b_877d_4774a556cd12);
+impl windows_core::RuntimeType for IMediaClipStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaClipStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -110,6 +128,9 @@ pub struct IMediaClipStatics2_Vtbl {
     CreateFromSurface: usize,
 }
 windows_core::imp::define_interface!(IMediaComposition, IMediaComposition_Vtbl, 0x2e06e605_dc71_41d6_b837_2d2bc14a2947);
+impl windows_core::RuntimeType for IMediaComposition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaComposition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +190,9 @@ pub struct IMediaComposition_Vtbl {
     GeneratePreviewMediaStreamSource: usize,
 }
 windows_core::imp::define_interface!(IMediaComposition2, IMediaComposition2_Vtbl, 0xa59e5372_2366_492c_bec8_e6dfba6d0281);
+impl windows_core::RuntimeType for IMediaComposition2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaComposition2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +202,9 @@ pub struct IMediaComposition2_Vtbl {
     OverlayLayers: usize,
 }
 windows_core::imp::define_interface!(IMediaCompositionStatics, IMediaCompositionStatics_Vtbl, 0x87a08f04_e32a_45ce_8f66_a30df0766224);
+impl windows_core::RuntimeType for IMediaCompositionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaCompositionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -187,6 +214,9 @@ pub struct IMediaCompositionStatics_Vtbl {
     LoadAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaOverlay, IMediaOverlay_Vtbl, 0xa902ae5d_7869_4830_8ab1_94dc01c05fa4);
+impl windows_core::RuntimeType for IMediaOverlay {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaOverlay_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -202,6 +232,9 @@ pub struct IMediaOverlay_Vtbl {
     pub SetAudioEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaOverlayFactory, IMediaOverlayFactory_Vtbl, 0xb584828a_6188_4f8f_a2e0_aa552d598e18);
+impl windows_core::RuntimeType for IMediaOverlayFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaOverlayFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -209,6 +242,9 @@ pub struct IMediaOverlayFactory_Vtbl {
     pub CreateWithPositionAndOpacity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, super::super::Foundation::Rect, f64, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaOverlayLayer, IMediaOverlayLayer_Vtbl, 0xa6d9ba57_eeda_46c6_bbe5_e398c84168ac);
+impl windows_core::RuntimeType for IMediaOverlayLayer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaOverlayLayer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -223,6 +259,9 @@ pub struct IMediaOverlayLayer_Vtbl {
     CustomCompositorDefinition: usize,
 }
 windows_core::imp::define_interface!(IMediaOverlayLayerFactory, IMediaOverlayLayerFactory_Vtbl, 0x947cb473_a39e_4362_abbf_9f8b5070a062);
+impl windows_core::RuntimeType for IMediaOverlayLayerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaOverlayLayerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -351,7 +390,7 @@ impl BackgroundAudioTrack {
     }
 }
 impl windows_core::RuntimeType for BackgroundAudioTrack {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundAudioTrack>();
 }
 unsafe impl windows_core::Interface for BackgroundAudioTrack {
     type Vtable = IBackgroundAudioTrack_Vtbl;
@@ -377,7 +416,7 @@ impl EmbeddedAudioTrack {
     }
 }
 impl windows_core::RuntimeType for EmbeddedAudioTrack {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmbeddedAudioTrack>();
 }
 unsafe impl windows_core::Interface for EmbeddedAudioTrack {
     type Vtable = IEmbeddedAudioTrack_Vtbl;
@@ -561,7 +600,7 @@ impl MediaClip {
     }
 }
 impl windows_core::RuntimeType for MediaClip {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaClip>();
 }
 unsafe impl windows_core::Interface for MediaClip {
     type Vtable = IMediaClip_Vtbl;
@@ -746,7 +785,7 @@ impl MediaComposition {
     }
 }
 impl windows_core::RuntimeType for MediaComposition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaComposition>();
 }
 unsafe impl windows_core::Interface for MediaComposition {
     type Vtable = IMediaComposition_Vtbl;
@@ -845,7 +884,7 @@ impl MediaOverlay {
     }
 }
 impl windows_core::RuntimeType for MediaOverlay {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaOverlay>();
 }
 unsafe impl windows_core::Interface for MediaOverlay {
     type Vtable = IMediaOverlay_Vtbl;
@@ -908,7 +947,7 @@ impl MediaOverlayLayer {
     }
 }
 impl windows_core::RuntimeType for MediaOverlayLayer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaOverlayLayer>();
 }
 unsafe impl windows_core::Interface for MediaOverlayLayer {
     type Vtable = IMediaOverlayLayer_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Effects/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAudioCaptureEffectsManager, IAudioCaptureEffectsManager_Vtbl, 0x8f85c271_038d_4393_8298_540110608eef);
+impl windows_core::RuntimeType for IAudioCaptureEffectsManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioCaptureEffectsManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IAudioCaptureEffectsManager_Vtbl {
     GetAudioCaptureEffects: usize,
 }
 windows_core::imp::define_interface!(IAudioEffect, IAudioEffect_Vtbl, 0x34aafa51_9207_4055_be93_6e5734a86ae4);
+impl windows_core::RuntimeType for IAudioEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +53,9 @@ pub struct IAudioEffectDefinition_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IAudioEffectDefinitionFactory, IAudioEffectDefinitionFactory_Vtbl, 0x8e1da646_e705_45ed_8a2b_fc4e4f405a97);
+impl windows_core::RuntimeType for IAudioEffectDefinitionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEffectDefinitionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +66,9 @@ pub struct IAudioEffectDefinitionFactory_Vtbl {
     CreateWithProperties: usize,
 }
 windows_core::imp::define_interface!(IAudioEffectsManagerStatics, IAudioEffectsManagerStatics_Vtbl, 0x66406c04_86fa_47cc_a315_f489d8c3fe10);
+impl windows_core::RuntimeType for IAudioEffectsManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEffectsManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +90,9 @@ pub struct IAudioEffectsManagerStatics_Vtbl {
     CreateAudioCaptureEffectsManagerWithMode: usize,
 }
 windows_core::imp::define_interface!(IAudioRenderEffectsManager, IAudioRenderEffectsManager_Vtbl, 0x4dc98966_8751_42b2_bfcb_39ca7864bd47);
+impl windows_core::RuntimeType for IAudioRenderEffectsManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioRenderEffectsManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +105,10 @@ pub struct IAudioRenderEffectsManager_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IAudioRenderEffectsManager2, IAudioRenderEffectsManager2_Vtbl, 0xa844cd09_5ecc_44b3_bb4e_1db07287139c);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IAudioRenderEffectsManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IAudioRenderEffectsManager2_Vtbl {
@@ -265,6 +284,9 @@ pub struct IBasicVideoEffect_Vtbl {
     pub DiscardQueuedFrames: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositeVideoFrameContext, ICompositeVideoFrameContext_Vtbl, 0x6c30024b_f514_4278_a5f7_b9188049d110);
+impl windows_core::RuntimeType for ICompositeVideoFrameContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositeVideoFrameContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -280,6 +302,9 @@ pub struct ICompositeVideoFrameContext_Vtbl {
     GetOverlayForSurface: usize,
 }
 windows_core::imp::define_interface!(IProcessAudioFrameContext, IProcessAudioFrameContext_Vtbl, 0x4cd92946_1222_4a27_a586_fb3e20273255);
+impl windows_core::RuntimeType for IProcessAudioFrameContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessAudioFrameContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -287,6 +312,9 @@ pub struct IProcessAudioFrameContext_Vtbl {
     pub OutputFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessVideoFrameContext, IProcessVideoFrameContext_Vtbl, 0x276f0e2b_6461_401e_ba78_0fdad6114eec);
+impl windows_core::RuntimeType for IProcessVideoFrameContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessVideoFrameContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,6 +322,9 @@ pub struct IProcessVideoFrameContext_Vtbl {
     pub OutputFrame: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISlowMotionEffectDefinition, ISlowMotionEffectDefinition_Vtbl, 0x35053cd0_176c_4763_82c4_1b02dbe31737);
+impl windows_core::RuntimeType for ISlowMotionEffectDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISlowMotionEffectDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -391,6 +422,9 @@ pub struct IVideoCompositorDefinition_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IVideoCompositorDefinitionFactory, IVideoCompositorDefinitionFactory_Vtbl, 0x4366fd10_68b8_4d52_89b6_02a968cca899);
+impl windows_core::RuntimeType for IVideoCompositorDefinitionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoCompositorDefinitionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -432,6 +466,9 @@ pub struct IVideoEffectDefinition_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IVideoEffectDefinitionFactory, IVideoEffectDefinitionFactory_Vtbl, 0x81439b4e_6e33_428f_9d21_b5aafef7617c);
+impl windows_core::RuntimeType for IVideoEffectDefinitionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEffectDefinitionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -442,6 +479,9 @@ pub struct IVideoEffectDefinitionFactory_Vtbl {
     CreateWithProperties: usize,
 }
 windows_core::imp::define_interface!(IVideoTransformEffectDefinition, IVideoTransformEffectDefinition_Vtbl, 0x9664bb6a_1ea6_4aa6_8074_abe8851ecae2);
+impl windows_core::RuntimeType for IVideoTransformEffectDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoTransformEffectDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -483,12 +523,18 @@ pub struct IVideoTransformEffectDefinition_Vtbl {
     ProcessingAlgorithm: usize,
 }
 windows_core::imp::define_interface!(IVideoTransformEffectDefinition2, IVideoTransformEffectDefinition2_Vtbl, 0xf0a8089f_66c8_4694_9fd9_1136abf7444a);
+impl windows_core::RuntimeType for IVideoTransformEffectDefinition2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoTransformEffectDefinition2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SphericalProjection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoTransformSphericalProjection, IVideoTransformSphericalProjection_Vtbl, 0xcf4401f0_9bf2_4c39_9f41_e022514a8468);
+impl windows_core::RuntimeType for IVideoTransformSphericalProjection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoTransformSphericalProjection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -550,7 +596,7 @@ impl AudioCaptureEffectsManager {
     }
 }
 impl windows_core::RuntimeType for AudioCaptureEffectsManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioCaptureEffectsManager>();
 }
 unsafe impl windows_core::Interface for AudioCaptureEffectsManager {
     type Vtable = IAudioCaptureEffectsManager_Vtbl;
@@ -575,7 +621,7 @@ impl AudioEffect {
     }
 }
 impl windows_core::RuntimeType for AudioEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioEffect>();
 }
 unsafe impl windows_core::Interface for AudioEffect {
     type Vtable = IAudioEffect_Vtbl;
@@ -630,7 +676,7 @@ impl AudioEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for AudioEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioEffectDefinition>();
 }
 unsafe impl windows_core::Interface for AudioEffectDefinition {
     type Vtable = IAudioEffectDefinition_Vtbl;
@@ -730,7 +776,7 @@ impl AudioRenderEffectsManager {
     }
 }
 impl windows_core::RuntimeType for AudioRenderEffectsManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioRenderEffectsManager>();
 }
 unsafe impl windows_core::Interface for AudioRenderEffectsManager {
     type Vtable = IAudioRenderEffectsManager_Vtbl;
@@ -781,7 +827,7 @@ impl CompositeVideoFrameContext {
     }
 }
 impl windows_core::RuntimeType for CompositeVideoFrameContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositeVideoFrameContext>();
 }
 unsafe impl windows_core::Interface for CompositeVideoFrameContext {
     type Vtable = ICompositeVideoFrameContext_Vtbl;
@@ -813,7 +859,7 @@ impl ProcessAudioFrameContext {
     }
 }
 impl windows_core::RuntimeType for ProcessAudioFrameContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessAudioFrameContext>();
 }
 unsafe impl windows_core::Interface for ProcessAudioFrameContext {
     type Vtable = IProcessAudioFrameContext_Vtbl;
@@ -845,7 +891,7 @@ impl ProcessVideoFrameContext {
     }
 }
 impl windows_core::RuntimeType for ProcessVideoFrameContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessVideoFrameContext>();
 }
 unsafe impl windows_core::Interface for ProcessVideoFrameContext {
     type Vtable = IProcessVideoFrameContext_Vtbl;
@@ -897,7 +943,7 @@ impl SlowMotionEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for SlowMotionEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISlowMotionEffectDefinition>();
 }
 unsafe impl windows_core::Interface for SlowMotionEffectDefinition {
     type Vtable = ISlowMotionEffectDefinition_Vtbl;
@@ -952,7 +998,7 @@ impl VideoCompositorDefinition {
     }
 }
 impl windows_core::RuntimeType for VideoCompositorDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoCompositorDefinition>();
 }
 unsafe impl windows_core::Interface for VideoCompositorDefinition {
     type Vtable = IVideoCompositorDefinition_Vtbl;
@@ -1007,7 +1053,7 @@ impl VideoEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for VideoEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoEffectDefinition>();
 }
 unsafe impl windows_core::Interface for VideoEffectDefinition {
     type Vtable = IVideoEffectDefinition_Vtbl;
@@ -1129,7 +1175,7 @@ impl VideoTransformEffectDefinition {
     }
 }
 impl windows_core::RuntimeType for VideoTransformEffectDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoEffectDefinition>();
 }
 unsafe impl windows_core::Interface for VideoTransformEffectDefinition {
     type Vtable = IVideoEffectDefinition_Vtbl;
@@ -1208,7 +1254,7 @@ impl VideoTransformSphericalProjection {
     }
 }
 impl windows_core::RuntimeType for VideoTransformSphericalProjection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoTransformSphericalProjection>();
 }
 unsafe impl windows_core::Interface for VideoTransformSphericalProjection {
     type Vtable = IVideoTransformSphericalProjection_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/FaceAnalysis/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/FaceAnalysis/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDetectedFace, IDetectedFace_Vtbl, 0x8200d454_66bc_34df_9410_e89400195414);
+impl windows_core::RuntimeType for IDetectedFace {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDetectedFace_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IDetectedFace_Vtbl {
     FaceBox: usize,
 }
 windows_core::imp::define_interface!(IFaceDetector, IFaceDetector_Vtbl, 0x16b672dc_fe6f_3117_8d95_c3f04d51630c);
+impl windows_core::RuntimeType for IFaceDetector {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceDetector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +43,9 @@ pub struct IFaceDetector_Vtbl {
     SetMaxDetectableFaceSize: usize,
 }
 windows_core::imp::define_interface!(IFaceDetectorStatics, IFaceDetectorStatics_Vtbl, 0xbc042d67_9047_33f6_881b_6746c1b218b8);
+impl windows_core::RuntimeType for IFaceDetectorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceDetectorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,6 +61,9 @@ pub struct IFaceDetectorStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFaceTracker, IFaceTracker_Vtbl, 0x6ba67d8c_a841_4420_93e6_2420a1884fcf);
+impl windows_core::RuntimeType for IFaceTracker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceTracker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +89,9 @@ pub struct IFaceTracker_Vtbl {
     SetMaxDetectableFaceSize: usize,
 }
 windows_core::imp::define_interface!(IFaceTrackerStatics, IFaceTrackerStatics_Vtbl, 0xe9629198_1801_3fa5_932e_31d767af6c4d);
+impl windows_core::RuntimeType for IFaceTrackerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFaceTrackerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,7 +121,7 @@ impl DetectedFace {
     }
 }
 impl windows_core::RuntimeType for DetectedFace {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDetectedFace>();
 }
 unsafe impl windows_core::Interface for DetectedFace {
     type Vtable = IDetectedFace_Vtbl;
@@ -203,7 +218,7 @@ impl FaceDetector {
     }
 }
 impl windows_core::RuntimeType for FaceDetector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFaceDetector>();
 }
 unsafe impl windows_core::Interface for FaceDetector {
     type Vtable = IFaceDetector_Vtbl;
@@ -289,7 +304,7 @@ impl FaceTracker {
     }
 }
 impl windows_core::RuntimeType for FaceTracker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFaceTracker>();
 }
 unsafe impl windows_core::Interface for FaceTracker {
     type Vtable = IFaceTracker_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Import/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Import/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPhotoImportDeleteImportedItemsFromSourceResult, IPhotoImportDeleteImportedItemsFromSourceResult_Vtbl, 0xf4e112f8_843d_428a_a1a6_81510292b0ae);
+impl windows_core::RuntimeType for IPhotoImportDeleteImportedItemsFromSourceResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportDeleteImportedItemsFromSourceResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +23,9 @@ pub struct IPhotoImportDeleteImportedItemsFromSourceResult_Vtbl {
     pub TotalSizeInBytes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportFindItemsResult, IPhotoImportFindItemsResult_Vtbl, 0x3915e647_6c78_492b_844e_8fe5e8f6bfb9);
+impl windows_core::RuntimeType for IPhotoImportFindItemsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportFindItemsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,12 +67,18 @@ pub struct IPhotoImportFindItemsResult_Vtbl {
     pub RemoveItemImported: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportFindItemsResult2, IPhotoImportFindItemsResult2_Vtbl, 0xfbdd6a3b_ecf9_406a_815e_5015625b0a88);
+impl windows_core::RuntimeType for IPhotoImportFindItemsResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportFindItemsResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AddItemsInDateRangeToSelection: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportImportItemsResult, IPhotoImportImportItemsResult_Vtbl, 0xe4d4f478_d419_4443_a84e_f06a850c0b00);
+impl windows_core::RuntimeType for IPhotoImportImportItemsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportImportItemsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +101,9 @@ pub struct IPhotoImportImportItemsResult_Vtbl {
     pub DeleteImportedItemsFromSourceAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportItem, IPhotoImportItem_Vtbl, 0xa9d07e76_9bfc_43b8_b356_633b6a988c9e);
+impl windows_core::RuntimeType for IPhotoImportItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,18 +137,27 @@ pub struct IPhotoImportItem_Vtbl {
     DeletedFileNames: usize,
 }
 windows_core::imp::define_interface!(IPhotoImportItem2, IPhotoImportItem2_Vtbl, 0xf1053505_f53b_46a3_9e30_3610791a9110);
+impl windows_core::RuntimeType for IPhotoImportItem2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportItem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Path: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportItemImportedEventArgs, IPhotoImportItemImportedEventArgs_Vtbl, 0x42cb2fdd_7d68_47b5_bc7c_ceb73e0c77dc);
+impl windows_core::RuntimeType for IPhotoImportItemImportedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportItemImportedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ImportedItem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportManagerStatics, IPhotoImportManagerStatics_Vtbl, 0x2771903d_a046_4f06_9b9c_bfd662e83287);
+impl windows_core::RuntimeType for IPhotoImportManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,6 +172,9 @@ pub struct IPhotoImportManagerStatics_Vtbl {
     GetPendingOperations: usize,
 }
 windows_core::imp::define_interface!(IPhotoImportOperation, IPhotoImportOperation_Vtbl, 0xd9f797e4_a09a_4ee4_a4b1_20940277a5be);
+impl windows_core::RuntimeType for IPhotoImportOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,12 +185,18 @@ pub struct IPhotoImportOperation_Vtbl {
     pub ContinueDeletingImportedItemsFromSourceAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportSelectionChangedEventArgs, IPhotoImportSelectionChangedEventArgs_Vtbl, 0x10461782_fa9d_4c30_8bc9_4d64911572d5);
+impl windows_core::RuntimeType for IPhotoImportSelectionChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportSelectionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSelectionEmpty: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportSession, IPhotoImportSession_Vtbl, 0xaa63916e_ecdb_4efe_94c6_5f5cafe34cfb);
+impl windows_core::RuntimeType for IPhotoImportSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -186,6 +219,9 @@ pub struct IPhotoImportSession_Vtbl {
     pub FindItemsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, PhotoImportContentTypeFilter, PhotoImportItemSelectionMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportSession2, IPhotoImportSession2_Vtbl, 0x2a526710_3ec6_469d_a375_2b9f4785391e);
+impl windows_core::RuntimeType for IPhotoImportSession2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportSession2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -195,6 +231,9 @@ pub struct IPhotoImportSession2_Vtbl {
     pub RememberDeselectedItems: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportSidecar, IPhotoImportSidecar_Vtbl, 0x46d7d757_f802_44c7_9c98_7a71f4bc1486);
+impl windows_core::RuntimeType for IPhotoImportSidecar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportSidecar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,6 +242,9 @@ pub struct IPhotoImportSidecar_Vtbl {
     pub Date: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportSource, IPhotoImportSource_Vtbl, 0x1f8ea35e_145b_4cd6_87f1_54965a982fef);
+impl windows_core::RuntimeType for IPhotoImportSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -231,6 +273,9 @@ pub struct IPhotoImportSource_Vtbl {
     pub CreateImportSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportSourceStatics, IPhotoImportSourceStatics_Vtbl, 0x0528e586_32d8_467c_8cee_23a1b2f43e85);
+impl windows_core::RuntimeType for IPhotoImportSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -241,6 +286,9 @@ pub struct IPhotoImportSourceStatics_Vtbl {
     FromFolderAsync: usize,
 }
 windows_core::imp::define_interface!(IPhotoImportStorageMedium, IPhotoImportStorageMedium_Vtbl, 0xf2b9b093_fc85_487f_87c2_58d675d05b07);
+impl windows_core::RuntimeType for IPhotoImportStorageMedium {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportStorageMedium_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +302,9 @@ pub struct IPhotoImportStorageMedium_Vtbl {
     pub Refresh: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhotoImportVideoSegment, IPhotoImportVideoSegment_Vtbl, 0x623c0289_321a_41d8_9166_8c62a333276c);
+impl windows_core::RuntimeType for IPhotoImportVideoSegment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhotoImportVideoSegment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -365,7 +416,7 @@ impl PhotoImportDeleteImportedItemsFromSourceResult {
     }
 }
 impl windows_core::RuntimeType for PhotoImportDeleteImportedItemsFromSourceResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportDeleteImportedItemsFromSourceResult>();
 }
 unsafe impl windows_core::Interface for PhotoImportDeleteImportedItemsFromSourceResult {
     type Vtable = IPhotoImportDeleteImportedItemsFromSourceResult_Vtbl;
@@ -610,7 +661,7 @@ impl PhotoImportFindItemsResult {
     }
 }
 impl windows_core::RuntimeType for PhotoImportFindItemsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportFindItemsResult>();
 }
 unsafe impl windows_core::Interface for PhotoImportFindItemsResult {
     type Vtable = IPhotoImportFindItemsResult_Vtbl;
@@ -727,7 +778,7 @@ impl PhotoImportImportItemsResult {
     }
 }
 impl windows_core::RuntimeType for PhotoImportImportItemsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportImportItemsResult>();
 }
 unsafe impl windows_core::Interface for PhotoImportImportItemsResult {
     type Vtable = IPhotoImportImportItemsResult_Vtbl;
@@ -845,7 +896,7 @@ impl PhotoImportItem {
     }
 }
 impl windows_core::RuntimeType for PhotoImportItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportItem>();
 }
 unsafe impl windows_core::Interface for PhotoImportItem {
     type Vtable = IPhotoImportItem_Vtbl;
@@ -870,7 +921,7 @@ impl PhotoImportItemImportedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PhotoImportItemImportedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportItemImportedEventArgs>();
 }
 unsafe impl windows_core::Interface for PhotoImportItemImportedEventArgs {
     type Vtable = IPhotoImportItemImportedEventArgs_Vtbl;
@@ -954,7 +1005,7 @@ impl PhotoImportOperation {
     }
 }
 impl windows_core::RuntimeType for PhotoImportOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportOperation>();
 }
 unsafe impl windows_core::Interface for PhotoImportOperation {
     type Vtable = IPhotoImportOperation_Vtbl;
@@ -979,7 +1030,7 @@ impl PhotoImportSelectionChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PhotoImportSelectionChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportSelectionChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for PhotoImportSelectionChangedEventArgs {
     type Vtable = IPhotoImportSelectionChangedEventArgs_Vtbl;
@@ -1094,7 +1145,7 @@ impl PhotoImportSession {
     }
 }
 impl windows_core::RuntimeType for PhotoImportSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportSession>();
 }
 unsafe impl windows_core::Interface for PhotoImportSession {
     type Vtable = IPhotoImportSession_Vtbl;
@@ -1133,7 +1184,7 @@ impl PhotoImportSidecar {
     }
 }
 impl windows_core::RuntimeType for PhotoImportSidecar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportSidecar>();
 }
 unsafe impl windows_core::Interface for PhotoImportSidecar {
     type Vtable = IPhotoImportSidecar_Vtbl;
@@ -1293,7 +1344,7 @@ impl PhotoImportSource {
     }
 }
 impl windows_core::RuntimeType for PhotoImportSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportSource>();
 }
 unsafe impl windows_core::Interface for PhotoImportSource {
     type Vtable = IPhotoImportSource_Vtbl;
@@ -1364,7 +1415,7 @@ impl PhotoImportStorageMedium {
     }
 }
 impl windows_core::RuntimeType for PhotoImportStorageMedium {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportStorageMedium>();
 }
 unsafe impl windows_core::Interface for PhotoImportStorageMedium {
     type Vtable = IPhotoImportStorageMedium_Vtbl;
@@ -1418,7 +1469,7 @@ impl PhotoImportVideoSegment {
     }
 }
 impl windows_core::RuntimeType for PhotoImportVideoSegment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhotoImportVideoSegment>();
 }
 unsafe impl windows_core::Interface for PhotoImportVideoSegment {
     type Vtable = IPhotoImportVideoSegment_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAudioEncodingProperties, IAudioEncodingProperties_Vtbl, 0x62bc7a16_005c_4b3b_8a0b_0a090e9687f3);
+impl windows_core::RuntimeType for IAudioEncodingProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEncodingProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,18 +15,27 @@ pub struct IAudioEncodingProperties_Vtbl {
     pub BitsPerSample: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioEncodingProperties2, IAudioEncodingProperties2_Vtbl, 0xc45d54da_80bd_4c23_80d5_72d4a181e894);
+impl windows_core::RuntimeType for IAudioEncodingProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEncodingProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSpatial: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioEncodingProperties3, IAudioEncodingProperties3_Vtbl, 0x87600341_748c_4f8d_b0fd_10caf08ff087);
+impl windows_core::RuntimeType for IAudioEncodingProperties3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEncodingProperties3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioEncodingPropertiesStatics, IAudioEncodingPropertiesStatics_Vtbl, 0x0cad332c_ebe9_4527_b36d_e42a13cf38db);
+impl windows_core::RuntimeType for IAudioEncodingPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEncodingPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +46,9 @@ pub struct IAudioEncodingPropertiesStatics_Vtbl {
     pub CreateWma: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioEncodingPropertiesStatics2, IAudioEncodingPropertiesStatics2_Vtbl, 0x7489316f_77a0_433d_8ed5_4040280e8665);
+impl windows_core::RuntimeType for IAudioEncodingPropertiesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEncodingPropertiesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +56,9 @@ pub struct IAudioEncodingPropertiesStatics2_Vtbl {
     pub CreateFlac: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioEncodingPropertiesWithFormatUserData, IAudioEncodingPropertiesWithFormatUserData_Vtbl, 0x98f10d79_13ea_49ff_be70_2673db69702c);
+impl windows_core::RuntimeType for IAudioEncodingPropertiesWithFormatUserData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioEncodingPropertiesWithFormatUserData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +66,9 @@ pub struct IAudioEncodingPropertiesWithFormatUserData_Vtbl {
     pub GetFormatUserData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAv1ProfileIdsStatics, IAv1ProfileIdsStatics_Vtbl, 0x9105812b_7c09_5882_88a4_678008a5174d);
+impl windows_core::RuntimeType for IAv1ProfileIdsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAv1ProfileIdsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -65,17 +86,26 @@ pub struct IAv1ProfileIdsStatics_Vtbl {
     pub ProfessionalChromaSubsampling422BitDepth12: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContainerEncodingProperties, IContainerEncodingProperties_Vtbl, 0x59ac2a57_b32a_479e_8a61_4b7f2e9e7ea0);
+impl windows_core::RuntimeType for IContainerEncodingProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContainerEncodingProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IContainerEncodingProperties2, IContainerEncodingProperties2_Vtbl, 0xb272c029_ae26_4819_baad_ad7a49b0a876);
+impl windows_core::RuntimeType for IContainerEncodingProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContainerEncodingProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IH264ProfileIdsStatics, IH264ProfileIdsStatics_Vtbl, 0x38654ca7_846a_4f97_a2e5_c3a15bbf70fd);
+impl windows_core::RuntimeType for IH264ProfileIdsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IH264ProfileIdsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,6 +121,9 @@ pub struct IH264ProfileIdsStatics_Vtbl {
     pub MultiviewHigh: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHevcProfileIdsStatics, IHevcProfileIdsStatics_Vtbl, 0x1e50d280_2aa7_53c1_973f_2189fa656f53);
+impl windows_core::RuntimeType for IHevcProfileIdsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHevcProfileIdsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,6 +151,9 @@ pub struct IHevcProfileIdsStatics_Vtbl {
     pub MainStillChromaSubsampling444BitDepth16: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageEncodingProperties, IImageEncodingProperties_Vtbl, 0x78625635_f331_4189_b1c3_b48d5ae034f1);
+impl windows_core::RuntimeType for IImageEncodingProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageEncodingProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,12 +163,18 @@ pub struct IImageEncodingProperties_Vtbl {
     pub Height: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageEncodingProperties2, IImageEncodingProperties2_Vtbl, 0xc854a2df_c923_469b_ac8e_6a9f3c1cd9e3);
+impl windows_core::RuntimeType for IImageEncodingProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageEncodingProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageEncodingPropertiesStatics, IImageEncodingPropertiesStatics_Vtbl, 0x257c68dc_8b99_439e_aa59_913a36161297);
+impl windows_core::RuntimeType for IImageEncodingPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageEncodingPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,6 +183,9 @@ pub struct IImageEncodingPropertiesStatics_Vtbl {
     pub CreateJpegXR: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageEncodingPropertiesStatics2, IImageEncodingPropertiesStatics2_Vtbl, 0xf6c25b29_3824_46b0_956e_501329e1be3c);
+impl windows_core::RuntimeType for IImageEncodingPropertiesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageEncodingPropertiesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,12 +193,18 @@ pub struct IImageEncodingPropertiesStatics2_Vtbl {
     pub CreateBmp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageEncodingPropertiesStatics3, IImageEncodingPropertiesStatics3_Vtbl, 0x48f4814d_a2ff_48dc_8ea0_e90680663656);
+impl windows_core::RuntimeType for IImageEncodingPropertiesStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageEncodingPropertiesStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateHeif: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingProfile, IMediaEncodingProfile_Vtbl, 0xe7dbf5a8_1db9_4783_876b_3dfe12acfdb3);
+impl windows_core::RuntimeType for IMediaEncodingProfile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingProfile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +216,9 @@ pub struct IMediaEncodingProfile_Vtbl {
     pub Container: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingProfile2, IMediaEncodingProfile2_Vtbl, 0x349b3e0a_4035_488e_9877_85632865ed10);
+impl windows_core::RuntimeType for IMediaEncodingProfile2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingProfile2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -186,6 +240,9 @@ pub struct IMediaEncodingProfile2_Vtbl {
     GetVideoTracks: usize,
 }
 windows_core::imp::define_interface!(IMediaEncodingProfile3, IMediaEncodingProfile3_Vtbl, 0xba6ebe88_7570_4e69_accf_5611ad015f88);
+impl windows_core::RuntimeType for IMediaEncodingProfile3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingProfile3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,6 +256,9 @@ pub struct IMediaEncodingProfile3_Vtbl {
     GetTimedMetadataTracks: usize,
 }
 windows_core::imp::define_interface!(IMediaEncodingProfileStatics, IMediaEncodingProfileStatics_Vtbl, 0x197f352c_2ede_4a45_a896_817a4854f8fe);
+impl windows_core::RuntimeType for IMediaEncodingProfileStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingProfileStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -217,6 +277,9 @@ pub struct IMediaEncodingProfileStatics_Vtbl {
     CreateFromStreamAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaEncodingProfileStatics2, IMediaEncodingProfileStatics2_Vtbl, 0xce8de74f_6af4_4288_8fe2_79adf1f79a43);
+impl windows_core::RuntimeType for IMediaEncodingProfileStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingProfileStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -224,6 +287,9 @@ pub struct IMediaEncodingProfileStatics2_Vtbl {
     pub CreateAvi: unsafe extern "system" fn(*mut core::ffi::c_void, VideoEncodingQuality, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingProfileStatics3, IMediaEncodingProfileStatics3_Vtbl, 0x90dac5aa_cf76_4294_a9ed_1a1420f51f6b);
+impl windows_core::RuntimeType for IMediaEncodingProfileStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingProfileStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -232,6 +298,9 @@ pub struct IMediaEncodingProfileStatics3_Vtbl {
     pub CreateHevc: unsafe extern "system" fn(*mut core::ffi::c_void, VideoEncodingQuality, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingProfileStatics4, IMediaEncodingProfileStatics4_Vtbl, 0x6fafd7b5_9404_514a_81dd_c9444d648af0);
+impl windows_core::RuntimeType for IMediaEncodingProfileStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingProfileStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -283,6 +352,9 @@ pub struct IMediaEncodingProperties_Vtbl {
     pub Subtype: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingSubtypesStatics, IMediaEncodingSubtypesStatics_Vtbl, 0x37b6580e_a171_4464_ba5a_53189e48c1c8);
+impl windows_core::RuntimeType for IMediaEncodingSubtypesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingSubtypesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -328,6 +400,9 @@ pub struct IMediaEncodingSubtypesStatics_Vtbl {
     pub Yv12: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingSubtypesStatics2, IMediaEncodingSubtypesStatics2_Vtbl, 0x4b7cd23d_42ff_4d33_8531_0626bee4b52d);
+impl windows_core::RuntimeType for IMediaEncodingSubtypesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingSubtypesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -337,6 +412,9 @@ pub struct IMediaEncodingSubtypesStatics2_Vtbl {
     pub D16: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingSubtypesStatics3, IMediaEncodingSubtypesStatics3_Vtbl, 0xba2414e4_883d_464e_a44f_097da08ef7ff);
+impl windows_core::RuntimeType for IMediaEncodingSubtypesStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingSubtypesStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -344,18 +422,27 @@ pub struct IMediaEncodingSubtypesStatics3_Vtbl {
     pub Flac: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingSubtypesStatics4, IMediaEncodingSubtypesStatics4_Vtbl, 0xddece58a_3949_4644_8a2c_59ef02c642fa);
+impl windows_core::RuntimeType for IMediaEncodingSubtypesStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingSubtypesStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub P010: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingSubtypesStatics5, IMediaEncodingSubtypesStatics5_Vtbl, 0x5ad4a007_ffce_4760_9828_5d0c99637e6a);
+impl windows_core::RuntimeType for IMediaEncodingSubtypesStatics5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingSubtypesStatics5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Heif: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingSubtypesStatics6, IMediaEncodingSubtypesStatics6_Vtbl, 0xa1252973_a984_5912_93bb_54e7e569e053);
+impl windows_core::RuntimeType for IMediaEncodingSubtypesStatics6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingSubtypesStatics6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -365,12 +452,18 @@ pub struct IMediaEncodingSubtypesStatics6_Vtbl {
     pub VobSub: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaEncodingSubtypesStatics7, IMediaEncodingSubtypesStatics7_Vtbl, 0x92f2dca7_9937_52a1_b619_ddfad81cd99c);
+impl windows_core::RuntimeType for IMediaEncodingSubtypesStatics7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaEncodingSubtypesStatics7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Av1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaRatio, IMediaRatio_Vtbl, 0xd2d0fee5_8929_401d_ac78_7d357e378163);
+impl windows_core::RuntimeType for IMediaRatio {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaRatio_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -380,6 +473,9 @@ pub struct IMediaRatio_Vtbl {
     pub Denominator: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMpeg2ProfileIdsStatics, IMpeg2ProfileIdsStatics_Vtbl, 0xa461ff85_e57a_4128_9b21_d5331b04235c);
+impl windows_core::RuntimeType for IMpeg2ProfileIdsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMpeg2ProfileIdsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -390,6 +486,9 @@ pub struct IMpeg2ProfileIdsStatics_Vtbl {
     pub High: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataEncodingProperties, ITimedMetadataEncodingProperties_Vtbl, 0x51cd30d3_d690_4cfa_97f4_4a398e9db420);
+impl windows_core::RuntimeType for ITimedMetadataEncodingProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataEncodingProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -398,6 +497,9 @@ pub struct ITimedMetadataEncodingProperties_Vtbl {
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataEncodingPropertiesStatics, ITimedMetadataEncodingPropertiesStatics_Vtbl, 0x6629bb67_6e55_5643_89a0_7a7e8d85b52c);
+impl windows_core::RuntimeType for ITimedMetadataEncodingPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataEncodingPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -407,6 +509,9 @@ pub struct ITimedMetadataEncodingPropertiesStatics_Vtbl {
     pub CreateVobSub: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingProperties, IVideoEncodingProperties_Vtbl, 0x76ee6c9a_37c2_4f2a_880a_1282bbb4373d);
+impl windows_core::RuntimeType for IVideoEncodingProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -420,6 +525,9 @@ pub struct IVideoEncodingProperties_Vtbl {
     pub PixelAspectRatio: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingProperties2, IVideoEncodingProperties2_Vtbl, 0xf743a1ef_d465_4290_a94b_ef0f1528f8e3);
+impl windows_core::RuntimeType for IVideoEncodingProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -429,24 +537,36 @@ pub struct IVideoEncodingProperties2_Vtbl {
     pub ProfileId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingProperties3, IVideoEncodingProperties3_Vtbl, 0x386bcdc4_873a_479f_b3eb_56c1fcbec6d7);
+impl windows_core::RuntimeType for IVideoEncodingProperties3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingProperties3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub StereoscopicVideoPackingMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut StereoscopicVideoPackingMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingProperties4, IVideoEncodingProperties4_Vtbl, 0x724ef014_c10c_40f2_9d72_3ee13b45fa8e);
+impl windows_core::RuntimeType for IVideoEncodingProperties4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingProperties4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SphericalVideoFrameFormat: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SphericalVideoFrameFormat) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingProperties5, IVideoEncodingProperties5_Vtbl, 0x4959080f_272f_4ece_a4df_c0ccdb33d840);
+impl windows_core::RuntimeType for IVideoEncodingProperties5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingProperties5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Copy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingPropertiesStatics, IVideoEncodingPropertiesStatics_Vtbl, 0x3ce14d44_1dc5_43db_9f38_ebebf90152cb);
+impl windows_core::RuntimeType for IVideoEncodingPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -455,12 +575,18 @@ pub struct IVideoEncodingPropertiesStatics_Vtbl {
     pub CreateUncompressed: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, u32, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingPropertiesStatics2, IVideoEncodingPropertiesStatics2_Vtbl, 0xcf1ebd5d_49fe_4d00_b59a_cfa4dfc51944);
+impl windows_core::RuntimeType for IVideoEncodingPropertiesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingPropertiesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateHevc: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoEncodingPropertiesStatics3, IVideoEncodingPropertiesStatics3_Vtbl, 0x65b46685_60da_5e51_91a2_b38c4763b872);
+impl windows_core::RuntimeType for IVideoEncodingPropertiesStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEncodingPropertiesStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -468,6 +594,9 @@ pub struct IVideoEncodingPropertiesStatics3_Vtbl {
     pub CreateAv1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVp9ProfileIdsStatics, IVp9ProfileIdsStatics_Vtbl, 0x20311a55_fe06_5883_92d9_6080c97743e5);
+impl windows_core::RuntimeType for IVp9ProfileIdsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVp9ProfileIdsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -634,7 +763,7 @@ impl AudioEncodingProperties {
     }
 }
 impl windows_core::RuntimeType for AudioEncodingProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioEncodingProperties>();
 }
 unsafe impl windows_core::Interface for AudioEncodingProperties {
     type Vtable = IAudioEncodingProperties_Vtbl;
@@ -776,7 +905,7 @@ impl ContainerEncodingProperties {
     }
 }
 impl windows_core::RuntimeType for ContainerEncodingProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContainerEncodingProperties>();
 }
 unsafe impl windows_core::Interface for ContainerEncodingProperties {
     type Vtable = IContainerEncodingProperties_Vtbl;
@@ -1122,7 +1251,7 @@ impl ImageEncodingProperties {
     }
 }
 impl windows_core::RuntimeType for ImageEncodingProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageEncodingProperties>();
 }
 unsafe impl windows_core::Interface for ImageEncodingProperties {
     type Vtable = IImageEncodingProperties_Vtbl;
@@ -1349,7 +1478,7 @@ impl MediaEncodingProfile {
     }
 }
 impl windows_core::RuntimeType for MediaEncodingProfile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaEncodingProfile>();
 }
 unsafe impl windows_core::Interface for MediaEncodingProfile {
     type Vtable = IMediaEncodingProfile_Vtbl;
@@ -1800,7 +1929,7 @@ impl MediaPropertySet {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for MediaPropertySet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IMap<windows_core::GUID, windows_core::IInspectable>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for MediaPropertySet {
@@ -1860,7 +1989,7 @@ impl MediaRatio {
     }
 }
 impl windows_core::RuntimeType for MediaRatio {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaRatio>();
 }
 unsafe impl windows_core::Interface for MediaRatio {
     type Vtable = IMediaRatio_Vtbl;
@@ -1997,7 +2126,7 @@ impl TimedMetadataEncodingProperties {
     }
 }
 impl windows_core::RuntimeType for TimedMetadataEncodingProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaEncodingProperties>();
 }
 unsafe impl windows_core::Interface for TimedMetadataEncodingProperties {
     type Vtable = IMediaEncodingProperties_Vtbl;
@@ -2187,7 +2316,7 @@ impl VideoEncodingProperties {
     }
 }
 impl windows_core::RuntimeType for VideoEncodingProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoEncodingProperties>();
 }
 unsafe impl windows_core::Interface for VideoEncodingProperties {
     type Vtable = IVideoEncodingProperties_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IMiracastReceiver, IMiracastReceiver_Vtbl, 0x7a315258_e444_51b4_aff7_b88daa1229e0);
+impl windows_core::RuntimeType for IMiracastReceiver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +26,9 @@ pub struct IMiracastReceiver_Vtbl {
     pub RemoveKnownTransmitter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverApplySettingsResult, IMiracastReceiverApplySettingsResult_Vtbl, 0xd0aa6272_09cd_58e1_a4f2_5d5143d312f9);
+impl windows_core::RuntimeType for IMiracastReceiverApplySettingsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverApplySettingsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +36,9 @@ pub struct IMiracastReceiverApplySettingsResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverConnection, IMiracastReceiverConnection_Vtbl, 0x704b2f36_d2e5_551f_a854_f822b7917d28);
+impl windows_core::RuntimeType for IMiracastReceiverConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +54,9 @@ pub struct IMiracastReceiverConnection_Vtbl {
     pub StreamControl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverConnectionCreatedEventArgs, IMiracastReceiverConnectionCreatedEventArgs_Vtbl, 0x7d8dfa39_307a_5c0f_94bd_d0c69d169982);
+impl windows_core::RuntimeType for IMiracastReceiverConnectionCreatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverConnectionCreatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +65,9 @@ pub struct IMiracastReceiverConnectionCreatedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverCursorImageChannel, IMiracastReceiverCursorImageChannel_Vtbl, 0xd9ac332d_723a_5a9d_b90a_81153efa2a0f);
+impl windows_core::RuntimeType for IMiracastReceiverCursorImageChannel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverCursorImageChannel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +90,9 @@ pub struct IMiracastReceiverCursorImageChannel_Vtbl {
     pub RemovePositionChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverCursorImageChannelSettings, IMiracastReceiverCursorImageChannelSettings_Vtbl, 0xccdbedff_bd00_5b9c_8e4c_00cacf86b634);
+impl windows_core::RuntimeType for IMiracastReceiverCursorImageChannelSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverCursorImageChannelSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,12 +108,18 @@ pub struct IMiracastReceiverCursorImageChannelSettings_Vtbl {
     SetMaxImageSize: usize,
 }
 windows_core::imp::define_interface!(IMiracastReceiverDisconnectedEventArgs, IMiracastReceiverDisconnectedEventArgs_Vtbl, 0xd9a15e5e_5fee_57e6_b4b0_04727db93229);
+impl windows_core::RuntimeType for IMiracastReceiverDisconnectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverDisconnectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverGameControllerDevice, IMiracastReceiverGameControllerDevice_Vtbl, 0x2d7171e8_bed4_5118_a058_e2477eb5888d);
+impl windows_core::RuntimeType for IMiracastReceiverGameControllerDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverGameControllerDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,6 +133,9 @@ pub struct IMiracastReceiverGameControllerDevice_Vtbl {
     pub RemoveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverInputDevices, IMiracastReceiverInputDevices_Vtbl, 0xda35bb02_28aa_5ee8_96f5_a42901c66f00);
+impl windows_core::RuntimeType for IMiracastReceiverInputDevices {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverInputDevices_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +143,9 @@ pub struct IMiracastReceiverInputDevices_Vtbl {
     pub GameController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverKeyboardDevice, IMiracastReceiverKeyboardDevice_Vtbl, 0xbeb67272_06c0_54ff_ac96_217464ff2501);
+impl windows_core::RuntimeType for IMiracastReceiverKeyboardDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverKeyboardDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,6 +157,9 @@ pub struct IMiracastReceiverKeyboardDevice_Vtbl {
     pub RemoveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverMediaSourceCreatedEventArgs, IMiracastReceiverMediaSourceCreatedEventArgs_Vtbl, 0x17cf519e_1246_531d_945a_6b158e39c3aa);
+impl windows_core::RuntimeType for IMiracastReceiverMediaSourceCreatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverMediaSourceCreatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +172,9 @@ pub struct IMiracastReceiverMediaSourceCreatedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverSession, IMiracastReceiverSession_Vtbl, 0x1d2bcdb4_ef8b_5209_bfc9_c32116504803);
+impl windows_core::RuntimeType for IMiracastReceiverSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +192,9 @@ pub struct IMiracastReceiverSession_Vtbl {
     pub StartAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverSessionStartResult, IMiracastReceiverSessionStartResult_Vtbl, 0xb7c573ee_40ca_51ff_95f2_c9de34f2e90e);
+impl windows_core::RuntimeType for IMiracastReceiverSessionStartResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverSessionStartResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -163,6 +202,9 @@ pub struct IMiracastReceiverSessionStartResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverSettings, IMiracastReceiverSettings_Vtbl, 0x57cd2f24_c55a_5fbe_9464_eb05307705dd);
+impl windows_core::RuntimeType for IMiracastReceiverSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +220,9 @@ pub struct IMiracastReceiverSettings_Vtbl {
     pub SetRequireAuthorizationFromKnownTransmitters: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverStatus, IMiracastReceiverStatus_Vtbl, 0xc28a5591_23ab_519e_ad09_90bff6dcc87e);
+impl windows_core::RuntimeType for IMiracastReceiverStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -191,6 +236,9 @@ pub struct IMiracastReceiverStatus_Vtbl {
     KnownTransmitters: usize,
 }
 windows_core::imp::define_interface!(IMiracastReceiverStreamControl, IMiracastReceiverStreamControl_Vtbl, 0x38ea2d8b_2769_5ad7_8a8a_254b9df7ba82);
+impl windows_core::RuntimeType for IMiracastReceiverStreamControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverStreamControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -202,6 +250,9 @@ pub struct IMiracastReceiverStreamControl_Vtbl {
     pub SetMuteAudio: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastReceiverVideoStreamSettings, IMiracastReceiverVideoStreamSettings_Vtbl, 0x169b5e1b_149d_52d0_b126_6f89744e4f50);
+impl windows_core::RuntimeType for IMiracastReceiverVideoStreamSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastReceiverVideoStreamSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -217,6 +268,9 @@ pub struct IMiracastReceiverVideoStreamSettings_Vtbl {
     pub SetBitrate: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMiracastTransmitter, IMiracastTransmitter_Vtbl, 0x342d79fd_2e64_5508_8a30_833d1eac70d0);
+impl windows_core::RuntimeType for IMiracastTransmitter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMiracastTransmitter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -347,7 +401,7 @@ impl MiracastReceiver {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiver {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiver>();
 }
 unsafe impl windows_core::Interface for MiracastReceiver {
     type Vtable = IMiracastReceiver_Vtbl;
@@ -379,7 +433,7 @@ impl MiracastReceiverApplySettingsResult {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverApplySettingsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverApplySettingsResult>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverApplySettingsResult {
     type Vtable = IMiracastReceiverApplySettingsResult_Vtbl;
@@ -460,7 +514,7 @@ impl MiracastReceiverConnection {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverConnection>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverConnection {
     type Vtable = IMiracastReceiverConnection_Vtbl;
@@ -499,7 +553,7 @@ impl MiracastReceiverConnectionCreatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverConnectionCreatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverConnectionCreatedEventArgs>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverConnectionCreatedEventArgs {
     type Vtable = IMiracastReceiverConnectionCreatedEventArgs_Vtbl;
@@ -576,7 +630,7 @@ impl MiracastReceiverCursorImageChannel {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverCursorImageChannel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverCursorImageChannel>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverCursorImageChannel {
     type Vtable = IMiracastReceiverCursorImageChannel_Vtbl;
@@ -618,7 +672,7 @@ impl MiracastReceiverCursorImageChannelSettings {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverCursorImageChannelSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverCursorImageChannelSettings>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverCursorImageChannelSettings {
     type Vtable = IMiracastReceiverCursorImageChannelSettings_Vtbl;
@@ -643,7 +697,7 @@ impl MiracastReceiverDisconnectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverDisconnectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverDisconnectedEventArgs>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverDisconnectedEventArgs {
     type Vtable = IMiracastReceiverDisconnectedEventArgs_Vtbl;
@@ -711,7 +765,7 @@ impl MiracastReceiverGameControllerDevice {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverGameControllerDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverGameControllerDevice>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverGameControllerDevice {
     type Vtable = IMiracastReceiverGameControllerDevice_Vtbl;
@@ -743,7 +797,7 @@ impl MiracastReceiverInputDevices {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverInputDevices {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverInputDevices>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverInputDevices {
     type Vtable = IMiracastReceiverInputDevices_Vtbl;
@@ -800,7 +854,7 @@ impl MiracastReceiverKeyboardDevice {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverKeyboardDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverKeyboardDevice>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverKeyboardDevice {
     type Vtable = IMiracastReceiverKeyboardDevice_Vtbl;
@@ -847,7 +901,7 @@ impl MiracastReceiverMediaSourceCreatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverMediaSourceCreatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverMediaSourceCreatedEventArgs>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverMediaSourceCreatedEventArgs {
     type Vtable = IMiracastReceiverMediaSourceCreatedEventArgs_Vtbl;
@@ -948,7 +1002,7 @@ impl MiracastReceiverSession {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverSession>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverSession {
     type Vtable = IMiracastReceiverSession_Vtbl;
@@ -980,7 +1034,7 @@ impl MiracastReceiverSessionStartResult {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverSessionStartResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverSessionStartResult>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverSessionStartResult {
     type Vtable = IMiracastReceiverSessionStartResult_Vtbl;
@@ -1053,7 +1107,7 @@ impl MiracastReceiverSettings {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverSettings>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverSettings {
     type Vtable = IMiracastReceiverSettings_Vtbl;
@@ -1107,7 +1161,7 @@ impl MiracastReceiverStatus {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverStatus>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverStatus {
     type Vtable = IMiracastReceiverStatus_Vtbl;
@@ -1167,7 +1221,7 @@ impl MiracastReceiverStreamControl {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverStreamControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverStreamControl>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverStreamControl {
     type Vtable = IMiracastReceiverStreamControl_Vtbl;
@@ -1209,7 +1263,7 @@ impl MiracastReceiverVideoStreamSettings {
     }
 }
 impl windows_core::RuntimeType for MiracastReceiverVideoStreamSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastReceiverVideoStreamSettings>();
 }
 unsafe impl windows_core::Interface for MiracastReceiverVideoStreamSettings {
     type Vtable = IMiracastReceiverVideoStreamSettings_Vtbl;
@@ -1271,7 +1325,7 @@ impl MiracastTransmitter {
     }
 }
 impl windows_core::RuntimeType for MiracastTransmitter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMiracastTransmitter>();
 }
 unsafe impl windows_core::Interface for MiracastTransmitter {
     type Vtable = IMiracastTransmitter_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Ocr/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Ocr/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IOcrEngine, IOcrEngine_Vtbl, 0x5a14bc41_5b76_3140_b680_8825562683ac);
+impl windows_core::RuntimeType for IOcrEngine {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOcrEngine_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct IOcrEngine_Vtbl {
     RecognizerLanguage: usize,
 }
 windows_core::imp::define_interface!(IOcrEngineStatics, IOcrEngineStatics_Vtbl, 0x5bffa85a_3384_3540_9940_699120d428a8);
+impl windows_core::RuntimeType for IOcrEngineStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOcrEngineStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +37,9 @@ pub struct IOcrEngineStatics_Vtbl {
     pub TryCreateFromUserProfileLanguages: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOcrLine, IOcrLine_Vtbl, 0x0043a16f_e31f_3a24_899c_d444bd088124);
+impl windows_core::RuntimeType for IOcrLine {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOcrLine_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +50,9 @@ pub struct IOcrLine_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOcrResult, IOcrResult_Vtbl, 0x9bd235b2_175b_3d6a_92e2_388c206e2f63);
+impl windows_core::RuntimeType for IOcrResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOcrResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,6 +64,9 @@ pub struct IOcrResult_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOcrWord, IOcrWord_Vtbl, 0x3c2a477a_5cd9_3525_ba2a_23d1e0a68a1d);
+impl windows_core::RuntimeType for IOcrWord {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOcrWord_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -128,7 +143,7 @@ impl OcrEngine {
     }
 }
 impl windows_core::RuntimeType for OcrEngine {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOcrEngine>();
 }
 unsafe impl windows_core::Interface for OcrEngine {
     type Vtable = IOcrEngine_Vtbl;
@@ -161,7 +176,7 @@ impl OcrLine {
     }
 }
 impl windows_core::RuntimeType for OcrLine {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOcrLine>();
 }
 unsafe impl windows_core::Interface for OcrLine {
     type Vtable = IOcrLine_Vtbl;
@@ -201,7 +216,7 @@ impl OcrResult {
     }
 }
 impl windows_core::RuntimeType for OcrResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOcrResult>();
 }
 unsafe impl windows_core::Interface for OcrResult {
     type Vtable = IOcrResult_Vtbl;
@@ -233,7 +248,7 @@ impl OcrWord {
     }
 }
 impl windows_core::RuntimeType for OcrWord {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOcrWord>();
 }
 unsafe impl windows_core::Interface for OcrWord {
     type Vtable = IOcrWord_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(ICurrentTimeChangeRequestedEventArgs, ICurrentTimeChangeRequestedEventArgs_Vtbl, 0x99711324_edc7_4bf5_91f6_3c8627db59e5);
+impl windows_core::RuntimeType for ICurrentTimeChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentTimeChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Time: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMuteChangeRequestedEventArgs, IMuteChangeRequestedEventArgs_Vtbl, 0xe4b4f5f6_af1f_4f1e_b437_7da32400e1d4);
+impl windows_core::RuntimeType for IMuteChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMuteChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +18,10 @@ pub struct IMuteChangeRequestedEventArgs_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToConnection, IPlayToConnection_Vtbl, 0x112fbfc8_f235_4fde_8d41_9bf27c9e9a40);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToConnection_Vtbl {
@@ -48,6 +58,10 @@ pub struct IPlayToConnection_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToConnectionErrorEventArgs, IPlayToConnectionErrorEventArgs_Vtbl, 0xbf5eada6_88e6_445f_9d40_d9b9f8939896);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToConnectionErrorEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToConnectionErrorEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +76,10 @@ pub struct IPlayToConnectionErrorEventArgs_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToConnectionStateChangedEventArgs, IPlayToConnectionStateChangedEventArgs_Vtbl, 0x68c4b50f_0c20_4980_8602_58c62238d423);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToConnectionStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToConnectionStateChangedEventArgs_Vtbl {
@@ -78,6 +96,10 @@ pub struct IPlayToConnectionStateChangedEventArgs_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToConnectionTransferredEventArgs, IPlayToConnectionTransferredEventArgs_Vtbl, 0xfae3193a_0683_47d9_8df0_18cbb48984d8);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToConnectionTransferredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToConnectionTransferredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +114,10 @@ pub struct IPlayToConnectionTransferredEventArgs_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToManager, IPlayToManager_Vtbl, 0xf56a206e_1b77_42ef_8f0d_b949f8d9b260);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToManager_Vtbl {
@@ -124,6 +150,10 @@ pub struct IPlayToManager_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToManagerStatics, IPlayToManagerStatics_Vtbl, 0x64e6a887_3982_4f3b_ba20_6155e435325b);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -137,6 +167,9 @@ pub struct IPlayToManagerStatics_Vtbl {
     ShowPlayToUI: usize,
 }
 windows_core::imp::define_interface!(IPlayToReceiver, IPlayToReceiver_Vtbl, 0xac15cf47_a162_4aa6_af1b_3aa35f3b9069);
+impl windows_core::RuntimeType for IPlayToReceiver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayToReceiver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +221,10 @@ pub struct IPlayToReceiver_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToSource, IPlayToSource_Vtbl, 0x7f138a08_fbb7_4b09_8356_aa5f4e335c31);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -211,6 +248,10 @@ pub struct IPlayToSource_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToSourceDeferral, IPlayToSourceDeferral_Vtbl, 0x4100891d_278e_4f29_859b_a9e501053e7d);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToSourceDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToSourceDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +262,10 @@ pub struct IPlayToSourceDeferral_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToSourceRequest, IPlayToSourceRequest_Vtbl, 0xf8584665_64f4_44a0_ac0d_468d2b8fda83);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToSourceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToSourceRequest_Vtbl {
@@ -245,6 +290,10 @@ pub struct IPlayToSourceRequest_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToSourceRequestedEventArgs, IPlayToSourceRequestedEventArgs_Vtbl, 0xc5cdc330_29df_4ec6_9da9_9fbdfcfc1b3e);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToSourceRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToSourceRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -255,6 +304,10 @@ pub struct IPlayToSourceRequestedEventArgs_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToSourceSelectedEventArgs, IPlayToSourceSelectedEventArgs_Vtbl, 0x0c9d8511_5202_4dcb_8c67_abda12bb3c12);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToSourceSelectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToSourceSelectedEventArgs_Vtbl {
@@ -283,6 +336,10 @@ pub struct IPlayToSourceSelectedEventArgs_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IPlayToSourceWithPreferredSourceUri, IPlayToSourceWithPreferredSourceUri_Vtbl, 0xaab253eb_3301_4dc4_afba_b2f2ed9635a0);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IPlayToSourceWithPreferredSourceUri {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IPlayToSourceWithPreferredSourceUri_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -296,12 +353,18 @@ pub struct IPlayToSourceWithPreferredSourceUri_Vtbl {
     SetPreferredSourceUri: usize,
 }
 windows_core::imp::define_interface!(IPlaybackRateChangeRequestedEventArgs, IPlaybackRateChangeRequestedEventArgs_Vtbl, 0x0f5661ae_2c88_4cca_8540_d586095d13a5);
+impl windows_core::RuntimeType for IPlaybackRateChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackRateChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Rate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISourceChangeRequestedEventArgs, ISourceChangeRequestedEventArgs_Vtbl, 0xfb3f3a96_7aa6_4a8b_86e7_54f6c6d34f64);
+impl windows_core::RuntimeType for ISourceChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISourceChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -326,6 +389,9 @@ pub struct ISourceChangeRequestedEventArgs_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IVolumeChangeRequestedEventArgs, IVolumeChangeRequestedEventArgs_Vtbl, 0x6f026d5c_cf75_4c2b_913e_6d7c6c329179);
+impl windows_core::RuntimeType for IVolumeChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVolumeChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -345,7 +411,7 @@ impl CurrentTimeChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CurrentTimeChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICurrentTimeChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for CurrentTimeChangeRequestedEventArgs {
     type Vtable = ICurrentTimeChangeRequestedEventArgs_Vtbl;
@@ -368,7 +434,7 @@ impl MuteChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MuteChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMuteChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for MuteChangeRequestedEventArgs {
     type Vtable = IMuteChangeRequestedEventArgs_Vtbl;
@@ -444,7 +510,7 @@ impl PlayToConnection {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToConnection>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToConnection {
@@ -486,7 +552,7 @@ impl PlayToConnectionErrorEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToConnectionErrorEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToConnectionErrorEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToConnectionErrorEventArgs {
@@ -528,7 +594,7 @@ impl PlayToConnectionStateChangedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToConnectionStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToConnectionStateChangedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToConnectionStateChangedEventArgs {
@@ -570,7 +636,7 @@ impl PlayToConnectionTransferredEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToConnectionTransferredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToConnectionTransferredEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToConnectionTransferredEventArgs {
@@ -658,7 +724,7 @@ impl PlayToManager {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToManager>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToManager {
@@ -927,7 +993,7 @@ impl PlayToReceiver {
     }
 }
 impl windows_core::RuntimeType for PlayToReceiver {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToReceiver>();
 }
 unsafe impl windows_core::Interface for PlayToReceiver {
     type Vtable = IPlayToReceiver_Vtbl;
@@ -992,7 +1058,7 @@ impl PlayToSource {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToSource>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToSource {
@@ -1023,7 +1089,7 @@ impl PlayToSourceDeferral {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToSourceDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToSourceDeferral>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToSourceDeferral {
@@ -1078,7 +1144,7 @@ impl PlayToSourceRequest {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToSourceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToSourceRequest>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToSourceRequest {
@@ -1112,7 +1178,7 @@ impl PlayToSourceRequestedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToSourceRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToSourceRequestedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToSourceRequestedEventArgs {
@@ -1178,7 +1244,7 @@ impl PlayToSourceSelectedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for PlayToSourceSelectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayToSourceSelectedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for PlayToSourceSelectedEventArgs {
@@ -1207,7 +1273,7 @@ impl PlaybackRateChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PlaybackRateChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaybackRateChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PlaybackRateChangeRequestedEventArgs {
     type Vtable = IPlaybackRateChangeRequestedEventArgs_Vtbl;
@@ -1296,7 +1362,7 @@ impl SourceChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SourceChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISourceChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for SourceChangeRequestedEventArgs {
     type Vtable = ISourceChangeRequestedEventArgs_Vtbl;
@@ -1319,7 +1385,7 @@ impl VolumeChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VolumeChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVolumeChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for VolumeChangeRequestedEventArgs {
     type Vtable = IVolumeChangeRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Playback/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playback/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IBackgroundMediaPlayerStatics, IBackgroundMediaPlayerStatics_Vtbl, 0x856ddbc1_55f7_471f_a0f2_68ac4c904592);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IBackgroundMediaPlayerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IBackgroundMediaPlayerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +46,9 @@ pub struct IBackgroundMediaPlayerStatics_Vtbl {
     Shutdown: usize,
 }
 windows_core::imp::define_interface!(ICurrentMediaPlaybackItemChangedEventArgs, ICurrentMediaPlaybackItemChangedEventArgs_Vtbl, 0x1743a892_5c43_4a15_967a_572d2d0f26c6);
+impl windows_core::RuntimeType for ICurrentMediaPlaybackItemChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentMediaPlaybackItemChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,12 +56,18 @@ pub struct ICurrentMediaPlaybackItemChangedEventArgs_Vtbl {
     pub OldItem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICurrentMediaPlaybackItemChangedEventArgs2, ICurrentMediaPlaybackItemChangedEventArgs2_Vtbl, 0x1d80a51e_996e_40a9_be48_e66ec90b2b7d);
+impl windows_core::RuntimeType for ICurrentMediaPlaybackItemChangedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICurrentMediaPlaybackItemChangedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaPlaybackItemChangedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreak, IMediaBreak_Vtbl, 0x714be270_0def_4ebc_a489_6b34930e1558);
+impl windows_core::RuntimeType for IMediaBreak {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreak_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,12 +82,18 @@ pub struct IMediaBreak_Vtbl {
     pub SetCanStart: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreakEndedEventArgs, IMediaBreakEndedEventArgs_Vtbl, 0x32b93276_1c5d_4fee_8732_236dc3a88580);
+impl windows_core::RuntimeType for IMediaBreakEndedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreakEndedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MediaBreak: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreakFactory, IMediaBreakFactory_Vtbl, 0x4516e002_18e0_4079_8b5f_d33495c15d2e);
+impl windows_core::RuntimeType for IMediaBreakFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreakFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -82,6 +101,9 @@ pub struct IMediaBreakFactory_Vtbl {
     pub CreateWithPresentationPosition: unsafe extern "system" fn(*mut core::ffi::c_void, MediaBreakInsertionMethod, super::super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreakManager, IMediaBreakManager_Vtbl, 0xa854ddb1_feb4_4d9b_9d97_0fdbe58e5e39);
+impl windows_core::RuntimeType for IMediaBreakManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreakManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +121,9 @@ pub struct IMediaBreakManager_Vtbl {
     pub SkipCurrentBreak: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreakSchedule, IMediaBreakSchedule_Vtbl, 0xa19a5813_98b6_41d8_83da_f971d22b7bba);
+impl windows_core::RuntimeType for IMediaBreakSchedule {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreakSchedule_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +142,9 @@ pub struct IMediaBreakSchedule_Vtbl {
     pub PlaybackItem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreakSeekedOverEventArgs, IMediaBreakSeekedOverEventArgs_Vtbl, 0xe5aa6746_0606_4492_b9d3_c3c8fde0a4ea);
+impl windows_core::RuntimeType for IMediaBreakSeekedOverEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreakSeekedOverEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -128,12 +156,18 @@ pub struct IMediaBreakSeekedOverEventArgs_Vtbl {
     pub NewPosition: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreakSkippedEventArgs, IMediaBreakSkippedEventArgs_Vtbl, 0x6ee94c05_2f54_4a3e_a3ab_24c3b270b4a3);
+impl windows_core::RuntimeType for IMediaBreakSkippedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreakSkippedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MediaBreak: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaBreakStartedEventArgs, IMediaBreakStartedEventArgs_Vtbl, 0xa87efe71_dfd4_454a_956e_0a4a648395f8);
+impl windows_core::RuntimeType for IMediaBreakStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaBreakStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -180,6 +214,9 @@ pub struct IMediaEnginePlaybackSource_Vtbl {
     SetPlaybackSource: usize,
 }
 windows_core::imp::define_interface!(IMediaItemDisplayProperties, IMediaItemDisplayProperties_Vtbl, 0x1e3c1b48_7097_4384_a217_c1291dfa8c16);
+impl windows_core::RuntimeType for IMediaItemDisplayProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaItemDisplayProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,6 +235,9 @@ pub struct IMediaItemDisplayProperties_Vtbl {
     pub ClearAll: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManager, IMediaPlaybackCommandManager_Vtbl, 0x5acee5a6_5cb6_4a5a_8521_cc86b1c1ed37);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -236,6 +276,9 @@ pub struct IMediaPlaybackCommandManager_Vtbl {
     pub RemoveRateReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs, IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs_Vtbl, 0x3d6f4f23_5230_4411_a0e9_bad94c2a045c);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -245,6 +288,9 @@ pub struct IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerCommandBehavior, IMediaPlaybackCommandManagerCommandBehavior_Vtbl, 0x786c1e78_ce78_4a10_afd6_843fcbb90c2e);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerCommandBehavior {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerCommandBehavior_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -256,6 +302,9 @@ pub struct IMediaPlaybackCommandManagerCommandBehavior_Vtbl {
     pub RemoveIsEnabledChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerFastForwardReceivedEventArgs, IMediaPlaybackCommandManagerFastForwardReceivedEventArgs_Vtbl, 0x30f064d9_b491_4d0a_bc21_3098bd1332e9);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerFastForwardReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerFastForwardReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -264,6 +313,9 @@ pub struct IMediaPlaybackCommandManagerFastForwardReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerNextReceivedEventArgs, IMediaPlaybackCommandManagerNextReceivedEventArgs_Vtbl, 0xe1504433_a2b0_45d4_b9de_5f42ac14a839);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerNextReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerNextReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +324,9 @@ pub struct IMediaPlaybackCommandManagerNextReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerPauseReceivedEventArgs, IMediaPlaybackCommandManagerPauseReceivedEventArgs_Vtbl, 0x5ceccd1c_c25c_4221_b16c_c3c98ce012d6);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerPauseReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerPauseReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -280,6 +335,9 @@ pub struct IMediaPlaybackCommandManagerPauseReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerPlayReceivedEventArgs, IMediaPlaybackCommandManagerPlayReceivedEventArgs_Vtbl, 0x9af0004e_578b_4c56_a006_16159d888a48);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerPlayReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerPlayReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -288,6 +346,9 @@ pub struct IMediaPlaybackCommandManagerPlayReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerPositionReceivedEventArgs, IMediaPlaybackCommandManagerPositionReceivedEventArgs_Vtbl, 0x5591a754_d627_4bdd_a90d_86a015b24902);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerPositionReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerPositionReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -297,6 +358,9 @@ pub struct IMediaPlaybackCommandManagerPositionReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerPreviousReceivedEventArgs, IMediaPlaybackCommandManagerPreviousReceivedEventArgs_Vtbl, 0x525e3081_4632_4f76_99b1_d771623f6287);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerPreviousReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerPreviousReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -305,6 +369,9 @@ pub struct IMediaPlaybackCommandManagerPreviousReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerRateReceivedEventArgs, IMediaPlaybackCommandManagerRateReceivedEventArgs_Vtbl, 0x18ea3939_4a16_4169_8b05_3eb9f5ff78eb);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerRateReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerRateReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +381,9 @@ pub struct IMediaPlaybackCommandManagerRateReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerRewindReceivedEventArgs, IMediaPlaybackCommandManagerRewindReceivedEventArgs_Vtbl, 0x9f085947_a3c0_425d_aaef_97ba7898b141);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerRewindReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerRewindReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -322,6 +392,9 @@ pub struct IMediaPlaybackCommandManagerRewindReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackCommandManagerShuffleReceivedEventArgs, IMediaPlaybackCommandManagerShuffleReceivedEventArgs_Vtbl, 0x50a05cef_63ee_4a96_b7b5_fee08b9ff90c);
+impl windows_core::RuntimeType for IMediaPlaybackCommandManagerShuffleReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackCommandManagerShuffleReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -331,6 +404,9 @@ pub struct IMediaPlaybackCommandManagerShuffleReceivedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItem, IMediaPlaybackItem_Vtbl, 0x047097d2_e4af_48ab_b283_6929e674ece2);
+impl windows_core::RuntimeType for IMediaPlaybackItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -367,6 +443,9 @@ pub struct IMediaPlaybackItem_Vtbl {
     TimedMetadataTracks: usize,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItem2, IMediaPlaybackItem2_Vtbl, 0xd859d171_d7ef_4b81_ac1f_f40493cbb091);
+impl windows_core::RuntimeType for IMediaPlaybackItem2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -379,6 +458,9 @@ pub struct IMediaPlaybackItem2_Vtbl {
     pub ApplyDisplayProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItem3, IMediaPlaybackItem3_Vtbl, 0x0d328220_b80a_4d09_9ff8_f87094a1c831);
+impl windows_core::RuntimeType for IMediaPlaybackItem3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItem3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -389,6 +471,9 @@ pub struct IMediaPlaybackItem3_Vtbl {
     pub SetAutoLoadedDisplayProperties: unsafe extern "system" fn(*mut core::ffi::c_void, AutoLoadedDisplayPropertyKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItemError, IMediaPlaybackItemError_Vtbl, 0x69fbef2b_dcd6_4df9_a450_dbf4c6f1c2c2);
+impl windows_core::RuntimeType for IMediaPlaybackItemError {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItemError_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -396,6 +481,9 @@ pub struct IMediaPlaybackItemError_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItemFactory, IMediaPlaybackItemFactory_Vtbl, 0x7133fce1_1769_4ff9_a7c1_38d2c4d42360);
+impl windows_core::RuntimeType for IMediaPlaybackItemFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItemFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -405,6 +493,9 @@ pub struct IMediaPlaybackItemFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItemFactory2, IMediaPlaybackItemFactory2_Vtbl, 0xd77cdf3a_b947_4972_b35d_adfb931a71e6);
+impl windows_core::RuntimeType for IMediaPlaybackItemFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItemFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -418,6 +509,9 @@ pub struct IMediaPlaybackItemFactory2_Vtbl {
     CreateWithStartTimeAndDurationLimit: usize,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItemFailedEventArgs, IMediaPlaybackItemFailedEventArgs_Vtbl, 0x7703134a_e9a7_47c3_862c_c656d30683d4);
+impl windows_core::RuntimeType for IMediaPlaybackItemFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItemFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -425,12 +519,18 @@ pub struct IMediaPlaybackItemFailedEventArgs_Vtbl {
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItemOpenedEventArgs, IMediaPlaybackItemOpenedEventArgs_Vtbl, 0xcbd9bd82_3037_4fbe_ae8f_39fc39edf4ef);
+impl windows_core::RuntimeType for IMediaPlaybackItemOpenedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItemOpenedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Item: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackItemStatics, IMediaPlaybackItemStatics_Vtbl, 0x4b1be7f4_4345_403c_8a67_f5de91df4c86);
+impl windows_core::RuntimeType for IMediaPlaybackItemStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackItemStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -440,6 +540,9 @@ pub struct IMediaPlaybackItemStatics_Vtbl {
     FindFromMediaSource: usize,
 }
 windows_core::imp::define_interface!(IMediaPlaybackList, IMediaPlaybackList_Vtbl, 0x7f77ee9c_dc42_4e26_a98d_7850df8ec925);
+impl windows_core::RuntimeType for IMediaPlaybackList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -464,6 +567,9 @@ pub struct IMediaPlaybackList_Vtbl {
     pub MoveTo: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackList2, IMediaPlaybackList2_Vtbl, 0x0e09b478_600a_4274_a14b_0b6723d0f48b);
+impl windows_core::RuntimeType for IMediaPlaybackList2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackList2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -481,6 +587,9 @@ pub struct IMediaPlaybackList2_Vtbl {
     SetShuffledItems: usize,
 }
 windows_core::imp::define_interface!(IMediaPlaybackList3, IMediaPlaybackList3_Vtbl, 0xdd24bba9_bc47_4463_aa90_c18b7e5ffde1);
+impl windows_core::RuntimeType for IMediaPlaybackList3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackList3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -488,6 +597,9 @@ pub struct IMediaPlaybackList3_Vtbl {
     pub SetMaxPlayedItemsToKeepOpen: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackSession, IMediaPlaybackSession_Vtbl, 0xc32b683d_0407_41ba_8946_8b345a5a5435);
+impl windows_core::RuntimeType for IMediaPlaybackSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -537,6 +649,9 @@ pub struct IMediaPlaybackSession_Vtbl {
     SetStereoscopicVideoPackingMode: usize,
 }
 windows_core::imp::define_interface!(IMediaPlaybackSession2, IMediaPlaybackSession2_Vtbl, 0xf8ba7c79_1fc8_4097_ad70_c0fa18cc0050);
+impl windows_core::RuntimeType for IMediaPlaybackSession2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackSession2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -566,6 +681,9 @@ pub struct IMediaPlaybackSession2_Vtbl {
     pub IsSupportedPlaybackRateRange: unsafe extern "system" fn(*mut core::ffi::c_void, f64, f64, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackSession3, IMediaPlaybackSession3_Vtbl, 0x7ba2b41a_a3e2_405f_b77b_a4812c238b66);
+impl windows_core::RuntimeType for IMediaPlaybackSession3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackSession3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -580,12 +698,18 @@ pub struct IMediaPlaybackSession3_Vtbl {
     pub GetOutputDegradationPolicyState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackSessionBufferingStartedEventArgs, IMediaPlaybackSessionBufferingStartedEventArgs_Vtbl, 0xcd6aafed_74e2_43b5_b115_76236c33791a);
+impl windows_core::RuntimeType for IMediaPlaybackSessionBufferingStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackSessionBufferingStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsPlaybackInterruption: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackSessionOutputDegradationPolicyState, IMediaPlaybackSessionOutputDegradationPolicyState_Vtbl, 0x558e727d_f633_49f9_965a_abaa1db709be);
+impl windows_core::RuntimeType for IMediaPlaybackSessionOutputDegradationPolicyState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackSessionOutputDegradationPolicyState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -602,6 +726,9 @@ pub struct IMediaPlaybackSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IMediaPlaybackSphericalVideoProjection, IMediaPlaybackSphericalVideoProjection_Vtbl, 0xd405b37c_6f0e_4661_b8ee_d487ba9752d5);
+impl windows_core::RuntimeType for IMediaPlaybackSphericalVideoProjection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackSphericalVideoProjection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -629,6 +756,9 @@ pub struct IMediaPlaybackSphericalVideoProjection_Vtbl {
     pub SetProjectionMode: unsafe extern "system" fn(*mut core::ffi::c_void, SphericalVideoProjectionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlaybackTimedMetadataTrackList, IMediaPlaybackTimedMetadataTrackList_Vtbl, 0x72b41319_bbfb_46a3_9372_9c9c744b9438);
+impl windows_core::RuntimeType for IMediaPlaybackTimedMetadataTrackList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlaybackTimedMetadataTrackList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -641,6 +771,9 @@ pub struct IMediaPlaybackTimedMetadataTrackList_Vtbl {
     pub SetPresentationMode: unsafe extern "system" fn(*mut core::ffi::c_void, u32, TimedMetadataTrackPresentationMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlayer, IMediaPlayer_Vtbl, 0x381a83cb_6fff_499b_8d64_2885dfc1249e);
+impl windows_core::RuntimeType for IMediaPlayer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -760,6 +893,9 @@ pub struct IMediaPlayer_Vtbl {
     SetUriSource: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayer2, IMediaPlayer2_Vtbl, 0x3c841218_2123_4fc5_9082_2f883f77bdf5);
+impl windows_core::RuntimeType for IMediaPlayer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -770,6 +906,9 @@ pub struct IMediaPlayer2_Vtbl {
     pub SetAudioDeviceType: unsafe extern "system" fn(*mut core::ffi::c_void, MediaPlayerAudioDeviceType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlayer3, IMediaPlayer3_Vtbl, 0xee0660da_031b_4feb_bd9b_92e0a0a8d299);
+impl windows_core::RuntimeType for IMediaPlayer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -806,6 +945,9 @@ pub struct IMediaPlayer3_Vtbl {
     GetAsCastingSource: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayer4, IMediaPlayer4_Vtbl, 0x80035db0_7448_4770_afcf_2a57450914c5);
+impl windows_core::RuntimeType for IMediaPlayer4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayer4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -816,6 +958,9 @@ pub struct IMediaPlayer4_Vtbl {
     GetSurface: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayer5, IMediaPlayer5_Vtbl, 0xcfe537fd_f86a_4446_bf4d_c8e792b7b4b3);
+impl windows_core::RuntimeType for IMediaPlayer5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayer5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -837,6 +982,9 @@ pub struct IMediaPlayer5_Vtbl {
     CopyFrameToStereoscopicVideoSurfaces: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayer6, IMediaPlayer6_Vtbl, 0xe0caa086_ae65_414c_b010_8bc55f00e692);
+impl windows_core::RuntimeType for IMediaPlayer6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayer6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -852,6 +1000,9 @@ pub struct IMediaPlayer6_Vtbl {
     RenderSubtitlesToSurfaceWithTargetRectangle: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayer7, IMediaPlayer7_Vtbl, 0x5d1dc478_4500_4531_b3f4_777a71491f7f);
+impl windows_core::RuntimeType for IMediaPlayer7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayer7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -861,6 +1012,9 @@ pub struct IMediaPlayer7_Vtbl {
     AudioStateMonitor: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayerDataReceivedEventArgs, IMediaPlayerDataReceivedEventArgs_Vtbl, 0xc75a9405_c801_412a_835b_83fc0e622a8e);
+impl windows_core::RuntimeType for IMediaPlayerDataReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerDataReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -870,6 +1024,9 @@ pub struct IMediaPlayerDataReceivedEventArgs_Vtbl {
     Data: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayerEffects, IMediaPlayerEffects_Vtbl, 0x85a1deda_cab6_4cc0_8be3_6035f4de2591);
+impl windows_core::RuntimeType for IMediaPlayerEffects {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerEffects_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -880,6 +1037,9 @@ pub struct IMediaPlayerEffects_Vtbl {
     pub RemoveAllEffects: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlayerEffects2, IMediaPlayerEffects2_Vtbl, 0xfa419a79_1bbe_46c5_ae1f_8ee69fb3c2c7);
+impl windows_core::RuntimeType for IMediaPlayerEffects2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerEffects2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -889,6 +1049,9 @@ pub struct IMediaPlayerEffects2_Vtbl {
     AddVideoEffect: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayerFailedEventArgs, IMediaPlayerFailedEventArgs_Vtbl, 0x2744e9b9_a7e3_4f16_bac4_7914ebc08301);
+impl windows_core::RuntimeType for IMediaPlayerFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -897,12 +1060,18 @@ pub struct IMediaPlayerFailedEventArgs_Vtbl {
     pub ErrorMessage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlayerRateChangedEventArgs, IMediaPlayerRateChangedEventArgs_Vtbl, 0x40600d58_3b61_4bb2_989f_fc65608b6cab);
+impl windows_core::RuntimeType for IMediaPlayerRateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerRateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub NewRate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlayerSource, IMediaPlayerSource_Vtbl, 0xbd4f8897_1423_4c3e_82c5_0fb1af94f715);
+impl windows_core::RuntimeType for IMediaPlayerSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -928,6 +1097,9 @@ pub struct IMediaPlayerSource_Vtbl {
     SetMediaSource: usize,
 }
 windows_core::imp::define_interface!(IMediaPlayerSource2, IMediaPlayerSource2_Vtbl, 0x82449b9f_7322_4c0b_b03b_3e69a48260c5);
+impl windows_core::RuntimeType for IMediaPlayerSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -935,6 +1107,9 @@ pub struct IMediaPlayerSource2_Vtbl {
     pub SetSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaPlayerSurface, IMediaPlayerSurface_Vtbl, 0x0ed653bc_b736_49c3_830b_764a3845313a);
+impl windows_core::RuntimeType for IMediaPlayerSurface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaPlayerSurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -949,6 +1124,9 @@ pub struct IMediaPlayerSurface_Vtbl {
     pub MediaPlayer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaybackMediaMarker, IPlaybackMediaMarker_Vtbl, 0xc4d22f5c_3c1c_4444_b6b9_778b0422d41a);
+impl windows_core::RuntimeType for IPlaybackMediaMarker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackMediaMarker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -957,6 +1135,9 @@ pub struct IPlaybackMediaMarker_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaybackMediaMarkerFactory, IPlaybackMediaMarkerFactory_Vtbl, 0x8c530a78_e0ae_4e1a_a8c8_e23f982a937b);
+impl windows_core::RuntimeType for IPlaybackMediaMarkerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackMediaMarkerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -964,12 +1145,18 @@ pub struct IPlaybackMediaMarkerFactory_Vtbl {
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaybackMediaMarkerReachedEventArgs, IPlaybackMediaMarkerReachedEventArgs_Vtbl, 0x578cd1b9_90e2_4e60_abc4_8740b01f6196);
+impl windows_core::RuntimeType for IPlaybackMediaMarkerReachedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackMediaMarkerReachedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PlaybackMediaMarker: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaybackMediaMarkerSequence, IPlaybackMediaMarkerSequence_Vtbl, 0xf2810cee_638b_46cf_8817_1d111fe9d8c4);
+impl windows_core::RuntimeType for IPlaybackMediaMarkerSequence {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackMediaMarkerSequence_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -978,6 +1165,9 @@ pub struct IPlaybackMediaMarkerSequence_Vtbl {
     pub Clear: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimedMetadataPresentationModeChangedEventArgs, ITimedMetadataPresentationModeChangedEventArgs_Vtbl, 0xd1636099_65df_45ae_8cef_dc0b53fdc2bb);
+impl windows_core::RuntimeType for ITimedMetadataPresentationModeChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimedMetadataPresentationModeChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1091,7 +1281,7 @@ impl CurrentMediaPlaybackItemChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CurrentMediaPlaybackItemChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICurrentMediaPlaybackItemChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for CurrentMediaPlaybackItemChangedEventArgs {
     type Vtable = ICurrentMediaPlaybackItemChangedEventArgs_Vtbl;
@@ -1166,7 +1356,7 @@ impl MediaBreak {
     }
 }
 impl windows_core::RuntimeType for MediaBreak {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBreak>();
 }
 unsafe impl windows_core::Interface for MediaBreak {
     type Vtable = IMediaBreak_Vtbl;
@@ -1191,7 +1381,7 @@ impl MediaBreakEndedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaBreakEndedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBreakEndedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaBreakEndedEventArgs {
     type Vtable = IMediaBreakEndedEventArgs_Vtbl;
@@ -1290,7 +1480,7 @@ impl MediaBreakManager {
     }
 }
 impl windows_core::RuntimeType for MediaBreakManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBreakManager>();
 }
 unsafe impl windows_core::Interface for MediaBreakManager {
     type Vtable = IMediaBreakManager_Vtbl;
@@ -1379,7 +1569,7 @@ impl MediaBreakSchedule {
     }
 }
 impl windows_core::RuntimeType for MediaBreakSchedule {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBreakSchedule>();
 }
 unsafe impl windows_core::Interface for MediaBreakSchedule {
     type Vtable = IMediaBreakSchedule_Vtbl;
@@ -1419,7 +1609,7 @@ impl MediaBreakSeekedOverEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaBreakSeekedOverEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBreakSeekedOverEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaBreakSeekedOverEventArgs {
     type Vtable = IMediaBreakSeekedOverEventArgs_Vtbl;
@@ -1444,7 +1634,7 @@ impl MediaBreakSkippedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaBreakSkippedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBreakSkippedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaBreakSkippedEventArgs {
     type Vtable = IMediaBreakSkippedEventArgs_Vtbl;
@@ -1469,7 +1659,7 @@ impl MediaBreakStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaBreakStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaBreakStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaBreakStartedEventArgs {
     type Vtable = IMediaBreakStartedEventArgs_Vtbl;
@@ -1532,7 +1722,7 @@ impl MediaItemDisplayProperties {
     }
 }
 impl windows_core::RuntimeType for MediaItemDisplayProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaItemDisplayProperties>();
 }
 unsafe impl windows_core::Interface for MediaItemDisplayProperties {
     type Vtable = IMediaItemDisplayProperties_Vtbl;
@@ -1628,7 +1818,7 @@ impl MediaPlaybackAudioTrackList {
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 impl windows_core::RuntimeType for MediaPlaybackAudioTrackList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVectorView<super::Core::AudioTrack>>();
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 unsafe impl windows_core::Interface for MediaPlaybackAudioTrackList {
@@ -1894,7 +2084,7 @@ impl MediaPlaybackCommandManager {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManager>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManager {
     type Vtable = IMediaPlaybackCommandManager_Vtbl;
@@ -1937,7 +2127,7 @@ impl MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerAutoRepeatModeReceivedEventArgs_Vtbl;
@@ -1994,7 +2184,7 @@ impl MediaPlaybackCommandManagerCommandBehavior {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerCommandBehavior {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerCommandBehavior>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerCommandBehavior {
     type Vtable = IMediaPlaybackCommandManagerCommandBehavior_Vtbl;
@@ -2030,7 +2220,7 @@ impl MediaPlaybackCommandManagerFastForwardReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerFastForwardReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerFastForwardReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerFastForwardReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerFastForwardReceivedEventArgs_Vtbl;
@@ -2066,7 +2256,7 @@ impl MediaPlaybackCommandManagerNextReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerNextReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerNextReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerNextReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerNextReceivedEventArgs_Vtbl;
@@ -2102,7 +2292,7 @@ impl MediaPlaybackCommandManagerPauseReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerPauseReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerPauseReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerPauseReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerPauseReceivedEventArgs_Vtbl;
@@ -2138,7 +2328,7 @@ impl MediaPlaybackCommandManagerPlayReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerPlayReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerPlayReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerPlayReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerPlayReceivedEventArgs_Vtbl;
@@ -2181,7 +2371,7 @@ impl MediaPlaybackCommandManagerPositionReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerPositionReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerPositionReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerPositionReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerPositionReceivedEventArgs_Vtbl;
@@ -2217,7 +2407,7 @@ impl MediaPlaybackCommandManagerPreviousReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerPreviousReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerPreviousReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerPreviousReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerPreviousReceivedEventArgs_Vtbl;
@@ -2260,7 +2450,7 @@ impl MediaPlaybackCommandManagerRateReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerRateReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerRateReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerRateReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerRateReceivedEventArgs_Vtbl;
@@ -2296,7 +2486,7 @@ impl MediaPlaybackCommandManagerRewindReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerRewindReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerRewindReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerRewindReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerRewindReceivedEventArgs_Vtbl;
@@ -2339,7 +2529,7 @@ impl MediaPlaybackCommandManagerShuffleReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackCommandManagerShuffleReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackCommandManagerShuffleReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackCommandManagerShuffleReceivedEventArgs {
     type Vtable = IMediaPlaybackCommandManagerShuffleReceivedEventArgs_Vtbl;
@@ -2565,7 +2755,7 @@ impl MediaPlaybackItem {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackItem>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackItem {
     type Vtable = IMediaPlaybackItem_Vtbl;
@@ -2597,7 +2787,7 @@ impl MediaPlaybackItemError {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackItemError {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackItemError>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackItemError {
     type Vtable = IMediaPlaybackItemError_Vtbl;
@@ -2629,7 +2819,7 @@ impl MediaPlaybackItemFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackItemFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackItemFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackItemFailedEventArgs {
     type Vtable = IMediaPlaybackItemFailedEventArgs_Vtbl;
@@ -2654,7 +2844,7 @@ impl MediaPlaybackItemOpenedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackItemOpenedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackItemOpenedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackItemOpenedEventArgs {
     type Vtable = IMediaPlaybackItemOpenedEventArgs_Vtbl;
@@ -2845,7 +3035,7 @@ impl MediaPlaybackList {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackList>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackList {
     type Vtable = IMediaPlaybackList_Vtbl;
@@ -3244,7 +3434,7 @@ impl MediaPlaybackSession {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackSession>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackSession {
     type Vtable = IMediaPlaybackSession_Vtbl;
@@ -3269,7 +3459,7 @@ impl MediaPlaybackSessionBufferingStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackSessionBufferingStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackSessionBufferingStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackSessionBufferingStartedEventArgs {
     type Vtable = IMediaPlaybackSessionBufferingStartedEventArgs_Vtbl;
@@ -3294,7 +3484,7 @@ impl MediaPlaybackSessionOutputDegradationPolicyState {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackSessionOutputDegradationPolicyState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackSessionOutputDegradationPolicyState>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackSessionOutputDegradationPolicyState {
     type Vtable = IMediaPlaybackSessionOutputDegradationPolicyState_Vtbl;
@@ -3371,7 +3561,7 @@ impl MediaPlaybackSphericalVideoProjection {
     }
 }
 impl windows_core::RuntimeType for MediaPlaybackSphericalVideoProjection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlaybackSphericalVideoProjection>();
 }
 unsafe impl windows_core::Interface for MediaPlaybackSphericalVideoProjection {
     type Vtable = IMediaPlaybackSphericalVideoProjection_Vtbl;
@@ -3464,7 +3654,7 @@ impl MediaPlaybackTimedMetadataTrackList {
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 impl windows_core::RuntimeType for MediaPlaybackTimedMetadataTrackList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVectorView<super::Core::TimedMetadataTrack>>();
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 unsafe impl windows_core::Interface for MediaPlaybackTimedMetadataTrackList {
@@ -3580,7 +3770,7 @@ impl MediaPlaybackVideoTrackList {
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 impl windows_core::RuntimeType for MediaPlaybackVideoTrackList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVectorView<super::Core::VideoTrack>>();
 }
 #[cfg(all(feature = "Foundation_Collections", feature = "Media_Core"))]
 unsafe impl windows_core::Interface for MediaPlaybackVideoTrackList {
@@ -4275,7 +4465,7 @@ impl MediaPlayer {
     }
 }
 impl windows_core::RuntimeType for MediaPlayer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlayer>();
 }
 unsafe impl windows_core::Interface for MediaPlayer {
     type Vtable = IMediaPlayer_Vtbl;
@@ -4301,7 +4491,7 @@ impl MediaPlayerDataReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlayerDataReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlayerDataReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlayerDataReceivedEventArgs {
     type Vtable = IMediaPlayerDataReceivedEventArgs_Vtbl;
@@ -4340,7 +4530,7 @@ impl MediaPlayerFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlayerFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlayerFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlayerFailedEventArgs {
     type Vtable = IMediaPlayerFailedEventArgs_Vtbl;
@@ -4365,7 +4555,7 @@ impl MediaPlayerRateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaPlayerRateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlayerRateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaPlayerRateChangedEventArgs {
     type Vtable = IMediaPlayerRateChangedEventArgs_Vtbl;
@@ -4411,7 +4601,7 @@ impl MediaPlayerSurface {
     }
 }
 impl windows_core::RuntimeType for MediaPlayerSurface {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaPlayerSurface>();
 }
 unsafe impl windows_core::Interface for MediaPlayerSurface {
     type Vtable = IMediaPlayerSurface_Vtbl;
@@ -4467,7 +4657,7 @@ impl PlaybackMediaMarker {
     }
 }
 impl windows_core::RuntimeType for PlaybackMediaMarker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaybackMediaMarker>();
 }
 unsafe impl windows_core::Interface for PlaybackMediaMarker {
     type Vtable = IPlaybackMediaMarker_Vtbl;
@@ -4492,7 +4682,7 @@ impl PlaybackMediaMarkerReachedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PlaybackMediaMarkerReachedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaybackMediaMarkerReachedEventArgs>();
 }
 unsafe impl windows_core::Interface for PlaybackMediaMarkerReachedEventArgs {
     type Vtable = IPlaybackMediaMarkerReachedEventArgs_Vtbl;
@@ -4538,7 +4728,7 @@ impl PlaybackMediaMarkerSequence {
     }
 }
 impl windows_core::RuntimeType for PlaybackMediaMarkerSequence {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaybackMediaMarkerSequence>();
 }
 unsafe impl windows_core::Interface for PlaybackMediaMarkerSequence {
     type Vtable = IPlaybackMediaMarkerSequence_Vtbl;
@@ -4594,7 +4784,7 @@ impl TimedMetadataPresentationModeChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TimedMetadataPresentationModeChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITimedMetadataPresentationModeChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for TimedMetadataPresentationModeChangedEventArgs {
     type Vtable = ITimedMetadataPresentationModeChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPlaylist, IPlaylist_Vtbl, 0x803736f5_cf44_4d97_83b3_7a089e9ab663);
+impl windows_core::RuntimeType for IPlaylist {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaylist_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +20,9 @@ pub struct IPlaylist_Vtbl {
     SaveAsWithFormatAsync: usize,
 }
 windows_core::imp::define_interface!(IPlaylistStatics, IPlaylistStatics_Vtbl, 0xc5c331cd_81f9_4ff3_95b9_70b6ff046b68);
+impl windows_core::RuntimeType for IPlaylistStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaylistStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,7 +97,7 @@ impl Playlist {
     }
 }
 impl windows_core::RuntimeType for Playlist {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaylist>();
 }
 unsafe impl windows_core::Interface for Playlist {
     type Vtable = IPlaylist_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(INDClient, INDClient_Vtbl, 0x3bd6781b_61b8_46e2_99a5_8abcb6b9f7d6);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for INDClient {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct INDClient_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +67,10 @@ pub struct INDClient_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(INDClientFactory, INDClientFactory_Vtbl, 0x3e53dd62_fee8_451f_b0d4_f706cca3e037);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for INDClientFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct INDClientFactory_Vtbl {
@@ -166,6 +174,10 @@ pub struct INDCustomData_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(INDCustomDataFactory, INDCustomDataFactory_Vtbl, 0xd65405ab_3424_4833_8c9a_af5fdeb22872);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for INDCustomDataFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct INDCustomDataFactory_Vtbl {
@@ -454,6 +466,10 @@ pub struct INDLicenseFetchDescriptor_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(INDLicenseFetchDescriptorFactory, INDLicenseFetchDescriptorFactory_Vtbl, 0xd0031202_cfac_4f00_ae6a_97af80b848f2);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for INDLicenseFetchDescriptorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct INDLicenseFetchDescriptorFactory_Vtbl {
@@ -869,6 +885,10 @@ pub struct INDStreamParserNotifier_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(INDTCPMessengerFactory, INDTCPMessengerFactory_Vtbl, 0x7dd85cfe_1b99_4f68_8f82_8177f7cedf2b);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for INDTCPMessengerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct INDTCPMessengerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1026,6 +1046,9 @@ pub struct INDTransmitterProperties_Vtbl {
     ModelNumber: usize,
 }
 windows_core::imp::define_interface!(IPlayReadyContentHeader, IPlayReadyContentHeader_Vtbl, 0x9a438a6a_7f4c_452e_88bd_0148c6387a2c);
+impl windows_core::RuntimeType for IPlayReadyContentHeader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyContentHeader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1041,6 +1064,9 @@ pub struct IPlayReadyContentHeader_Vtbl {
     pub HeaderWithEmbeddedUpdates: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyContentHeader2, IPlayReadyContentHeader2_Vtbl, 0x359c79f4_2180_498c_965b_e754d875eab2);
+impl windows_core::RuntimeType for IPlayReadyContentHeader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyContentHeader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1048,6 +1074,9 @@ pub struct IPlayReadyContentHeader2_Vtbl {
     pub KeyIdStrings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyContentHeaderFactory, IPlayReadyContentHeaderFactory_Vtbl, 0xcb97c8ff_b758_4776_bf01_217a8b510b2c);
+impl windows_core::RuntimeType for IPlayReadyContentHeaderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyContentHeaderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1056,12 +1085,18 @@ pub struct IPlayReadyContentHeaderFactory_Vtbl {
     pub CreateInstanceFromPlayReadyHeader: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyContentHeaderFactory2, IPlayReadyContentHeaderFactory2_Vtbl, 0xd1239cf5_ae6d_4778_97fd_6e3a2eeadbeb);
+impl windows_core::RuntimeType for IPlayReadyContentHeaderFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyContentHeaderFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstanceFromComponents2: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, *const windows_core::GUID, u32, *const std::mem::MaybeUninit<windows_core::HSTRING>, PlayReadyEncryptionAlgorithm, *mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyContentResolver, IPlayReadyContentResolver_Vtbl, 0xfbfd2523_906d_4982_a6b8_6849565a7ce8);
+impl windows_core::RuntimeType for IPlayReadyContentResolver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyContentResolver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1119,6 +1154,9 @@ pub struct IPlayReadyDomain_Vtbl {
     pub DomainJoinUrl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyDomainIterableFactory, IPlayReadyDomainIterableFactory_Vtbl, 0x4df384ee_3121_4df3_a5e8_d0c24c0500fc);
+impl windows_core::RuntimeType for IPlayReadyDomainIterableFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyDomainIterableFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1128,6 +1166,9 @@ pub struct IPlayReadyDomainIterableFactory_Vtbl {
     CreateInstance: usize,
 }
 windows_core::imp::define_interface!(IPlayReadyDomainJoinServiceRequest, IPlayReadyDomainJoinServiceRequest_Vtbl, 0x171b4a5a_405f_4739_b040_67b9f0c38758);
+impl windows_core::RuntimeType for IPlayReadyDomainJoinServiceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyDomainJoinServiceRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1139,6 +1180,9 @@ pub struct IPlayReadyDomainJoinServiceRequest_Vtbl {
     pub SetDomainServiceId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyDomainLeaveServiceRequest, IPlayReadyDomainLeaveServiceRequest_Vtbl, 0x062d58be_97ad_4917_aa03_46d4c252d464);
+impl windows_core::RuntimeType for IPlayReadyDomainLeaveServiceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyDomainLeaveServiceRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1148,6 +1192,9 @@ pub struct IPlayReadyDomainLeaveServiceRequest_Vtbl {
     pub SetDomainServiceId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyITADataGenerator, IPlayReadyITADataGenerator_Vtbl, 0x24446b8e_10b9_4530_b25b_901a8029a9b2);
+impl windows_core::RuntimeType for IPlayReadyITADataGenerator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyITADataGenerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1157,6 +1204,9 @@ pub struct IPlayReadyITADataGenerator_Vtbl {
     GenerateData: usize,
 }
 windows_core::imp::define_interface!(IPlayReadyIndividualizationServiceRequest, IPlayReadyIndividualizationServiceRequest_Vtbl, 0x21f5a86b_008c_4611_ab2f_aaa6c69f0e24);
+impl windows_core::RuntimeType for IPlayReadyIndividualizationServiceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyIndividualizationServiceRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1229,6 +1279,9 @@ pub struct IPlayReadyLicense_Vtbl {
     pub GetKIDAtChainDepth: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyLicense2, IPlayReadyLicense2_Vtbl, 0x30f4e7a7_d8e3_48a0_bcda_ff9f40530436);
+impl windows_core::RuntimeType for IPlayReadyLicense2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyLicense2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1353,12 +1406,18 @@ pub struct IPlayReadyLicenseAcquisitionServiceRequest_Vtbl {
     pub SetDomainServiceId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyLicenseAcquisitionServiceRequest2, IPlayReadyLicenseAcquisitionServiceRequest2_Vtbl, 0xb7fa5eb5_fe0c_b225_bc60_5a9edd32ceb5);
+impl windows_core::RuntimeType for IPlayReadyLicenseAcquisitionServiceRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyLicenseAcquisitionServiceRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SessionId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyLicenseAcquisitionServiceRequest3, IPlayReadyLicenseAcquisitionServiceRequest3_Vtbl, 0x394e5f4d_7f75_430d_b2e7_7f75f34b2d75);
+impl windows_core::RuntimeType for IPlayReadyLicenseAcquisitionServiceRequest3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyLicenseAcquisitionServiceRequest3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1368,6 +1427,9 @@ pub struct IPlayReadyLicenseAcquisitionServiceRequest3_Vtbl {
     CreateLicenseIterable: usize,
 }
 windows_core::imp::define_interface!(IPlayReadyLicenseIterableFactory, IPlayReadyLicenseIterableFactory_Vtbl, 0xd4179f08_0837_4978_8e68_be4293c8d7a6);
+impl windows_core::RuntimeType for IPlayReadyLicenseIterableFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyLicenseIterableFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1377,6 +1439,9 @@ pub struct IPlayReadyLicenseIterableFactory_Vtbl {
     CreateInstance: usize,
 }
 windows_core::imp::define_interface!(IPlayReadyLicenseManagement, IPlayReadyLicenseManagement_Vtbl, 0xaaeb2141_0957_4405_b892_8bf3ec5dadd9);
+impl windows_core::RuntimeType for IPlayReadyLicenseManagement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyLicenseManagement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1451,6 +1516,9 @@ pub struct IPlayReadyLicenseSession2_Vtbl {
     CreateLicenseIterable: usize,
 }
 windows_core::imp::define_interface!(IPlayReadyLicenseSessionFactory, IPlayReadyLicenseSessionFactory_Vtbl, 0x62492699_6527_429e_98be_48d798ac2739);
+impl windows_core::RuntimeType for IPlayReadyLicenseSessionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyLicenseSessionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1460,6 +1528,9 @@ pub struct IPlayReadyLicenseSessionFactory_Vtbl {
     CreateInstance: usize,
 }
 windows_core::imp::define_interface!(IPlayReadyMeteringReportServiceRequest, IPlayReadyMeteringReportServiceRequest_Vtbl, 0xc12b231c_0ecd_4f11_a185_1e24a4a67fb7);
+impl windows_core::RuntimeType for IPlayReadyMeteringReportServiceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyMeteringReportServiceRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1467,11 +1538,17 @@ pub struct IPlayReadyMeteringReportServiceRequest_Vtbl {
     pub SetMeteringCertificate: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyRevocationServiceRequest, IPlayReadyRevocationServiceRequest_Vtbl, 0x543d66ac_faf0_4560_84a5_0e4acec939e4);
+impl windows_core::RuntimeType for IPlayReadyRevocationServiceRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyRevocationServiceRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPlayReadySecureStopIterableFactory, IPlayReadySecureStopIterableFactory_Vtbl, 0x5f1f0165_4214_4d9e_81eb_e89f9d294aee);
+impl windows_core::RuntimeType for IPlayReadySecureStopIterableFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadySecureStopIterableFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1607,6 +1684,9 @@ pub struct IPlayReadySecureStopServiceRequest_Vtbl {
     pub PublisherCertificate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32, *mut *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadySecureStopServiceRequestFactory, IPlayReadySecureStopServiceRequestFactory_Vtbl, 0x0e448ac9_e67e_494e_9f49_6285438c76cf);
+impl windows_core::RuntimeType for IPlayReadySecureStopServiceRequestFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadySecureStopServiceRequestFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1709,6 +1789,9 @@ pub struct IPlayReadyServiceRequest_Vtbl {
     pub ProcessManualEnablingResponse: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadySoapMessage, IPlayReadySoapMessage_Vtbl, 0xb659fcb5_ce41_41ba_8a0d_61df5fffa139);
+impl windows_core::RuntimeType for IPlayReadySoapMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadySoapMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1720,6 +1803,9 @@ pub struct IPlayReadySoapMessage_Vtbl {
     pub Uri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyStatics, IPlayReadyStatics_Vtbl, 0x5e69c00d_247c_469a_8f31_5c1a1571d9c6);
+impl windows_core::RuntimeType for IPlayReadyStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1733,12 +1819,18 @@ pub struct IPlayReadyStatics_Vtbl {
     pub PlayReadySecurityVersion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyStatics2, IPlayReadyStatics2_Vtbl, 0x1f8d6a92_5f9a_423e_9466_b33969af7a3d);
+impl windows_core::RuntimeType for IPlayReadyStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PlayReadyCertificateSecurityLevel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyStatics3, IPlayReadyStatics3_Vtbl, 0x3fa33f71_2dd3_4bed_ae49_f7148e63e710);
+impl windows_core::RuntimeType for IPlayReadyStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1746,6 +1838,9 @@ pub struct IPlayReadyStatics3_Vtbl {
     pub CheckSupportedHardware: unsafe extern "system" fn(*mut core::ffi::c_void, PlayReadyHardwareDRMFeatures, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyStatics4, IPlayReadyStatics4_Vtbl, 0x50a91300_d824_4231_9d5e_78ef8844c7d7);
+impl windows_core::RuntimeType for IPlayReadyStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1753,6 +1848,9 @@ pub struct IPlayReadyStatics4_Vtbl {
     pub ProtectionSystemId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlayReadyStatics5, IPlayReadyStatics5_Vtbl, 0x230a7075_dfa0_4f8e_a779_cefea9c6824b);
+impl windows_core::RuntimeType for IPlayReadyStatics5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlayReadyStatics5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1909,7 +2007,7 @@ impl NDClient {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for NDClient {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INDClient>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for NDClient {
@@ -1962,7 +2060,7 @@ impl NDCustomData {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for NDCustomData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INDCustomData>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for NDCustomData {
@@ -2026,7 +2124,7 @@ impl NDDownloadEngineNotifier {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for NDDownloadEngineNotifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INDDownloadEngineNotifier>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for NDDownloadEngineNotifier {
@@ -2098,7 +2196,7 @@ impl NDLicenseFetchDescriptor {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for NDLicenseFetchDescriptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INDLicenseFetchDescriptor>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for NDLicenseFetchDescriptor {
@@ -2140,7 +2238,7 @@ impl NDStorageFileHelper {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for NDStorageFileHelper {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INDStorageFileHelper>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for NDStorageFileHelper {
@@ -2204,7 +2302,7 @@ impl NDStreamParserNotifier {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for NDStreamParserNotifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INDStreamParserNotifier>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for NDStreamParserNotifier {
@@ -2273,7 +2371,7 @@ impl NDTCPMessenger {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for NDTCPMessenger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INDMessenger>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for NDTCPMessenger {
@@ -2421,7 +2519,7 @@ impl PlayReadyContentHeader {
     }
 }
 impl windows_core::RuntimeType for PlayReadyContentHeader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyContentHeader>();
 }
 unsafe impl windows_core::Interface for PlayReadyContentHeader {
     type Vtable = IPlayReadyContentHeader_Vtbl;
@@ -2493,7 +2591,7 @@ impl PlayReadyDomain {
     }
 }
 impl windows_core::RuntimeType for PlayReadyDomain {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyDomain>();
 }
 unsafe impl windows_core::Interface for PlayReadyDomain {
     type Vtable = IPlayReadyDomain_Vtbl;
@@ -2535,7 +2633,7 @@ impl PlayReadyDomainIterable {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PlayReadyDomainIterable {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterable<IPlayReadyDomain>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PlayReadyDomainIterable {
@@ -2607,7 +2705,7 @@ impl PlayReadyDomainIterator {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PlayReadyDomainIterator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterator<IPlayReadyDomain>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PlayReadyDomainIterator {
@@ -2740,7 +2838,7 @@ impl PlayReadyDomainJoinServiceRequest {
     }
 }
 impl windows_core::RuntimeType for PlayReadyDomainJoinServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyDomainJoinServiceRequest>();
 }
 unsafe impl windows_core::Interface for PlayReadyDomainJoinServiceRequest {
     type Vtable = IPlayReadyDomainJoinServiceRequest_Vtbl;
@@ -2860,7 +2958,7 @@ impl PlayReadyDomainLeaveServiceRequest {
     }
 }
 impl windows_core::RuntimeType for PlayReadyDomainLeaveServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyDomainLeaveServiceRequest>();
 }
 unsafe impl windows_core::Interface for PlayReadyDomainLeaveServiceRequest {
     type Vtable = IPlayReadyDomainLeaveServiceRequest_Vtbl;
@@ -2894,7 +2992,7 @@ impl PlayReadyITADataGenerator {
     }
 }
 impl windows_core::RuntimeType for PlayReadyITADataGenerator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyITADataGenerator>();
 }
 unsafe impl windows_core::Interface for PlayReadyITADataGenerator {
     type Vtable = IPlayReadyITADataGenerator_Vtbl;
@@ -2992,7 +3090,7 @@ impl PlayReadyIndividualizationServiceRequest {
     }
 }
 impl windows_core::RuntimeType for PlayReadyIndividualizationServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyIndividualizationServiceRequest>();
 }
 unsafe impl windows_core::Interface for PlayReadyIndividualizationServiceRequest {
     type Vtable = IPlayReadyIndividualizationServiceRequest_Vtbl;
@@ -3086,7 +3184,7 @@ impl PlayReadyLicense {
     }
 }
 impl windows_core::RuntimeType for PlayReadyLicense {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyLicense>();
 }
 unsafe impl windows_core::Interface for PlayReadyLicense {
     type Vtable = IPlayReadyLicense_Vtbl;
@@ -3227,7 +3325,7 @@ impl PlayReadyLicenseAcquisitionServiceRequest {
     }
 }
 impl windows_core::RuntimeType for PlayReadyLicenseAcquisitionServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyLicenseAcquisitionServiceRequest>();
 }
 unsafe impl windows_core::Interface for PlayReadyLicenseAcquisitionServiceRequest {
     type Vtable = IPlayReadyLicenseAcquisitionServiceRequest_Vtbl;
@@ -3279,7 +3377,7 @@ impl PlayReadyLicenseIterable {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PlayReadyLicenseIterable {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterable<IPlayReadyLicense>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PlayReadyLicenseIterable {
@@ -3351,7 +3449,7 @@ impl PlayReadyLicenseIterator {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PlayReadyLicenseIterator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterator<IPlayReadyLicense>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PlayReadyLicenseIterator {
@@ -3430,7 +3528,7 @@ impl PlayReadyLicenseSession {
     }
 }
 impl windows_core::RuntimeType for PlayReadyLicenseSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyLicenseSession>();
 }
 unsafe impl windows_core::Interface for PlayReadyLicenseSession {
     type Vtable = IPlayReadyLicenseSession_Vtbl;
@@ -3539,7 +3637,7 @@ impl PlayReadyMeteringReportServiceRequest {
     }
 }
 impl windows_core::RuntimeType for PlayReadyMeteringReportServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyMeteringReportServiceRequest>();
 }
 unsafe impl windows_core::Interface for PlayReadyMeteringReportServiceRequest {
     type Vtable = IPlayReadyMeteringReportServiceRequest_Vtbl;
@@ -3637,7 +3735,7 @@ impl PlayReadyRevocationServiceRequest {
     }
 }
 impl windows_core::RuntimeType for PlayReadyRevocationServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadyRevocationServiceRequest>();
 }
 unsafe impl windows_core::Interface for PlayReadyRevocationServiceRequest {
     type Vtable = IPlayReadyRevocationServiceRequest_Vtbl;
@@ -3679,7 +3777,7 @@ impl PlayReadySecureStopIterable {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PlayReadySecureStopIterable {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterable<IPlayReadySecureStopServiceRequest>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PlayReadySecureStopIterable {
@@ -3751,7 +3849,7 @@ impl PlayReadySecureStopIterator {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PlayReadySecureStopIterator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IIterator<IPlayReadySecureStopServiceRequest>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PlayReadySecureStopIterator {
@@ -3896,7 +3994,7 @@ impl PlayReadySecureStopServiceRequest {
     }
 }
 impl windows_core::RuntimeType for PlayReadySecureStopServiceRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadySecureStopServiceRequest>();
 }
 unsafe impl windows_core::Interface for PlayReadySecureStopServiceRequest {
     type Vtable = IPlayReadySecureStopServiceRequest_Vtbl;
@@ -3934,7 +4032,7 @@ impl PlayReadySoapMessage {
     }
 }
 impl windows_core::RuntimeType for PlayReadySoapMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlayReadySoapMessage>();
 }
 unsafe impl windows_core::Interface for PlayReadySoapMessage {
     type Vtable = IPlayReadySoapMessage_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Media_Protection_PlayReady")]
 pub mod PlayReady;
 windows_core::imp::define_interface!(IComponentLoadFailedEventArgs, IComponentLoadFailedEventArgs_Vtbl, 0x95972e93_7746_417e_8495_f031bbc5862c);
+impl windows_core::RuntimeType for IComponentLoadFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IComponentLoadFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct IComponentLoadFailedEventArgs_Vtbl {
     pub Completion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IComponentRenewalStatics, IComponentRenewalStatics_Vtbl, 0x6ffbcd67_b795_48c5_8b7b_a7c4efe202e3);
+impl windows_core::RuntimeType for IComponentRenewalStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IComponentRenewalStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RenewSystemComponentsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHdcpSession, IHdcpSession_Vtbl, 0x718845e9_64d7_426d_809b_1be461941a2a);
+impl windows_core::RuntimeType for IHdcpSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHdcpSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +33,9 @@ pub struct IHdcpSession_Vtbl {
     pub RemoveProtectionChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaProtectionManager, IMediaProtectionManager_Vtbl, 0x45694947_c741_434b_a79e_474c12d93d2f);
+impl windows_core::RuntimeType for IMediaProtectionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaProtectionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +51,9 @@ pub struct IMediaProtectionManager_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IMediaProtectionPMPServer, IMediaProtectionPMPServer_Vtbl, 0x0c111226_7b26_4d31_95bb_9c1b08ef7fc0);
+impl windows_core::RuntimeType for IMediaProtectionPMPServer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaProtectionPMPServer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +63,9 @@ pub struct IMediaProtectionPMPServer_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IMediaProtectionPMPServerFactory, IMediaProtectionPMPServerFactory_Vtbl, 0x602c8e5e_f7d2_487e_af91_dbc4252b2182);
+impl windows_core::RuntimeType for IMediaProtectionPMPServerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaProtectionPMPServerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +75,9 @@ pub struct IMediaProtectionPMPServerFactory_Vtbl {
     CreatePMPServer: usize,
 }
 windows_core::imp::define_interface!(IMediaProtectionServiceCompletion, IMediaProtectionServiceCompletion_Vtbl, 0x8b5cca18_cfd5_44ee_a2ed_df76010c14b5);
+impl windows_core::RuntimeType for IMediaProtectionServiceCompletion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaProtectionServiceCompletion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,12 +111,18 @@ pub struct IMediaProtectionServiceRequest_Vtbl {
     pub Type: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionCapabilities, IProtectionCapabilities_Vtbl, 0xc7ac5d7e_7480_4d29_a464_7bcd913dd8e4);
+impl windows_core::RuntimeType for IProtectionCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsTypeSupported: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut ProtectionCapabilityResult) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRevocationAndRenewalInformation, IRevocationAndRenewalInformation_Vtbl, 0xf3a1937b_2501_439e_a6e7_6fc95e175fcf);
+impl windows_core::RuntimeType for IRevocationAndRenewalInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRevocationAndRenewalInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,6 +132,9 @@ pub struct IRevocationAndRenewalInformation_Vtbl {
     Items: usize,
 }
 windows_core::imp::define_interface!(IRevocationAndRenewalItem, IRevocationAndRenewalItem_Vtbl, 0x3099c20c_3cf0_49ea_902d_caf32d2dde2c);
+impl windows_core::RuntimeType for IRevocationAndRenewalItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRevocationAndRenewalItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,6 +145,9 @@ pub struct IRevocationAndRenewalItem_Vtbl {
     pub RenewalId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IServiceRequestedEventArgs, IServiceRequestedEventArgs_Vtbl, 0x34283baf_abb4_4fc1_bd89_93f106573a49);
+impl windows_core::RuntimeType for IServiceRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServiceRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,6 +155,9 @@ pub struct IServiceRequestedEventArgs_Vtbl {
     pub Completion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IServiceRequestedEventArgs2, IServiceRequestedEventArgs2_Vtbl, 0x553c69d6_fafe_4128_8dfa_130e398a13a7);
+impl windows_core::RuntimeType for IServiceRequestedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServiceRequestedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,7 +187,7 @@ impl ComponentLoadFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ComponentLoadFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IComponentLoadFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for ComponentLoadFailedEventArgs {
     type Vtable = IComponentLoadFailedEventArgs_Vtbl;
@@ -236,7 +272,7 @@ impl HdcpSession {
     }
 }
 impl windows_core::RuntimeType for HdcpSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHdcpSession>();
 }
 unsafe impl windows_core::Interface for HdcpSession {
     type Vtable = IHdcpSession_Vtbl;
@@ -311,7 +347,7 @@ impl MediaProtectionManager {
     }
 }
 impl windows_core::RuntimeType for MediaProtectionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaProtectionManager>();
 }
 unsafe impl windows_core::Interface for MediaProtectionManager {
     type Vtable = IMediaProtectionManager_Vtbl;
@@ -352,7 +388,7 @@ impl MediaProtectionPMPServer {
     }
 }
 impl windows_core::RuntimeType for MediaProtectionPMPServer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaProtectionPMPServer>();
 }
 unsafe impl windows_core::Interface for MediaProtectionPMPServer {
     type Vtable = IMediaProtectionPMPServer_Vtbl;
@@ -374,7 +410,7 @@ impl MediaProtectionServiceCompletion {
     }
 }
 impl windows_core::RuntimeType for MediaProtectionServiceCompletion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaProtectionServiceCompletion>();
 }
 unsafe impl windows_core::Interface for MediaProtectionServiceCompletion {
     type Vtable = IMediaProtectionServiceCompletion_Vtbl;
@@ -406,7 +442,7 @@ impl ProtectionCapabilities {
     }
 }
 impl windows_core::RuntimeType for ProtectionCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectionCapabilities>();
 }
 unsafe impl windows_core::Interface for ProtectionCapabilities {
     type Vtable = IProtectionCapabilities_Vtbl;
@@ -432,7 +468,7 @@ impl RevocationAndRenewalInformation {
     }
 }
 impl windows_core::RuntimeType for RevocationAndRenewalInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRevocationAndRenewalInformation>();
 }
 unsafe impl windows_core::Interface for RevocationAndRenewalInformation {
     type Vtable = IRevocationAndRenewalInformation_Vtbl;
@@ -485,7 +521,7 @@ impl RevocationAndRenewalItem {
     }
 }
 impl windows_core::RuntimeType for RevocationAndRenewalItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRevocationAndRenewalItem>();
 }
 unsafe impl windows_core::Interface for RevocationAndRenewalItem {
     type Vtable = IRevocationAndRenewalItem_Vtbl;
@@ -525,7 +561,7 @@ impl ServiceRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ServiceRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IServiceRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for ServiceRequestedEventArgs {
     type Vtable = IServiceRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
@@ -1,16 +1,25 @@
 windows_core::imp::define_interface!(ISpeechContinuousRecognitionCompletedEventArgs, ISpeechContinuousRecognitionCompletedEventArgs_Vtbl, 0xe3d069bb_e30c_5e18_424b_7fbe81f8fbd0);
+impl windows_core::RuntimeType for ISpeechContinuousRecognitionCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechContinuousRecognitionCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpeechRecognitionResultStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechContinuousRecognitionResultGeneratedEventArgs, ISpeechContinuousRecognitionResultGeneratedEventArgs_Vtbl, 0x19091e1e_6e7e_5a46_40fb_76594f786504);
+impl windows_core::RuntimeType for ISpeechContinuousRecognitionResultGeneratedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechContinuousRecognitionResultGeneratedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Result: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechContinuousRecognitionSession, ISpeechContinuousRecognitionSession_Vtbl, 0x6a213c04_6614_49f8_99a2_b5e9b3a085c8);
+impl windows_core::RuntimeType for ISpeechContinuousRecognitionSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechContinuousRecognitionSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +37,9 @@ pub struct ISpeechContinuousRecognitionSession_Vtbl {
     pub RemoveResultGenerated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionCompilationResult, ISpeechRecognitionCompilationResult_Vtbl, 0x407e6c5d_6ac7_4da4_9cc1_2fce32cf7489);
+impl windows_core::RuntimeType for ISpeechRecognitionCompilationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionCompilationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +104,9 @@ pub struct ISpeechRecognitionConstraint_Vtbl {
     pub SetProbability: unsafe extern "system" fn(*mut core::ffi::c_void, SpeechRecognitionConstraintProbability) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionGrammarFileConstraint, ISpeechRecognitionGrammarFileConstraint_Vtbl, 0xb5031a8f_85ca_4fa4_b11a_474fc41b3835);
+impl windows_core::RuntimeType for ISpeechRecognitionGrammarFileConstraint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionGrammarFileConstraint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,6 +116,9 @@ pub struct ISpeechRecognitionGrammarFileConstraint_Vtbl {
     GrammarFile: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionGrammarFileConstraintFactory, ISpeechRecognitionGrammarFileConstraintFactory_Vtbl, 0x3da770eb_c479_4c27_9f19_89974ef392d1);
+impl windows_core::RuntimeType for ISpeechRecognitionGrammarFileConstraintFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionGrammarFileConstraintFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,18 +132,27 @@ pub struct ISpeechRecognitionGrammarFileConstraintFactory_Vtbl {
     CreateWithTag: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionHypothesis, ISpeechRecognitionHypothesis_Vtbl, 0x7a7b25b0_99c5_4f7d_bf84_10aa1302b634);
+impl windows_core::RuntimeType for ISpeechRecognitionHypothesis {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionHypothesis_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionHypothesisGeneratedEventArgs, ISpeechRecognitionHypothesisGeneratedEventArgs_Vtbl, 0x55161a7a_8023_5866_411d_1213bb271476);
+impl windows_core::RuntimeType for ISpeechRecognitionHypothesisGeneratedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionHypothesisGeneratedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Hypothesis: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionListConstraint, ISpeechRecognitionListConstraint_Vtbl, 0x09c487e9_e4ad_4526_81f2_4946fb481d98);
+impl windows_core::RuntimeType for ISpeechRecognitionListConstraint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionListConstraint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,6 +162,9 @@ pub struct ISpeechRecognitionListConstraint_Vtbl {
     Commands: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionListConstraintFactory, ISpeechRecognitionListConstraintFactory_Vtbl, 0x40f3cdc7_562a_426a_9f3b_3b4e282be1d5);
+impl windows_core::RuntimeType for ISpeechRecognitionListConstraintFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionListConstraintFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,12 +178,18 @@ pub struct ISpeechRecognitionListConstraintFactory_Vtbl {
     CreateWithTag: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionQualityDegradingEventArgs, ISpeechRecognitionQualityDegradingEventArgs_Vtbl, 0x4fe24105_8c3a_4c7e_8d0a_5bd4f5b14ad8);
+impl windows_core::RuntimeType for ISpeechRecognitionQualityDegradingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionQualityDegradingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Problem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpeechRecognitionAudioProblem) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionResult, ISpeechRecognitionResult_Vtbl, 0x4e303157_034e_4652_857e_d0454cc4beec);
+impl windows_core::RuntimeType for ISpeechRecognitionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,6 +209,9 @@ pub struct ISpeechRecognitionResult_Vtbl {
     pub RawConfidence: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionResult2, ISpeechRecognitionResult2_Vtbl, 0xaf7ed1ba_451b_4166_a0c1_1ffe84032d03);
+impl windows_core::RuntimeType for ISpeechRecognitionResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -180,6 +219,9 @@ pub struct ISpeechRecognitionResult2_Vtbl {
     pub PhraseDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionSemanticInterpretation, ISpeechRecognitionSemanticInterpretation_Vtbl, 0xaae1da9b_7e32_4c1f_89fe_0c65f486f52e);
+impl windows_core::RuntimeType for ISpeechRecognitionSemanticInterpretation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionSemanticInterpretation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +231,9 @@ pub struct ISpeechRecognitionSemanticInterpretation_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionTopicConstraint, ISpeechRecognitionTopicConstraint_Vtbl, 0xbf6fdf19_825d_4e69_a681_36e48cf1c93e);
+impl windows_core::RuntimeType for ISpeechRecognitionTopicConstraint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionTopicConstraint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -196,6 +241,9 @@ pub struct ISpeechRecognitionTopicConstraint_Vtbl {
     pub TopicHint: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionTopicConstraintFactory, ISpeechRecognitionTopicConstraintFactory_Vtbl, 0x6e6863df_ec05_47d7_a5df_56a3431e58d2);
+impl windows_core::RuntimeType for ISpeechRecognitionTopicConstraintFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionTopicConstraintFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,11 +251,17 @@ pub struct ISpeechRecognitionTopicConstraintFactory_Vtbl {
     pub CreateWithTag: unsafe extern "system" fn(*mut core::ffi::c_void, SpeechRecognitionScenario, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognitionVoiceCommandDefinitionConstraint, ISpeechRecognitionVoiceCommandDefinitionConstraint_Vtbl, 0xf2791c2b_1ef4_4ae7_9d77_b6ff10b8a3c2);
+impl windows_core::RuntimeType for ISpeechRecognitionVoiceCommandDefinitionConstraint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognitionVoiceCommandDefinitionConstraint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISpeechRecognizer, ISpeechRecognizer_Vtbl, 0x0bc3c9cb_c26a_40f2_aeb5_8096b2e48073);
+impl windows_core::RuntimeType for ISpeechRecognizer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -230,6 +284,9 @@ pub struct ISpeechRecognizer_Vtbl {
     pub RemoveStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognizer2, ISpeechRecognizer2_Vtbl, 0x63c9baf1_91e3_4ea4_86a1_7c3867d084a6);
+impl windows_core::RuntimeType for ISpeechRecognizer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,6 +297,9 @@ pub struct ISpeechRecognizer2_Vtbl {
     pub RemoveHypothesisGenerated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognizerFactory, ISpeechRecognizerFactory_Vtbl, 0x60c488dd_7fb8_4033_ac70_d046f64818e1);
+impl windows_core::RuntimeType for ISpeechRecognizerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -249,12 +309,18 @@ pub struct ISpeechRecognizerFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognizerStateChangedEventArgs, ISpeechRecognizerStateChangedEventArgs_Vtbl, 0x563d4f09_ba03_4bad_ad81_ddc6c4dab0c3);
+impl windows_core::RuntimeType for ISpeechRecognizerStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizerStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpeechRecognizerState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognizerStatics, ISpeechRecognizerStatics_Vtbl, 0x87a35eac_a7dc_4b0b_bcc9_24f47c0b7ebf);
+impl windows_core::RuntimeType for ISpeechRecognizerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +338,9 @@ pub struct ISpeechRecognizerStatics_Vtbl {
     SupportedGrammarLanguages: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognizerStatics2, ISpeechRecognizerStatics2_Vtbl, 0x1d1b0d95_7565_4ef9_a2f3_ba15162a96cf);
+impl windows_core::RuntimeType for ISpeechRecognizerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +350,9 @@ pub struct ISpeechRecognizerStatics2_Vtbl {
     TrySetSystemSpeechLanguageAsync: usize,
 }
 windows_core::imp::define_interface!(ISpeechRecognizerTimeouts, ISpeechRecognizerTimeouts_Vtbl, 0x2ef76fca_6a3c_4dca_a153_df1bc88a79af);
+impl windows_core::RuntimeType for ISpeechRecognizerTimeouts {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizerTimeouts_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -292,6 +364,9 @@ pub struct ISpeechRecognizerTimeouts_Vtbl {
     pub SetBabbleTimeout: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechRecognizerUIOptions, ISpeechRecognizerUIOptions_Vtbl, 0x7888d641_b92b_44ba_a25f_d1864630641f);
+impl windows_core::RuntimeType for ISpeechRecognizerUIOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechRecognizerUIOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -305,6 +380,9 @@ pub struct ISpeechRecognizerUIOptions_Vtbl {
     pub SetShowConfirmation: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoiceCommandManager, IVoiceCommandManager_Vtbl, 0xaa3a8dd5_b6e7_4ee2_baa9_dd6baced0a2b);
+impl windows_core::RuntimeType for IVoiceCommandManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -318,6 +396,9 @@ pub struct IVoiceCommandManager_Vtbl {
     InstalledCommandSets: usize,
 }
 windows_core::imp::define_interface!(IVoiceCommandSet, IVoiceCommandSet_Vtbl, 0x0bedda75_46e6_4b11_a088_5c68632899b5);
+impl windows_core::RuntimeType for IVoiceCommandSet {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceCommandSet_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -342,7 +423,7 @@ impl SpeechContinuousRecognitionCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpeechContinuousRecognitionCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechContinuousRecognitionCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpeechContinuousRecognitionCompletedEventArgs {
     type Vtable = ISpeechContinuousRecognitionCompletedEventArgs_Vtbl;
@@ -367,7 +448,7 @@ impl SpeechContinuousRecognitionResultGeneratedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpeechContinuousRecognitionResultGeneratedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechContinuousRecognitionResultGeneratedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpeechContinuousRecognitionResultGeneratedEventArgs {
     type Vtable = ISpeechContinuousRecognitionResultGeneratedEventArgs_Vtbl;
@@ -463,7 +544,7 @@ impl SpeechContinuousRecognitionSession {
     }
 }
 impl windows_core::RuntimeType for SpeechContinuousRecognitionSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechContinuousRecognitionSession>();
 }
 unsafe impl windows_core::Interface for SpeechContinuousRecognitionSession {
     type Vtable = ISpeechContinuousRecognitionSession_Vtbl;
@@ -488,7 +569,7 @@ impl SpeechRecognitionCompilationResult {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionCompilationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionCompilationResult>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionCompilationResult {
     type Vtable = ISpeechRecognitionCompilationResult_Vtbl;
@@ -580,7 +661,7 @@ impl SpeechRecognitionGrammarFileConstraint {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionGrammarFileConstraint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionGrammarFileConstraint>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionGrammarFileConstraint {
     type Vtable = ISpeechRecognitionGrammarFileConstraint_Vtbl;
@@ -605,7 +686,7 @@ impl SpeechRecognitionHypothesis {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionHypothesis {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionHypothesis>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionHypothesis {
     type Vtable = ISpeechRecognitionHypothesis_Vtbl;
@@ -630,7 +711,7 @@ impl SpeechRecognitionHypothesisGeneratedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionHypothesisGeneratedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionHypothesisGeneratedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionHypothesisGeneratedEventArgs {
     type Vtable = ISpeechRecognitionHypothesisGeneratedEventArgs_Vtbl;
@@ -722,7 +803,7 @@ impl SpeechRecognitionListConstraint {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionListConstraint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionListConstraint>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionListConstraint {
     type Vtable = ISpeechRecognitionListConstraint_Vtbl;
@@ -747,7 +828,7 @@ impl SpeechRecognitionQualityDegradingEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionQualityDegradingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionQualityDegradingEventArgs>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionQualityDegradingEventArgs {
     type Vtable = ISpeechRecognitionQualityDegradingEventArgs_Vtbl;
@@ -837,7 +918,7 @@ impl SpeechRecognitionResult {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionResult>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionResult {
     type Vtable = ISpeechRecognitionResult_Vtbl;
@@ -863,7 +944,7 @@ impl SpeechRecognitionSemanticInterpretation {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionSemanticInterpretation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionSemanticInterpretation>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionSemanticInterpretation {
     type Vtable = ISpeechRecognitionSemanticInterpretation_Vtbl;
@@ -953,7 +1034,7 @@ impl SpeechRecognitionTopicConstraint {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionTopicConstraint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionTopicConstraint>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionTopicConstraint {
     type Vtable = ISpeechRecognitionTopicConstraint_Vtbl;
@@ -1012,7 +1093,7 @@ impl SpeechRecognitionVoiceCommandDefinitionConstraint {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognitionVoiceCommandDefinitionConstraint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognitionVoiceCommandDefinitionConstraint>();
 }
 unsafe impl windows_core::Interface for SpeechRecognitionVoiceCommandDefinitionConstraint {
     type Vtable = ISpeechRecognitionVoiceCommandDefinitionConstraint_Vtbl;
@@ -1212,7 +1293,7 @@ impl SpeechRecognizer {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognizer>();
 }
 unsafe impl windows_core::Interface for SpeechRecognizer {
     type Vtable = ISpeechRecognizer_Vtbl;
@@ -1237,7 +1318,7 @@ impl SpeechRecognizerStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognizerStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognizerStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpeechRecognizerStateChangedEventArgs {
     type Vtable = ISpeechRecognizerStateChangedEventArgs_Vtbl;
@@ -1288,7 +1369,7 @@ impl SpeechRecognizerTimeouts {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognizerTimeouts {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognizerTimeouts>();
 }
 unsafe impl windows_core::Interface for SpeechRecognizerTimeouts {
     type Vtable = ISpeechRecognizerTimeouts_Vtbl;
@@ -1350,7 +1431,7 @@ impl SpeechRecognizerUIOptions {
     }
 }
 impl windows_core::RuntimeType for SpeechRecognizerUIOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechRecognizerUIOptions>();
 }
 unsafe impl windows_core::Interface for SpeechRecognizerUIOptions {
     type Vtable = ISpeechRecognizerUIOptions_Vtbl;
@@ -1421,7 +1502,7 @@ impl VoiceCommandSet {
     }
 }
 impl windows_core::RuntimeType for VoiceCommandSet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceCommandSet>();
 }
 unsafe impl windows_core::Interface for VoiceCommandSet {
     type Vtable = IVoiceCommandSet_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IInstalledVoicesStatic, IInstalledVoicesStatic_Vtbl, 0x7d526ecc_7533_4c3f_85be_888c2baeebdc);
+impl windows_core::RuntimeType for IInstalledVoicesStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInstalledVoicesStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,12 +12,18 @@ pub struct IInstalledVoicesStatic_Vtbl {
     pub DefaultVoice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInstalledVoicesStatic2, IInstalledVoicesStatic2_Vtbl, 0x64255f2e_358d_4058_be9a_fd3fcb423530);
+impl windows_core::RuntimeType for IInstalledVoicesStatic2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInstalledVoicesStatic2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TrySetDefaultVoiceAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechSynthesisStream, ISpeechSynthesisStream_Vtbl, 0x83e46e93_244c_4622_ba0b_6229c4d0d65d);
+impl windows_core::RuntimeType for ISpeechSynthesisStream {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechSynthesisStream_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +33,9 @@ pub struct ISpeechSynthesisStream_Vtbl {
     Markers: usize,
 }
 windows_core::imp::define_interface!(ISpeechSynthesizer, ISpeechSynthesizer_Vtbl, 0xce9f7c76_97f4_4ced_ad68_d51c458e45c6);
+impl windows_core::RuntimeType for ISpeechSynthesizer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechSynthesizer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,12 +45,18 @@ pub struct ISpeechSynthesizer_Vtbl {
     pub Voice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechSynthesizer2, ISpeechSynthesizer2_Vtbl, 0xa7c5ecb2_4339_4d6a_bbf8_c7a4f1544c2e);
+impl windows_core::RuntimeType for ISpeechSynthesizer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechSynthesizer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Options: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechSynthesizerOptions, ISpeechSynthesizerOptions_Vtbl, 0xa0e23871_cc3d_43c9_91b1_ee185324d83d);
+impl windows_core::RuntimeType for ISpeechSynthesizerOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechSynthesizerOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +66,9 @@ pub struct ISpeechSynthesizerOptions_Vtbl {
     pub SetIncludeSentenceBoundaryMetadata: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechSynthesizerOptions2, ISpeechSynthesizerOptions2_Vtbl, 0x1cbef60e_119c_4bed_b118_d250c3a25793);
+impl windows_core::RuntimeType for ISpeechSynthesizerOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechSynthesizerOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +80,9 @@ pub struct ISpeechSynthesizerOptions2_Vtbl {
     pub SetAudioPitch: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeechSynthesizerOptions3, ISpeechSynthesizerOptions3_Vtbl, 0x401ed877_902c_4814_a582_a5d0c0769fa8);
+impl windows_core::RuntimeType for ISpeechSynthesizerOptions3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeechSynthesizerOptions3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,6 +92,9 @@ pub struct ISpeechSynthesizerOptions3_Vtbl {
     pub SetPunctuationSilence: unsafe extern "system" fn(*mut core::ffi::c_void, SpeechPunctuationSilence) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVoiceInformation, IVoiceInformation_Vtbl, 0xb127d6a4_1291_4604_aa9c_83134083352c);
+impl windows_core::RuntimeType for IVoiceInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVoiceInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -210,7 +237,7 @@ impl SpeechSynthesisStream {
     }
 }
 impl windows_core::RuntimeType for SpeechSynthesisStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechSynthesisStream>();
 }
 unsafe impl windows_core::Interface for SpeechSynthesisStream {
     type Vtable = ISpeechSynthesisStream_Vtbl;
@@ -307,7 +334,7 @@ impl SpeechSynthesizer {
     }
 }
 impl windows_core::RuntimeType for SpeechSynthesizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechSynthesizer>();
 }
 unsafe impl windows_core::Interface for SpeechSynthesizer {
     type Vtable = ISpeechSynthesizer_Vtbl;
@@ -402,7 +429,7 @@ impl SpeechSynthesizerOptions {
     }
 }
 impl windows_core::RuntimeType for SpeechSynthesizerOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeechSynthesizerOptions>();
 }
 unsafe impl windows_core::Interface for SpeechSynthesizerOptions {
     type Vtable = ISpeechSynthesizerOptions_Vtbl;
@@ -455,7 +482,7 @@ impl VoiceInformation {
     }
 }
 impl windows_core::RuntimeType for VoiceInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVoiceInformation>();
 }
 unsafe impl windows_core::Interface for VoiceInformation {
     type Vtable = IVoiceInformation_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAdaptiveMediaSource, IAdaptiveMediaSource_Vtbl, 0x4c7332ef_d39f_4396_b4d9_043957a7c964);
+impl windows_core::RuntimeType for IAdaptiveMediaSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,12 +36,18 @@ pub struct IAdaptiveMediaSource_Vtbl {
     pub RemoveDownloadFailed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSource2, IAdaptiveMediaSource2_Vtbl, 0x17890342_6760_4bb9_a58a_f7aa98b08c0e);
+impl windows_core::RuntimeType for IAdaptiveMediaSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AdvancedSettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSource3, IAdaptiveMediaSource3_Vtbl, 0xba7023fd_c334_461b_a36e_c99f54f7174a);
+impl windows_core::RuntimeType for IAdaptiveMediaSource3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSource3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +59,9 @@ pub struct IAdaptiveMediaSource3_Vtbl {
     pub GetCorrelatedTimes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceAdvancedSettings, IAdaptiveMediaSourceAdvancedSettings_Vtbl, 0x55db1680_1aeb_47dc_aa08_9a11610ba45a);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceAdvancedSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceAdvancedSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +73,9 @@ pub struct IAdaptiveMediaSourceAdvancedSettings_Vtbl {
     pub SetBitrateDowngradeTriggerRatio: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceCorrelatedTimes, IAdaptiveMediaSourceCorrelatedTimes_Vtbl, 0x05108787_e032_48e1_ab8d_002b0b3051df);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceCorrelatedTimes {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceCorrelatedTimes_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +84,9 @@ pub struct IAdaptiveMediaSourceCorrelatedTimes_Vtbl {
     pub ProgramDateTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceCreationResult, IAdaptiveMediaSourceCreationResult_Vtbl, 0x4686b6b2_800f_4e31_9093_76d4782013e7);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceCreationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceCreationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,12 +98,18 @@ pub struct IAdaptiveMediaSourceCreationResult_Vtbl {
     HttpResponseMessage: usize,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceCreationResult2, IAdaptiveMediaSourceCreationResult2_Vtbl, 0x1c3243bf_1c44_404b_a201_df45ac7898e8);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceCreationResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceCreationResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDiagnosticAvailableEventArgs, IAdaptiveMediaSourceDiagnosticAvailableEventArgs_Vtbl, 0x3af64f06_6d9c_494a_b7a9_b3a5dee6ad68);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDiagnosticAvailableEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDiagnosticAvailableEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,12 +124,18 @@ pub struct IAdaptiveMediaSourceDiagnosticAvailableEventArgs_Vtbl {
     pub Bitrate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDiagnosticAvailableEventArgs2, IAdaptiveMediaSourceDiagnosticAvailableEventArgs2_Vtbl, 0x8c6dd857_16a5_4d9f_810e_00bd901b3ef9);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDiagnosticAvailableEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDiagnosticAvailableEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDiagnosticAvailableEventArgs3, IAdaptiveMediaSourceDiagnosticAvailableEventArgs3_Vtbl, 0xc3650cd5_daeb_4103_84da_68769ad513ff);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDiagnosticAvailableEventArgs3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDiagnosticAvailableEventArgs3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -113,6 +143,9 @@ pub struct IAdaptiveMediaSourceDiagnosticAvailableEventArgs3_Vtbl {
     pub ResourceContentType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDiagnostics, IAdaptiveMediaSourceDiagnostics_Vtbl, 0x9b24ee68_962e_448c_aebf_b29b56098e23);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDiagnostics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDiagnostics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,6 +153,9 @@ pub struct IAdaptiveMediaSourceDiagnostics_Vtbl {
     pub RemoveDiagnosticAvailable: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadBitrateChangedEventArgs, IAdaptiveMediaSourceDownloadBitrateChangedEventArgs_Vtbl, 0x670c0a44_e04e_4eff_816a_17399f78f4ba);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadBitrateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadBitrateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,12 +163,18 @@ pub struct IAdaptiveMediaSourceDownloadBitrateChangedEventArgs_Vtbl {
     pub NewValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2, IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2_Vtbl, 0xf3f1f444_96ae_4de0_b540_2b3246e6968c);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadBitrateChangedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AdaptiveMediaSourceDownloadBitrateChangedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadCompletedEventArgs, IAdaptiveMediaSourceDownloadCompletedEventArgs_Vtbl, 0x19240dc3_5b37_4a1a_8970_d621cb6ca83b);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -146,6 +188,9 @@ pub struct IAdaptiveMediaSourceDownloadCompletedEventArgs_Vtbl {
     HttpResponseMessage: usize,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadCompletedEventArgs2, IAdaptiveMediaSourceDownloadCompletedEventArgs2_Vtbl, 0x704744c4_964a_40e4_af95_9177dd6dfa00);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadCompletedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadCompletedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,6 +199,9 @@ pub struct IAdaptiveMediaSourceDownloadCompletedEventArgs2_Vtbl {
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadCompletedEventArgs3, IAdaptiveMediaSourceDownloadCompletedEventArgs3_Vtbl, 0x0f8a8bd1_93b2_47c6_badc_8be2c8f7f6e8);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadCompletedEventArgs3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadCompletedEventArgs3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +209,9 @@ pub struct IAdaptiveMediaSourceDownloadCompletedEventArgs3_Vtbl {
     pub ResourceContentType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadFailedEventArgs, IAdaptiveMediaSourceDownloadFailedEventArgs_Vtbl, 0x37739048_f4ab_40a4_b135_c6dfd8bd7ff1);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -174,6 +225,9 @@ pub struct IAdaptiveMediaSourceDownloadFailedEventArgs_Vtbl {
     HttpResponseMessage: usize,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadFailedEventArgs2, IAdaptiveMediaSourceDownloadFailedEventArgs2_Vtbl, 0x70919568_967c_4986_90c5_c6fc4b31e2d8);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadFailedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadFailedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +237,9 @@ pub struct IAdaptiveMediaSourceDownloadFailedEventArgs2_Vtbl {
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadFailedEventArgs3, IAdaptiveMediaSourceDownloadFailedEventArgs3_Vtbl, 0xd0354549_1132_4a10_915a_c2211b5b9409);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadFailedEventArgs3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadFailedEventArgs3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -190,12 +247,18 @@ pub struct IAdaptiveMediaSourceDownloadFailedEventArgs3_Vtbl {
     pub ResourceContentType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadRequestedDeferral, IAdaptiveMediaSourceDownloadRequestedDeferral_Vtbl, 0x05c68f64_fa20_4dbd_9821_4bf4c9bf77ab);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadRequestedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadRequestedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadRequestedEventArgs, IAdaptiveMediaSourceDownloadRequestedEventArgs_Vtbl, 0xc83fdffd_44a9_47a2_bf96_03398b4bfaaf);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,6 +270,9 @@ pub struct IAdaptiveMediaSourceDownloadRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadRequestedEventArgs2, IAdaptiveMediaSourceDownloadRequestedEventArgs2_Vtbl, 0xb37d8bfe_aa44_4d82_825b_611de3bcfecb);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadRequestedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadRequestedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,6 +280,9 @@ pub struct IAdaptiveMediaSourceDownloadRequestedEventArgs2_Vtbl {
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadRequestedEventArgs3, IAdaptiveMediaSourceDownloadRequestedEventArgs3_Vtbl, 0x333c50fd_4f62_4481_ab44_1e47b0574225);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadRequestedEventArgs3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadRequestedEventArgs3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +290,9 @@ pub struct IAdaptiveMediaSourceDownloadRequestedEventArgs3_Vtbl {
     pub ResourceContentType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadResult, IAdaptiveMediaSourceDownloadResult_Vtbl, 0xf4afdc73_bcee_4a6a_9f0a_fec41e2339b0);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +320,9 @@ pub struct IAdaptiveMediaSourceDownloadResult_Vtbl {
     pub SetExtendedStatus: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadResult2, IAdaptiveMediaSourceDownloadResult2_Vtbl, 0x15552cb7_7b80_4ac4_8660_a4b97f7c70f0);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -257,6 +332,9 @@ pub struct IAdaptiveMediaSourceDownloadResult2_Vtbl {
     pub SetResourceByteRangeLength: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceDownloadStatistics, IAdaptiveMediaSourceDownloadStatistics_Vtbl, 0xa306cefb_e96a_4dff_a9b8_1ae08c01ae98);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceDownloadStatistics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceDownloadStatistics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -266,6 +344,9 @@ pub struct IAdaptiveMediaSourceDownloadStatistics_Vtbl {
     pub TimeToLastByteReceived: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs, IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs_Vtbl, 0x23a29f6d_7dda_4a51_87a9_6fa8c5b292be);
+impl windows_core::RuntimeType for IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +355,9 @@ pub struct IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs_Vtbl {
     pub AudioOnly: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdaptiveMediaSourceStatics, IAdaptiveMediaSourceStatics_Vtbl, 0x50a6bd5d_66ef_4cd3_9579_9e660507dc3f);
+impl windows_core::RuntimeType for IAdaptiveMediaSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveMediaSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -582,7 +666,7 @@ impl AdaptiveMediaSource {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSource>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSource {
     type Vtable = IAdaptiveMediaSource_Vtbl;
@@ -639,7 +723,7 @@ impl AdaptiveMediaSourceAdvancedSettings {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceAdvancedSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceAdvancedSettings>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceAdvancedSettings {
     type Vtable = IAdaptiveMediaSourceAdvancedSettings_Vtbl;
@@ -678,7 +762,7 @@ impl AdaptiveMediaSourceCorrelatedTimes {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceCorrelatedTimes {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceCorrelatedTimes>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceCorrelatedTimes {
     type Vtable = IAdaptiveMediaSourceCorrelatedTimes_Vtbl;
@@ -725,7 +809,7 @@ impl AdaptiveMediaSourceCreationResult {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceCreationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceCreationResult>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceCreationResult {
     type Vtable = IAdaptiveMediaSourceCreationResult_Vtbl;
@@ -827,7 +911,7 @@ impl AdaptiveMediaSourceDiagnosticAvailableEventArgs {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDiagnosticAvailableEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDiagnosticAvailableEventArgs>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDiagnosticAvailableEventArgs {
     type Vtable = IAdaptiveMediaSourceDiagnosticAvailableEventArgs_Vtbl;
@@ -859,7 +943,7 @@ impl AdaptiveMediaSourceDiagnostics {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDiagnostics {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDiagnostics>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDiagnostics {
     type Vtable = IAdaptiveMediaSourceDiagnostics_Vtbl;
@@ -898,7 +982,7 @@ impl AdaptiveMediaSourceDownloadBitrateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDownloadBitrateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {
     type Vtable = IAdaptiveMediaSourceDownloadBitrateChangedEventArgs_Vtbl;
@@ -987,7 +1071,7 @@ impl AdaptiveMediaSourceDownloadCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDownloadCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDownloadCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDownloadCompletedEventArgs {
     type Vtable = IAdaptiveMediaSourceDownloadCompletedEventArgs_Vtbl;
@@ -1083,7 +1167,7 @@ impl AdaptiveMediaSourceDownloadFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDownloadFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDownloadFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDownloadFailedEventArgs {
     type Vtable = IAdaptiveMediaSourceDownloadFailedEventArgs_Vtbl;
@@ -1105,7 +1189,7 @@ impl AdaptiveMediaSourceDownloadRequestedDeferral {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDownloadRequestedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDownloadRequestedDeferral>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDownloadRequestedDeferral {
     type Vtable = IAdaptiveMediaSourceDownloadRequestedDeferral_Vtbl;
@@ -1193,7 +1277,7 @@ impl AdaptiveMediaSourceDownloadRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDownloadRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDownloadRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDownloadRequestedEventArgs {
     type Vtable = IAdaptiveMediaSourceDownloadRequestedEventArgs_Vtbl;
@@ -1307,7 +1391,7 @@ impl AdaptiveMediaSourceDownloadResult {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDownloadResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDownloadResult>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDownloadResult {
     type Vtable = IAdaptiveMediaSourceDownloadResult_Vtbl;
@@ -1353,7 +1437,7 @@ impl AdaptiveMediaSourceDownloadStatistics {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourceDownloadStatistics {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourceDownloadStatistics>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourceDownloadStatistics {
     type Vtable = IAdaptiveMediaSourceDownloadStatistics_Vtbl;
@@ -1392,7 +1476,7 @@ impl AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {
     type Vtable = IAdaptiveMediaSourcePlaybackBitrateChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IMediaTranscoder, IMediaTranscoder_Vtbl, 0x190c99d2_a0aa_4d34_86bc_eed1b12c2f5b);
+impl windows_core::RuntimeType for IMediaTranscoder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaTranscoder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +34,9 @@ pub struct IMediaTranscoder_Vtbl {
     PrepareStreamTranscodeAsync: usize,
 }
 windows_core::imp::define_interface!(IMediaTranscoder2, IMediaTranscoder2_Vtbl, 0x40531d74_35e0_4f04_8574_ca8bc4e5a082);
+impl windows_core::RuntimeType for IMediaTranscoder2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaTranscoder2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +48,9 @@ pub struct IMediaTranscoder2_Vtbl {
     pub VideoProcessingAlgorithm: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaVideoProcessingAlgorithm) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPrepareTranscodeResult, IPrepareTranscodeResult_Vtbl, 0x05f25dce_994f_4a34_9d68_97ccce1730d6);
+impl windows_core::RuntimeType for IPrepareTranscodeResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPrepareTranscodeResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -185,7 +194,7 @@ impl MediaTranscoder {
     }
 }
 impl windows_core::RuntimeType for MediaTranscoder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaTranscoder>();
 }
 unsafe impl windows_core::Interface for MediaTranscoder {
     type Vtable = IMediaTranscoder_Vtbl;
@@ -224,7 +233,7 @@ impl PrepareTranscodeResult {
     }
 }
 impl windows_core::RuntimeType for PrepareTranscodeResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPrepareTranscodeResult>();
 }
 unsafe impl windows_core::Interface for PrepareTranscodeResult {
     type Vtable = IPrepareTranscodeResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/mod.rs
@@ -53,6 +53,9 @@ pub mod Streaming;
 #[cfg(feature = "Media_Transcoding")]
 pub mod Transcoding;
 windows_core::imp::define_interface!(IAudioBuffer, IAudioBuffer_Vtbl, 0x35175827_724b_4c6a_b130_f6537f9ae0d0);
+impl windows_core::RuntimeType for IAudioBuffer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioBuffer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,24 +64,36 @@ pub struct IAudioBuffer_Vtbl {
     pub SetLength: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioFrame, IAudioFrame_Vtbl, 0xe36ac304_aab2_4277_9ed0_43cedf8e29c6);
+impl windows_core::RuntimeType for IAudioFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LockBuffer: unsafe extern "system" fn(*mut core::ffi::c_void, AudioBufferAccessMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioFrameFactory, IAudioFrameFactory_Vtbl, 0x91a90ade_2422_40a6_b9ad_30d02404317d);
+impl windows_core::RuntimeType for IAudioFrameFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioFrameFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAutoRepeatModeChangeRequestedEventArgs, IAutoRepeatModeChangeRequestedEventArgs_Vtbl, 0xea137efa_d852_438e_882b_c990109a78f4);
+impl windows_core::RuntimeType for IAutoRepeatModeChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutoRepeatModeChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestedAutoRepeatMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MediaPlaybackAutoRepeatMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImageDisplayProperties, IImageDisplayProperties_Vtbl, 0xcd0bc7ef_54e7_411f_9933_f0e98b0a96d2);
+impl windows_core::RuntimeType for IImageDisplayProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageDisplayProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +104,10 @@ pub struct IImageDisplayProperties_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IMediaControl, IMediaControl_Vtbl, 0x98f1fbe1_7a8d_42cb_b6fe_8fe698264f13);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IMediaControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IMediaControl_Vtbl {
@@ -250,6 +269,9 @@ pub struct IMediaExtension_Vtbl {
     SetProperties: usize,
 }
 windows_core::imp::define_interface!(IMediaExtensionManager, IMediaExtensionManager_Vtbl, 0x4a25eaf5_242d_4dfb_97f4_69b7c42576ff);
+impl windows_core::RuntimeType for IMediaExtensionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaExtensionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -285,6 +307,9 @@ pub struct IMediaExtensionManager_Vtbl {
     RegisterVideoEncoderWithSettings: usize,
 }
 windows_core::imp::define_interface!(IMediaExtensionManager2, IMediaExtensionManager2_Vtbl, 0x5bcebf47_4043_4fed_acaf_54ec29dfb1f7);
+impl windows_core::RuntimeType for IMediaExtensionManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaExtensionManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -434,6 +459,9 @@ pub struct IMediaMarker_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaMarkerTypesStatics, IMediaMarkerTypesStatics_Vtbl, 0xbb198040_482f_4743_8832_45853821ece0);
+impl windows_core::RuntimeType for IMediaMarkerTypesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaMarkerTypesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -463,6 +491,9 @@ pub struct IMediaMarkers_Vtbl {
     Markers: usize,
 }
 windows_core::imp::define_interface!(IMediaProcessingTriggerDetails, IMediaProcessingTriggerDetails_Vtbl, 0xeb8564ac_a351_4f4e_b4f0_9bf2408993db);
+impl windows_core::RuntimeType for IMediaProcessingTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaProcessingTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -472,6 +503,9 @@ pub struct IMediaProcessingTriggerDetails_Vtbl {
     Arguments: usize,
 }
 windows_core::imp::define_interface!(IMediaTimelineController, IMediaTimelineController_Vtbl, 0x8ed361f3_0b78_4360_bf71_0c841999ea1b);
+impl windows_core::RuntimeType for IMediaTimelineController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaTimelineController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -489,6 +523,9 @@ pub struct IMediaTimelineController_Vtbl {
     pub RemoveStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaTimelineController2, IMediaTimelineController2_Vtbl, 0xef74ea38_9e72_4df9_8355_6e90c81bbadd);
+impl windows_core::RuntimeType for IMediaTimelineController2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaTimelineController2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -502,12 +539,18 @@ pub struct IMediaTimelineController2_Vtbl {
     pub RemoveEnded: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaTimelineControllerFailedEventArgs, IMediaTimelineControllerFailedEventArgs_Vtbl, 0x8821f81d_3e77_43fb_be26_4fc87a044834);
+impl windows_core::RuntimeType for IMediaTimelineControllerFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaTimelineControllerFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMusicDisplayProperties, IMusicDisplayProperties_Vtbl, 0x6bbf0c59_d0a0_4d26_92a0_f978e1d18e7b);
+impl windows_core::RuntimeType for IMusicDisplayProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMusicDisplayProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -519,6 +562,9 @@ pub struct IMusicDisplayProperties_Vtbl {
     pub SetArtist: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMusicDisplayProperties2, IMusicDisplayProperties2_Vtbl, 0x00368462_97d3_44b9_b00f_008afcefaf18);
+impl windows_core::RuntimeType for IMusicDisplayProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMusicDisplayProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -532,6 +578,9 @@ pub struct IMusicDisplayProperties2_Vtbl {
     Genres: usize,
 }
 windows_core::imp::define_interface!(IMusicDisplayProperties3, IMusicDisplayProperties3_Vtbl, 0x4db51ac1_0681_4e8c_9401_b8159d9eefc7);
+impl windows_core::RuntimeType for IMusicDisplayProperties3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMusicDisplayProperties3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -539,24 +588,36 @@ pub struct IMusicDisplayProperties3_Vtbl {
     pub SetAlbumTrackCount: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaybackPositionChangeRequestedEventArgs, IPlaybackPositionChangeRequestedEventArgs_Vtbl, 0xb4493f88_eb28_4961_9c14_335e44f3e125);
+impl windows_core::RuntimeType for IPlaybackPositionChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackPositionChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestedPlaybackPosition: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaybackRateChangeRequestedEventArgs, IPlaybackRateChangeRequestedEventArgs_Vtbl, 0x2ce2c41f_3cd6_4f77_9ba7_eb27c26a2140);
+impl windows_core::RuntimeType for IPlaybackRateChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaybackRateChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestedPlaybackRate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShuffleEnabledChangeRequestedEventArgs, IShuffleEnabledChangeRequestedEventArgs_Vtbl, 0x49b593fe_4fd0_4666_a314_c0e01940d302);
+impl windows_core::RuntimeType for IShuffleEnabledChangeRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShuffleEnabledChangeRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestedShuffleEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaTransportControls, ISystemMediaTransportControls_Vtbl, 0x99fa3ff4_1742_42a6_902e_087d41f965ec);
+impl windows_core::RuntimeType for ISystemMediaTransportControls {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaTransportControls_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -592,6 +653,9 @@ pub struct ISystemMediaTransportControls_Vtbl {
     pub RemovePropertyChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaTransportControls2, ISystemMediaTransportControls2_Vtbl, 0xea98d2f6_7f3c_4af2_a586_72889808efb1);
+impl windows_core::RuntimeType for ISystemMediaTransportControls2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaTransportControls2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -612,12 +676,18 @@ pub struct ISystemMediaTransportControls2_Vtbl {
     pub RemoveAutoRepeatModeChangeRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaTransportControlsButtonPressedEventArgs, ISystemMediaTransportControlsButtonPressedEventArgs_Vtbl, 0xb7f47116_a56f_4dc8_9e11_92031f4a87c2);
+impl windows_core::RuntimeType for ISystemMediaTransportControlsButtonPressedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaTransportControlsButtonPressedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Button: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SystemMediaTransportControlsButton) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaTransportControlsDisplayUpdater, ISystemMediaTransportControlsDisplayUpdater_Vtbl, 0x8abbc53e_fa55_4ecf_ad8e_c984e5dd1550);
+impl windows_core::RuntimeType for ISystemMediaTransportControlsDisplayUpdater {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaTransportControlsDisplayUpdater_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -644,18 +714,27 @@ pub struct ISystemMediaTransportControlsDisplayUpdater_Vtbl {
     pub Update: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaTransportControlsPropertyChangedEventArgs, ISystemMediaTransportControlsPropertyChangedEventArgs_Vtbl, 0xd0ca0936_339b_4cb3_8eeb_737607f56e08);
+impl windows_core::RuntimeType for ISystemMediaTransportControlsPropertyChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaTransportControlsPropertyChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Property: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SystemMediaTransportControlsProperty) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaTransportControlsStatics, ISystemMediaTransportControlsStatics_Vtbl, 0x43ba380a_eca4_4832_91ab_d415fae484c6);
+impl windows_core::RuntimeType for ISystemMediaTransportControlsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaTransportControlsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaTransportControlsTimelineProperties, ISystemMediaTransportControlsTimelineProperties_Vtbl, 0x5125316a_c3a2_475b_8507_93534dc88f15);
+impl windows_core::RuntimeType for ISystemMediaTransportControlsTimelineProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaTransportControlsTimelineProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -671,6 +750,9 @@ pub struct ISystemMediaTransportControlsTimelineProperties_Vtbl {
     pub SetPosition: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoDisplayProperties, IVideoDisplayProperties_Vtbl, 0x5609fdb1_5d2d_4872_8170_45dee5bc2f5c);
+impl windows_core::RuntimeType for IVideoDisplayProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoDisplayProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -680,6 +762,9 @@ pub struct IVideoDisplayProperties_Vtbl {
     pub SetSubtitle: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoDisplayProperties2, IVideoDisplayProperties2_Vtbl, 0xb410e1ce_ab52_41ab_a486_cc10fab152f9);
+impl windows_core::RuntimeType for IVideoDisplayProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoDisplayProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -689,12 +774,18 @@ pub struct IVideoDisplayProperties2_Vtbl {
     Genres: usize,
 }
 windows_core::imp::define_interface!(IVideoEffectsStatics, IVideoEffectsStatics_Vtbl, 0x1fcda5e8_baf1_4521_980c_3bcebb44cf38);
+impl windows_core::RuntimeType for IVideoEffectsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoEffectsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub VideoStabilization: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoFrame, IVideoFrame_Vtbl, 0x0cc06625_90fc_4c92_bd95_7ded21819d1c);
+impl windows_core::RuntimeType for IVideoFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -709,6 +800,9 @@ pub struct IVideoFrame_Vtbl {
     Direct3DSurface: usize,
 }
 windows_core::imp::define_interface!(IVideoFrame2, IVideoFrame2_Vtbl, 0x3837840d_336c_4366_8d46_060798736c5d);
+impl windows_core::RuntimeType for IVideoFrame2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoFrame2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -718,6 +812,9 @@ pub struct IVideoFrame2_Vtbl {
     CopyToWithBoundsAsync: usize,
 }
 windows_core::imp::define_interface!(IVideoFrameFactory, IVideoFrameFactory_Vtbl, 0x014b6d69_2228_4c92_92ff_50c380d3e776);
+impl windows_core::RuntimeType for IVideoFrameFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoFrameFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -731,6 +828,9 @@ pub struct IVideoFrameFactory_Vtbl {
     CreateWithAlpha: usize,
 }
 windows_core::imp::define_interface!(IVideoFrameStatics, IVideoFrameStatics_Vtbl, 0xab2a556f_6111_4b33_8ec3_2b209a02e17a);
+impl windows_core::RuntimeType for IVideoFrameStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoFrameStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -788,7 +888,7 @@ impl AudioBuffer {
     }
 }
 impl windows_core::RuntimeType for AudioBuffer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioBuffer>();
 }
 unsafe impl windows_core::Interface for AudioBuffer {
     type Vtable = IAudioBuffer_Vtbl;
@@ -904,7 +1004,7 @@ impl AudioFrame {
     }
 }
 impl windows_core::RuntimeType for AudioFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioFrame>();
 }
 unsafe impl windows_core::Interface for AudioFrame {
     type Vtable = IAudioFrame_Vtbl;
@@ -929,7 +1029,7 @@ impl AutoRepeatModeChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AutoRepeatModeChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutoRepeatModeChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for AutoRepeatModeChangeRequestedEventArgs {
     type Vtable = IAutoRepeatModeChangeRequestedEventArgs_Vtbl;
@@ -969,7 +1069,7 @@ impl ImageDisplayProperties {
     }
 }
 impl windows_core::RuntimeType for ImageDisplayProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageDisplayProperties>();
 }
 unsafe impl windows_core::Interface for ImageDisplayProperties {
     type Vtable = IImageDisplayProperties_Vtbl;
@@ -1312,7 +1412,7 @@ impl MediaExtensionManager {
     }
 }
 impl windows_core::RuntimeType for MediaExtensionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaExtensionManager>();
 }
 unsafe impl windows_core::Interface for MediaExtensionManager {
     type Vtable = IMediaExtensionManager_Vtbl;
@@ -1355,7 +1455,7 @@ impl MediaProcessingTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for MediaProcessingTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaProcessingTriggerDetails>();
 }
 unsafe impl windows_core::Interface for MediaProcessingTriggerDetails {
     type Vtable = IMediaProcessingTriggerDetails_Vtbl;
@@ -1502,7 +1602,7 @@ impl MediaTimelineController {
     }
 }
 impl windows_core::RuntimeType for MediaTimelineController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaTimelineController>();
 }
 unsafe impl windows_core::Interface for MediaTimelineController {
     type Vtable = IMediaTimelineController_Vtbl;
@@ -1527,7 +1627,7 @@ impl MediaTimelineControllerFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MediaTimelineControllerFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaTimelineControllerFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for MediaTimelineControllerFailedEventArgs {
     type Vtable = IMediaTimelineControllerFailedEventArgs_Vtbl;
@@ -1619,7 +1719,7 @@ impl MusicDisplayProperties {
     }
 }
 impl windows_core::RuntimeType for MusicDisplayProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMusicDisplayProperties>();
 }
 unsafe impl windows_core::Interface for MusicDisplayProperties {
     type Vtable = IMusicDisplayProperties_Vtbl;
@@ -1644,7 +1744,7 @@ impl PlaybackPositionChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PlaybackPositionChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaybackPositionChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PlaybackPositionChangeRequestedEventArgs {
     type Vtable = IPlaybackPositionChangeRequestedEventArgs_Vtbl;
@@ -1669,7 +1769,7 @@ impl PlaybackRateChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PlaybackRateChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaybackRateChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PlaybackRateChangeRequestedEventArgs {
     type Vtable = IPlaybackRateChangeRequestedEventArgs_Vtbl;
@@ -1694,7 +1794,7 @@ impl ShuffleEnabledChangeRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ShuffleEnabledChangeRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShuffleEnabledChangeRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for ShuffleEnabledChangeRequestedEventArgs {
     type Vtable = IShuffleEnabledChangeRequestedEventArgs_Vtbl;
@@ -1993,7 +2093,7 @@ impl SystemMediaTransportControls {
     }
 }
 impl windows_core::RuntimeType for SystemMediaTransportControls {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMediaTransportControls>();
 }
 unsafe impl windows_core::Interface for SystemMediaTransportControls {
     type Vtable = ISystemMediaTransportControls_Vtbl;
@@ -2018,7 +2118,7 @@ impl SystemMediaTransportControlsButtonPressedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SystemMediaTransportControlsButtonPressedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMediaTransportControlsButtonPressedEventArgs>();
 }
 unsafe impl windows_core::Interface for SystemMediaTransportControlsButtonPressedEventArgs {
     type Vtable = ISystemMediaTransportControlsButtonPressedEventArgs_Vtbl;
@@ -2114,7 +2214,7 @@ impl SystemMediaTransportControlsDisplayUpdater {
     }
 }
 impl windows_core::RuntimeType for SystemMediaTransportControlsDisplayUpdater {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMediaTransportControlsDisplayUpdater>();
 }
 unsafe impl windows_core::Interface for SystemMediaTransportControlsDisplayUpdater {
     type Vtable = ISystemMediaTransportControlsDisplayUpdater_Vtbl;
@@ -2139,7 +2239,7 @@ impl SystemMediaTransportControlsPropertyChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SystemMediaTransportControlsPropertyChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMediaTransportControlsPropertyChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for SystemMediaTransportControlsPropertyChangedEventArgs {
     type Vtable = ISystemMediaTransportControlsPropertyChangedEventArgs_Vtbl;
@@ -2219,7 +2319,7 @@ impl SystemMediaTransportControlsTimelineProperties {
     }
 }
 impl windows_core::RuntimeType for SystemMediaTransportControlsTimelineProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMediaTransportControlsTimelineProperties>();
 }
 unsafe impl windows_core::Interface for SystemMediaTransportControlsTimelineProperties {
     type Vtable = ISystemMediaTransportControlsTimelineProperties_Vtbl;
@@ -2267,7 +2367,7 @@ impl VideoDisplayProperties {
     }
 }
 impl windows_core::RuntimeType for VideoDisplayProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoDisplayProperties>();
 }
 unsafe impl windows_core::Interface for VideoDisplayProperties {
     type Vtable = IVideoDisplayProperties_Vtbl;
@@ -2482,7 +2582,7 @@ impl VideoFrame {
     }
 }
 impl windows_core::RuntimeType for VideoFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoFrame>();
 }
 unsafe impl windows_core::Interface for VideoFrame {
     type Vtable = IVideoFrame_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBackgroundDownloader, IBackgroundDownloader_Vtbl, 0xc1c79333_6649_4b1d_a826_a4b3dd234d0b);
+impl windows_core::RuntimeType for IBackgroundDownloader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundDownloader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +19,9 @@ pub struct IBackgroundDownloader_Vtbl {
     CreateDownloadAsync: usize,
 }
 windows_core::imp::define_interface!(IBackgroundDownloader2, IBackgroundDownloader2_Vtbl, 0xa94a5847_348d_4a35_890e_8a1ef3798479);
+impl windows_core::RuntimeType for IBackgroundDownloader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundDownloader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,18 +61,27 @@ pub struct IBackgroundDownloader2_Vtbl {
     SetFailureTileNotification: usize,
 }
 windows_core::imp::define_interface!(IBackgroundDownloader3, IBackgroundDownloader3_Vtbl, 0xd11a8c48_86e8_48e2_b615_6976aabf861d);
+impl windows_core::RuntimeType for IBackgroundDownloader3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundDownloader3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CompletionGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundDownloaderFactory, IBackgroundDownloaderFactory_Vtbl, 0x26836c24_d89e_46f4_a29a_4f4d4f144155);
+impl windows_core::RuntimeType for IBackgroundDownloaderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundDownloaderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithCompletionGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundDownloaderStaticMethods, IBackgroundDownloaderStaticMethods_Vtbl, 0x52a65a35_c64e_426c_9919_540d0d21a650);
+impl windows_core::RuntimeType for IBackgroundDownloaderStaticMethods {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundDownloaderStaticMethods_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +95,9 @@ pub struct IBackgroundDownloaderStaticMethods_Vtbl {
     GetCurrentDownloadsForGroupAsync: usize,
 }
 windows_core::imp::define_interface!(IBackgroundDownloaderStaticMethods2, IBackgroundDownloaderStaticMethods2_Vtbl, 0x2faa1327_1ad4_4ca5_b2cd_08dbf0746afe);
+impl windows_core::RuntimeType for IBackgroundDownloaderStaticMethods2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundDownloaderStaticMethods2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +108,10 @@ pub struct IBackgroundDownloaderStaticMethods2_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IBackgroundDownloaderUserConsent, IBackgroundDownloaderUserConsent_Vtbl, 0x5d14e906_9266_4808_bd71_5925f2a3130a);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IBackgroundDownloaderUserConsent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IBackgroundDownloaderUserConsent_Vtbl {
@@ -211,6 +233,9 @@ pub struct IBackgroundTransferBase_Vtbl {
     pub SetCostPolicy: unsafe extern "system" fn(*mut core::ffi::c_void, BackgroundTransferCostPolicy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTransferCompletionGroup, IBackgroundTransferCompletionGroup_Vtbl, 0x2d930225_986b_574d_7950_0add47f5d706);
+impl windows_core::RuntimeType for IBackgroundTransferCompletionGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTransferCompletionGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,6 +247,9 @@ pub struct IBackgroundTransferCompletionGroup_Vtbl {
     pub Enable: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTransferCompletionGroupTriggerDetails, IBackgroundTransferCompletionGroupTriggerDetails_Vtbl, 0x7b6be286_6e47_5136_7fcb_fa4389f46f5b);
+impl windows_core::RuntimeType for IBackgroundTransferCompletionGroupTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTransferCompletionGroupTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,6 +263,9 @@ pub struct IBackgroundTransferCompletionGroupTriggerDetails_Vtbl {
     Uploads: usize,
 }
 windows_core::imp::define_interface!(IBackgroundTransferContentPart, IBackgroundTransferContentPart_Vtbl, 0xe8e15657_d7d1_4ed8_838e_674ac217ace6);
+impl windows_core::RuntimeType for IBackgroundTransferContentPart {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTransferContentPart_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -273,6 +304,9 @@ pub struct IBackgroundTransferContentPartFactory_Vtbl {
     pub CreateWithNameAndFileName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTransferErrorStaticMethods, IBackgroundTransferErrorStaticMethods_Vtbl, 0xaad33b04_1192_4bf4_8b68_39c5add244e2);
+impl windows_core::RuntimeType for IBackgroundTransferErrorStaticMethods {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTransferErrorStaticMethods_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -282,6 +316,9 @@ pub struct IBackgroundTransferErrorStaticMethods_Vtbl {
     GetStatus: usize,
 }
 windows_core::imp::define_interface!(IBackgroundTransferGroup, IBackgroundTransferGroup_Vtbl, 0xd8c3e3e4_6459_4540_85eb_aaa1c8903677);
+impl windows_core::RuntimeType for IBackgroundTransferGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTransferGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,6 +327,9 @@ pub struct IBackgroundTransferGroup_Vtbl {
     pub SetTransferBehavior: unsafe extern "system" fn(*mut core::ffi::c_void, BackgroundTransferBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTransferGroupStatics, IBackgroundTransferGroupStatics_Vtbl, 0x02ec50b2_7d18_495b_aa22_32a97d45d3e2);
+impl windows_core::RuntimeType for IBackgroundTransferGroupStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTransferGroupStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -400,6 +440,9 @@ pub struct IBackgroundTransferOperationPriority_Vtbl {
     pub SetPriority: unsafe extern "system" fn(*mut core::ffi::c_void, BackgroundTransferPriority) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundTransferRangesDownloadedEventArgs, IBackgroundTransferRangesDownloadedEventArgs_Vtbl, 0x3ebc7453_bf48_4a88_9248_b0c165184f5c);
+impl windows_core::RuntimeType for IBackgroundTransferRangesDownloadedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundTransferRangesDownloadedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -411,6 +454,9 @@ pub struct IBackgroundTransferRangesDownloadedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundUploader, IBackgroundUploader_Vtbl, 0xc595c9ae_cead_465b_8801_c55ac90a01ce);
+impl windows_core::RuntimeType for IBackgroundUploader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundUploader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -436,6 +482,9 @@ pub struct IBackgroundUploader_Vtbl {
     CreateUploadWithSubTypeAndBoundaryAsync: usize,
 }
 windows_core::imp::define_interface!(IBackgroundUploader2, IBackgroundUploader2_Vtbl, 0x8e0612ce_0c34_4463_807f_198a1b8bd4ad);
+impl windows_core::RuntimeType for IBackgroundUploader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundUploader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -475,18 +524,27 @@ pub struct IBackgroundUploader2_Vtbl {
     SetFailureTileNotification: usize,
 }
 windows_core::imp::define_interface!(IBackgroundUploader3, IBackgroundUploader3_Vtbl, 0xb95e9439_5bf0_4b3a_8c47_2c6199a854b9);
+impl windows_core::RuntimeType for IBackgroundUploader3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundUploader3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CompletionGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundUploaderFactory, IBackgroundUploaderFactory_Vtbl, 0x736203c7_10e7_48a0_ac3c_1ac71095ec57);
+impl windows_core::RuntimeType for IBackgroundUploaderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundUploaderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithCompletionGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackgroundUploaderStaticMethods, IBackgroundUploaderStaticMethods_Vtbl, 0xf2875cfb_9b05_4741_9121_740a83e247df);
+impl windows_core::RuntimeType for IBackgroundUploaderStaticMethods {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundUploaderStaticMethods_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -500,6 +558,9 @@ pub struct IBackgroundUploaderStaticMethods_Vtbl {
     GetCurrentUploadsForGroupAsync: usize,
 }
 windows_core::imp::define_interface!(IBackgroundUploaderStaticMethods2, IBackgroundUploaderStaticMethods2_Vtbl, 0xe919ac62_ea08_42f0_a2ac_07e467549080);
+impl windows_core::RuntimeType for IBackgroundUploaderStaticMethods2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackgroundUploaderStaticMethods2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -511,6 +572,10 @@ pub struct IBackgroundUploaderStaticMethods2_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IBackgroundUploaderUserConsent, IBackgroundUploaderUserConsent_Vtbl, 0x3bb384cb_0760_461d_907f_5138f84d44c1);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IBackgroundUploaderUserConsent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IBackgroundUploaderUserConsent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -520,6 +585,9 @@ pub struct IBackgroundUploaderUserConsent_Vtbl {
     RequestUnconstrainedUploadsAsync: usize,
 }
 windows_core::imp::define_interface!(IContentPrefetcher, IContentPrefetcher_Vtbl, 0xa8d6f754_7dc1_4cd9_8810_2a6aa9417e11);
+impl windows_core::RuntimeType for IContentPrefetcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentPrefetcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -531,12 +599,18 @@ pub struct IContentPrefetcher_Vtbl {
     pub IndirectContentUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContentPrefetcherTime, IContentPrefetcherTime_Vtbl, 0xe361fd08_132a_4fde_a7cc_fcb0e66523af);
+impl windows_core::RuntimeType for IContentPrefetcherTime {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentPrefetcherTime_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LastSuccessfulPrefetchTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDownloadOperation, IDownloadOperation_Vtbl, 0xbd87ebb0_5714_4e09_ba68_bef73903b0d7);
+impl windows_core::RuntimeType for IDownloadOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDownloadOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -551,12 +625,18 @@ pub struct IDownloadOperation_Vtbl {
     pub Resume: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDownloadOperation2, IDownloadOperation2_Vtbl, 0xa3cced40_8f9c_4353_9cd4_290dee387c38);
+impl windows_core::RuntimeType for IDownloadOperation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDownloadOperation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TransferGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDownloadOperation3, IDownloadOperation3_Vtbl, 0x5027351c_7d5e_4adc_b8d3_df5c6031b9cc);
+impl windows_core::RuntimeType for IDownloadOperation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDownloadOperation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -583,12 +663,18 @@ pub struct IDownloadOperation3_Vtbl {
     CurrentWebErrorStatus: usize,
 }
 windows_core::imp::define_interface!(IDownloadOperation4, IDownloadOperation4_Vtbl, 0x0cdaaef4_8cef_404a_966d_f058400bed80);
+impl windows_core::RuntimeType for IDownloadOperation4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDownloadOperation4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MakeCurrentInTransferGroup: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDownloadOperation5, IDownloadOperation5_Vtbl, 0xa699a86f_5590_463a_b8d6_1e491a2760a5);
+impl windows_core::RuntimeType for IDownloadOperation5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDownloadOperation5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -596,6 +682,9 @@ pub struct IDownloadOperation5_Vtbl {
     pub RemoveRequestHeader: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IResponseInformation, IResponseInformation_Vtbl, 0xf8bb9a12_f713_4792_8b68_d9d297f91d2e);
+impl windows_core::RuntimeType for IResponseInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResponseInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -610,6 +699,10 @@ pub struct IResponseInformation_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IUnconstrainedTransferRequestResult, IUnconstrainedTransferRequestResult_Vtbl, 0x4c24b81f_d944_4112_a98e_6a69522b7ebb);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IUnconstrainedTransferRequestResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IUnconstrainedTransferRequestResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -619,6 +712,9 @@ pub struct IUnconstrainedTransferRequestResult_Vtbl {
     IsUnconstrained: usize,
 }
 windows_core::imp::define_interface!(IUploadOperation, IUploadOperation_Vtbl, 0x3e5624e0_7389_434c_8b35_427fd36bbdae);
+impl windows_core::RuntimeType for IUploadOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUploadOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -631,18 +727,27 @@ pub struct IUploadOperation_Vtbl {
     pub AttachAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUploadOperation2, IUploadOperation2_Vtbl, 0x556189f2_2774_4df6_9fa5_209f2bfb12f7);
+impl windows_core::RuntimeType for IUploadOperation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUploadOperation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TransferGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUploadOperation3, IUploadOperation3_Vtbl, 0x42c92ca3_de39_4546_bc62_3774b4294de3);
+impl windows_core::RuntimeType for IUploadOperation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUploadOperation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MakeCurrentInTransferGroup: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUploadOperation4, IUploadOperation4_Vtbl, 0x50edef31_fac5_41ee_b030_dc77caee9faa);
+impl windows_core::RuntimeType for IUploadOperation4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUploadOperation4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -922,7 +1027,7 @@ impl BackgroundDownloader {
     }
 }
 impl windows_core::RuntimeType for BackgroundDownloader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundDownloader>();
 }
 unsafe impl windows_core::Interface for BackgroundDownloader {
     type Vtable = IBackgroundDownloader_Vtbl;
@@ -966,7 +1071,7 @@ impl BackgroundTransferCompletionGroup {
     }
 }
 impl windows_core::RuntimeType for BackgroundTransferCompletionGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTransferCompletionGroup>();
 }
 unsafe impl windows_core::Interface for BackgroundTransferCompletionGroup {
     type Vtable = IBackgroundTransferCompletionGroup_Vtbl;
@@ -1000,7 +1105,7 @@ impl BackgroundTransferCompletionGroupTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for BackgroundTransferCompletionGroupTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTransferCompletionGroupTriggerDetails>();
 }
 unsafe impl windows_core::Interface for BackgroundTransferCompletionGroupTriggerDetails {
     type Vtable = IBackgroundTransferCompletionGroupTriggerDetails_Vtbl;
@@ -1058,7 +1163,7 @@ impl BackgroundTransferContentPart {
     }
 }
 impl windows_core::RuntimeType for BackgroundTransferContentPart {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTransferContentPart>();
 }
 unsafe impl windows_core::Interface for BackgroundTransferContentPart {
     type Vtable = IBackgroundTransferContentPart_Vtbl;
@@ -1123,7 +1228,7 @@ impl BackgroundTransferGroup {
     }
 }
 impl windows_core::RuntimeType for BackgroundTransferGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTransferGroup>();
 }
 unsafe impl windows_core::Interface for BackgroundTransferGroup {
     type Vtable = IBackgroundTransferGroup_Vtbl;
@@ -1163,7 +1268,7 @@ impl BackgroundTransferRangesDownloadedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BackgroundTransferRangesDownloadedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundTransferRangesDownloadedEventArgs>();
 }
 unsafe impl windows_core::Interface for BackgroundTransferRangesDownloadedEventArgs {
     type Vtable = IBackgroundTransferRangesDownloadedEventArgs_Vtbl;
@@ -1469,7 +1574,7 @@ impl BackgroundUploader {
     }
 }
 impl windows_core::RuntimeType for BackgroundUploader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackgroundUploader>();
 }
 unsafe impl windows_core::Interface for BackgroundUploader {
     type Vtable = IBackgroundUploader_Vtbl;
@@ -1715,7 +1820,7 @@ impl DownloadOperation {
     }
 }
 impl windows_core::RuntimeType for DownloadOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDownloadOperation>();
 }
 unsafe impl windows_core::Interface for DownloadOperation {
     type Vtable = IDownloadOperation_Vtbl;
@@ -1762,7 +1867,7 @@ impl ResponseInformation {
     }
 }
 impl windows_core::RuntimeType for ResponseInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResponseInformation>();
 }
 unsafe impl windows_core::Interface for ResponseInformation {
     type Vtable = IResponseInformation_Vtbl;
@@ -1792,7 +1897,7 @@ impl UnconstrainedTransferRequestResult {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for UnconstrainedTransferRequestResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUnconstrainedTransferRequestResult>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for UnconstrainedTransferRequestResult {
@@ -1929,7 +2034,7 @@ impl UploadOperation {
     }
 }
 impl windows_core::RuntimeType for UploadOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUploadOperation>();
 }
 unsafe impl windows_core::Interface for UploadOperation {
     type Vtable = IUploadOperation_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAttributedNetworkUsage, IAttributedNetworkUsage_Vtbl, 0xf769b039_eca2_45eb_ade1_b0368b756c49);
+impl windows_core::RuntimeType for IAttributedNetworkUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAttributedNetworkUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct IAttributedNetworkUsage_Vtbl {
     AttributionThumbnail: usize,
 }
 windows_core::imp::define_interface!(ICellularApnContext, ICellularApnContext_Vtbl, 0x6fa529f4_effd_4542_9ab2_705bbf94943a);
+impl windows_core::RuntimeType for ICellularApnContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICellularApnContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +35,9 @@ pub struct ICellularApnContext_Vtbl {
     pub SetAuthenticationType: unsafe extern "system" fn(*mut core::ffi::c_void, CellularApnAuthenticationType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICellularApnContext2, ICellularApnContext2_Vtbl, 0x76b0eb1a_ac49_4350_b1e5_dc4763bc69c7);
+impl windows_core::RuntimeType for ICellularApnContext2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICellularApnContext2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +45,9 @@ pub struct ICellularApnContext2_Vtbl {
     pub SetProfileName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionCost, IConnectionCost_Vtbl, 0xbad7d829_3416_4b10_a202_bac0b075bdae);
+impl windows_core::RuntimeType for IConnectionCost {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionCost_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,12 +57,18 @@ pub struct IConnectionCost_Vtbl {
     pub ApproachingDataLimit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionCost2, IConnectionCost2_Vtbl, 0x8e113a05_e209_4549_bb25_5e0db691cb05);
+impl windows_core::RuntimeType for IConnectionCost2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionCost2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BackgroundDataUsageRestricted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionProfile, IConnectionProfile_Vtbl, 0x71ba143c_598e_49d0_84eb_8febaedcc195);
+impl windows_core::RuntimeType for IConnectionProfile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -74,6 +92,9 @@ pub struct IConnectionProfile_Vtbl {
     pub NetworkSecuritySettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionProfile2, IConnectionProfile2_Vtbl, 0xe2045145_4c9f_400c_9150_7ec7d6e2888a);
+impl windows_core::RuntimeType for IConnectionProfile2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfile2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +115,9 @@ pub struct IConnectionProfile2_Vtbl {
     GetConnectivityIntervalsAsync: usize,
 }
 windows_core::imp::define_interface!(IConnectionProfile3, IConnectionProfile3_Vtbl, 0x578c2528_4cd9_4161_8045_201cfd5b115c);
+impl windows_core::RuntimeType for IConnectionProfile3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfile3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,6 +127,9 @@ pub struct IConnectionProfile3_Vtbl {
     GetAttributedNetworkUsageAsync: usize,
 }
 windows_core::imp::define_interface!(IConnectionProfile4, IConnectionProfile4_Vtbl, 0x7a2d42cd_81e0_4ae6_abed_ab9ca13eb714);
+impl windows_core::RuntimeType for IConnectionProfile4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfile4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -112,6 +139,9 @@ pub struct IConnectionProfile4_Vtbl {
     GetProviderNetworkUsageAsync: usize,
 }
 windows_core::imp::define_interface!(IConnectionProfile5, IConnectionProfile5_Vtbl, 0x85361ec7_9c73_4be0_8f14_578eec71ee0e);
+impl windows_core::RuntimeType for IConnectionProfile5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfile5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -119,12 +149,18 @@ pub struct IConnectionProfile5_Vtbl {
     pub TryDeleteAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionProfile6, IConnectionProfile6_Vtbl, 0xdc27dfe2_7a6f_5d0e_9589_2fe2e5b6f9aa);
+impl windows_core::RuntimeType for IConnectionProfile6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfile6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsDomainAuthenticatedBy: unsafe extern "system" fn(*mut core::ffi::c_void, DomainAuthenticationKind, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionProfileFilter, IConnectionProfileFilter_Vtbl, 0x204c7cc8_bd2d_4e8d_a4b3_455ec337388a);
+impl windows_core::RuntimeType for IConnectionProfileFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfileFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +176,9 @@ pub struct IConnectionProfileFilter_Vtbl {
     pub ServiceProviderGuid: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionProfileFilter2, IConnectionProfileFilter2_Vtbl, 0xcd068ee1_c3fc_4fad_9ddc_593faa4b7885);
+impl windows_core::RuntimeType for IConnectionProfileFilter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfileFilter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -155,6 +194,9 @@ pub struct IConnectionProfileFilter2_Vtbl {
     RawData: usize,
 }
 windows_core::imp::define_interface!(IConnectionProfileFilter3, IConnectionProfileFilter3_Vtbl, 0x0aaa09c0_5014_447c_8809_aee4cb0af94a);
+impl windows_core::RuntimeType for IConnectionProfileFilter3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionProfileFilter3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -162,12 +204,18 @@ pub struct IConnectionProfileFilter3_Vtbl {
     pub PurposeGuid: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectionSession, IConnectionSession_Vtbl, 0xff905d4c_f83b_41b0_8a0c_1462d9c56b73);
+impl windows_core::RuntimeType for IConnectionSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ConnectionProfile: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectivityInterval, IConnectivityInterval_Vtbl, 0x4faa3fff_6746_4824_a964_eed8e87f8709);
+impl windows_core::RuntimeType for IConnectivityInterval {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectivityInterval_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,6 +223,9 @@ pub struct IConnectivityInterval_Vtbl {
     pub ConnectionDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IConnectivityManagerStatics, IConnectivityManagerStatics_Vtbl, 0x5120d4b1_4fb1_48b0_afc9_42e0092a8164);
+impl windows_core::RuntimeType for IConnectivityManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectivityManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +234,9 @@ pub struct IConnectivityManagerStatics_Vtbl {
     pub RemoveHttpRoutePolicy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPlanStatus, IDataPlanStatus_Vtbl, 0x977a8b8c_3885_40f3_8851_42cd2bd568bb);
+impl windows_core::RuntimeType for IDataPlanStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPlanStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -194,6 +248,9 @@ pub struct IDataPlanStatus_Vtbl {
     pub MaxTransferSizeInMegabytes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataPlanUsage, IDataPlanUsage_Vtbl, 0xb921492d_3b44_47ff_b361_be59e69ed1b0);
+impl windows_core::RuntimeType for IDataPlanUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataPlanUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -202,6 +259,10 @@ pub struct IDataPlanUsage_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IDataUsage, IDataUsage_Vtbl, 0xc1431dd3_b146_4d39_b959_0c69b096c512);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IDataUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IDataUsage_Vtbl {
@@ -216,6 +277,9 @@ pub struct IDataUsage_Vtbl {
     BytesReceived: usize,
 }
 windows_core::imp::define_interface!(IIPInformation, IIPInformation_Vtbl, 0xd85145e0_138f_47d7_9b3a_36bb488cef33);
+impl windows_core::RuntimeType for IIPInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIPInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -223,6 +287,9 @@ pub struct IIPInformation_Vtbl {
     pub PrefixLength: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanIdentifier, ILanIdentifier_Vtbl, 0x48aa53aa_1108_4546_a6cb_9a74da4b7ba0);
+impl windows_core::RuntimeType for ILanIdentifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanIdentifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -231,6 +298,9 @@ pub struct ILanIdentifier_Vtbl {
     pub NetworkAdapterId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILanIdentifierData, ILanIdentifierData_Vtbl, 0xa74e83c3_d639_45be_a36a_c4e4aeaf6d9b);
+impl windows_core::RuntimeType for ILanIdentifierData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILanIdentifierData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -241,6 +311,9 @@ pub struct ILanIdentifierData_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(INetworkAdapter, INetworkAdapter_Vtbl, 0x3b542e03_5388_496c_a8a3_affd39aec2e6);
+impl windows_core::RuntimeType for INetworkAdapter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkAdapter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -252,6 +325,9 @@ pub struct INetworkAdapter_Vtbl {
     pub GetConnectedProfileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkInformationStatics, INetworkInformationStatics_Vtbl, 0x5074f851_950d_4165_9c15_365619481eea);
+impl windows_core::RuntimeType for INetworkInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -277,6 +353,9 @@ pub struct INetworkInformationStatics_Vtbl {
     pub RemoveNetworkStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkInformationStatics2, INetworkInformationStatics2_Vtbl, 0x459ced14_2832_49b6_ba6e_e265f04786a8);
+impl windows_core::RuntimeType for INetworkInformationStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkInformationStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -286,6 +365,9 @@ pub struct INetworkInformationStatics2_Vtbl {
     FindConnectionProfilesAsync: usize,
 }
 windows_core::imp::define_interface!(INetworkItem, INetworkItem_Vtbl, 0x01bc4d39_f5e0_4567_a28c_42080c831b2b);
+impl windows_core::RuntimeType for INetworkItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -293,6 +375,9 @@ pub struct INetworkItem_Vtbl {
     pub GetNetworkTypes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut NetworkTypes) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkSecuritySettings, INetworkSecuritySettings_Vtbl, 0x7ca07e8d_917b_4b5f_b84d_28f7a5ac5402);
+impl windows_core::RuntimeType for INetworkSecuritySettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkSecuritySettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -300,6 +385,9 @@ pub struct INetworkSecuritySettings_Vtbl {
     pub NetworkEncryptionType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut NetworkEncryptionType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkStateChangeEventDetails, INetworkStateChangeEventDetails_Vtbl, 0x1f0cf333_d7a6_44dd_a4e9_687c476b903d);
+impl windows_core::RuntimeType for INetworkStateChangeEventDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkStateChangeEventDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -311,6 +399,9 @@ pub struct INetworkStateChangeEventDetails_Vtbl {
     pub HasNewWwanRegistrationState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkStateChangeEventDetails2, INetworkStateChangeEventDetails2_Vtbl, 0xd643c0e8_30d3_4f6a_ad47_6a1873ceb3c1);
+impl windows_core::RuntimeType for INetworkStateChangeEventDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkStateChangeEventDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -318,6 +409,9 @@ pub struct INetworkStateChangeEventDetails2_Vtbl {
     pub HasNewTetheringClientCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkUsage, INetworkUsage_Vtbl, 0x49da8fce_9985_4927_bf5b_072b5c65f8d9);
+impl windows_core::RuntimeType for INetworkUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -326,6 +420,9 @@ pub struct INetworkUsage_Vtbl {
     pub ConnectionDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProviderNetworkUsage, IProviderNetworkUsage_Vtbl, 0x5ec69e04_7931_48c8_b8f3_46300fa42728);
+impl windows_core::RuntimeType for IProviderNetworkUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProviderNetworkUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -334,6 +431,9 @@ pub struct IProviderNetworkUsage_Vtbl {
     pub ProviderId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProxyConfiguration, IProxyConfiguration_Vtbl, 0xef3a60b4_9004_4dd6_b7d8_b3e502f4aad0);
+impl windows_core::RuntimeType for IProxyConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProxyConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -344,6 +444,9 @@ pub struct IProxyConfiguration_Vtbl {
     pub CanConnectDirectly: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRoutePolicy, IRoutePolicy_Vtbl, 0x11abc4ac_0fc7_42e4_8742_569923b1ca11);
+impl windows_core::RuntimeType for IRoutePolicy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRoutePolicy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -352,18 +455,27 @@ pub struct IRoutePolicy_Vtbl {
     pub HostNameType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::DomainNameType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRoutePolicyFactory, IRoutePolicyFactory_Vtbl, 0x36027933_a18e_4db5_a697_f58fa7364e44);
+impl windows_core::RuntimeType for IRoutePolicyFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRoutePolicyFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateRoutePolicy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, super::DomainNameType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWlanConnectionProfileDetails, IWlanConnectionProfileDetails_Vtbl, 0x562098cb_b35a_4bf1_a884_b7557e88ff86);
+impl windows_core::RuntimeType for IWlanConnectionProfileDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWlanConnectionProfileDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetConnectedSsid: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWwanConnectionProfileDetails, IWwanConnectionProfileDetails_Vtbl, 0x0e4da8fe_835f_4df3_82fd_df556ebc09ef);
+impl windows_core::RuntimeType for IWwanConnectionProfileDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWwanConnectionProfileDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -373,6 +485,9 @@ pub struct IWwanConnectionProfileDetails_Vtbl {
     pub GetCurrentDataClass: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WwanDataClass) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWwanConnectionProfileDetails2, IWwanConnectionProfileDetails2_Vtbl, 0x7a754ede_a1ed_48b2_8e92_b460033d52e2);
+impl windows_core::RuntimeType for IWwanConnectionProfileDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWwanConnectionProfileDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -425,7 +540,7 @@ impl AttributedNetworkUsage {
     }
 }
 impl windows_core::RuntimeType for AttributedNetworkUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAttributedNetworkUsage>();
 }
 unsafe impl windows_core::Interface for AttributedNetworkUsage {
     type Vtable = IAttributedNetworkUsage_Vtbl;
@@ -527,7 +642,7 @@ impl CellularApnContext {
     }
 }
 impl windows_core::RuntimeType for CellularApnContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICellularApnContext>();
 }
 unsafe impl windows_core::Interface for CellularApnContext {
     type Vtable = ICellularApnContext_Vtbl;
@@ -580,7 +695,7 @@ impl ConnectionCost {
     }
 }
 impl windows_core::RuntimeType for ConnectionCost {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConnectionCost>();
 }
 unsafe impl windows_core::Interface for ConnectionCost {
     type Vtable = IConnectionCost_Vtbl;
@@ -766,7 +881,7 @@ impl ConnectionProfile {
     }
 }
 impl windows_core::RuntimeType for ConnectionProfile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConnectionProfile>();
 }
 unsafe impl windows_core::Interface for ConnectionProfile {
     type Vtable = IConnectionProfile_Vtbl;
@@ -913,7 +1028,7 @@ impl ConnectionProfileFilter {
     }
 }
 impl windows_core::RuntimeType for ConnectionProfileFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConnectionProfileFilter>();
 }
 unsafe impl windows_core::Interface for ConnectionProfileFilter {
     type Vtable = IConnectionProfileFilter_Vtbl;
@@ -943,7 +1058,7 @@ impl ConnectionSession {
     }
 }
 impl windows_core::RuntimeType for ConnectionSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConnectionSession>();
 }
 unsafe impl windows_core::Interface for ConnectionSession {
     type Vtable = IConnectionSession_Vtbl;
@@ -975,7 +1090,7 @@ impl ConnectivityInterval {
     }
 }
 impl windows_core::RuntimeType for ConnectivityInterval {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConnectivityInterval>();
 }
 unsafe impl windows_core::Interface for ConnectivityInterval {
     type Vtable = IConnectivityInterval_Vtbl;
@@ -1067,7 +1182,7 @@ impl DataPlanStatus {
     }
 }
 impl windows_core::RuntimeType for DataPlanStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataPlanStatus>();
 }
 unsafe impl windows_core::Interface for DataPlanStatus {
     type Vtable = IDataPlanStatus_Vtbl;
@@ -1099,7 +1214,7 @@ impl DataPlanUsage {
     }
 }
 impl windows_core::RuntimeType for DataPlanUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataPlanUsage>();
 }
 unsafe impl windows_core::Interface for DataPlanUsage {
     type Vtable = IDataPlanUsage_Vtbl;
@@ -1137,7 +1252,7 @@ impl DataUsage {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for DataUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataUsage>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for DataUsage {
@@ -1173,7 +1288,7 @@ impl IPInformation {
     }
 }
 impl windows_core::RuntimeType for IPInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIPInformation>();
 }
 unsafe impl windows_core::Interface for IPInformation {
     type Vtable = IIPInformation_Vtbl;
@@ -1212,7 +1327,7 @@ impl LanIdentifier {
     }
 }
 impl windows_core::RuntimeType for LanIdentifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILanIdentifier>();
 }
 unsafe impl windows_core::Interface for LanIdentifier {
     type Vtable = ILanIdentifier_Vtbl;
@@ -1245,7 +1360,7 @@ impl LanIdentifierData {
     }
 }
 impl windows_core::RuntimeType for LanIdentifierData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILanIdentifierData>();
 }
 unsafe impl windows_core::Interface for LanIdentifierData {
     type Vtable = ILanIdentifierData_Vtbl;
@@ -1305,7 +1420,7 @@ impl NetworkAdapter {
     }
 }
 impl windows_core::RuntimeType for NetworkAdapter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkAdapter>();
 }
 unsafe impl windows_core::Interface for NetworkAdapter {
     type Vtable = INetworkAdapter_Vtbl;
@@ -1421,7 +1536,7 @@ impl NetworkItem {
     }
 }
 impl windows_core::RuntimeType for NetworkItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkItem>();
 }
 unsafe impl windows_core::Interface for NetworkItem {
     type Vtable = INetworkItem_Vtbl;
@@ -1453,7 +1568,7 @@ impl NetworkSecuritySettings {
     }
 }
 impl windows_core::RuntimeType for NetworkSecuritySettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkSecuritySettings>();
 }
 unsafe impl windows_core::Interface for NetworkSecuritySettings {
     type Vtable = INetworkSecuritySettings_Vtbl;
@@ -1527,7 +1642,7 @@ impl NetworkStateChangeEventDetails {
     }
 }
 impl windows_core::RuntimeType for NetworkStateChangeEventDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkStateChangeEventDetails>();
 }
 unsafe impl windows_core::Interface for NetworkStateChangeEventDetails {
     type Vtable = INetworkStateChangeEventDetails_Vtbl;
@@ -1566,7 +1681,7 @@ impl NetworkUsage {
     }
 }
 impl windows_core::RuntimeType for NetworkUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkUsage>();
 }
 unsafe impl windows_core::Interface for NetworkUsage {
     type Vtable = INetworkUsage_Vtbl;
@@ -1605,7 +1720,7 @@ impl ProviderNetworkUsage {
     }
 }
 impl windows_core::RuntimeType for ProviderNetworkUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProviderNetworkUsage>();
 }
 unsafe impl windows_core::Interface for ProviderNetworkUsage {
     type Vtable = IProviderNetworkUsage_Vtbl;
@@ -1638,7 +1753,7 @@ impl ProxyConfiguration {
     }
 }
 impl windows_core::RuntimeType for ProxyConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProxyConfiguration>();
 }
 unsafe impl windows_core::Interface for ProxyConfiguration {
     type Vtable = IProxyConfiguration_Vtbl;
@@ -1692,7 +1807,7 @@ impl RoutePolicy {
     }
 }
 impl windows_core::RuntimeType for RoutePolicy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRoutePolicy>();
 }
 unsafe impl windows_core::Interface for RoutePolicy {
     type Vtable = IRoutePolicy_Vtbl;
@@ -1717,7 +1832,7 @@ impl WlanConnectionProfileDetails {
     }
 }
 impl windows_core::RuntimeType for WlanConnectionProfileDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWlanConnectionProfileDetails>();
 }
 unsafe impl windows_core::Interface for WlanConnectionProfileDetails {
     type Vtable = IWlanConnectionProfileDetails_Vtbl;
@@ -1778,7 +1893,7 @@ impl WwanConnectionProfileDetails {
     }
 }
 impl windows_core::RuntimeType for WwanConnectionProfileDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWwanConnectionProfileDetails>();
 }
 unsafe impl windows_core::Interface for WwanConnectionProfileDetails {
     type Vtable = IWwanConnectionProfileDetails_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IESim, IESim_Vtbl, 0x6f6e6e26_f123_437d_8ced_dc1d2bc0c3a9);
+impl windows_core::RuntimeType for IESim {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESim_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +22,9 @@ pub struct IESim_Vtbl {
     pub RemoveProfileChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESim2, IESim2_Vtbl, 0xbd4fd0a0_c68f_56eb_b99b_8f34b8100299);
+impl windows_core::RuntimeType for IESim2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESim2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,18 +34,27 @@ pub struct IESim2_Vtbl {
     pub DiscoverWithServerAddressAndMatchingIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESim3, IESim3_Vtbl, 0xfe1edf45_01b8_5d31_b8d3_d9cbebb2b831);
+impl windows_core::RuntimeType for IESim3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESim3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SlotIndex: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimAddedEventArgs, IESimAddedEventArgs_Vtbl, 0x38bd0a58_4d5a_4d08_8da7_e73eff369ddd);
+impl windows_core::RuntimeType for IESimAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ESim: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimDiscoverEvent, IESimDiscoverEvent_Vtbl, 0xe59ac3e3_39bc_5f6f_9321_0d4a182d261b);
+impl windows_core::RuntimeType for IESimDiscoverEvent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimDiscoverEvent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,6 +62,9 @@ pub struct IESimDiscoverEvent_Vtbl {
     pub RspServerAddress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimDiscoverResult, IESimDiscoverResult_Vtbl, 0x56b4bb5e_ab2f_5ac6_b359_dd5a8e237926);
+impl windows_core::RuntimeType for IESimDiscoverResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimDiscoverResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +77,9 @@ pub struct IESimDiscoverResult_Vtbl {
     pub Result: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimDownloadProfileMetadataResult, IESimDownloadProfileMetadataResult_Vtbl, 0xc4234d9e_5ad6_426d_8d00_4434f449afec);
+impl windows_core::RuntimeType for IESimDownloadProfileMetadataResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimDownloadProfileMetadataResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +87,9 @@ pub struct IESimDownloadProfileMetadataResult_Vtbl {
     pub ProfileMetadata: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimManagerStatics, IESimManagerStatics_Vtbl, 0x0bfa2c0c_df88_4631_bf04_c12e281b3962);
+impl windows_core::RuntimeType for IESimManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,18 +99,27 @@ pub struct IESimManagerStatics_Vtbl {
     pub RemoveServiceInfoChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimOperationResult, IESimOperationResult_Vtbl, 0xa67b63b1_309b_4e77_9e7e_cd93f1ddc7b9);
+impl windows_core::RuntimeType for IESimOperationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimOperationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ESimOperationStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimPolicy, IESimPolicy_Vtbl, 0x41e1b99d_cf7e_4315_882b_6f1e74b0d38f);
+impl windows_core::RuntimeType for IESimPolicy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimPolicy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShouldEnableManagingUi: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimProfile, IESimProfile_Vtbl, 0xee1e7880_06a9_4027_b4f8_ddb23d7810e0);
+impl windows_core::RuntimeType for IESimProfile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimProfile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,6 +139,9 @@ pub struct IESimProfile_Vtbl {
     pub SetNicknameAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimProfileMetadata, IESimProfileMetadata_Vtbl, 0xed25831f_90db_498d_a7b4_ebce807d3c23);
+impl windows_core::RuntimeType for IESimProfileMetadata {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimProfileMetadata_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,6 +163,9 @@ pub struct IESimProfileMetadata_Vtbl {
     pub RemoveStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimProfilePolicy, IESimProfilePolicy_Vtbl, 0xe6dd0f1d_9c5c_46c5_a289_a948999bf062);
+impl windows_core::RuntimeType for IESimProfilePolicy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimProfilePolicy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -135,12 +174,18 @@ pub struct IESimProfilePolicy_Vtbl {
     pub IsManagedByEnterprise: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimRemovedEventArgs, IESimRemovedEventArgs_Vtbl, 0xdec5277b_2fd9_4ed9_8376_d9b5e41278a3);
+impl windows_core::RuntimeType for IESimRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ESim: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimServiceInfo, IESimServiceInfo_Vtbl, 0xf16aabcf_7f59_4a51_8494_bd89d5ff50ee);
+impl windows_core::RuntimeType for IESimServiceInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimServiceInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,12 +193,18 @@ pub struct IESimServiceInfo_Vtbl {
     pub IsESimUiEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimUpdatedEventArgs, IESimUpdatedEventArgs_Vtbl, 0x4c125cec_508d_4b88_83cb_68bef8168d12);
+impl windows_core::RuntimeType for IESimUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ESim: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IESimWatcher, IESimWatcher_Vtbl, 0xc1f84ceb_a28d_4fbf_9771_6e31b81ccf22);
+impl windows_core::RuntimeType for IESimWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IESimWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,12 +223,18 @@ pub struct IESimWatcher_Vtbl {
     pub RemoveUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFdnAccessManagerStatics, IFdnAccessManagerStatics_Vtbl, 0xf2aa4395_f1e6_4319_aa3e_477ca64b2bdf);
+impl windows_core::RuntimeType for IFdnAccessManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFdnAccessManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestUnlockAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHotspotAuthenticationContext, IHotspotAuthenticationContext_Vtbl, 0xe756c791_1003_4de5_83c7_de61d88831d0);
+impl windows_core::RuntimeType for IHotspotAuthenticationContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHotspotAuthenticationContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,24 +255,36 @@ pub struct IHotspotAuthenticationContext_Vtbl {
     pub TriggerAttentionRequired: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHotspotAuthenticationContext2, IHotspotAuthenticationContext2_Vtbl, 0xe756c791_1004_4de5_83c7_de61d88831d0);
+impl windows_core::RuntimeType for IHotspotAuthenticationContext2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHotspotAuthenticationContext2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IssueCredentialsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHotspotAuthenticationContextStatics, IHotspotAuthenticationContextStatics_Vtbl, 0xe756c791_1002_4de5_83c7_de61d88831d0);
+impl windows_core::RuntimeType for IHotspotAuthenticationContextStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHotspotAuthenticationContextStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryGetAuthenticationContext: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHotspotAuthenticationEventDetails, IHotspotAuthenticationEventDetails_Vtbl, 0xe756c791_1001_4de5_83c7_de61d88831d0);
+impl windows_core::RuntimeType for IHotspotAuthenticationEventDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHotspotAuthenticationEventDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub EventToken: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHotspotCredentialsAuthenticationResult, IHotspotCredentialsAuthenticationResult_Vtbl, 0xe756c791_1005_4de5_83c7_de61d88831d0);
+impl windows_core::RuntimeType for IHotspotCredentialsAuthenticationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHotspotCredentialsAuthenticationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -228,6 +297,9 @@ pub struct IHotspotCredentialsAuthenticationResult_Vtbl {
     AuthenticationReplyXml: usize,
 }
 windows_core::imp::define_interface!(IKnownCSimFilePathsStatics, IKnownCSimFilePathsStatics_Vtbl, 0xb458aeed_49f1_4c22_b073_96d511bf9c35);
+impl windows_core::RuntimeType for IKnownCSimFilePathsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownCSimFilePathsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -245,6 +317,9 @@ pub struct IKnownCSimFilePathsStatics_Vtbl {
     Gid2: usize,
 }
 windows_core::imp::define_interface!(IKnownRuimFilePathsStatics, IKnownRuimFilePathsStatics_Vtbl, 0x3883c8b9_ff24_4571_a867_09f960426e14);
+impl windows_core::RuntimeType for IKnownRuimFilePathsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownRuimFilePathsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -262,6 +337,9 @@ pub struct IKnownRuimFilePathsStatics_Vtbl {
     Gid2: usize,
 }
 windows_core::imp::define_interface!(IKnownSimFilePathsStatics, IKnownSimFilePathsStatics_Vtbl, 0x80cd1a63_37a5_43d3_80a3_ccd23e8fecee);
+impl windows_core::RuntimeType for IKnownSimFilePathsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownSimFilePathsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -283,6 +361,9 @@ pub struct IKnownSimFilePathsStatics_Vtbl {
     Gid2: usize,
 }
 windows_core::imp::define_interface!(IKnownUSimFilePathsStatics, IKnownUSimFilePathsStatics_Vtbl, 0x7c34e581_1f1b_43f4_9530_8b092d32d71f);
+impl windows_core::RuntimeType for IKnownUSimFilePathsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownUSimFilePathsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -308,6 +389,9 @@ pub struct IKnownUSimFilePathsStatics_Vtbl {
     Gid2: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAccount, IMobileBroadbandAccount_Vtbl, 0x36c24ccd_cee2_43e0_a603_ee86a36d6570);
+impl windows_core::RuntimeType for IMobileBroadbandAccount {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAccount_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -318,6 +402,9 @@ pub struct IMobileBroadbandAccount_Vtbl {
     pub CurrentDeviceInformation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAccount2, IMobileBroadbandAccount2_Vtbl, 0x38f52f1c_1136_4257_959f_b658a352b6d4);
+impl windows_core::RuntimeType for IMobileBroadbandAccount2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAccount2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -327,18 +414,27 @@ pub struct IMobileBroadbandAccount2_Vtbl {
     GetConnectionProfiles: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAccount3, IMobileBroadbandAccount3_Vtbl, 0x092a1e21_9379_4b9b_ad31_d5fee2f748c6);
+impl windows_core::RuntimeType for IMobileBroadbandAccount3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAccount3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AccountExperienceUrl: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAccountEventArgs, IMobileBroadbandAccountEventArgs_Vtbl, 0x3853c880_77de_4c04_bead_a123b08c9f59);
+impl windows_core::RuntimeType for IMobileBroadbandAccountEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAccountEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub NetworkAccountId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAccountStatics, IMobileBroadbandAccountStatics_Vtbl, 0xaa7f4d24_afc1_4fc8_ae9a_a9175310faad);
+impl windows_core::RuntimeType for IMobileBroadbandAccountStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAccountStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -349,6 +445,9 @@ pub struct IMobileBroadbandAccountStatics_Vtbl {
     pub CreateFromNetworkAccountId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAccountUpdatedEventArgs, IMobileBroadbandAccountUpdatedEventArgs_Vtbl, 0x7bc31d88_a6bd_49e1_80ab_6b91354a57d4);
+impl windows_core::RuntimeType for IMobileBroadbandAccountUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAccountUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -357,6 +456,9 @@ pub struct IMobileBroadbandAccountUpdatedEventArgs_Vtbl {
     pub HasNetworkChanged: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAccountWatcher, IMobileBroadbandAccountWatcher_Vtbl, 0x6bf3335e_23b5_449f_928d_5e0d3e04471d);
+impl windows_core::RuntimeType for IMobileBroadbandAccountWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAccountWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -375,6 +477,9 @@ pub struct IMobileBroadbandAccountWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAntennaSar, IMobileBroadbandAntennaSar_Vtbl, 0xb9af4b7e_cbf9_4109_90be_5c06bfd513b6);
+impl windows_core::RuntimeType for IMobileBroadbandAntennaSar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAntennaSar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -382,12 +487,18 @@ pub struct IMobileBroadbandAntennaSar_Vtbl {
     pub SarBackoffIndex: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandAntennaSarFactory, IMobileBroadbandAntennaSarFactory_Vtbl, 0xa91e1716_c04d_4a21_8698_1459dc672c6e);
+impl windows_core::RuntimeType for IMobileBroadbandAntennaSarFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandAntennaSarFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithIndex: unsafe extern "system" fn(*mut core::ffi::c_void, i32, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellCdma, IMobileBroadbandCellCdma_Vtbl, 0x0601b3b4_411a_4f2e_8287_76f5650c60cd);
+impl windows_core::RuntimeType for IMobileBroadbandCellCdma {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellCdma_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -401,6 +512,9 @@ pub struct IMobileBroadbandCellCdma_Vtbl {
     pub SystemId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellGsm, IMobileBroadbandCellGsm_Vtbl, 0xcc917f06_7ee0_47b8_9e1f_c3b48df9df5b);
+impl windows_core::RuntimeType for IMobileBroadbandCellGsm {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellGsm_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -413,6 +527,9 @@ pub struct IMobileBroadbandCellGsm_Vtbl {
     pub TimingAdvanceInBitPeriods: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellLte, IMobileBroadbandCellLte_Vtbl, 0x9197c87b_2b78_456d_8b53_aaa25d0af741);
+impl windows_core::RuntimeType for IMobileBroadbandCellLte {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellLte_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -426,6 +543,9 @@ pub struct IMobileBroadbandCellLte_Vtbl {
     pub TrackingAreaCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellNR, IMobileBroadbandCellNR_Vtbl, 0xa13f0deb_66fc_4b4b_83a9_a487a3a5a0a6);
+impl windows_core::RuntimeType for IMobileBroadbandCellNR {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellNR_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -440,6 +560,9 @@ pub struct IMobileBroadbandCellNR_Vtbl {
     pub SignalToNoiseRatioInDB: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellTdscdma, IMobileBroadbandCellTdscdma_Vtbl, 0x0eda1655_db0e_4182_8cda_cc419a7bde08);
+impl windows_core::RuntimeType for IMobileBroadbandCellTdscdma {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellTdscdma_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -453,6 +576,9 @@ pub struct IMobileBroadbandCellTdscdma_Vtbl {
     pub TimingAdvanceInBitPeriods: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellUmts, IMobileBroadbandCellUmts_Vtbl, 0x77b4b5ae_49c8_4f15_b285_4c26a7f67215);
+impl windows_core::RuntimeType for IMobileBroadbandCellUmts {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellUmts_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -466,6 +592,9 @@ pub struct IMobileBroadbandCellUmts_Vtbl {
     pub SignalToNoiseRatioInDB: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellsInfo, IMobileBroadbandCellsInfo_Vtbl, 0x89a9562a_e472_4da5_929c_de61711dd261);
+impl windows_core::RuntimeType for IMobileBroadbandCellsInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellsInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -511,6 +640,9 @@ pub struct IMobileBroadbandCellsInfo_Vtbl {
     ServingCellsUmts: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCellsInfo2, IMobileBroadbandCellsInfo2_Vtbl, 0x66205912_b89f_4e12_bbb6_d5cf09a820ca);
+impl windows_core::RuntimeType for IMobileBroadbandCellsInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCellsInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -524,12 +656,18 @@ pub struct IMobileBroadbandCellsInfo2_Vtbl {
     ServingCellsNR: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandCurrentSlotIndexChangedEventArgs, IMobileBroadbandCurrentSlotIndexChangedEventArgs_Vtbl, 0xf718b184_c370_5fd4_a670_1846cb9bce47);
+impl windows_core::RuntimeType for IMobileBroadbandCurrentSlotIndexChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandCurrentSlotIndexChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CurrentSlotIndex: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceInformation, IMobileBroadbandDeviceInformation_Vtbl, 0xe6d08168_e381_4c6e_9be8_fe156969a446);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -555,6 +693,9 @@ pub struct IMobileBroadbandDeviceInformation_Vtbl {
     pub CurrentRadioState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MobileBroadbandRadioState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceInformation2, IMobileBroadbandDeviceInformation2_Vtbl, 0x2e467af1_f932_4737_a722_03ba72370cb8);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceInformation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceInformation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -563,6 +704,9 @@ pub struct IMobileBroadbandDeviceInformation2_Vtbl {
     pub SerialNumber: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceInformation3, IMobileBroadbandDeviceInformation3_Vtbl, 0xe08bb4bd_5d30_4b5a_92cc_d54df881d49e);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceInformation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceInformation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -571,12 +715,18 @@ pub struct IMobileBroadbandDeviceInformation3_Vtbl {
     pub SimGid1: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceInformation4, IMobileBroadbandDeviceInformation4_Vtbl, 0x263f3152_7b9d_582c_b17c_f80a60b50031);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceInformation4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceInformation4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SlotManager: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceService, IMobileBroadbandDeviceService_Vtbl, 0x22be1a52_bd80_40ac_8e1f_2e07836a3dbd);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -589,6 +739,9 @@ pub struct IMobileBroadbandDeviceService_Vtbl {
     pub OpenCommandSession: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceServiceCommandResult, IMobileBroadbandDeviceServiceCommandResult_Vtbl, 0xb0f46abb_94d6_44b9_a538_f0810b645389);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceServiceCommandResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceServiceCommandResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -599,6 +752,9 @@ pub struct IMobileBroadbandDeviceServiceCommandResult_Vtbl {
     ResponseData: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceServiceCommandSession, IMobileBroadbandDeviceServiceCommandSession_Vtbl, 0xfc098a45_913b_4914_b6c3_ae6304593e75);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceServiceCommandSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceServiceCommandSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -613,6 +769,9 @@ pub struct IMobileBroadbandDeviceServiceCommandSession_Vtbl {
     pub CloseSession: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceServiceDataReceivedEventArgs, IMobileBroadbandDeviceServiceDataReceivedEventArgs_Vtbl, 0xb6aa13de_1380_40e3_8618_73cbca48138c);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceServiceDataReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceServiceDataReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -622,6 +781,9 @@ pub struct IMobileBroadbandDeviceServiceDataReceivedEventArgs_Vtbl {
     ReceivedData: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceServiceDataSession, IMobileBroadbandDeviceServiceDataSession_Vtbl, 0xdad62333_8bcf_4289_8a37_045c2169486a);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceServiceDataSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceServiceDataSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -634,6 +796,9 @@ pub struct IMobileBroadbandDeviceServiceDataSession_Vtbl {
     pub RemoveDataReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceServiceInformation, IMobileBroadbandDeviceServiceInformation_Vtbl, 0x53d69b5b_c4ed_45f0_803a_d9417a6d9846);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceServiceInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceServiceInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -642,6 +807,9 @@ pub struct IMobileBroadbandDeviceServiceInformation_Vtbl {
     pub IsDataWriteSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceServiceTriggerDetails, IMobileBroadbandDeviceServiceTriggerDetails_Vtbl, 0x4a055b70_b9ae_4458_9241_a6a5fbf18a0c);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceServiceTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceServiceTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -653,12 +821,18 @@ pub struct IMobileBroadbandDeviceServiceTriggerDetails_Vtbl {
     ReceivedData: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandDeviceServiceTriggerDetails2, IMobileBroadbandDeviceServiceTriggerDetails2_Vtbl, 0xd83d5f16_336a_553f_94bb_0cd1a2ff0c81);
+impl windows_core::RuntimeType for IMobileBroadbandDeviceServiceTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandDeviceServiceTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub EventId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModem, IMobileBroadbandModem_Vtbl, 0xd0356912_e9f9_4f67_a03d_43189a316bf1);
+impl windows_core::RuntimeType for IMobileBroadbandModem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -677,6 +851,9 @@ pub struct IMobileBroadbandModem_Vtbl {
     pub CurrentNetwork: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModem2, IMobileBroadbandModem2_Vtbl, 0x12862b28_b9eb_4ee2_bbe3_711f53eea373);
+impl windows_core::RuntimeType for IMobileBroadbandModem2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -684,6 +861,9 @@ pub struct IMobileBroadbandModem2_Vtbl {
     pub SetIsPassthroughEnabledAsync: unsafe extern "system" fn(*mut core::ffi::c_void, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModem3, IMobileBroadbandModem3_Vtbl, 0xe9fec6ea_2f34_4582_9102_c314d2a87eec);
+impl windows_core::RuntimeType for IMobileBroadbandModem3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModem3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -693,6 +873,9 @@ pub struct IMobileBroadbandModem3_Vtbl {
     pub RemoveIsInEmergencyCallModeChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModem4, IMobileBroadbandModem4_Vtbl, 0x4a0398c2_91be_412b_b569_586e9f0030d1);
+impl windows_core::RuntimeType for IMobileBroadbandModem4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModem4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -702,6 +885,9 @@ pub struct IMobileBroadbandModem4_Vtbl {
     pub GetIsPassthroughEnabledWithSlotIndex: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModemConfiguration, IMobileBroadbandModemConfiguration_Vtbl, 0xfce035a3_d6cd_4320_b982_be9d3ec7890f);
+impl windows_core::RuntimeType for IMobileBroadbandModemConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModemConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -710,12 +896,18 @@ pub struct IMobileBroadbandModemConfiguration_Vtbl {
     pub HomeProviderName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModemConfiguration2, IMobileBroadbandModemConfiguration2_Vtbl, 0x320ff5c5_e460_42ae_aa51_69621e7a4477);
+impl windows_core::RuntimeType for IMobileBroadbandModemConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModemConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SarManager: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModemIsolation, IMobileBroadbandModemIsolation_Vtbl, 0xb5618fec_e661_4330_9bb4_3480212ec354);
+impl windows_core::RuntimeType for IMobileBroadbandModemIsolation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModemIsolation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -725,12 +917,18 @@ pub struct IMobileBroadbandModemIsolation_Vtbl {
     pub ClearConfigurationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModemIsolationFactory, IMobileBroadbandModemIsolationFactory_Vtbl, 0x21d7ec58_c2b1_4c2f_a030_72820a24ecd9);
+impl windows_core::RuntimeType for IMobileBroadbandModemIsolationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModemIsolationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandModemStatics, IMobileBroadbandModemStatics_Vtbl, 0xf99ed637_d6f1_4a78_8cbc_6421a65063c8);
+impl windows_core::RuntimeType for IMobileBroadbandModemStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandModemStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -739,6 +937,9 @@ pub struct IMobileBroadbandModemStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandNetwork, IMobileBroadbandNetwork_Vtbl, 0xcb63928c_0309_4cb6_a8c1_6a5a3c8e1ff6);
+impl windows_core::RuntimeType for IMobileBroadbandNetwork {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandNetwork_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -757,6 +958,9 @@ pub struct IMobileBroadbandNetwork_Vtbl {
     pub ShowConnectionUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandNetwork2, IMobileBroadbandNetwork2_Vtbl, 0x5a55db22_62f7_4bdd_ba1d_477441960ba0);
+impl windows_core::RuntimeType for IMobileBroadbandNetwork2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandNetwork2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -767,12 +971,18 @@ pub struct IMobileBroadbandNetwork2_Vtbl {
     RegistrationUiccApps: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandNetwork3, IMobileBroadbandNetwork3_Vtbl, 0x33670a8a_c7ef_444c_ab6c_df7ef7a390fe);
+impl windows_core::RuntimeType for IMobileBroadbandNetwork3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandNetwork3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetCellsInfoAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandNetworkRegistrationStateChange, IMobileBroadbandNetworkRegistrationStateChange_Vtbl, 0xbeaf94e1_960f_49b4_a08d_7d85e968c7ec);
+impl windows_core::RuntimeType for IMobileBroadbandNetworkRegistrationStateChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandNetworkRegistrationStateChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -780,6 +990,9 @@ pub struct IMobileBroadbandNetworkRegistrationStateChange_Vtbl {
     pub Network: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails, IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails_Vtbl, 0x89135cff_28b8_46aa_b137_1c4b0f21edfe);
+impl windows_core::RuntimeType for IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -789,6 +1002,9 @@ pub struct IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails_Vtbl {
     NetworkRegistrationStateChanges: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandPco, IMobileBroadbandPco_Vtbl, 0xd4e4fcbe_e3a3_43c5_a87b_6c86d229d7fa);
+impl windows_core::RuntimeType for IMobileBroadbandPco {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandPco_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -800,12 +1016,18 @@ pub struct IMobileBroadbandPco_Vtbl {
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandPcoDataChangeTriggerDetails, IMobileBroadbandPcoDataChangeTriggerDetails_Vtbl, 0x263f5114_64e0_4493_909b_2d14a01962b1);
+impl windows_core::RuntimeType for IMobileBroadbandPcoDataChangeTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandPcoDataChangeTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub UpdatedData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandPin, IMobileBroadbandPin_Vtbl, 0xe661d709_e779_45bf_8281_75323df9e321);
+impl windows_core::RuntimeType for IMobileBroadbandPin {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandPin_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -823,6 +1045,9 @@ pub struct IMobileBroadbandPin_Vtbl {
     pub UnblockAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandPinLockStateChange, IMobileBroadbandPinLockStateChange_Vtbl, 0xbe16673e_1f04_4f95_8b90_e7f559dde7e5);
+impl windows_core::RuntimeType for IMobileBroadbandPinLockStateChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandPinLockStateChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -831,6 +1056,9 @@ pub struct IMobileBroadbandPinLockStateChange_Vtbl {
     pub PinLockState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MobileBroadbandPinLockState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandPinLockStateChangeTriggerDetails, IMobileBroadbandPinLockStateChangeTriggerDetails_Vtbl, 0xd338c091_3e91_4d38_9036_aee83a6e79ad);
+impl windows_core::RuntimeType for IMobileBroadbandPinLockStateChangeTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandPinLockStateChangeTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -840,6 +1068,9 @@ pub struct IMobileBroadbandPinLockStateChangeTriggerDetails_Vtbl {
     PinLockStateChanges: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandPinManager, IMobileBroadbandPinManager_Vtbl, 0x83567edd_6e1f_4b9b_a413_2b1f50cc36df);
+impl windows_core::RuntimeType for IMobileBroadbandPinManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandPinManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -850,6 +1081,9 @@ pub struct IMobileBroadbandPinManager_Vtbl {
     pub GetPin: unsafe extern "system" fn(*mut core::ffi::c_void, MobileBroadbandPinType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandPinOperationResult, IMobileBroadbandPinOperationResult_Vtbl, 0x11dddc32_31e7_49f5_b663_123d3bef0362);
+impl windows_core::RuntimeType for IMobileBroadbandPinOperationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandPinOperationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -857,6 +1091,9 @@ pub struct IMobileBroadbandPinOperationResult_Vtbl {
     pub AttemptsRemaining: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandRadioStateChange, IMobileBroadbandRadioStateChange_Vtbl, 0xb054a561_9833_4aed_9717_4348b21a24b3);
+impl windows_core::RuntimeType for IMobileBroadbandRadioStateChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandRadioStateChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -864,6 +1101,9 @@ pub struct IMobileBroadbandRadioStateChange_Vtbl {
     pub RadioState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MobileBroadbandRadioState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandRadioStateChangeTriggerDetails, IMobileBroadbandRadioStateChangeTriggerDetails_Vtbl, 0x71301ace_093c_42c6_b0db_ad1f75a65445);
+impl windows_core::RuntimeType for IMobileBroadbandRadioStateChangeTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandRadioStateChangeTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -873,6 +1113,9 @@ pub struct IMobileBroadbandRadioStateChangeTriggerDetails_Vtbl {
     RadioStateChanges: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandSarManager, IMobileBroadbandSarManager_Vtbl, 0xe5b26833_967e_40c9_a485_19c0dd209e22);
+impl windows_core::RuntimeType for IMobileBroadbandSarManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandSarManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -899,6 +1142,9 @@ pub struct IMobileBroadbandSarManager_Vtbl {
     pub StopTransmissionStateMonitoring: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandSlotInfo, IMobileBroadbandSlotInfo_Vtbl, 0xbd350b32_882e_542a_b17d_0bb1b49bae9e);
+impl windows_core::RuntimeType for IMobileBroadbandSlotInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandSlotInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -906,18 +1152,27 @@ pub struct IMobileBroadbandSlotInfo_Vtbl {
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MobileBroadbandSlotState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandSlotInfo2, IMobileBroadbandSlotInfo2_Vtbl, 0x393cb039_ca44_524c_822d_83a3620f0efc);
+impl windows_core::RuntimeType for IMobileBroadbandSlotInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandSlotInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IccId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandSlotInfoChangedEventArgs, IMobileBroadbandSlotInfoChangedEventArgs_Vtbl, 0x3158839f_950c_54ce_a48d_ba4529b48f0f);
+impl windows_core::RuntimeType for IMobileBroadbandSlotInfoChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandSlotInfoChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SlotInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandSlotManager, IMobileBroadbandSlotManager_Vtbl, 0xeba07cd6_2019_5f81_a294_cc364a11d0b2);
+impl windows_core::RuntimeType for IMobileBroadbandSlotManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandSlotManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -934,12 +1189,18 @@ pub struct IMobileBroadbandSlotManager_Vtbl {
     pub RemoveCurrentSlotIndexChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandTransmissionStateChangedEventArgs, IMobileBroadbandTransmissionStateChangedEventArgs_Vtbl, 0x612e3875_040a_4f99_a4f9_61d7c32da129);
+impl windows_core::RuntimeType for IMobileBroadbandTransmissionStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandTransmissionStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsTransmitting: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandUicc, IMobileBroadbandUicc_Vtbl, 0xe634f691_525a_4ce2_8fce_aa4162579154);
+impl windows_core::RuntimeType for IMobileBroadbandUicc {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandUicc_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -947,6 +1208,9 @@ pub struct IMobileBroadbandUicc_Vtbl {
     pub GetUiccAppsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandUiccApp, IMobileBroadbandUiccApp_Vtbl, 0x4d170556_98a1_43dd_b2ec_50c90cf248df);
+impl windows_core::RuntimeType for IMobileBroadbandUiccApp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandUiccApp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -965,6 +1229,9 @@ pub struct IMobileBroadbandUiccApp_Vtbl {
     ReadRecordAsync: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandUiccAppReadRecordResult, IMobileBroadbandUiccAppReadRecordResult_Vtbl, 0x64c95285_358e_47c5_8249_695f383b2bdb);
+impl windows_core::RuntimeType for IMobileBroadbandUiccAppReadRecordResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandUiccAppReadRecordResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -975,6 +1242,9 @@ pub struct IMobileBroadbandUiccAppReadRecordResult_Vtbl {
     Data: usize,
 }
 windows_core::imp::define_interface!(IMobileBroadbandUiccAppRecordDetailsResult, IMobileBroadbandUiccAppRecordDetailsResult_Vtbl, 0xd919682f_be14_4934_981d_2f57b9ed83e6);
+impl windows_core::RuntimeType for IMobileBroadbandUiccAppRecordDetailsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandUiccAppRecordDetailsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -986,6 +1256,9 @@ pub struct IMobileBroadbandUiccAppRecordDetailsResult_Vtbl {
     pub WriteAccessCondition: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UiccAccessCondition) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMobileBroadbandUiccAppsResult, IMobileBroadbandUiccAppsResult_Vtbl, 0x744930eb_8157_4a41_8494_6bf54c9b1d2b);
+impl windows_core::RuntimeType for IMobileBroadbandUiccAppsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMobileBroadbandUiccAppsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -996,12 +1269,18 @@ pub struct IMobileBroadbandUiccAppsResult_Vtbl {
     UiccApps: usize,
 }
 windows_core::imp::define_interface!(INetworkOperatorDataUsageTriggerDetails, INetworkOperatorDataUsageTriggerDetails_Vtbl, 0x50e3126d_a465_4eeb_9317_28a167630cea);
+impl windows_core::RuntimeType for INetworkOperatorDataUsageTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorDataUsageTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub NotificationKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut NetworkOperatorDataUsageNotificationKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorNotificationEventDetails, INetworkOperatorNotificationEventDetails_Vtbl, 0xbc68a9d1_82e1_4488_9f2c_1276c2468fac);
+impl windows_core::RuntimeType for INetworkOperatorNotificationEventDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorNotificationEventDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1016,6 +1295,9 @@ pub struct INetworkOperatorNotificationEventDetails_Vtbl {
     SmsMessage: usize,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringAccessPointConfiguration, INetworkOperatorTetheringAccessPointConfiguration_Vtbl, 0x0bcc0284_412e_403d_acc6_b757e34774a4);
+impl windows_core::RuntimeType for INetworkOperatorTetheringAccessPointConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringAccessPointConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1025,6 +1307,9 @@ pub struct INetworkOperatorTetheringAccessPointConfiguration_Vtbl {
     pub SetPassphrase: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringAccessPointConfiguration2, INetworkOperatorTetheringAccessPointConfiguration2_Vtbl, 0xb1809142_7238_59a0_928b_74ab46fd64b6);
+impl windows_core::RuntimeType for INetworkOperatorTetheringAccessPointConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringAccessPointConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1034,6 +1319,9 @@ pub struct INetworkOperatorTetheringAccessPointConfiguration2_Vtbl {
     pub SetBand: unsafe extern "system" fn(*mut core::ffi::c_void, TetheringWiFiBand) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringClient, INetworkOperatorTetheringClient_Vtbl, 0x709d254c_595f_4847_bb30_646935542918);
+impl windows_core::RuntimeType for INetworkOperatorTetheringClient {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringClient_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1044,6 +1332,9 @@ pub struct INetworkOperatorTetheringClient_Vtbl {
     HostNames: usize,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringClientManager, INetworkOperatorTetheringClientManager_Vtbl, 0x91b14016_8dca_4225_bbed_eef8b8d718d7);
+impl windows_core::RuntimeType for INetworkOperatorTetheringClientManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringClientManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1053,12 +1344,18 @@ pub struct INetworkOperatorTetheringClientManager_Vtbl {
     GetTetheringClients: usize,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringEntitlementCheck, INetworkOperatorTetheringEntitlementCheck_Vtbl, 0x0108916d_9e9a_4af6_8da3_60493b19c204);
+impl windows_core::RuntimeType for INetworkOperatorTetheringEntitlementCheck {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringEntitlementCheck_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AuthorizeTethering: unsafe extern "system" fn(*mut core::ffi::c_void, bool, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringManager, INetworkOperatorTetheringManager_Vtbl, 0xd45a8da0_0e86_4d98_8ba4_dd70d4b764d3);
+impl windows_core::RuntimeType for INetworkOperatorTetheringManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1071,6 +1368,9 @@ pub struct INetworkOperatorTetheringManager_Vtbl {
     pub StopTetheringAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringManagerStatics, INetworkOperatorTetheringManagerStatics_Vtbl, 0x3ebcbacc_f8c3_405c_9964_70a1eeabe194);
+impl windows_core::RuntimeType for INetworkOperatorTetheringManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1078,6 +1378,9 @@ pub struct INetworkOperatorTetheringManagerStatics_Vtbl {
     pub CreateFromNetworkAccountId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringManagerStatics2, INetworkOperatorTetheringManagerStatics2_Vtbl, 0x5b235412_35f0_49e7_9b08_16d278fbaa42);
+impl windows_core::RuntimeType for INetworkOperatorTetheringManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1091,6 +1394,9 @@ pub struct INetworkOperatorTetheringManagerStatics2_Vtbl {
     CreateFromConnectionProfile: usize,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringManagerStatics3, INetworkOperatorTetheringManagerStatics3_Vtbl, 0x8fdaadb6_4af9_4f21_9b58_d53e9f24231e);
+impl windows_core::RuntimeType for INetworkOperatorTetheringManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1100,6 +1406,9 @@ pub struct INetworkOperatorTetheringManagerStatics3_Vtbl {
     CreateFromConnectionProfileWithTargetAdapter: usize,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringManagerStatics4, INetworkOperatorTetheringManagerStatics4_Vtbl, 0xb3b9f9d0_ebff_46a4_a847_d663d8b0977e);
+impl windows_core::RuntimeType for INetworkOperatorTetheringManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1110,6 +1419,9 @@ pub struct INetworkOperatorTetheringManagerStatics4_Vtbl {
     pub DisableNoConnectionsTimeoutAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INetworkOperatorTetheringOperationResult, INetworkOperatorTetheringOperationResult_Vtbl, 0xebd203a1_01ba_476d_b4b3_bf3d12c8f80c);
+impl windows_core::RuntimeType for INetworkOperatorTetheringOperationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INetworkOperatorTetheringOperationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1117,6 +1429,9 @@ pub struct INetworkOperatorTetheringOperationResult_Vtbl {
     pub AdditionalErrorMessage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProvisionFromXmlDocumentResults, IProvisionFromXmlDocumentResults_Vtbl, 0x217700e0_8203_11df_adb9_f4ce462d9137);
+impl windows_core::RuntimeType for IProvisionFromXmlDocumentResults {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProvisionFromXmlDocumentResults_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1124,6 +1439,9 @@ pub struct IProvisionFromXmlDocumentResults_Vtbl {
     pub ProvisionResultsXml: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProvisionedProfile, IProvisionedProfile_Vtbl, 0x217700e0_8202_11df_adb9_f4ce462d9137);
+impl windows_core::RuntimeType for IProvisionedProfile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProvisionedProfile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1134,6 +1452,9 @@ pub struct IProvisionedProfile_Vtbl {
     pub UpdateUsage: unsafe extern "system" fn(*mut core::ffi::c_void, ProfileUsage) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProvisioningAgent, IProvisioningAgent_Vtbl, 0x217700e0_8201_11df_adb9_f4ce462d9137);
+impl windows_core::RuntimeType for IProvisioningAgent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProvisioningAgent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1141,12 +1462,18 @@ pub struct IProvisioningAgent_Vtbl {
     pub GetProvisionedProfile: unsafe extern "system" fn(*mut core::ffi::c_void, ProfileMediaType, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProvisioningAgentStaticMethods, IProvisioningAgentStaticMethods_Vtbl, 0x217700e0_8101_11df_adb9_f4ce462d9137);
+impl windows_core::RuntimeType for IProvisioningAgentStaticMethods {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProvisioningAgentStaticMethods_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateFromNetworkAccountId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITetheringEntitlementCheckTriggerDetails, ITetheringEntitlementCheckTriggerDetails_Vtbl, 0x03c65e9d_5926_41f3_a94e_b50926fc421b);
+impl windows_core::RuntimeType for ITetheringEntitlementCheckTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITetheringEntitlementCheckTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1155,6 +1482,9 @@ pub struct ITetheringEntitlementCheckTriggerDetails_Vtbl {
     pub DenyTethering: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUssdMessage, IUssdMessage_Vtbl, 0x2f9acf82_2004_4d5d_bf81_2aba1b4be4a8);
+impl windows_core::RuntimeType for IUssdMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUssdMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1166,12 +1496,18 @@ pub struct IUssdMessage_Vtbl {
     pub SetPayloadAsText: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUssdMessageFactory, IUssdMessageFactory_Vtbl, 0x2f9acf82_1003_4d5d_bf81_2aba1b4be4a8);
+impl windows_core::RuntimeType for IUssdMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUssdMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMessage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUssdReply, IUssdReply_Vtbl, 0x2f9acf82_2005_4d5d_bf81_2aba1b4be4a8);
+impl windows_core::RuntimeType for IUssdReply {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUssdReply_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1179,6 +1515,9 @@ pub struct IUssdReply_Vtbl {
     pub Message: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUssdSession, IUssdSession_Vtbl, 0x2f9acf82_2002_4d5d_bf81_2aba1b4be4a8);
+impl windows_core::RuntimeType for IUssdSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUssdSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1186,6 +1525,9 @@ pub struct IUssdSession_Vtbl {
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUssdSessionStatics, IUssdSessionStatics_Vtbl, 0x2f9acf82_1001_4d5d_bf81_2aba1b4be4a8);
+impl windows_core::RuntimeType for IUssdSessionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUssdSessionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1319,7 +1661,7 @@ impl ESim {
     }
 }
 impl windows_core::RuntimeType for ESim {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESim>();
 }
 unsafe impl windows_core::Interface for ESim {
     type Vtable = IESim_Vtbl;
@@ -1344,7 +1686,7 @@ impl ESimAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ESimAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for ESimAddedEventArgs {
     type Vtable = IESimAddedEventArgs_Vtbl;
@@ -1376,7 +1718,7 @@ impl ESimDiscoverEvent {
     }
 }
 impl windows_core::RuntimeType for ESimDiscoverEvent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimDiscoverEvent>();
 }
 unsafe impl windows_core::Interface for ESimDiscoverEvent {
     type Vtable = IESimDiscoverEvent_Vtbl;
@@ -1423,7 +1765,7 @@ impl ESimDiscoverResult {
     }
 }
 impl windows_core::RuntimeType for ESimDiscoverResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimDiscoverResult>();
 }
 unsafe impl windows_core::Interface for ESimDiscoverResult {
     type Vtable = IESimDiscoverResult_Vtbl;
@@ -1455,7 +1797,7 @@ impl ESimDownloadProfileMetadataResult {
     }
 }
 impl windows_core::RuntimeType for ESimDownloadProfileMetadataResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimDownloadProfileMetadataResult>();
 }
 unsafe impl windows_core::Interface for ESimDownloadProfileMetadataResult {
     type Vtable = IESimDownloadProfileMetadataResult_Vtbl;
@@ -1515,7 +1857,7 @@ impl ESimOperationResult {
     }
 }
 impl windows_core::RuntimeType for ESimOperationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimOperationResult>();
 }
 unsafe impl windows_core::Interface for ESimOperationResult {
     type Vtable = IESimOperationResult_Vtbl;
@@ -1540,7 +1882,7 @@ impl ESimPolicy {
     }
 }
 impl windows_core::RuntimeType for ESimPolicy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimPolicy>();
 }
 unsafe impl windows_core::Interface for ESimPolicy {
     type Vtable = IESimPolicy_Vtbl;
@@ -1636,7 +1978,7 @@ impl ESimProfile {
     }
 }
 impl windows_core::RuntimeType for ESimProfile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimProfile>();
 }
 unsafe impl windows_core::Interface for ESimProfile {
     type Vtable = IESimProfile_Vtbl;
@@ -1746,7 +2088,7 @@ impl ESimProfileMetadata {
     }
 }
 impl windows_core::RuntimeType for ESimProfileMetadata {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimProfileMetadata>();
 }
 unsafe impl windows_core::Interface for ESimProfileMetadata {
     type Vtable = IESimProfileMetadata_Vtbl;
@@ -1785,7 +2127,7 @@ impl ESimProfilePolicy {
     }
 }
 impl windows_core::RuntimeType for ESimProfilePolicy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimProfilePolicy>();
 }
 unsafe impl windows_core::Interface for ESimProfilePolicy {
     type Vtable = IESimProfilePolicy_Vtbl;
@@ -1810,7 +2152,7 @@ impl ESimRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ESimRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for ESimRemovedEventArgs {
     type Vtable = IESimRemovedEventArgs_Vtbl;
@@ -1842,7 +2184,7 @@ impl ESimServiceInfo {
     }
 }
 impl windows_core::RuntimeType for ESimServiceInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimServiceInfo>();
 }
 unsafe impl windows_core::Interface for ESimServiceInfo {
     type Vtable = IESimServiceInfo_Vtbl;
@@ -1867,7 +2209,7 @@ impl ESimUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ESimUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ESimUpdatedEventArgs {
     type Vtable = IESimUpdatedEventArgs_Vtbl;
@@ -1970,7 +2312,7 @@ impl ESimWatcher {
     }
 }
 impl windows_core::RuntimeType for ESimWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IESimWatcher>();
 }
 unsafe impl windows_core::Interface for ESimWatcher {
     type Vtable = IESimWatcher_Vtbl;
@@ -2076,7 +2418,7 @@ impl HotspotAuthenticationContext {
     }
 }
 impl windows_core::RuntimeType for HotspotAuthenticationContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHotspotAuthenticationContext>();
 }
 unsafe impl windows_core::Interface for HotspotAuthenticationContext {
     type Vtable = IHotspotAuthenticationContext_Vtbl;
@@ -2099,7 +2441,7 @@ impl HotspotAuthenticationEventDetails {
     }
 }
 impl windows_core::RuntimeType for HotspotAuthenticationEventDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHotspotAuthenticationEventDetails>();
 }
 unsafe impl windows_core::Interface for HotspotAuthenticationEventDetails {
     type Vtable = IHotspotAuthenticationEventDetails_Vtbl;
@@ -2144,7 +2486,7 @@ impl HotspotCredentialsAuthenticationResult {
     }
 }
 impl windows_core::RuntimeType for HotspotCredentialsAuthenticationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHotspotCredentialsAuthenticationResult>();
 }
 unsafe impl windows_core::Interface for HotspotCredentialsAuthenticationResult {
     type Vtable = IHotspotCredentialsAuthenticationResult_Vtbl;
@@ -2377,7 +2719,7 @@ impl MobileBroadbandAccount {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandAccount {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandAccount>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandAccount {
     type Vtable = IMobileBroadbandAccount_Vtbl;
@@ -2400,7 +2742,7 @@ impl MobileBroadbandAccountEventArgs {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandAccountEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandAccountEventArgs>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandAccountEventArgs {
     type Vtable = IMobileBroadbandAccountEventArgs_Vtbl;
@@ -2437,7 +2779,7 @@ impl MobileBroadbandAccountUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandAccountUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandAccountUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandAccountUpdatedEventArgs {
     type Vtable = IMobileBroadbandAccountUpdatedEventArgs_Vtbl;
@@ -2545,7 +2887,7 @@ impl MobileBroadbandAccountWatcher {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandAccountWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandAccountWatcher>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandAccountWatcher {
     type Vtable = IMobileBroadbandAccountWatcher_Vtbl;
@@ -2586,7 +2928,7 @@ impl MobileBroadbandAntennaSar {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandAntennaSar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandAntennaSar>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandAntennaSar {
     type Vtable = IMobileBroadbandAntennaSar_Vtbl;
@@ -2660,7 +3002,7 @@ impl MobileBroadbandCellCdma {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCellCdma {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCellCdma>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCellCdma {
     type Vtable = IMobileBroadbandCellCdma_Vtbl;
@@ -2727,7 +3069,7 @@ impl MobileBroadbandCellGsm {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCellGsm {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCellGsm>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCellGsm {
     type Vtable = IMobileBroadbandCellGsm_Vtbl;
@@ -2801,7 +3143,7 @@ impl MobileBroadbandCellLte {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCellLte {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCellLte>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCellLte {
     type Vtable = IMobileBroadbandCellLte_Vtbl;
@@ -2882,7 +3224,7 @@ impl MobileBroadbandCellNR {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCellNR {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCellNR>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCellNR {
     type Vtable = IMobileBroadbandCellNR_Vtbl;
@@ -2956,7 +3298,7 @@ impl MobileBroadbandCellTdscdma {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCellTdscdma {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCellTdscdma>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCellTdscdma {
     type Vtable = IMobileBroadbandCellTdscdma_Vtbl;
@@ -3030,7 +3372,7 @@ impl MobileBroadbandCellUmts {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCellUmts {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCellUmts>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCellUmts {
     type Vtable = IMobileBroadbandCellUmts_Vtbl;
@@ -3144,7 +3486,7 @@ impl MobileBroadbandCellsInfo {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCellsInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCellsInfo>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCellsInfo {
     type Vtable = IMobileBroadbandCellsInfo_Vtbl;
@@ -3169,7 +3511,7 @@ impl MobileBroadbandCurrentSlotIndexChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandCurrentSlotIndexChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandCurrentSlotIndexChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandCurrentSlotIndexChangedEventArgs {
     type Vtable = IMobileBroadbandCurrentSlotIndexChangedEventArgs_Vtbl;
@@ -3336,7 +3678,7 @@ impl MobileBroadbandDeviceInformation {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceInformation>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceInformation {
     type Vtable = IMobileBroadbandDeviceInformation_Vtbl;
@@ -3381,7 +3723,7 @@ impl MobileBroadbandDeviceService {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceService {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceService>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceService {
     type Vtable = IMobileBroadbandDeviceService_Vtbl;
@@ -3414,7 +3756,7 @@ impl MobileBroadbandDeviceServiceCommandResult {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceServiceCommandResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceServiceCommandResult>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceServiceCommandResult {
     type Vtable = IMobileBroadbandDeviceServiceCommandResult_Vtbl;
@@ -3458,7 +3800,7 @@ impl MobileBroadbandDeviceServiceCommandSession {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceServiceCommandSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceServiceCommandSession>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceServiceCommandSession {
     type Vtable = IMobileBroadbandDeviceServiceCommandSession_Vtbl;
@@ -3484,7 +3826,7 @@ impl MobileBroadbandDeviceServiceDataReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceServiceDataReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceServiceDataReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceServiceDataReceivedEventArgs {
     type Vtable = IMobileBroadbandDeviceServiceDataReceivedEventArgs_Vtbl;
@@ -3531,7 +3873,7 @@ impl MobileBroadbandDeviceServiceDataSession {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceServiceDataSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceServiceDataSession>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceServiceDataSession {
     type Vtable = IMobileBroadbandDeviceServiceDataSession_Vtbl;
@@ -3570,7 +3912,7 @@ impl MobileBroadbandDeviceServiceInformation {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceServiceInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceServiceInformation>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceServiceInformation {
     type Vtable = IMobileBroadbandDeviceServiceInformation_Vtbl;
@@ -3617,7 +3959,7 @@ impl MobileBroadbandDeviceServiceTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandDeviceServiceTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandDeviceServiceTriggerDetails>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandDeviceServiceTriggerDetails {
     type Vtable = IMobileBroadbandDeviceServiceTriggerDetails_Vtbl;
@@ -3799,7 +4141,7 @@ impl MobileBroadbandModem {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandModem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandModem>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandModem {
     type Vtable = IMobileBroadbandModem_Vtbl;
@@ -3845,7 +4187,7 @@ impl MobileBroadbandModemConfiguration {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandModemConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandModemConfiguration>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandModemConfiguration {
     type Vtable = IMobileBroadbandModemConfiguration_Vtbl;
@@ -3901,7 +4243,7 @@ impl MobileBroadbandModemIsolation {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandModemIsolation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandModemIsolation>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandModemIsolation {
     type Vtable = IMobileBroadbandModemIsolation_Vtbl;
@@ -4009,7 +4351,7 @@ impl MobileBroadbandNetwork {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandNetwork {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandNetwork>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandNetwork {
     type Vtable = IMobileBroadbandNetwork_Vtbl;
@@ -4039,7 +4381,7 @@ impl MobileBroadbandNetworkRegistrationStateChange {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandNetworkRegistrationStateChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandNetworkRegistrationStateChange>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandNetworkRegistrationStateChange {
     type Vtable = IMobileBroadbandNetworkRegistrationStateChange_Vtbl;
@@ -4065,7 +4407,7 @@ impl MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandNetworkRegistrationStateChangeTriggerDetails {
     type Vtable = IMobileBroadbandNetworkRegistrationStateChangeTriggerDetails_Vtbl;
@@ -4105,7 +4447,7 @@ impl MobileBroadbandPco {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPco {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandPco>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPco {
     type Vtable = IMobileBroadbandPco_Vtbl;
@@ -4130,7 +4472,7 @@ impl MobileBroadbandPcoDataChangeTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPcoDataChangeTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandPcoDataChangeTriggerDetails>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPcoDataChangeTriggerDetails {
     type Vtable = IMobileBroadbandPcoDataChangeTriggerDetails_Vtbl;
@@ -4232,7 +4574,7 @@ impl MobileBroadbandPin {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPin {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandPin>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPin {
     type Vtable = IMobileBroadbandPin_Vtbl;
@@ -4271,7 +4613,7 @@ impl MobileBroadbandPinLockStateChange {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPinLockStateChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandPinLockStateChange>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPinLockStateChange {
     type Vtable = IMobileBroadbandPinLockStateChange_Vtbl;
@@ -4297,7 +4639,7 @@ impl MobileBroadbandPinLockStateChangeTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPinLockStateChangeTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandPinLockStateChangeTriggerDetails>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPinLockStateChangeTriggerDetails {
     type Vtable = IMobileBroadbandPinLockStateChangeTriggerDetails_Vtbl;
@@ -4330,7 +4672,7 @@ impl MobileBroadbandPinManager {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPinManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandPinManager>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPinManager {
     type Vtable = IMobileBroadbandPinManager_Vtbl;
@@ -4362,7 +4704,7 @@ impl MobileBroadbandPinOperationResult {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandPinOperationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandPinOperationResult>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandPinOperationResult {
     type Vtable = IMobileBroadbandPinOperationResult_Vtbl;
@@ -4394,7 +4736,7 @@ impl MobileBroadbandRadioStateChange {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandRadioStateChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandRadioStateChange>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandRadioStateChange {
     type Vtable = IMobileBroadbandRadioStateChange_Vtbl;
@@ -4420,7 +4762,7 @@ impl MobileBroadbandRadioStateChangeTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandRadioStateChangeTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandRadioStateChangeTriggerDetails>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandRadioStateChangeTriggerDetails {
     type Vtable = IMobileBroadbandRadioStateChangeTriggerDetails_Vtbl;
@@ -4542,7 +4884,7 @@ impl MobileBroadbandSarManager {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandSarManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandSarManager>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandSarManager {
     type Vtable = IMobileBroadbandSarManager_Vtbl;
@@ -4581,7 +4923,7 @@ impl MobileBroadbandSlotInfo {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandSlotInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandSlotInfo>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandSlotInfo {
     type Vtable = IMobileBroadbandSlotInfo_Vtbl;
@@ -4606,7 +4948,7 @@ impl MobileBroadbandSlotInfoChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandSlotInfoChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandSlotInfoChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandSlotInfoChangedEventArgs {
     type Vtable = IMobileBroadbandSlotInfoChangedEventArgs_Vtbl;
@@ -4681,7 +5023,7 @@ impl MobileBroadbandSlotManager {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandSlotManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandSlotManager>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandSlotManager {
     type Vtable = IMobileBroadbandSlotManager_Vtbl;
@@ -4706,7 +5048,7 @@ impl MobileBroadbandTransmissionStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandTransmissionStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandTransmissionStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandTransmissionStateChangedEventArgs {
     type Vtable = IMobileBroadbandTransmissionStateChangedEventArgs_Vtbl;
@@ -4738,7 +5080,7 @@ impl MobileBroadbandUicc {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandUicc {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandUicc>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandUicc {
     type Vtable = IMobileBroadbandUicc_Vtbl;
@@ -4793,7 +5135,7 @@ impl MobileBroadbandUiccApp {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandUiccApp {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandUiccApp>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandUiccApp {
     type Vtable = IMobileBroadbandUiccApp_Vtbl;
@@ -4826,7 +5168,7 @@ impl MobileBroadbandUiccAppReadRecordResult {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandUiccAppReadRecordResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandUiccAppReadRecordResult>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandUiccAppReadRecordResult {
     type Vtable = IMobileBroadbandUiccAppReadRecordResult_Vtbl;
@@ -4886,7 +5228,7 @@ impl MobileBroadbandUiccAppRecordDetailsResult {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandUiccAppRecordDetailsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandUiccAppRecordDetailsResult>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandUiccAppRecordDetailsResult {
     type Vtable = IMobileBroadbandUiccAppRecordDetailsResult_Vtbl;
@@ -4919,7 +5261,7 @@ impl MobileBroadbandUiccAppsResult {
     }
 }
 impl windows_core::RuntimeType for MobileBroadbandUiccAppsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMobileBroadbandUiccAppsResult>();
 }
 unsafe impl windows_core::Interface for MobileBroadbandUiccAppsResult {
     type Vtable = IMobileBroadbandUiccAppsResult_Vtbl;
@@ -4944,7 +5286,7 @@ impl NetworkOperatorDataUsageTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorDataUsageTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorDataUsageTriggerDetails>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorDataUsageTriggerDetails {
     type Vtable = INetworkOperatorDataUsageTriggerDetails_Vtbl;
@@ -5009,7 +5351,7 @@ impl NetworkOperatorNotificationEventDetails {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorNotificationEventDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorNotificationEventDetails>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorNotificationEventDetails {
     type Vtable = INetworkOperatorNotificationEventDetails_Vtbl;
@@ -5081,7 +5423,7 @@ impl NetworkOperatorTetheringAccessPointConfiguration {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorTetheringAccessPointConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorTetheringAccessPointConfiguration>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorTetheringAccessPointConfiguration {
     type Vtable = INetworkOperatorTetheringAccessPointConfiguration_Vtbl;
@@ -5114,7 +5456,7 @@ impl NetworkOperatorTetheringClient {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorTetheringClient {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorTetheringClient>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorTetheringClient {
     type Vtable = INetworkOperatorTetheringClient_Vtbl;
@@ -5279,7 +5621,7 @@ impl NetworkOperatorTetheringManager {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorTetheringManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorTetheringManager>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorTetheringManager {
     type Vtable = INetworkOperatorTetheringManager_Vtbl;
@@ -5309,7 +5651,7 @@ impl NetworkOperatorTetheringOperationResult {
     }
 }
 impl windows_core::RuntimeType for NetworkOperatorTetheringOperationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INetworkOperatorTetheringOperationResult>();
 }
 unsafe impl windows_core::Interface for NetworkOperatorTetheringOperationResult {
     type Vtable = INetworkOperatorTetheringOperationResult_Vtbl;
@@ -5339,7 +5681,7 @@ impl ProvisionFromXmlDocumentResults {
     }
 }
 impl windows_core::RuntimeType for ProvisionFromXmlDocumentResults {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProvisionFromXmlDocumentResults>();
 }
 unsafe impl windows_core::Interface for ProvisionFromXmlDocumentResults {
     type Vtable = IProvisionFromXmlDocumentResults_Vtbl;
@@ -5364,7 +5706,7 @@ impl ProvisionedProfile {
     }
 }
 impl windows_core::RuntimeType for ProvisionedProfile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProvisionedProfile>();
 }
 unsafe impl windows_core::Interface for ProvisionedProfile {
     type Vtable = IProvisionedProfile_Vtbl;
@@ -5412,7 +5754,7 @@ impl ProvisioningAgent {
     }
 }
 impl windows_core::RuntimeType for ProvisioningAgent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProvisioningAgent>();
 }
 unsafe impl windows_core::Interface for ProvisioningAgent {
     type Vtable = IProvisioningAgent_Vtbl;
@@ -5443,7 +5785,7 @@ impl TetheringEntitlementCheckTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for TetheringEntitlementCheckTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITetheringEntitlementCheckTriggerDetails>();
 }
 unsafe impl windows_core::Interface for TetheringEntitlementCheckTriggerDetails {
     type Vtable = ITetheringEntitlementCheckTriggerDetails_Vtbl;
@@ -5505,7 +5847,7 @@ impl UssdMessage {
     }
 }
 impl windows_core::RuntimeType for UssdMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUssdMessage>();
 }
 unsafe impl windows_core::Interface for UssdMessage {
     type Vtable = IUssdMessage_Vtbl;
@@ -5537,7 +5879,7 @@ impl UssdReply {
     }
 }
 impl windows_core::RuntimeType for UssdReply {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUssdReply>();
 }
 unsafe impl windows_core::Interface for UssdReply {
     type Vtable = IUssdReply_Vtbl;
@@ -5584,7 +5926,7 @@ impl UssdSession {
     }
 }
 impl windows_core::RuntimeType for UssdSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUssdSession>();
 }
 unsafe impl windows_core::Interface for UssdSession {
     type Vtable = IUssdSession_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IConnectionRequestedEventArgs, IConnectionRequestedEventArgs_Vtbl, 0xeb6891ae_4f1e_4c66_bd0d_46924a942e08);
+impl windows_core::RuntimeType for IConnectionRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IConnectionRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PeerInformation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPeerFinderStatics, IPeerFinderStatics_Vtbl, 0x914b3b61_f6e1_47c4_a14c_148a1903d0c6);
+impl windows_core::RuntimeType for IPeerFinderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeerFinderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,6 +44,9 @@ pub struct IPeerFinderStatics_Vtbl {
     ConnectAsync: usize,
 }
 windows_core::imp::define_interface!(IPeerFinderStatics2, IPeerFinderStatics2_Vtbl, 0xd6e73c65_fdd0_4b0b_9312_866408935d82);
+impl windows_core::RuntimeType for IPeerFinderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeerFinderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,12 +63,18 @@ pub struct IPeerFinderStatics2_Vtbl {
     pub CreateWatcher: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPeerInformation, IPeerInformation_Vtbl, 0x20024f08_9fff_45f4_b6e9_408b2ebef373);
+impl windows_core::RuntimeType for IPeerInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeerInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPeerInformation3, IPeerInformation3_Vtbl, 0xb20f612a_dbd0_40f8_95bd_2d4209c7836f);
+impl windows_core::RuntimeType for IPeerInformation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeerInformation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -70,6 +85,9 @@ pub struct IPeerInformation3_Vtbl {
     DiscoveryData: usize,
 }
 windows_core::imp::define_interface!(IPeerInformationWithHostAndService, IPeerInformationWithHostAndService_Vtbl, 0xecc7ccad_1b70_4e8b_92db_bbe781419308);
+impl windows_core::RuntimeType for IPeerInformationWithHostAndService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeerInformationWithHostAndService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +95,9 @@ pub struct IPeerInformationWithHostAndService_Vtbl {
     pub ServiceName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPeerWatcher, IPeerWatcher_Vtbl, 0x3cee21f8_2fa6_4679_9691_03c94a420f34);
+impl windows_core::RuntimeType for IPeerWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPeerWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,6 +116,9 @@ pub struct IPeerWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximityDevice, IProximityDevice_Vtbl, 0xefa8a552_f6e1_4329_a0fc_ab6b0fd28262);
+impl windows_core::RuntimeType for IProximityDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximityDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,6 +146,9 @@ pub struct IProximityDevice_Vtbl {
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximityDeviceStatics, IProximityDeviceStatics_Vtbl, 0x914ba01d_f6e1_47c4_a14c_148a1903d0c6);
+impl windows_core::RuntimeType for IProximityDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximityDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -130,6 +157,9 @@ pub struct IProximityDeviceStatics_Vtbl {
     pub FromId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProximityMessage, IProximityMessage_Vtbl, 0xefab0782_f6e1_4675_a045_d8e320c24808);
+impl windows_core::RuntimeType for IProximityMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProximityMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -142,6 +172,9 @@ pub struct IProximityMessage_Vtbl {
     pub DataAsString: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITriggeredConnectionStateChangedEventArgs, ITriggeredConnectionStateChangedEventArgs_Vtbl, 0xc6a780ad_f6e1_4d54_96e2_33f620bca88a);
+impl windows_core::RuntimeType for ITriggeredConnectionStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITriggeredConnectionStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -166,7 +199,7 @@ impl ConnectionRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ConnectionRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IConnectionRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for ConnectionRequestedEventArgs {
     type Vtable = IConnectionRequestedEventArgs_Vtbl;
@@ -364,7 +397,7 @@ impl PeerInformation {
     }
 }
 impl windows_core::RuntimeType for PeerInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPeerInformation>();
 }
 unsafe impl windows_core::Interface for PeerInformation {
     type Vtable = IPeerInformation_Vtbl;
@@ -467,7 +500,7 @@ impl PeerWatcher {
     }
 }
 impl windows_core::RuntimeType for PeerWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPeerWatcher>();
 }
 unsafe impl windows_core::Interface for PeerWatcher {
     type Vtable = IPeerWatcher_Vtbl;
@@ -636,7 +669,7 @@ impl ProximityDevice {
     }
 }
 impl windows_core::RuntimeType for ProximityDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProximityDevice>();
 }
 unsafe impl windows_core::Interface for ProximityDevice {
     type Vtable = IProximityDevice_Vtbl;
@@ -683,7 +716,7 @@ impl ProximityMessage {
     }
 }
 impl windows_core::RuntimeType for ProximityMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProximityMessage>();
 }
 unsafe impl windows_core::Interface for ProximityMessage {
     type Vtable = IProximityMessage_Vtbl;
@@ -723,7 +756,7 @@ impl TriggeredConnectionStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TriggeredConnectionStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITriggeredConnectionStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for TriggeredConnectionStateChangedEventArgs {
     type Vtable = ITriggeredConnectionStateChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPushNotificationChannel, IPushNotificationChannel_Vtbl, 0x2b28102e_ef0b_4f39_9b8a_a3c194de7081);
+impl windows_core::RuntimeType for IPushNotificationChannel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IPushNotificationChannel_Vtbl {
     pub RemovePushNotificationReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPushNotificationChannelManagerForUser, IPushNotificationChannelManagerForUser_Vtbl, 0xa4c45704_1182_42c7_8890_f563c4890dc4);
+impl windows_core::RuntimeType for IPushNotificationChannelManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannelManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +27,9 @@ pub struct IPushNotificationChannelManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IPushNotificationChannelManagerForUser2, IPushNotificationChannelManagerForUser2_Vtbl, 0xc38b066a_7cc1_4dac_87fd_be6e920414a4);
+impl windows_core::RuntimeType for IPushNotificationChannelManagerForUser2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannelManagerForUser2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +43,9 @@ pub struct IPushNotificationChannelManagerForUser2_Vtbl {
     CreateRawPushNotificationChannelWithAlternateKeyForApplicationAsyncWithId: usize,
 }
 windows_core::imp::define_interface!(IPushNotificationChannelManagerStatics, IPushNotificationChannelManagerStatics_Vtbl, 0x8baf9b65_77a1_4588_bd19_861529a9dcf0);
+impl windows_core::RuntimeType for IPushNotificationChannelManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannelManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +54,9 @@ pub struct IPushNotificationChannelManagerStatics_Vtbl {
     pub CreatePushNotificationChannelForSecondaryTileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPushNotificationChannelManagerStatics2, IPushNotificationChannelManagerStatics2_Vtbl, 0xb444a65d_a7e9_4b28_950e_f375a907f9df);
+impl windows_core::RuntimeType for IPushNotificationChannelManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannelManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,12 +66,18 @@ pub struct IPushNotificationChannelManagerStatics2_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IPushNotificationChannelManagerStatics3, IPushNotificationChannelManagerStatics3_Vtbl, 0x4701fefe_0ede_4a3f_ae78_bfa471496925);
+impl windows_core::RuntimeType for IPushNotificationChannelManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannelManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPushNotificationChannelManagerStatics4, IPushNotificationChannelManagerStatics4_Vtbl, 0xbc540efb_7820_5a5b_9c01_b4757f774025);
+impl windows_core::RuntimeType for IPushNotificationChannelManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannelManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,11 +85,17 @@ pub struct IPushNotificationChannelManagerStatics4_Vtbl {
     pub RemoveChannelsRevoked: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPushNotificationChannelsRevokedEventArgs, IPushNotificationChannelsRevokedEventArgs_Vtbl, 0x20e1a24c_1a34_5beb_aae2_40c232c8c140);
+impl windows_core::RuntimeType for IPushNotificationChannelsRevokedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationChannelsRevokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPushNotificationReceivedEventArgs, IPushNotificationReceivedEventArgs_Vtbl, 0xd1065e0c_36cd_484c_b935_0a99b753cf00);
+impl windows_core::RuntimeType for IPushNotificationReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPushNotificationReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,12 +117,18 @@ pub struct IPushNotificationReceivedEventArgs_Vtbl {
     pub RawNotification: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRawNotification, IRawNotification_Vtbl, 0x1a227281_3b79_42ac_9963_22ab00d4f0b7);
+impl windows_core::RuntimeType for IRawNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRawNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Content: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRawNotification2, IRawNotification2_Vtbl, 0xe6d0cf19_0c6f_4cdd_9424_eec5be014d26);
+impl windows_core::RuntimeType for IRawNotification2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRawNotification2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,6 +139,9 @@ pub struct IRawNotification2_Vtbl {
     pub ChannelId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRawNotification3, IRawNotification3_Vtbl, 0x62737dde_8a73_424c_ab44_5635f40a96e5);
+impl windows_core::RuntimeType for IRawNotification3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRawNotification3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -153,7 +189,7 @@ impl PushNotificationChannel {
     }
 }
 impl windows_core::RuntimeType for PushNotificationChannel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPushNotificationChannel>();
 }
 unsafe impl windows_core::Interface for PushNotificationChannel {
     type Vtable = IPushNotificationChannel_Vtbl;
@@ -294,7 +330,7 @@ impl PushNotificationChannelManagerForUser {
     }
 }
 impl windows_core::RuntimeType for PushNotificationChannelManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPushNotificationChannelManagerForUser>();
 }
 unsafe impl windows_core::Interface for PushNotificationChannelManagerForUser {
     type Vtable = IPushNotificationChannelManagerForUser_Vtbl;
@@ -311,7 +347,7 @@ pub struct PushNotificationChannelsRevokedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(PushNotificationChannelsRevokedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl PushNotificationChannelsRevokedEventArgs {}
 impl windows_core::RuntimeType for PushNotificationChannelsRevokedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPushNotificationChannelsRevokedEventArgs>();
 }
 unsafe impl windows_core::Interface for PushNotificationChannelsRevokedEventArgs {
     type Vtable = IPushNotificationChannelsRevokedEventArgs_Vtbl;
@@ -378,7 +414,7 @@ impl PushNotificationReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PushNotificationReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPushNotificationReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for PushNotificationReceivedEventArgs {
     type Vtable = IPushNotificationReceivedEventArgs_Vtbl;
@@ -426,7 +462,7 @@ impl RawNotification {
     }
 }
 impl windows_core::RuntimeType for RawNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRawNotification>();
 }
 unsafe impl windows_core::Interface for RawNotification {
     type Vtable = IRawNotification_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDnssdRegistrationResult, IDnssdRegistrationResult_Vtbl, 0x3d786ad2_e606_5350_73ea_7e97f066162f);
+impl windows_core::RuntimeType for IDnssdRegistrationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDnssdRegistrationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IDnssdRegistrationResult_Vtbl {
     pub HasInstanceNameChanged: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDnssdServiceInstance, IDnssdServiceInstance_Vtbl, 0xe246db7e_98a5_4ca1_b9e4_c253d33c35ff);
+impl windows_core::RuntimeType for IDnssdServiceInstance {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDnssdServiceInstance_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,12 +48,18 @@ pub struct IDnssdServiceInstance_Vtbl {
     RegisterDatagramSocketAsync2: usize,
 }
 windows_core::imp::define_interface!(IDnssdServiceInstanceFactory, IDnssdServiceInstanceFactory_Vtbl, 0x6cb061a1_c478_4331_9684_4af2186c0a2b);
+impl windows_core::RuntimeType for IDnssdServiceInstanceFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDnssdServiceInstanceFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, u16, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDnssdServiceWatcher, IDnssdServiceWatcher_Vtbl, 0xcc34d9c1_db7d_4b69_983d_c6f83f205682);
+impl windows_core::RuntimeType for IDnssdServiceWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDnssdServiceWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -104,7 +116,7 @@ impl DnssdRegistrationResult {
     }
 }
 impl windows_core::RuntimeType for DnssdRegistrationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDnssdRegistrationResult>();
 }
 unsafe impl windows_core::Interface for DnssdRegistrationResult {
     type Vtable = IDnssdRegistrationResult_Vtbl;
@@ -256,7 +268,7 @@ impl DnssdServiceInstance {
     }
 }
 impl windows_core::RuntimeType for DnssdServiceInstance {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDnssdServiceInstance>();
 }
 unsafe impl windows_core::Interface for DnssdServiceInstance {
     type Vtable = IDnssdServiceInstance_Vtbl;
@@ -323,7 +335,7 @@ impl DnssdServiceInstanceCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for DnssdServiceInstanceCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IVectorView<DnssdServiceInstance>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for DnssdServiceInstanceCollection {
@@ -418,7 +430,7 @@ impl DnssdServiceWatcher {
     }
 }
 impl windows_core::RuntimeType for DnssdServiceWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDnssdServiceWatcher>();
 }
 unsafe impl windows_core::Interface for DnssdServiceWatcher {
     type Vtable = IDnssdServiceWatcher_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IControlChannelTrigger, IControlChannelTrigger_Vtbl, 0x7d1431a7_ee96_40e8_a199_8703cd969ec3);
+impl windows_core::RuntimeType for IControlChannelTrigger {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IControlChannelTrigger_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +24,9 @@ pub struct IControlChannelTrigger_Vtbl {
     pub FlushTransport: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IControlChannelTrigger2, IControlChannelTrigger2_Vtbl, 0xaf00d237_51be_4514_9725_3556e1879580);
+impl windows_core::RuntimeType for IControlChannelTrigger2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IControlChannelTrigger2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +52,9 @@ pub struct IControlChannelTriggerEventDetails_Vtbl {
     pub ControlChannelTrigger: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IControlChannelTriggerFactory, IControlChannelTriggerFactory_Vtbl, 0xda4b7cf0_8d71_446f_88c3_b95184a2d6cd);
+impl windows_core::RuntimeType for IControlChannelTriggerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IControlChannelTriggerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -88,6 +97,9 @@ pub struct IControlChannelTriggerResetEventDetails_Vtbl {
     pub SoftwareSlotReset: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDatagramSocket, IDatagramSocket_Vtbl, 0x7fe25bbb_c3bc_4677_8446_ca28a465a3af);
+impl windows_core::RuntimeType for IDatagramSocket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +126,9 @@ pub struct IDatagramSocket_Vtbl {
     pub RemoveMessageReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDatagramSocket2, IDatagramSocket2_Vtbl, 0xd83ba354_9a9d_4185_a20a_1424c9c2a7cd);
+impl windows_core::RuntimeType for IDatagramSocket2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocket2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -123,6 +138,9 @@ pub struct IDatagramSocket2_Vtbl {
     BindServiceNameAndAdapterAsync: usize,
 }
 windows_core::imp::define_interface!(IDatagramSocket3, IDatagramSocket3_Vtbl, 0x37544f09_ab92_4306_9ac1_0c381283d9c6);
+impl windows_core::RuntimeType for IDatagramSocket3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocket3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -134,6 +152,9 @@ pub struct IDatagramSocket3_Vtbl {
     pub TransferOwnershipWithContextAndKeepAliveTime: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDatagramSocketControl, IDatagramSocketControl_Vtbl, 0x52ac3f2e_349a_4135_bb58_b79b2647d390);
+impl windows_core::RuntimeType for IDatagramSocketControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocketControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -143,6 +164,9 @@ pub struct IDatagramSocketControl_Vtbl {
     pub SetOutboundUnicastHopLimit: unsafe extern "system" fn(*mut core::ffi::c_void, u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDatagramSocketControl2, IDatagramSocketControl2_Vtbl, 0x33ead5c2_979c_4415_82a1_3cfaf646c192);
+impl windows_core::RuntimeType for IDatagramSocketControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocketControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,6 +176,9 @@ pub struct IDatagramSocketControl2_Vtbl {
     pub SetDontFragment: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDatagramSocketControl3, IDatagramSocketControl3_Vtbl, 0xd4eb8256_1f6d_4598_9b57_d42a001df349);
+impl windows_core::RuntimeType for IDatagramSocketControl3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocketControl3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -159,6 +186,9 @@ pub struct IDatagramSocketControl3_Vtbl {
     pub SetMulticastOnly: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDatagramSocketInformation, IDatagramSocketInformation_Vtbl, 0x5f1a569a_55fb_48cd_9706_7a974f7b1585);
+impl windows_core::RuntimeType for IDatagramSocketInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocketInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -168,6 +198,9 @@ pub struct IDatagramSocketInformation_Vtbl {
     pub RemotePort: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDatagramSocketMessageReceivedEventArgs, IDatagramSocketMessageReceivedEventArgs_Vtbl, 0x9e2ddca2_1712_4ce4_b179_8c652c6d107e);
+impl windows_core::RuntimeType for IDatagramSocketMessageReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocketMessageReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -184,6 +217,9 @@ pub struct IDatagramSocketMessageReceivedEventArgs_Vtbl {
     GetDataStream: usize,
 }
 windows_core::imp::define_interface!(IDatagramSocketStatics, IDatagramSocketStatics_Vtbl, 0xe9c62aee_1494_4a21_bb7e_8589fc751d9d);
+impl windows_core::RuntimeType for IDatagramSocketStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDatagramSocketStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,6 +233,9 @@ pub struct IDatagramSocketStatics_Vtbl {
     GetEndpointPairsWithSortOptionsAsync: usize,
 }
 windows_core::imp::define_interface!(IMessageWebSocket, IMessageWebSocket_Vtbl, 0x33727d08_34d5_4746_ad7b_8dde5bc2ef88);
+impl windows_core::RuntimeType for IMessageWebSocket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageWebSocket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -206,6 +245,9 @@ pub struct IMessageWebSocket_Vtbl {
     pub RemoveMessageReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMessageWebSocket2, IMessageWebSocket2_Vtbl, 0xbed0cee7_f9c8_440a_9ad5_737281d9742e);
+impl windows_core::RuntimeType for IMessageWebSocket2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageWebSocket2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -213,6 +255,9 @@ pub struct IMessageWebSocket2_Vtbl {
     pub RemoveServerCustomValidationRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMessageWebSocket3, IMessageWebSocket3_Vtbl, 0x59d9defb_71af_4349_8487_911fcf681597);
+impl windows_core::RuntimeType for IMessageWebSocket3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageWebSocket3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -226,6 +271,9 @@ pub struct IMessageWebSocket3_Vtbl {
     SendFinalFrameAsync: usize,
 }
 windows_core::imp::define_interface!(IMessageWebSocketControl, IMessageWebSocketControl_Vtbl, 0x8118388a_c629_4f0a_80fb_81fc05538862);
+impl windows_core::RuntimeType for IMessageWebSocketControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageWebSocketControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,6 +283,9 @@ pub struct IMessageWebSocketControl_Vtbl {
     pub SetMessageType: unsafe extern "system" fn(*mut core::ffi::c_void, SocketMessageType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMessageWebSocketControl2, IMessageWebSocketControl2_Vtbl, 0xe30fd791_080c_400a_a712_27dfa9e744d8);
+impl windows_core::RuntimeType for IMessageWebSocketControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageWebSocketControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -253,6 +304,9 @@ pub struct IMessageWebSocketControl2_Vtbl {
     SetClientCertificate: usize,
 }
 windows_core::imp::define_interface!(IMessageWebSocketMessageReceivedEventArgs, IMessageWebSocketMessageReceivedEventArgs_Vtbl, 0x478c22ac_4c4b_42ed_9ed7_1ef9f94fa3d5);
+impl windows_core::RuntimeType for IMessageWebSocketMessageReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageWebSocketMessageReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -267,12 +321,18 @@ pub struct IMessageWebSocketMessageReceivedEventArgs_Vtbl {
     GetDataStream: usize,
 }
 windows_core::imp::define_interface!(IMessageWebSocketMessageReceivedEventArgs2, IMessageWebSocketMessageReceivedEventArgs2_Vtbl, 0x89ce06fd_dd6f_4a07_87f9_f9eb4d89d83d);
+impl windows_core::RuntimeType for IMessageWebSocketMessageReceivedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageWebSocketMessageReceivedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsMessageComplete: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IServerMessageWebSocket, IServerMessageWebSocket_Vtbl, 0xe3ac9240_813b_5efd_7e11_ae2305fc77f1);
+impl windows_core::RuntimeType for IServerMessageWebSocket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServerMessageWebSocket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -289,6 +349,9 @@ pub struct IServerMessageWebSocket_Vtbl {
     pub CloseWithStatus: unsafe extern "system" fn(*mut core::ffi::c_void, u16, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IServerMessageWebSocketControl, IServerMessageWebSocketControl_Vtbl, 0x69c2f051_1c1f_587a_4519_2181610192b7);
+impl windows_core::RuntimeType for IServerMessageWebSocketControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServerMessageWebSocketControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -296,6 +359,9 @@ pub struct IServerMessageWebSocketControl_Vtbl {
     pub SetMessageType: unsafe extern "system" fn(*mut core::ffi::c_void, SocketMessageType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IServerMessageWebSocketInformation, IServerMessageWebSocketInformation_Vtbl, 0xfc32b45f_4448_5505_6cc9_09afa8915f5d);
+impl windows_core::RuntimeType for IServerMessageWebSocketInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServerMessageWebSocketInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -304,6 +370,9 @@ pub struct IServerMessageWebSocketInformation_Vtbl {
     pub LocalAddress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IServerStreamWebSocket, IServerStreamWebSocket_Vtbl, 0x2ced5bbf_74f6_55e4_79df_9132680dfee8);
+impl windows_core::RuntimeType for IServerStreamWebSocket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServerStreamWebSocket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -321,6 +390,9 @@ pub struct IServerStreamWebSocket_Vtbl {
     pub CloseWithStatus: unsafe extern "system" fn(*mut core::ffi::c_void, u16, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IServerStreamWebSocketInformation, IServerStreamWebSocketInformation_Vtbl, 0xfc32b45f_4448_5505_6cc9_09aba8915f5d);
+impl windows_core::RuntimeType for IServerStreamWebSocketInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServerStreamWebSocketInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -329,6 +401,9 @@ pub struct IServerStreamWebSocketInformation_Vtbl {
     pub LocalAddress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISocketActivityContext, ISocketActivityContext_Vtbl, 0x43b04d64_4c85_4396_a637_1d973f6ebd49);
+impl windows_core::RuntimeType for ISocketActivityContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISocketActivityContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -338,6 +413,9 @@ pub struct ISocketActivityContext_Vtbl {
     Data: usize,
 }
 windows_core::imp::define_interface!(ISocketActivityContextFactory, ISocketActivityContextFactory_Vtbl, 0xb99fc3c3_088c_4388_83ae_2525138e049a);
+impl windows_core::RuntimeType for ISocketActivityContextFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISocketActivityContextFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -347,6 +425,9 @@ pub struct ISocketActivityContextFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ISocketActivityInformation, ISocketActivityInformation_Vtbl, 0x8d8a42e4_a87e_4b74_9968_185b2511defe);
+impl windows_core::RuntimeType for ISocketActivityInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISocketActivityInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -359,6 +440,9 @@ pub struct ISocketActivityInformation_Vtbl {
     pub StreamSocketListener: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISocketActivityInformationStatics, ISocketActivityInformationStatics_Vtbl, 0x8570b47a_7e7d_4736_8041_1327a6543c56);
+impl windows_core::RuntimeType for ISocketActivityInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISocketActivityInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -368,6 +452,9 @@ pub struct ISocketActivityInformationStatics_Vtbl {
     AllSockets: usize,
 }
 windows_core::imp::define_interface!(ISocketActivityTriggerDetails, ISocketActivityTriggerDetails_Vtbl, 0x45f406a7_fc9f_4f81_acad_355fef51e67b);
+impl windows_core::RuntimeType for ISocketActivityTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISocketActivityTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -375,12 +462,18 @@ pub struct ISocketActivityTriggerDetails_Vtbl {
     pub SocketInformation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISocketErrorStatics, ISocketErrorStatics_Vtbl, 0x828337f4_7d56_4d8e_b7b4_a07dd7c1bca9);
+impl windows_core::RuntimeType for ISocketErrorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISocketErrorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetStatus: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut SocketErrorStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocket, IStreamSocket_Vtbl, 0x69a22cf3_fc7b_4857_af38_f6e7de6a5b49);
+impl windows_core::RuntimeType for IStreamSocket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -401,6 +494,9 @@ pub struct IStreamSocket_Vtbl {
     pub UpgradeToSslAsync: unsafe extern "system" fn(*mut core::ffi::c_void, SocketProtectionLevel, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocket2, IStreamSocket2_Vtbl, 0x29d0e575_f314_4d09_adf0_0fbd967fbd9f);
+impl windows_core::RuntimeType for IStreamSocket2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocket2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -410,6 +506,9 @@ pub struct IStreamSocket2_Vtbl {
     ConnectWithProtectionLevelAndAdapterAsync: usize,
 }
 windows_core::imp::define_interface!(IStreamSocket3, IStreamSocket3_Vtbl, 0x3f430b00_9d28_4854_bac3_2301941ec223);
+impl windows_core::RuntimeType for IStreamSocket3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocket3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -421,6 +520,9 @@ pub struct IStreamSocket3_Vtbl {
     pub TransferOwnershipWithContextAndKeepAliveTime: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketControl, IStreamSocketControl_Vtbl, 0xfe25adf1_92ab_4af3_9992_0f4c85e36cc4);
+impl windows_core::RuntimeType for IStreamSocketControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -436,6 +538,9 @@ pub struct IStreamSocketControl_Vtbl {
     pub SetOutboundUnicastHopLimit: unsafe extern "system" fn(*mut core::ffi::c_void, u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketControl2, IStreamSocketControl2_Vtbl, 0xc2d09a56_060f_44c1_b8e2_1fbf60bd62c5);
+impl windows_core::RuntimeType for IStreamSocketControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -445,6 +550,9 @@ pub struct IStreamSocketControl2_Vtbl {
     IgnorableServerCertificateErrors: usize,
 }
 windows_core::imp::define_interface!(IStreamSocketControl3, IStreamSocketControl3_Vtbl, 0xc56a444c_4e74_403e_894c_b31cae5c7342);
+impl windows_core::RuntimeType for IStreamSocketControl3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketControl3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -460,6 +568,9 @@ pub struct IStreamSocketControl3_Vtbl {
     SetClientCertificate: usize,
 }
 windows_core::imp::define_interface!(IStreamSocketControl4, IStreamSocketControl4_Vtbl, 0x964e2b3d_ec27_4888_b3ce_c74b418423ad);
+impl windows_core::RuntimeType for IStreamSocketControl4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketControl4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -467,6 +578,9 @@ pub struct IStreamSocketControl4_Vtbl {
     pub SetMinProtectionLevel: unsafe extern "system" fn(*mut core::ffi::c_void, SocketProtectionLevel) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketInformation, IStreamSocketInformation_Vtbl, 0x3b80ae30_5e68_4205_88f0_dc85d2e25ded);
+impl windows_core::RuntimeType for IStreamSocketInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -485,6 +599,9 @@ pub struct IStreamSocketInformation_Vtbl {
     SessionKey: usize,
 }
 windows_core::imp::define_interface!(IStreamSocketInformation2, IStreamSocketInformation2_Vtbl, 0x12c28452_4bdc_4ee4_976a_cf130e9d92e3);
+impl windows_core::RuntimeType for IStreamSocketInformation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketInformation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -503,6 +620,9 @@ pub struct IStreamSocketInformation2_Vtbl {
     ServerIntermediateCertificates: usize,
 }
 windows_core::imp::define_interface!(IStreamSocketListener, IStreamSocketListener_Vtbl, 0xff513437_df9f_4df0_bf82_0ec5d7b35aae);
+impl windows_core::RuntimeType for IStreamSocketListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -514,6 +634,9 @@ pub struct IStreamSocketListener_Vtbl {
     pub RemoveConnectionReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketListener2, IStreamSocketListener2_Vtbl, 0x658dc13e_bb3e_4458_b232_ed1088694b98);
+impl windows_core::RuntimeType for IStreamSocketListener2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketListener2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -524,6 +647,9 @@ pub struct IStreamSocketListener2_Vtbl {
     BindServiceNameWithProtectionLevelAndAdapterAsync: usize,
 }
 windows_core::imp::define_interface!(IStreamSocketListener3, IStreamSocketListener3_Vtbl, 0x4798201c_bdf8_4919_8542_28d450e74507);
+impl windows_core::RuntimeType for IStreamSocketListener3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketListener3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -534,12 +660,18 @@ pub struct IStreamSocketListener3_Vtbl {
     pub TransferOwnershipWithContext: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketListenerConnectionReceivedEventArgs, IStreamSocketListenerConnectionReceivedEventArgs_Vtbl, 0x0c472ea9_373f_447b_85b1_ddd4548803ba);
+impl windows_core::RuntimeType for IStreamSocketListenerConnectionReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketListenerConnectionReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Socket: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketListenerControl, IStreamSocketListenerControl_Vtbl, 0x20d8c576_8d8a_4dba_9722_a16c4d984980);
+impl windows_core::RuntimeType for IStreamSocketListenerControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketListenerControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -547,6 +679,9 @@ pub struct IStreamSocketListenerControl_Vtbl {
     pub SetQualityOfService: unsafe extern "system" fn(*mut core::ffi::c_void, SocketQualityOfService) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketListenerControl2, IStreamSocketListenerControl2_Vtbl, 0x948bb665_2c3e_404b_b8b0_8eb249a2b0a1);
+impl windows_core::RuntimeType for IStreamSocketListenerControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketListenerControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -560,12 +695,18 @@ pub struct IStreamSocketListenerControl2_Vtbl {
     pub SetOutboundUnicastHopLimit: unsafe extern "system" fn(*mut core::ffi::c_void, u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketListenerInformation, IStreamSocketListenerInformation_Vtbl, 0xe62ba82f_a63a_430b_bf62_29e93e5633b4);
+impl windows_core::RuntimeType for IStreamSocketListenerInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketListenerInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LocalPort: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamSocketStatics, IStreamSocketStatics_Vtbl, 0xa420bc4a_6e2e_4af5_b556_355ae0cd4f29);
+impl windows_core::RuntimeType for IStreamSocketStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamSocketStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -579,6 +720,9 @@ pub struct IStreamSocketStatics_Vtbl {
     GetEndpointPairsWithSortOptionsAsync: usize,
 }
 windows_core::imp::define_interface!(IStreamWebSocket, IStreamWebSocket_Vtbl, 0xbd4a49d8_b289_45bb_97eb_c7525205a843);
+impl windows_core::RuntimeType for IStreamWebSocket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamWebSocket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -590,6 +734,9 @@ pub struct IStreamWebSocket_Vtbl {
     InputStream: usize,
 }
 windows_core::imp::define_interface!(IStreamWebSocket2, IStreamWebSocket2_Vtbl, 0xaa4d08cb_93f5_4678_8236_57cce5417ed5);
+impl windows_core::RuntimeType for IStreamWebSocket2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamWebSocket2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -597,6 +744,9 @@ pub struct IStreamWebSocket2_Vtbl {
     pub RemoveServerCustomValidationRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamWebSocketControl, IStreamWebSocketControl_Vtbl, 0xb4f478b1_a45a_48db_953a_645b7d964c07);
+impl windows_core::RuntimeType for IStreamWebSocketControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamWebSocketControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -604,6 +754,9 @@ pub struct IStreamWebSocketControl_Vtbl {
     pub SetNoDelay: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStreamWebSocketControl2, IStreamWebSocketControl2_Vtbl, 0x215d9f7e_fa58_40da_9f11_a48dafe95037);
+impl windows_core::RuntimeType for IStreamWebSocketControl2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStreamWebSocketControl2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -685,6 +838,9 @@ pub struct IWebSocket_Vtbl {
     pub CloseWithStatus: unsafe extern "system" fn(*mut core::ffi::c_void, u16, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebSocketClosedEventArgs, IWebSocketClosedEventArgs_Vtbl, 0xceb78d07_d0a8_4703_a091_c8c2c0915bc3);
+impl windows_core::RuntimeType for IWebSocketClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebSocketClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -851,6 +1007,9 @@ pub struct IWebSocketControl2_Vtbl {
     IgnorableServerCertificateErrors: usize,
 }
 windows_core::imp::define_interface!(IWebSocketErrorStatics, IWebSocketErrorStatics_Vtbl, 0x27cdf35b_1f61_4709_8e02_61283ada4e9d);
+impl windows_core::RuntimeType for IWebSocketErrorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebSocketErrorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -972,6 +1131,9 @@ pub struct IWebSocketInformation2_Vtbl {
     ServerIntermediateCertificates: usize,
 }
 windows_core::imp::define_interface!(IWebSocketServerCustomValidationRequestedEventArgs, IWebSocketServerCustomValidationRequestedEventArgs_Vtbl, 0xffeffe48_022a_4ab7_8b36_e10af4640e6b);
+impl windows_core::RuntimeType for IWebSocketServerCustomValidationRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebSocketServerCustomValidationRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1097,7 +1259,7 @@ impl ControlChannelTrigger {
     }
 }
 impl windows_core::RuntimeType for ControlChannelTrigger {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IControlChannelTrigger>();
 }
 unsafe impl windows_core::Interface for ControlChannelTrigger {
     type Vtable = IControlChannelTrigger_Vtbl;
@@ -1298,7 +1460,7 @@ impl DatagramSocket {
     }
 }
 impl windows_core::RuntimeType for DatagramSocket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDatagramSocket>();
 }
 unsafe impl windows_core::Interface for DatagramSocket {
     type Vtable = IDatagramSocket_Vtbl;
@@ -1371,7 +1533,7 @@ impl DatagramSocketControl {
     }
 }
 impl windows_core::RuntimeType for DatagramSocketControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDatagramSocketControl>();
 }
 unsafe impl windows_core::Interface for DatagramSocketControl {
     type Vtable = IDatagramSocketControl_Vtbl;
@@ -1417,7 +1579,7 @@ impl DatagramSocketInformation {
     }
 }
 impl windows_core::RuntimeType for DatagramSocketInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDatagramSocketInformation>();
 }
 unsafe impl windows_core::Interface for DatagramSocketInformation {
     type Vtable = IDatagramSocketInformation_Vtbl;
@@ -1472,7 +1634,7 @@ impl DatagramSocketMessageReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DatagramSocketMessageReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDatagramSocketMessageReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for DatagramSocketMessageReceivedEventArgs {
     type Vtable = IDatagramSocketMessageReceivedEventArgs_Vtbl;
@@ -1606,7 +1768,7 @@ impl MessageWebSocket {
     }
 }
 impl windows_core::RuntimeType for MessageWebSocket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMessageWebSocket>();
 }
 unsafe impl windows_core::Interface for MessageWebSocket {
     type Vtable = IMessageWebSocket_Vtbl;
@@ -1751,7 +1913,7 @@ impl MessageWebSocketControl {
     }
 }
 impl windows_core::RuntimeType for MessageWebSocketControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMessageWebSocketControl>();
 }
 unsafe impl windows_core::Interface for MessageWebSocketControl {
     type Vtable = IMessageWebSocketControl_Vtbl;
@@ -1822,7 +1984,7 @@ impl MessageWebSocketInformation {
     }
 }
 impl windows_core::RuntimeType for MessageWebSocketInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebSocketInformation>();
 }
 unsafe impl windows_core::Interface for MessageWebSocketInformation {
     type Vtable = IWebSocketInformation_Vtbl;
@@ -1870,7 +2032,7 @@ impl MessageWebSocketMessageReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for MessageWebSocketMessageReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMessageWebSocketMessageReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for MessageWebSocketMessageReceivedEventArgs {
     type Vtable = IMessageWebSocketMessageReceivedEventArgs_Vtbl;
@@ -1947,7 +2109,7 @@ impl ServerMessageWebSocket {
     }
 }
 impl windows_core::RuntimeType for ServerMessageWebSocket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IServerMessageWebSocket>();
 }
 unsafe impl windows_core::Interface for ServerMessageWebSocket {
     type Vtable = IServerMessageWebSocket_Vtbl;
@@ -1976,7 +2138,7 @@ impl ServerMessageWebSocketControl {
     }
 }
 impl windows_core::RuntimeType for ServerMessageWebSocketControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IServerMessageWebSocketControl>();
 }
 unsafe impl windows_core::Interface for ServerMessageWebSocketControl {
     type Vtable = IServerMessageWebSocketControl_Vtbl;
@@ -2015,7 +2177,7 @@ impl ServerMessageWebSocketInformation {
     }
 }
 impl windows_core::RuntimeType for ServerMessageWebSocketInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IServerMessageWebSocketInformation>();
 }
 unsafe impl windows_core::Interface for ServerMessageWebSocketInformation {
     type Vtable = IServerMessageWebSocketInformation_Vtbl;
@@ -2079,7 +2241,7 @@ impl ServerStreamWebSocket {
     }
 }
 impl windows_core::RuntimeType for ServerStreamWebSocket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IServerStreamWebSocket>();
 }
 unsafe impl windows_core::Interface for ServerStreamWebSocket {
     type Vtable = IServerStreamWebSocket_Vtbl;
@@ -2118,7 +2280,7 @@ impl ServerStreamWebSocketInformation {
     }
 }
 impl windows_core::RuntimeType for ServerStreamWebSocketInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IServerStreamWebSocketInformation>();
 }
 unsafe impl windows_core::Interface for ServerStreamWebSocketInformation {
     type Vtable = IServerStreamWebSocketInformation_Vtbl;
@@ -2159,7 +2321,7 @@ impl SocketActivityContext {
     }
 }
 impl windows_core::RuntimeType for SocketActivityContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISocketActivityContext>();
 }
 unsafe impl windows_core::Interface for SocketActivityContext {
     type Vtable = ISocketActivityContext_Vtbl;
@@ -2238,7 +2400,7 @@ impl SocketActivityInformation {
     }
 }
 impl windows_core::RuntimeType for SocketActivityInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISocketActivityInformation>();
 }
 unsafe impl windows_core::Interface for SocketActivityInformation {
     type Vtable = ISocketActivityInformation_Vtbl;
@@ -2270,7 +2432,7 @@ impl SocketActivityTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for SocketActivityTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISocketActivityTriggerDetails>();
 }
 unsafe impl windows_core::Interface for SocketActivityTriggerDetails {
     type Vtable = ISocketActivityTriggerDetails_Vtbl;
@@ -2467,7 +2629,7 @@ impl StreamSocket {
     }
 }
 impl windows_core::RuntimeType for StreamSocket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamSocket>();
 }
 unsafe impl windows_core::Interface for StreamSocket {
     type Vtable = IStreamSocket_Vtbl;
@@ -2586,7 +2748,7 @@ impl StreamSocketControl {
     }
 }
 impl windows_core::RuntimeType for StreamSocketControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamSocketControl>();
 }
 unsafe impl windows_core::Interface for StreamSocketControl {
     type Vtable = IStreamSocketControl_Vtbl;
@@ -2706,7 +2868,7 @@ impl StreamSocketInformation {
     }
 }
 impl windows_core::RuntimeType for StreamSocketInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamSocketInformation>();
 }
 unsafe impl windows_core::Interface for StreamSocketInformation {
     type Vtable = IStreamSocketInformation_Vtbl;
@@ -2825,7 +2987,7 @@ impl StreamSocketListener {
     }
 }
 impl windows_core::RuntimeType for StreamSocketListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamSocketListener>();
 }
 unsafe impl windows_core::Interface for StreamSocketListener {
     type Vtable = IStreamSocketListener_Vtbl;
@@ -2850,7 +3012,7 @@ impl StreamSocketListenerConnectionReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for StreamSocketListenerConnectionReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamSocketListenerConnectionReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for StreamSocketListenerConnectionReceivedEventArgs {
     type Vtable = IStreamSocketListenerConnectionReceivedEventArgs_Vtbl;
@@ -2923,7 +3085,7 @@ impl StreamSocketListenerControl {
     }
 }
 impl windows_core::RuntimeType for StreamSocketListenerControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamSocketListenerControl>();
 }
 unsafe impl windows_core::Interface for StreamSocketListenerControl {
     type Vtable = IStreamSocketListenerControl_Vtbl;
@@ -2948,7 +3110,7 @@ impl StreamSocketListenerInformation {
     }
 }
 impl windows_core::RuntimeType for StreamSocketListenerInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamSocketListenerInformation>();
 }
 unsafe impl windows_core::Interface for StreamSocketListenerInformation {
     type Vtable = IStreamSocketListenerInformation_Vtbl;
@@ -3054,7 +3216,7 @@ impl StreamWebSocket {
     }
 }
 impl windows_core::RuntimeType for StreamWebSocket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamWebSocket>();
 }
 unsafe impl windows_core::Interface for StreamWebSocket {
     type Vtable = IStreamWebSocket_Vtbl;
@@ -3177,7 +3339,7 @@ impl StreamWebSocketControl {
     }
 }
 impl windows_core::RuntimeType for StreamWebSocketControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStreamWebSocketControl>();
 }
 unsafe impl windows_core::Interface for StreamWebSocketControl {
     type Vtable = IStreamWebSocketControl_Vtbl;
@@ -3248,7 +3410,7 @@ impl StreamWebSocketInformation {
     }
 }
 impl windows_core::RuntimeType for StreamWebSocketInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebSocketInformation>();
 }
 unsafe impl windows_core::Interface for StreamWebSocketInformation {
     type Vtable = IWebSocketInformation_Vtbl;
@@ -3280,7 +3442,7 @@ impl WebSocketClosedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebSocketClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebSocketClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebSocketClosedEventArgs {
     type Vtable = IWebSocketClosedEventArgs_Vtbl;
@@ -3337,7 +3499,7 @@ impl WebSocketKeepAlive {
 }
 #[cfg(feature = "ApplicationModel_Background")]
 impl windows_core::RuntimeType for WebSocketKeepAlive {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Background::IBackgroundTask>();
 }
 #[cfg(feature = "ApplicationModel_Background")]
 unsafe impl windows_core::Interface for WebSocketKeepAlive {
@@ -3401,7 +3563,7 @@ impl WebSocketServerCustomValidationRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebSocketServerCustomValidationRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebSocketServerCustomValidationRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebSocketServerCustomValidationRequestedEventArgs {
     type Vtable = IWebSocketServerCustomValidationRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IVpnAppId, IVpnAppId_Vtbl, 0x7b06a635_5c58_41d9_94a7_bfbcf1d8ca54);
+impl windows_core::RuntimeType for IVpnAppId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnAppId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct IVpnAppId_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnAppIdFactory, IVpnAppIdFactory_Vtbl, 0x46adfd2a_0aab_4fdb_821d_d3ddc919788b);
+impl windows_core::RuntimeType for IVpnAppIdFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnAppIdFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, VpnAppIdType, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnChannel, IVpnChannel_Vtbl, 0x4ac78d07_d1a8_4303_a091_c8d2e0915bc3);
+impl windows_core::RuntimeType for IVpnChannel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +53,9 @@ pub struct IVpnChannel_Vtbl {
     pub SetAllowedSslTlsVersions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnChannel2, IVpnChannel2_Vtbl, 0x2255d165_993b_4629_ad60_f1c3f3537f50);
+impl windows_core::RuntimeType for IVpnChannel2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannel2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +88,9 @@ pub struct IVpnChannel2_Vtbl {
     StartWithTrafficFilter: usize,
 }
 windows_core::imp::define_interface!(IVpnChannel4, IVpnChannel4_Vtbl, 0xd7266ede_2937_419d_9570_486aebb81803);
+impl windows_core::RuntimeType for IVpnChannel4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannel4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,6 +108,9 @@ pub struct IVpnChannel4_Vtbl {
     pub CurrentRequestTransportContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnChannel5, IVpnChannel5_Vtbl, 0xde7a0992_8384_4fbc_882c_1fd23124cd3b);
+impl windows_core::RuntimeType for IVpnChannel5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannel5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,6 +120,9 @@ pub struct IVpnChannel5_Vtbl {
     pub FlushVpnSendPacketBuffers: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnChannel6, IVpnChannel6_Vtbl, 0x55843696_bd63_49c5_abca_5da77885551a);
+impl windows_core::RuntimeType for IVpnChannel6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannel6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -111,18 +132,27 @@ pub struct IVpnChannel6_Vtbl {
     ActivateForeground: usize,
 }
 windows_core::imp::define_interface!(IVpnChannelActivityEventArgs, IVpnChannelActivityEventArgs_Vtbl, 0xa36c88f2_afdc_4775_855d_d4ac0a35fc55);
+impl windows_core::RuntimeType for IVpnChannelActivityEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannelActivityEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Type: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VpnChannelActivityEventType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnChannelActivityStateChangedArgs, IVpnChannelActivityStateChangedArgs_Vtbl, 0x3d750565_fdc0_4bbe_a23b_45fffc6d97a1);
+impl windows_core::RuntimeType for IVpnChannelActivityStateChangedArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannelActivityStateChangedArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ActivityState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VpnChannelActivityEventType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnChannelConfiguration, IVpnChannelConfiguration_Vtbl, 0x0e2ddca2_2012_4fe4_b179_8c652c6d107e);
+impl windows_core::RuntimeType for IVpnChannelConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannelConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -134,6 +164,9 @@ pub struct IVpnChannelConfiguration_Vtbl {
     pub CustomField: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnChannelConfiguration2, IVpnChannelConfiguration2_Vtbl, 0xf30b574c_7824_471c_a118_63dbc93ae4c7);
+impl windows_core::RuntimeType for IVpnChannelConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnChannelConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -218,6 +251,9 @@ pub struct IVpnCredential_Vtbl {
     OldPasswordCredential: usize,
 }
 windows_core::imp::define_interface!(IVpnCustomCheckBox, IVpnCustomCheckBox_Vtbl, 0x43878753_03c5_4e61_93d7_a957714c4282);
+impl windows_core::RuntimeType for IVpnCustomCheckBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomCheckBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -226,6 +262,9 @@ pub struct IVpnCustomCheckBox_Vtbl {
     pub Checked: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomComboBox, IVpnCustomComboBox_Vtbl, 0x9a24158e_dba1_4c6f_8270_dcf3c9761c4c);
+impl windows_core::RuntimeType for IVpnCustomComboBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomComboBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,6 +279,9 @@ pub struct IVpnCustomComboBox_Vtbl {
     pub Selected: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomEditBox, IVpnCustomEditBox_Vtbl, 0x3002d9a0_cfbf_4c0b_8f3c_66f503c20b39);
+impl windows_core::RuntimeType for IVpnCustomEditBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomEditBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -250,6 +292,9 @@ pub struct IVpnCustomEditBox_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomErrorBox, IVpnCustomErrorBox_Vtbl, 0x9ec4efb2_c942_42af_b223_588b48328721);
+impl windows_core::RuntimeType for IVpnCustomErrorBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomErrorBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -305,6 +350,9 @@ pub struct IVpnCustomPrompt_Vtbl {
     pub Bordered: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomPromptBooleanInput, IVpnCustomPromptBooleanInput_Vtbl, 0xc4c9a69e_ff47_4527_9f27_a49292019979);
+impl windows_core::RuntimeType for IVpnCustomPromptBooleanInput {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomPromptBooleanInput_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -363,6 +411,9 @@ pub struct IVpnCustomPromptElement_Vtbl {
     pub Emphasized: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomPromptOptionSelector, IVpnCustomPromptOptionSelector_Vtbl, 0x3b8f34d9_8ec1_4e95_9a4e_7ba64d38f330);
+impl windows_core::RuntimeType for IVpnCustomPromptOptionSelector {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomPromptOptionSelector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -373,6 +424,9 @@ pub struct IVpnCustomPromptOptionSelector_Vtbl {
     pub SelectedIndex: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomPromptText, IVpnCustomPromptText_Vtbl, 0x3bc8bdee_3a42_49a3_abdd_07b2edea752d);
+impl windows_core::RuntimeType for IVpnCustomPromptText {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomPromptText_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -380,6 +434,9 @@ pub struct IVpnCustomPromptText_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomPromptTextInput, IVpnCustomPromptTextInput_Vtbl, 0xc9da9c75_913c_47d5_88ba_48fc48930235);
+impl windows_core::RuntimeType for IVpnCustomPromptTextInput {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomPromptTextInput_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -390,6 +447,9 @@ pub struct IVpnCustomPromptTextInput_Vtbl {
     pub Text: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnCustomTextBox, IVpnCustomTextBox_Vtbl, 0xdaa4c3ca_8f23_4d36_91f1_76d937827942);
+impl windows_core::RuntimeType for IVpnCustomTextBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnCustomTextBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -397,6 +457,9 @@ pub struct IVpnCustomTextBox_Vtbl {
     pub DisplayText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnDomainNameAssignment, IVpnDomainNameAssignment_Vtbl, 0x4135b141_ccdb_49b5_9401_039a8ae767e9);
+impl windows_core::RuntimeType for IVpnDomainNameAssignment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnDomainNameAssignment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -408,6 +471,9 @@ pub struct IVpnDomainNameAssignment_Vtbl {
     pub ProxyAutoConfigurationUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnDomainNameInfo, IVpnDomainNameInfo_Vtbl, 0xad2eb82f_ea8e_4f7a_843e_1a87e32e1b9a);
+impl windows_core::RuntimeType for IVpnDomainNameInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnDomainNameInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -425,6 +491,9 @@ pub struct IVpnDomainNameInfo_Vtbl {
     WebProxyServers: usize,
 }
 windows_core::imp::define_interface!(IVpnDomainNameInfo2, IVpnDomainNameInfo2_Vtbl, 0xab871151_6c53_4828_9883_d886de104407);
+impl windows_core::RuntimeType for IVpnDomainNameInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnDomainNameInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -461,6 +530,9 @@ pub struct IVpnDomainNameInfoFactory_Vtbl {
     CreateVpnDomainNameInfo: usize,
 }
 windows_core::imp::define_interface!(IVpnForegroundActivatedEventArgs, IVpnForegroundActivatedEventArgs_Vtbl, 0x85b465b0_cadb_4d70_ac92_543a24dc9ebc);
+impl windows_core::RuntimeType for IVpnForegroundActivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnForegroundActivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -472,6 +544,9 @@ pub struct IVpnForegroundActivatedEventArgs_Vtbl {
     pub ActivationOperation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnForegroundActivationOperation, IVpnForegroundActivationOperation_Vtbl, 0x9e010d57_f17a_4bd5_9b6d_f984f1297d3c);
+impl windows_core::RuntimeType for IVpnForegroundActivationOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnForegroundActivationOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -481,6 +556,9 @@ pub struct IVpnForegroundActivationOperation_Vtbl {
     Complete: usize,
 }
 windows_core::imp::define_interface!(IVpnInterfaceId, IVpnInterfaceId_Vtbl, 0x9e2ddca2_1712_4ce4_b179_8c652c6d1011);
+impl windows_core::RuntimeType for IVpnInterfaceId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnInterfaceId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -506,6 +584,9 @@ pub struct IVpnInterfaceIdFactory_Vtbl {
     pub CreateVpnInterfaceId: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnManagementAgent, IVpnManagementAgent_Vtbl, 0x193696cd_a5c4_4abe_852b_785be4cb3e34);
+impl windows_core::RuntimeType for IVpnManagementAgent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnManagementAgent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -526,6 +607,9 @@ pub struct IVpnManagementAgent_Vtbl {
     pub DisconnectProfileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnNamespaceAssignment, IVpnNamespaceAssignment_Vtbl, 0xd7f7db18_307d_4c0e_bd62_8fa270bbadd6);
+impl windows_core::RuntimeType for IVpnNamespaceAssignment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnNamespaceAssignment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -541,6 +625,9 @@ pub struct IVpnNamespaceAssignment_Vtbl {
     pub ProxyAutoConfigUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnNamespaceInfo, IVpnNamespaceInfo_Vtbl, 0x30edfb43_444f_44c5_8167_a35a91f1af94);
+impl windows_core::RuntimeType for IVpnNamespaceInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnNamespaceInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -591,6 +678,9 @@ pub struct IVpnNamespaceInfoFactory_Vtbl {
     CreateVpnNamespaceInfo: usize,
 }
 windows_core::imp::define_interface!(IVpnNativeProfile, IVpnNativeProfile_Vtbl, 0xa4aee29e_6417_4333_9842_f0a66db69802);
+impl windows_core::RuntimeType for IVpnNativeProfile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnNativeProfile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -610,6 +700,9 @@ pub struct IVpnNativeProfile_Vtbl {
     pub SetEapConfiguration: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnNativeProfile2, IVpnNativeProfile2_Vtbl, 0x0fec2467_cdb5_4ac7_b5a3_0afb5ec47682);
+impl windows_core::RuntimeType for IVpnNativeProfile2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnNativeProfile2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -618,6 +711,9 @@ pub struct IVpnNativeProfile2_Vtbl {
     pub ConnectionStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut VpnManagementConnectionStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPacketBuffer, IVpnPacketBuffer_Vtbl, 0xc2f891fc_4d5c_4a63_b70d_4e307eacce55);
+impl windows_core::RuntimeType for IVpnPacketBuffer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPacketBuffer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -631,12 +727,18 @@ pub struct IVpnPacketBuffer_Vtbl {
     pub TransportAffinity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPacketBuffer2, IVpnPacketBuffer2_Vtbl, 0x665e91f0_8805_4bf5_a619_2e84882e6b4f);
+impl windows_core::RuntimeType for IVpnPacketBuffer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPacketBuffer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AppId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPacketBuffer3, IVpnPacketBuffer3_Vtbl, 0xe256072f_107b_4c40_b127_5bc53e0ad960);
+impl windows_core::RuntimeType for IVpnPacketBuffer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPacketBuffer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -666,6 +768,9 @@ pub struct IVpnPacketBufferFactory_Vtbl {
     pub CreateVpnPacketBuffer: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPacketBufferList, IVpnPacketBufferList_Vtbl, 0xc2f891fc_4d5c_4a63_b70d_4e307eacce77);
+impl windows_core::RuntimeType for IVpnPacketBufferList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPacketBufferList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -679,6 +784,9 @@ pub struct IVpnPacketBufferList_Vtbl {
     pub Size: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPacketBufferList2, IVpnPacketBufferList2_Vtbl, 0x3e7acfe5_ea1e_482a_8d98_c065f57d89ea);
+impl windows_core::RuntimeType for IVpnPacketBufferList2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPacketBufferList2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -688,6 +796,9 @@ pub struct IVpnPacketBufferList2_Vtbl {
     pub RemoveTrailingPacket: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPickedCredential, IVpnPickedCredential_Vtbl, 0x9a793ac7_8854_4e52_ad97_24dd9a842bce);
+impl windows_core::RuntimeType for IVpnPickedCredential {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPickedCredential_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -758,6 +869,9 @@ pub struct IVpnPlugIn_Vtbl {
     pub Decapsulate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPlugInProfile, IVpnPlugInProfile_Vtbl, 0x0edf0da4_4f00_4589_8d7b_4bf988f6542c);
+impl windows_core::RuntimeType for IVpnPlugInProfile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPlugInProfile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -771,6 +885,9 @@ pub struct IVpnPlugInProfile_Vtbl {
     pub SetVpnPluginPackageFamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnPlugInProfile2, IVpnPlugInProfile2_Vtbl, 0x611c4892_cf94_4ad6_ba99_00f4ff34565e);
+impl windows_core::RuntimeType for IVpnPlugInProfile2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnPlugInProfile2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -877,6 +994,9 @@ pub struct IVpnProfile_Vtbl {
     pub SetAlwaysOn: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnRoute, IVpnRoute_Vtbl, 0xb5731b83_0969_4699_938e_7776db29cfb3);
+impl windows_core::RuntimeType for IVpnRoute {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnRoute_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -886,6 +1006,9 @@ pub struct IVpnRoute_Vtbl {
     pub PrefixSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnRouteAssignment, IVpnRouteAssignment_Vtbl, 0xdb64de22_ce39_4a76_9550_f61039f80e48);
+impl windows_core::RuntimeType for IVpnRouteAssignment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnRouteAssignment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -947,6 +1070,9 @@ pub struct IVpnRouteFactory_Vtbl {
     pub CreateVpnRoute: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnSystemHealth, IVpnSystemHealth_Vtbl, 0x99a8f8af_c0ee_4e75_817a_f231aee5123d);
+impl windows_core::RuntimeType for IVpnSystemHealth {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnSystemHealth_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -956,6 +1082,9 @@ pub struct IVpnSystemHealth_Vtbl {
     StatementOfHealth: usize,
 }
 windows_core::imp::define_interface!(IVpnTrafficFilter, IVpnTrafficFilter_Vtbl, 0x2f691b60_6c9f_47f5_ac36_bb1b042e2c50);
+impl windows_core::RuntimeType for IVpnTrafficFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnTrafficFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -987,6 +1116,9 @@ pub struct IVpnTrafficFilter_Vtbl {
     pub SetRoutingPolicyType: unsafe extern "system" fn(*mut core::ffi::c_void, VpnRoutingPolicyType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnTrafficFilterAssignment, IVpnTrafficFilterAssignment_Vtbl, 0x56ccd45c_e664_471e_89cd_601603b9e0f3);
+impl windows_core::RuntimeType for IVpnTrafficFilterAssignment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnTrafficFilterAssignment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1000,6 +1132,9 @@ pub struct IVpnTrafficFilterAssignment_Vtbl {
     pub SetAllowInbound: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVpnTrafficFilterFactory, IVpnTrafficFilterFactory_Vtbl, 0x480d41d5_7f99_474c_86ee_96df168318f1);
+impl windows_core::RuntimeType for IVpnTrafficFilterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVpnTrafficFilterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1045,7 +1180,7 @@ impl VpnAppId {
     }
 }
 impl windows_core::RuntimeType for VpnAppId {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnAppId>();
 }
 unsafe impl windows_core::Interface for VpnAppId {
     type Vtable = IVpnAppId_Vtbl;
@@ -1385,7 +1520,7 @@ impl VpnChannel {
     }
 }
 impl windows_core::RuntimeType for VpnChannel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnChannel>();
 }
 unsafe impl windows_core::Interface for VpnChannel {
     type Vtable = IVpnChannel_Vtbl;
@@ -1410,7 +1545,7 @@ impl VpnChannelActivityEventArgs {
     }
 }
 impl windows_core::RuntimeType for VpnChannelActivityEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnChannelActivityEventArgs>();
 }
 unsafe impl windows_core::Interface for VpnChannelActivityEventArgs {
     type Vtable = IVpnChannelActivityEventArgs_Vtbl;
@@ -1435,7 +1570,7 @@ impl VpnChannelActivityStateChangedArgs {
     }
 }
 impl windows_core::RuntimeType for VpnChannelActivityStateChangedArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnChannelActivityStateChangedArgs>();
 }
 unsafe impl windows_core::Interface for VpnChannelActivityStateChangedArgs {
     type Vtable = IVpnChannelActivityStateChangedArgs_Vtbl;
@@ -1483,7 +1618,7 @@ impl VpnChannelConfiguration {
     }
 }
 impl windows_core::RuntimeType for VpnChannelConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnChannelConfiguration>();
 }
 unsafe impl windows_core::Interface for VpnChannelConfiguration {
     type Vtable = IVpnChannelConfiguration_Vtbl;
@@ -1533,7 +1668,7 @@ impl VpnCredential {
     }
 }
 impl windows_core::RuntimeType for VpnCredential {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCredential>();
 }
 unsafe impl windows_core::Interface for VpnCredential {
     type Vtable = IVpnCredential_Vtbl;
@@ -1610,7 +1745,7 @@ impl VpnCustomCheckBox {
     }
 }
 impl windows_core::RuntimeType for VpnCustomCheckBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomCheckBox>();
 }
 unsafe impl windows_core::Interface for VpnCustomCheckBox {
     type Vtable = IVpnCustomCheckBox_Vtbl;
@@ -1692,7 +1827,7 @@ impl VpnCustomComboBox {
     }
 }
 impl windows_core::RuntimeType for VpnCustomComboBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomComboBox>();
 }
 unsafe impl windows_core::Interface for VpnCustomComboBox {
     type Vtable = IVpnCustomComboBox_Vtbl;
@@ -1780,7 +1915,7 @@ impl VpnCustomEditBox {
     }
 }
 impl windows_core::RuntimeType for VpnCustomEditBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomEditBox>();
 }
 unsafe impl windows_core::Interface for VpnCustomEditBox {
     type Vtable = IVpnCustomEditBox_Vtbl;
@@ -1839,7 +1974,7 @@ impl VpnCustomErrorBox {
     }
 }
 impl windows_core::RuntimeType for VpnCustomErrorBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomErrorBox>();
 }
 unsafe impl windows_core::Interface for VpnCustomErrorBox {
     type Vtable = IVpnCustomErrorBox_Vtbl;
@@ -1916,7 +2051,7 @@ impl VpnCustomPromptBooleanInput {
     }
 }
 impl windows_core::RuntimeType for VpnCustomPromptBooleanInput {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomPromptBooleanInput>();
 }
 unsafe impl windows_core::Interface for VpnCustomPromptBooleanInput {
     type Vtable = IVpnCustomPromptBooleanInput_Vtbl;
@@ -1990,7 +2125,7 @@ impl VpnCustomPromptOptionSelector {
     }
 }
 impl windows_core::RuntimeType for VpnCustomPromptOptionSelector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomPromptOptionSelector>();
 }
 unsafe impl windows_core::Interface for VpnCustomPromptOptionSelector {
     type Vtable = IVpnCustomPromptOptionSelector_Vtbl;
@@ -2060,7 +2195,7 @@ impl VpnCustomPromptText {
     }
 }
 impl windows_core::RuntimeType for VpnCustomPromptText {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomPromptText>();
 }
 unsafe impl windows_core::Interface for VpnCustomPromptText {
     type Vtable = IVpnCustomPromptText_Vtbl;
@@ -2148,7 +2283,7 @@ impl VpnCustomPromptTextInput {
     }
 }
 impl windows_core::RuntimeType for VpnCustomPromptTextInput {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomPromptTextInput>();
 }
 unsafe impl windows_core::Interface for VpnCustomPromptTextInput {
     type Vtable = IVpnCustomPromptTextInput_Vtbl;
@@ -2218,7 +2353,7 @@ impl VpnCustomTextBox {
     }
 }
 impl windows_core::RuntimeType for VpnCustomTextBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnCustomTextBox>();
 }
 unsafe impl windows_core::Interface for VpnCustomTextBox {
     type Vtable = IVpnCustomTextBox_Vtbl;
@@ -2265,7 +2400,7 @@ impl VpnDomainNameAssignment {
     }
 }
 impl windows_core::RuntimeType for VpnDomainNameAssignment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnDomainNameAssignment>();
 }
 unsafe impl windows_core::Interface for VpnDomainNameAssignment {
     type Vtable = IVpnDomainNameAssignment_Vtbl;
@@ -2348,7 +2483,7 @@ impl VpnDomainNameInfo {
     }
 }
 impl windows_core::RuntimeType for VpnDomainNameInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnDomainNameInfo>();
 }
 unsafe impl windows_core::Interface for VpnDomainNameInfo {
     type Vtable = IVpnDomainNameInfo_Vtbl;
@@ -2422,7 +2557,7 @@ impl VpnForegroundActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VpnForegroundActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnForegroundActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for VpnForegroundActivatedEventArgs {
     type Vtable = IVpnForegroundActivatedEventArgs_Vtbl;
@@ -2448,7 +2583,7 @@ impl VpnForegroundActivationOperation {
     }
 }
 impl windows_core::RuntimeType for VpnForegroundActivationOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnForegroundActivationOperation>();
 }
 unsafe impl windows_core::Interface for VpnForegroundActivationOperation {
     type Vtable = IVpnForegroundActivationOperation_Vtbl;
@@ -2481,7 +2616,7 @@ impl VpnInterfaceId {
     }
 }
 impl windows_core::RuntimeType for VpnInterfaceId {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnInterfaceId>();
 }
 unsafe impl windows_core::Interface for VpnInterfaceId {
     type Vtable = IVpnInterfaceId_Vtbl;
@@ -2590,7 +2725,7 @@ impl VpnManagementAgent {
     }
 }
 impl windows_core::RuntimeType for VpnManagementAgent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnManagementAgent>();
 }
 unsafe impl windows_core::Interface for VpnManagementAgent {
     type Vtable = IVpnManagementAgent_Vtbl;
@@ -2645,7 +2780,7 @@ impl VpnNamespaceAssignment {
     }
 }
 impl windows_core::RuntimeType for VpnNamespaceAssignment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnNamespaceAssignment>();
 }
 unsafe impl windows_core::Interface for VpnNamespaceAssignment {
     type Vtable = IVpnNamespaceAssignment_Vtbl;
@@ -2722,7 +2857,7 @@ impl VpnNamespaceInfo {
     }
 }
 impl windows_core::RuntimeType for VpnNamespaceInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnNamespaceInfo>();
 }
 unsafe impl windows_core::Interface for VpnNamespaceInfo {
     type Vtable = IVpnNamespaceInfo_Vtbl;
@@ -2894,7 +3029,7 @@ impl VpnNativeProfile {
     }
 }
 impl windows_core::RuntimeType for VpnNativeProfile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnNativeProfile>();
 }
 unsafe impl windows_core::Interface for VpnNativeProfile {
     type Vtable = IVpnNativeProfile_Vtbl;
@@ -2977,7 +3112,7 @@ impl VpnPacketBuffer {
     }
 }
 impl windows_core::RuntimeType for VpnPacketBuffer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnPacketBuffer>();
 }
 unsafe impl windows_core::Interface for VpnPacketBuffer {
     type Vtable = IVpnPacketBuffer_Vtbl;
@@ -3055,7 +3190,7 @@ impl VpnPacketBufferList {
     }
 }
 impl windows_core::RuntimeType for VpnPacketBufferList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnPacketBufferList>();
 }
 unsafe impl windows_core::Interface for VpnPacketBufferList {
     type Vtable = IVpnPacketBufferList_Vtbl;
@@ -3112,7 +3247,7 @@ impl VpnPickedCredential {
     }
 }
 impl windows_core::RuntimeType for VpnPickedCredential {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnPickedCredential>();
 }
 unsafe impl windows_core::Interface for VpnPickedCredential {
     type Vtable = IVpnPickedCredential_Vtbl;
@@ -3251,7 +3386,7 @@ impl VpnPlugInProfile {
     }
 }
 impl windows_core::RuntimeType for VpnPlugInProfile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnPlugInProfile>();
 }
 unsafe impl windows_core::Interface for VpnPlugInProfile {
     type Vtable = IVpnPlugInProfile_Vtbl;
@@ -3308,7 +3443,7 @@ impl VpnRoute {
     }
 }
 impl windows_core::RuntimeType for VpnRoute {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnRoute>();
 }
 unsafe impl windows_core::Interface for VpnRoute {
     type Vtable = IVpnRoute_Vtbl;
@@ -3408,7 +3543,7 @@ impl VpnRouteAssignment {
     }
 }
 impl windows_core::RuntimeType for VpnRouteAssignment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnRouteAssignment>();
 }
 unsafe impl windows_core::Interface for VpnRouteAssignment {
     type Vtable = IVpnRouteAssignment_Vtbl;
@@ -3434,7 +3569,7 @@ impl VpnSystemHealth {
     }
 }
 impl windows_core::RuntimeType for VpnSystemHealth {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnSystemHealth>();
 }
 unsafe impl windows_core::Interface for VpnSystemHealth {
     type Vtable = IVpnSystemHealth_Vtbl;
@@ -3542,7 +3677,7 @@ impl VpnTrafficFilter {
     }
 }
 impl windows_core::RuntimeType for VpnTrafficFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnTrafficFilter>();
 }
 unsafe impl windows_core::Interface for VpnTrafficFilter {
     type Vtable = IVpnTrafficFilter_Vtbl;
@@ -3597,7 +3732,7 @@ impl VpnTrafficFilterAssignment {
     }
 }
 impl windows_core::RuntimeType for VpnTrafficFilterAssignment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVpnTrafficFilterAssignment>();
 }
 unsafe impl windows_core::Interface for VpnTrafficFilterAssignment {
     type Vtable = IVpnTrafficFilterAssignment_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IXboxLiveDeviceAddress, IXboxLiveDeviceAddress_Vtbl, 0xf5bbd279_3c86_4b57_a31a_b9462408fd01);
+impl windows_core::RuntimeType for IXboxLiveDeviceAddress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveDeviceAddress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +19,9 @@ pub struct IXboxLiveDeviceAddress_Vtbl {
     pub NetworkAccessKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut XboxLiveNetworkAccessKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveDeviceAddressStatics, IXboxLiveDeviceAddressStatics_Vtbl, 0x5954a819_4a79_4931_827c_7f503e963263);
+impl windows_core::RuntimeType for IXboxLiveDeviceAddressStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveDeviceAddressStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +35,9 @@ pub struct IXboxLiveDeviceAddressStatics_Vtbl {
     pub MaxSnapshotBytesSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveEndpointPair, IXboxLiveEndpointPair_Vtbl, 0x1e9a839b_813e_44e0_b87f_c87a093475e4);
+impl windows_core::RuntimeType for IXboxLiveEndpointPair {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveEndpointPair_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,6 +55,9 @@ pub struct IXboxLiveEndpointPair_Vtbl {
     pub LocalPort: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveEndpointPairCreationResult, IXboxLiveEndpointPairCreationResult_Vtbl, 0xd9a8bb95_2aab_4d1e_9794_33ecc0dcf0fe);
+impl windows_core::RuntimeType for IXboxLiveEndpointPairCreationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveEndpointPairCreationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,6 +67,9 @@ pub struct IXboxLiveEndpointPairCreationResult_Vtbl {
     pub EndpointPair: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveEndpointPairStateChangedEventArgs, IXboxLiveEndpointPairStateChangedEventArgs_Vtbl, 0x592e3b55_de08_44e7_ac3b_b9b9a169583a);
+impl windows_core::RuntimeType for IXboxLiveEndpointPairStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveEndpointPairStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +77,9 @@ pub struct IXboxLiveEndpointPairStateChangedEventArgs_Vtbl {
     pub NewState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut XboxLiveEndpointPairState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveEndpointPairStatics, IXboxLiveEndpointPairStatics_Vtbl, 0x64316b30_217a_4243_8ee1_6729281d27db);
+impl windows_core::RuntimeType for IXboxLiveEndpointPairStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveEndpointPairStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +87,9 @@ pub struct IXboxLiveEndpointPairStatics_Vtbl {
     pub FindEndpointPairByHostNamesAndPorts: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveEndpointPairTemplate, IXboxLiveEndpointPairTemplate_Vtbl, 0x6b286ecf_3457_40ce_b9a1_c0cfe0213ea7);
+impl windows_core::RuntimeType for IXboxLiveEndpointPairTemplate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveEndpointPairTemplate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +111,9 @@ pub struct IXboxLiveEndpointPairTemplate_Vtbl {
     EndpointPairs: usize,
 }
 windows_core::imp::define_interface!(IXboxLiveEndpointPairTemplateStatics, IXboxLiveEndpointPairTemplateStatics_Vtbl, 0x1e13137b_737b_4a23_bc64_0870f75655ba);
+impl windows_core::RuntimeType for IXboxLiveEndpointPairTemplateStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveEndpointPairTemplateStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,12 +124,18 @@ pub struct IXboxLiveEndpointPairTemplateStatics_Vtbl {
     Templates: usize,
 }
 windows_core::imp::define_interface!(IXboxLiveInboundEndpointPairCreatedEventArgs, IXboxLiveInboundEndpointPairCreatedEventArgs_Vtbl, 0xdc183b62_22ba_48d2_80de_c23968bd198b);
+impl windows_core::RuntimeType for IXboxLiveInboundEndpointPairCreatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveInboundEndpointPairCreatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub EndpointPair: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveQualityOfServiceMeasurement, IXboxLiveQualityOfServiceMeasurement_Vtbl, 0x4d682bce_a5d6_47e6_a236_cfde5fbdf2ed);
+impl windows_core::RuntimeType for IXboxLiveQualityOfServiceMeasurement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveQualityOfServiceMeasurement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +175,9 @@ pub struct IXboxLiveQualityOfServiceMeasurement_Vtbl {
     PrivatePayloadResults: usize,
 }
 windows_core::imp::define_interface!(IXboxLiveQualityOfServiceMeasurementStatics, IXboxLiveQualityOfServiceMeasurementStatics_Vtbl, 0x6e352dca_23cf_440a_b077_5e30857a8234);
+impl windows_core::RuntimeType for IXboxLiveQualityOfServiceMeasurementStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveQualityOfServiceMeasurementStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -167,6 +200,9 @@ pub struct IXboxLiveQualityOfServiceMeasurementStatics_Vtbl {
     pub MaxPrivatePayloadSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveQualityOfServiceMetricResult, IXboxLiveQualityOfServiceMetricResult_Vtbl, 0xaeec53d1_3561_4782_b0cf_d3ae29d9fa87);
+impl windows_core::RuntimeType for IXboxLiveQualityOfServiceMetricResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveQualityOfServiceMetricResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -176,6 +212,9 @@ pub struct IXboxLiveQualityOfServiceMetricResult_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IXboxLiveQualityOfServicePrivatePayloadResult, IXboxLiveQualityOfServicePrivatePayloadResult_Vtbl, 0x5a6302ae_6f38_41c0_9fcc_ea6cb978cafc);
+impl windows_core::RuntimeType for IXboxLiveQualityOfServicePrivatePayloadResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IXboxLiveQualityOfServicePrivatePayloadResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -296,7 +335,7 @@ impl XboxLiveDeviceAddress {
     }
 }
 impl windows_core::RuntimeType for XboxLiveDeviceAddress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveDeviceAddress>();
 }
 unsafe impl windows_core::Interface for XboxLiveDeviceAddress {
     type Vtable = IXboxLiveDeviceAddress_Vtbl;
@@ -413,7 +452,7 @@ impl XboxLiveEndpointPair {
     }
 }
 impl windows_core::RuntimeType for XboxLiveEndpointPair {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveEndpointPair>();
 }
 unsafe impl windows_core::Interface for XboxLiveEndpointPair {
     type Vtable = IXboxLiveEndpointPair_Vtbl;
@@ -459,7 +498,7 @@ impl XboxLiveEndpointPairCreationResult {
     }
 }
 impl windows_core::RuntimeType for XboxLiveEndpointPairCreationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveEndpointPairCreationResult>();
 }
 unsafe impl windows_core::Interface for XboxLiveEndpointPairCreationResult {
     type Vtable = IXboxLiveEndpointPairCreationResult_Vtbl;
@@ -491,7 +530,7 @@ impl XboxLiveEndpointPairStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for XboxLiveEndpointPairStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveEndpointPairStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for XboxLiveEndpointPairStateChangedEventArgs {
     type Vtable = IXboxLiveEndpointPairStateChangedEventArgs_Vtbl;
@@ -631,7 +670,7 @@ impl XboxLiveEndpointPairTemplate {
     }
 }
 impl windows_core::RuntimeType for XboxLiveEndpointPairTemplate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveEndpointPairTemplate>();
 }
 unsafe impl windows_core::Interface for XboxLiveEndpointPairTemplate {
     type Vtable = IXboxLiveEndpointPairTemplate_Vtbl;
@@ -656,7 +695,7 @@ impl XboxLiveInboundEndpointPairCreatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for XboxLiveInboundEndpointPairCreatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveInboundEndpointPairCreatedEventArgs>();
 }
 unsafe impl windows_core::Interface for XboxLiveInboundEndpointPairCreatedEventArgs {
     type Vtable = IXboxLiveInboundEndpointPairCreatedEventArgs_Vtbl;
@@ -857,7 +896,7 @@ impl XboxLiveQualityOfServiceMeasurement {
     }
 }
 impl windows_core::RuntimeType for XboxLiveQualityOfServiceMeasurement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveQualityOfServiceMeasurement>();
 }
 unsafe impl windows_core::Interface for XboxLiveQualityOfServiceMeasurement {
     type Vtable = IXboxLiveQualityOfServiceMeasurement_Vtbl;
@@ -903,7 +942,7 @@ impl XboxLiveQualityOfServiceMetricResult {
     }
 }
 impl windows_core::RuntimeType for XboxLiveQualityOfServiceMetricResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveQualityOfServiceMetricResult>();
 }
 unsafe impl windows_core::Interface for XboxLiveQualityOfServiceMetricResult {
     type Vtable = IXboxLiveQualityOfServiceMetricResult_Vtbl;
@@ -943,7 +982,7 @@ impl XboxLiveQualityOfServicePrivatePayloadResult {
     }
 }
 impl windows_core::RuntimeType for XboxLiveQualityOfServicePrivatePayloadResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IXboxLiveQualityOfServicePrivatePayloadResult>();
 }
 unsafe impl windows_core::Interface for XboxLiveQualityOfServicePrivatePayloadResult {
     type Vtable = IXboxLiveQualityOfServicePrivatePayloadResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Networking/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/mod.rs
@@ -17,6 +17,9 @@ pub mod Vpn;
 #[cfg(feature = "Networking_XboxLive")]
 pub mod XboxLive;
 windows_core::imp::define_interface!(IEndpointPair, IEndpointPair_Vtbl, 0x33a0aa36_f8fa_4b30_b856_76517c3bd06d);
+impl windows_core::RuntimeType for IEndpointPair {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEndpointPair_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,12 +33,18 @@ pub struct IEndpointPair_Vtbl {
     pub SetRemoteServiceName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEndpointPairFactory, IEndpointPairFactory_Vtbl, 0xb609d971_64e0_442b_aa6f_cc8c8f181f78);
+impl windows_core::RuntimeType for IEndpointPairFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEndpointPairFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateEndpointPair: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHostName, IHostName_Vtbl, 0xbf8ecaad_ed96_49a7_9084_d416cae88dcb);
+impl windows_core::RuntimeType for IHostName {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHostName_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,12 +59,18 @@ pub struct IHostName_Vtbl {
     pub IsEqual: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHostNameFactory, IHostNameFactory_Vtbl, 0x458c23ed_712f_4576_adf1_c20b2c643558);
+impl windows_core::RuntimeType for IHostNameFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHostNameFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateHostName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHostNameStatics, IHostNameStatics_Vtbl, 0xf68cd4bf_a388_4e8b_91ea_54dd6dd901c0);
+impl windows_core::RuntimeType for IHostNameStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHostNameStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,7 +148,7 @@ impl EndpointPair {
     }
 }
 impl windows_core::RuntimeType for EndpointPair {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEndpointPair>();
 }
 unsafe impl windows_core::Interface for EndpointPair {
     type Vtable = IEndpointPair_Vtbl;
@@ -227,7 +242,7 @@ impl HostName {
     }
 }
 impl windows_core::RuntimeType for HostName {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHostName>();
 }
 unsafe impl windows_core::Interface for HostName {
     type Vtable = IHostName_Vtbl;

--- a/crates/libs/windows/src/Windows/Perception/Automation/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Automation/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICorePerceptionAutomationStatics, ICorePerceptionAutomationStatics_Vtbl, 0x0bb04541_4ce2_4923_9a76_8187ecc59112);
+impl windows_core::RuntimeType for ICorePerceptionAutomationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICorePerceptionAutomationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Perception/People/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/People/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IEyesPose, IEyesPose_Vtbl, 0x682a9b23_8a1e_5b86_a060_906ffacb62a4);
+impl windows_core::RuntimeType for IEyesPose {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEyesPose_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IEyesPose_Vtbl {
     pub UpdateTimestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEyesPoseStatics, IEyesPoseStatics_Vtbl, 0x1cff7413_b21f_54c0_80c1_e60d994ca58c);
+impl windows_core::RuntimeType for IEyesPoseStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEyesPoseStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct IEyesPoseStatics_Vtbl {
     RequestAccessAsync: usize,
 }
 windows_core::imp::define_interface!(IHandMeshObserver, IHandMeshObserver_Vtbl, 0x85ae30cb_6fc3_55c4_a7b4_29e33896ca69);
+impl windows_core::RuntimeType for IHandMeshObserver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHandMeshObserver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +45,9 @@ pub struct IHandMeshObserver_Vtbl {
     pub ModelId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHandMeshVertexState, IHandMeshVertexState_Vtbl, 0x046c5fef_1d8b_55de_ab2c_1cd424886d8f);
+impl windows_core::RuntimeType for IHandMeshVertexState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHandMeshVertexState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +62,9 @@ pub struct IHandMeshVertexState_Vtbl {
     pub UpdateTimestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHandPose, IHandPose_Vtbl, 0x4d98e79a_bb08_5d09_91de_df0dd3fae46c);
+impl windows_core::RuntimeType for IHandPose {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHandPose_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +86,9 @@ pub struct IHandPose_Vtbl {
     GetRelativeJoints: usize,
 }
 windows_core::imp::define_interface!(IHeadPose, IHeadPose_Vtbl, 0x7f5ac5a5_49db_379f_9429_32a2faf34fa6);
+impl windows_core::RuntimeType for IHeadPose {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHeadPose_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -134,7 +152,7 @@ impl EyesPose {
     }
 }
 impl windows_core::RuntimeType for EyesPose {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEyesPose>();
 }
 unsafe impl windows_core::Interface for EyesPose {
     type Vtable = IEyesPose_Vtbl;
@@ -209,7 +227,7 @@ impl HandMeshObserver {
     }
 }
 impl windows_core::RuntimeType for HandMeshObserver {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHandMeshObserver>();
 }
 unsafe impl windows_core::Interface for HandMeshObserver {
     type Vtable = IHandMeshObserver_Vtbl;
@@ -247,7 +265,7 @@ impl HandMeshVertexState {
     }
 }
 impl windows_core::RuntimeType for HandMeshVertexState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHandMeshVertexState>();
 }
 unsafe impl windows_core::Interface for HandMeshVertexState {
     type Vtable = IHandMeshVertexState_Vtbl;
@@ -300,7 +318,7 @@ impl HandPose {
     }
 }
 impl windows_core::RuntimeType for HandPose {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHandPose>();
 }
 unsafe impl windows_core::Interface for HandPose {
     type Vtable = IHandPose_Vtbl;
@@ -342,7 +360,7 @@ impl HeadPose {
     }
 }
 impl windows_core::RuntimeType for HeadPose {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHeadPose>();
 }
 unsafe impl windows_core::Interface for HeadPose {
     type Vtable = IHeadPose_Vtbl;

--- a/crates/libs/windows/src/Windows/Perception/Spatial/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/Preview/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISpatialGraphInteropFrameOfReferencePreview, ISpatialGraphInteropFrameOfReferencePreview_Vtbl, 0xa8271b23_735f_5729_a98e_e64ed189abc5);
+impl windows_core::RuntimeType for ISpatialGraphInteropFrameOfReferencePreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialGraphInteropFrameOfReferencePreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct ISpatialGraphInteropFrameOfReferencePreview_Vtbl {
     CoordinateSystemToNodeTransform: usize,
 }
 windows_core::imp::define_interface!(ISpatialGraphInteropPreviewStatics, ISpatialGraphInteropPreviewStatics_Vtbl, 0xc042644c_20d8_4ed0_aef7_6805b8e53f55);
+impl windows_core::RuntimeType for ISpatialGraphInteropPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialGraphInteropPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +31,9 @@ pub struct ISpatialGraphInteropPreviewStatics_Vtbl {
     pub CreateLocatorForNode: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialGraphInteropPreviewStatics2, ISpatialGraphInteropPreviewStatics2_Vtbl, 0x2490b15f_6cbd_4b1e_b765_31e462a32df2);
+impl windows_core::RuntimeType for ISpatialGraphInteropPreviewStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialGraphInteropPreviewStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,7 +76,7 @@ impl SpatialGraphInteropFrameOfReferencePreview {
     }
 }
 impl windows_core::RuntimeType for SpatialGraphInteropFrameOfReferencePreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialGraphInteropFrameOfReferencePreview>();
 }
 unsafe impl windows_core::Interface for SpatialGraphInteropFrameOfReferencePreview {
     type Vtable = ISpatialGraphInteropFrameOfReferencePreview_Vtbl;

--- a/crates/libs/windows/src/Windows/Perception/Spatial/Surfaces/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/Surfaces/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISpatialSurfaceInfo, ISpatialSurfaceInfo_Vtbl, 0xf8e9ebe7_39b7_3962_bb03_57f56e1fb0a1);
+impl windows_core::RuntimeType for ISpatialSurfaceInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct ISpatialSurfaceInfo_Vtbl {
     pub TryComputeLatestMeshWithOptionsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, f64, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialSurfaceMesh, ISpatialSurfaceMesh_Vtbl, 0x108f57d9_df0d_3950_a0fd_f972c77c27b4);
+impl windows_core::RuntimeType for ISpatialSurfaceMesh {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceMesh_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +32,9 @@ pub struct ISpatialSurfaceMesh_Vtbl {
     pub VertexNormals: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialSurfaceMeshBuffer, ISpatialSurfaceMeshBuffer_Vtbl, 0x93cf59e0_871f_33f8_98b2_03d101458f6f);
+impl windows_core::RuntimeType for ISpatialSurfaceMeshBuffer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceMeshBuffer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +50,9 @@ pub struct ISpatialSurfaceMeshBuffer_Vtbl {
     Data: usize,
 }
 windows_core::imp::define_interface!(ISpatialSurfaceMeshOptions, ISpatialSurfaceMeshOptions_Vtbl, 0xd2759f89_3572_3d2d_a10d_5fee9394aa37);
+impl windows_core::RuntimeType for ISpatialSurfaceMeshOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceMeshOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,6 +84,9 @@ pub struct ISpatialSurfaceMeshOptions_Vtbl {
     pub SetIncludeVertexNormals: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialSurfaceMeshOptionsStatics, ISpatialSurfaceMeshOptionsStatics_Vtbl, 0x9b340abf_9781_4505_8935_013575caae5e);
+impl windows_core::RuntimeType for ISpatialSurfaceMeshOptionsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceMeshOptionsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +104,9 @@ pub struct ISpatialSurfaceMeshOptionsStatics_Vtbl {
     SupportedVertexNormalFormats: usize,
 }
 windows_core::imp::define_interface!(ISpatialSurfaceObserver, ISpatialSurfaceObserver_Vtbl, 0x10b69819_ddca_3483_ac3a_748fe8c86df5);
+impl windows_core::RuntimeType for ISpatialSurfaceObserver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceObserver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,12 +123,18 @@ pub struct ISpatialSurfaceObserver_Vtbl {
     pub RemoveObservedSurfacesChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialSurfaceObserverStatics, ISpatialSurfaceObserverStatics_Vtbl, 0x165951ed_2108_4168_9175_87e027bc9285);
+impl windows_core::RuntimeType for ISpatialSurfaceObserverStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceObserverStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestAccessAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialSurfaceObserverStatics2, ISpatialSurfaceObserverStatics2_Vtbl, 0x0f534261_c55d_4e6b_a895_a19de69a42e3);
+impl windows_core::RuntimeType for ISpatialSurfaceObserverStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialSurfaceObserverStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,7 +189,7 @@ impl SpatialSurfaceInfo {
     }
 }
 impl windows_core::RuntimeType for SpatialSurfaceInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialSurfaceInfo>();
 }
 unsafe impl windows_core::Interface for SpatialSurfaceInfo {
     type Vtable = ISpatialSurfaceInfo_Vtbl;
@@ -226,7 +250,7 @@ impl SpatialSurfaceMesh {
     }
 }
 impl windows_core::RuntimeType for SpatialSurfaceMesh {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialSurfaceMesh>();
 }
 unsafe impl windows_core::Interface for SpatialSurfaceMesh {
     type Vtable = ISpatialSurfaceMesh_Vtbl;
@@ -274,7 +298,7 @@ impl SpatialSurfaceMeshBuffer {
     }
 }
 impl windows_core::RuntimeType for SpatialSurfaceMeshBuffer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialSurfaceMeshBuffer>();
 }
 unsafe impl windows_core::Interface for SpatialSurfaceMeshBuffer {
     type Vtable = ISpatialSurfaceMeshBuffer_Vtbl;
@@ -375,7 +399,7 @@ impl SpatialSurfaceMeshOptions {
     }
 }
 impl windows_core::RuntimeType for SpatialSurfaceMeshOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialSurfaceMeshOptions>();
 }
 unsafe impl windows_core::Interface for SpatialSurfaceMeshOptions {
     type Vtable = ISpatialSurfaceMeshOptions_Vtbl;
@@ -459,7 +483,7 @@ impl SpatialSurfaceObserver {
     }
 }
 impl windows_core::RuntimeType for SpatialSurfaceObserver {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialSurfaceObserver>();
 }
 unsafe impl windows_core::Interface for SpatialSurfaceObserver {
     type Vtable = ISpatialSurfaceObserver_Vtbl;

--- a/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
@@ -3,6 +3,9 @@ pub mod Preview;
 #[cfg(feature = "Perception_Spatial_Surfaces")]
 pub mod Surfaces;
 windows_core::imp::define_interface!(ISpatialAnchor, ISpatialAnchor_Vtbl, 0x0529e5ce_1d34_3702_bcec_eabff578a869);
+impl windows_core::RuntimeType for ISpatialAnchor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,12 +15,18 @@ pub struct ISpatialAnchor_Vtbl {
     pub RemoveRawCoordinateSystemAdjusted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAnchor2, ISpatialAnchor2_Vtbl, 0xed17c908_a695_4cf6_92fd_97263ba71047);
+impl windows_core::RuntimeType for ISpatialAnchor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemovedByUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAnchorExportSufficiency, ISpatialAnchorExportSufficiency_Vtbl, 0x77c25b2b_3409_4088_b91b_fdfd05d1648f);
+impl windows_core::RuntimeType for ISpatialAnchorExportSufficiency {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchorExportSufficiency_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +35,9 @@ pub struct ISpatialAnchorExportSufficiency_Vtbl {
     pub RecommendedSufficiencyLevel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAnchorExporter, ISpatialAnchorExporter_Vtbl, 0x9a2a4338_24fb_4269_89c5_88304aeef20f);
+impl windows_core::RuntimeType for ISpatialAnchorExporter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchorExporter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +48,9 @@ pub struct ISpatialAnchorExporter_Vtbl {
     TryExportAnchorAsync: usize,
 }
 windows_core::imp::define_interface!(ISpatialAnchorExporterStatics, ISpatialAnchorExporterStatics_Vtbl, 0xed2507b8_2475_439c_85ff_7fed341fdc88);
+impl windows_core::RuntimeType for ISpatialAnchorExporterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchorExporterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,12 +58,18 @@ pub struct ISpatialAnchorExporterStatics_Vtbl {
     pub RequestAccessAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAnchorManagerStatics, ISpatialAnchorManagerStatics_Vtbl, 0x88e30eab_f3b7_420b_b086_8a80c07d910d);
+impl windows_core::RuntimeType for ISpatialAnchorManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchorManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestStoreAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialAnchorRawCoordinateSystemAdjustedEventArgs, ISpatialAnchorRawCoordinateSystemAdjustedEventArgs_Vtbl, 0xa1e81eb8_56c7_3117_a2e4_81e0fcf28e00);
+impl windows_core::RuntimeType for ISpatialAnchorRawCoordinateSystemAdjustedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchorRawCoordinateSystemAdjustedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +79,9 @@ pub struct ISpatialAnchorRawCoordinateSystemAdjustedEventArgs_Vtbl {
     OldRawCoordinateSystemToNewRawCoordinateSystemTransform: usize,
 }
 windows_core::imp::define_interface!(ISpatialAnchorStatics, ISpatialAnchorStatics_Vtbl, 0xa9928642_0174_311c_ae79_0e5107669f16);
+impl windows_core::RuntimeType for ISpatialAnchorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,6 +96,9 @@ pub struct ISpatialAnchorStatics_Vtbl {
     TryCreateWithPositionAndOrientationRelativeTo: usize,
 }
 windows_core::imp::define_interface!(ISpatialAnchorStore, ISpatialAnchorStore_Vtbl, 0xb0bc3636_486a_3cb0_9e6f_1245165c4db6);
+impl windows_core::RuntimeType for ISpatialAnchorStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialAnchorStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,6 +112,10 @@ pub struct ISpatialAnchorStore_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISpatialAnchorTransferManagerStatics, ISpatialAnchorTransferManagerStatics_Vtbl, 0x03bbf9b9_12d8_4bce_8835_c5df3ac0adab);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISpatialAnchorTransferManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISpatialAnchorTransferManagerStatics_Vtbl {
@@ -103,11 +134,17 @@ pub struct ISpatialAnchorTransferManagerStatics_Vtbl {
     RequestAccessAsync: usize,
 }
 windows_core::imp::define_interface!(ISpatialBoundingVolume, ISpatialBoundingVolume_Vtbl, 0xfb2065da_68c3_33df_b7af_4c787207999c);
+impl windows_core::RuntimeType for ISpatialBoundingVolume {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialBoundingVolume_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISpatialBoundingVolumeStatics, ISpatialBoundingVolumeStatics_Vtbl, 0x05889117_b3e1_36d8_b017_566181a5b196);
+impl windows_core::RuntimeType for ISpatialBoundingVolumeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialBoundingVolumeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,6 +166,9 @@ pub struct ISpatialBoundingVolumeStatics_Vtbl {
     FromFrustum: usize,
 }
 windows_core::imp::define_interface!(ISpatialCoordinateSystem, ISpatialCoordinateSystem_Vtbl, 0x69ebca4b_60a3_3586_a653_59a7bd676d07);
+impl windows_core::RuntimeType for ISpatialCoordinateSystem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialCoordinateSystem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -138,6 +178,9 @@ pub struct ISpatialCoordinateSystem_Vtbl {
     TryGetTransformTo: usize,
 }
 windows_core::imp::define_interface!(ISpatialEntity, ISpatialEntity_Vtbl, 0x166de955_e1eb_454c_ba08_e6c0668ddc65);
+impl windows_core::RuntimeType for ISpatialEntity {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntity_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -149,12 +192,18 @@ pub struct ISpatialEntity_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(ISpatialEntityAddedEventArgs, ISpatialEntityAddedEventArgs_Vtbl, 0xa397f49b_156a_4707_ac2c_d31d570ed399);
+impl windows_core::RuntimeType for ISpatialEntityAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntityAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Entity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialEntityFactory, ISpatialEntityFactory_Vtbl, 0xe1f1e325_349f_4225_a2f3_4b01c15fe056);
+impl windows_core::RuntimeType for ISpatialEntityFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntityFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,12 +214,18 @@ pub struct ISpatialEntityFactory_Vtbl {
     CreateWithSpatialAnchorAndProperties: usize,
 }
 windows_core::imp::define_interface!(ISpatialEntityRemovedEventArgs, ISpatialEntityRemovedEventArgs_Vtbl, 0x91741800_536d_4e9f_abf6_415b5444d651);
+impl windows_core::RuntimeType for ISpatialEntityRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntityRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Entity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialEntityStore, ISpatialEntityStore_Vtbl, 0x329788ba_e513_4f06_889d_1be30ecf43e6);
+impl windows_core::RuntimeType for ISpatialEntityStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntityStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,6 +234,9 @@ pub struct ISpatialEntityStore_Vtbl {
     pub CreateEntityWatcher: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialEntityStoreStatics, ISpatialEntityStoreStatics_Vtbl, 0x6b4b389e_7c50_4e92_8a62_4d1d4b7ccd3e);
+impl windows_core::RuntimeType for ISpatialEntityStoreStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntityStoreStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,12 +247,18 @@ pub struct ISpatialEntityStoreStatics_Vtbl {
     TryGetForRemoteSystemSession: usize,
 }
 windows_core::imp::define_interface!(ISpatialEntityUpdatedEventArgs, ISpatialEntityUpdatedEventArgs_Vtbl, 0xe5671766_627b_43cb_a49f_b3be6d47deed);
+impl windows_core::RuntimeType for ISpatialEntityUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntityUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Entity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialEntityWatcher, ISpatialEntityWatcher_Vtbl, 0xb3b85fa0_6d5e_4bbc_805d_5fe5b9ba1959);
+impl windows_core::RuntimeType for ISpatialEntityWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialEntityWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -211,6 +275,9 @@ pub struct ISpatialEntityWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialLocation, ISpatialLocation_Vtbl, 0x1d81d29d_24a1_37d5_8fa1_39b4f9ad67e2);
+impl windows_core::RuntimeType for ISpatialLocation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialLocation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,6 +307,9 @@ pub struct ISpatialLocation_Vtbl {
     AbsoluteAngularAcceleration: usize,
 }
 windows_core::imp::define_interface!(ISpatialLocation2, ISpatialLocation2_Vtbl, 0x117f2416_38a7_4a18_b404_ab8fabe1d78b);
+impl windows_core::RuntimeType for ISpatialLocation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialLocation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -253,6 +323,9 @@ pub struct ISpatialLocation2_Vtbl {
     AbsoluteAngularAccelerationAxisAngle: usize,
 }
 windows_core::imp::define_interface!(ISpatialLocator, ISpatialLocator_Vtbl, 0xf6478925_9e0c_3bb6_997e_b64ecca24cf4);
+impl windows_core::RuntimeType for ISpatialLocator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialLocator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,6 +363,9 @@ pub struct ISpatialLocator_Vtbl {
     CreateStationaryFrameOfReferenceAtCurrentLocationWithPositionAndOrientationAndRelativeHeading: usize,
 }
 windows_core::imp::define_interface!(ISpatialLocatorAttachedFrameOfReference, ISpatialLocatorAttachedFrameOfReference_Vtbl, 0xe1774ef6_1f4f_499c_9625_ef5e6ed7a048);
+impl windows_core::RuntimeType for ISpatialLocatorAttachedFrameOfReference {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialLocatorAttachedFrameOfReference_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +390,9 @@ pub struct ISpatialLocatorAttachedFrameOfReference_Vtbl {
     pub TryGetRelativeHeadingAtTimestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialLocatorPositionalTrackingDeactivatingEventArgs, ISpatialLocatorPositionalTrackingDeactivatingEventArgs_Vtbl, 0xb8a84063_e3f4_368b_9061_9ea9d1d6cc16);
+impl windows_core::RuntimeType for ISpatialLocatorPositionalTrackingDeactivatingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialLocatorPositionalTrackingDeactivatingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -321,12 +400,18 @@ pub struct ISpatialLocatorPositionalTrackingDeactivatingEventArgs_Vtbl {
     pub SetCanceled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialLocatorStatics, ISpatialLocatorStatics_Vtbl, 0xb76e3340_a7c2_361b_bb82_56e93b89b1bb);
+impl windows_core::RuntimeType for ISpatialLocatorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialLocatorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialStageFrameOfReference, ISpatialStageFrameOfReference_Vtbl, 0x7a8a3464_ad0d_4590_ab86_33062b674926);
+impl windows_core::RuntimeType for ISpatialStageFrameOfReference {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialStageFrameOfReference_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -340,6 +425,9 @@ pub struct ISpatialStageFrameOfReference_Vtbl {
     TryGetMovementBounds: usize,
 }
 windows_core::imp::define_interface!(ISpatialStageFrameOfReferenceStatics, ISpatialStageFrameOfReferenceStatics_Vtbl, 0xf78d5c4d_a0a4_499c_8d91_a8c965d40654);
+impl windows_core::RuntimeType for ISpatialStageFrameOfReferenceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialStageFrameOfReferenceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -349,6 +437,9 @@ pub struct ISpatialStageFrameOfReferenceStatics_Vtbl {
     pub RequestNewStageAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialStationaryFrameOfReference, ISpatialStationaryFrameOfReference_Vtbl, 0x09dbccb9_bcf8_3e7f_be7e_7edccbb178a8);
+impl windows_core::RuntimeType for ISpatialStationaryFrameOfReference {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialStationaryFrameOfReference_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -430,7 +521,7 @@ impl SpatialAnchor {
     }
 }
 impl windows_core::RuntimeType for SpatialAnchor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialAnchor>();
 }
 unsafe impl windows_core::Interface for SpatialAnchor {
     type Vtable = ISpatialAnchor_Vtbl;
@@ -469,7 +560,7 @@ impl SpatialAnchorExportSufficiency {
     }
 }
 impl windows_core::RuntimeType for SpatialAnchorExportSufficiency {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialAnchorExportSufficiency>();
 }
 unsafe impl windows_core::Interface for SpatialAnchorExportSufficiency {
     type Vtable = ISpatialAnchorExportSufficiency_Vtbl;
@@ -526,7 +617,7 @@ impl SpatialAnchorExporter {
     }
 }
 impl windows_core::RuntimeType for SpatialAnchorExporter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialAnchorExporter>();
 }
 unsafe impl windows_core::Interface for SpatialAnchorExporter {
     type Vtable = ISpatialAnchorExporter_Vtbl;
@@ -569,7 +660,7 @@ impl SpatialAnchorRawCoordinateSystemAdjustedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialAnchorRawCoordinateSystemAdjustedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialAnchorRawCoordinateSystemAdjustedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialAnchorRawCoordinateSystemAdjustedEventArgs {
     type Vtable = ISpatialAnchorRawCoordinateSystemAdjustedEventArgs_Vtbl;
@@ -613,7 +704,7 @@ impl SpatialAnchorStore {
     }
 }
 impl windows_core::RuntimeType for SpatialAnchorStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialAnchorStore>();
 }
 unsafe impl windows_core::Interface for SpatialAnchorStore {
     type Vtable = ISpatialAnchorStore_Vtbl;
@@ -719,7 +810,7 @@ impl SpatialBoundingVolume {
     }
 }
 impl windows_core::RuntimeType for SpatialBoundingVolume {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialBoundingVolume>();
 }
 unsafe impl windows_core::Interface for SpatialBoundingVolume {
     type Vtable = ISpatialBoundingVolume_Vtbl;
@@ -748,7 +839,7 @@ impl SpatialCoordinateSystem {
     }
 }
 impl windows_core::RuntimeType for SpatialCoordinateSystem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialCoordinateSystem>();
 }
 unsafe impl windows_core::Interface for SpatialCoordinateSystem {
     type Vtable = ISpatialCoordinateSystem_Vtbl;
@@ -813,7 +904,7 @@ impl SpatialEntity {
     }
 }
 impl windows_core::RuntimeType for SpatialEntity {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialEntity>();
 }
 unsafe impl windows_core::Interface for SpatialEntity {
     type Vtable = ISpatialEntity_Vtbl;
@@ -838,7 +929,7 @@ impl SpatialEntityAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialEntityAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialEntityAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialEntityAddedEventArgs {
     type Vtable = ISpatialEntityAddedEventArgs_Vtbl;
@@ -863,7 +954,7 @@ impl SpatialEntityRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialEntityRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialEntityRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialEntityRemovedEventArgs {
     type Vtable = ISpatialEntityRemovedEventArgs_Vtbl;
@@ -929,7 +1020,7 @@ impl SpatialEntityStore {
     }
 }
 impl windows_core::RuntimeType for SpatialEntityStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialEntityStore>();
 }
 unsafe impl windows_core::Interface for SpatialEntityStore {
     type Vtable = ISpatialEntityStore_Vtbl;
@@ -954,7 +1045,7 @@ impl SpatialEntityUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialEntityUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialEntityUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialEntityUpdatedEventArgs {
     type Vtable = ISpatialEntityUpdatedEventArgs_Vtbl;
@@ -1043,7 +1134,7 @@ impl SpatialEntityWatcher {
     }
 }
 impl windows_core::RuntimeType for SpatialEntityWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialEntityWatcher>();
 }
 unsafe impl windows_core::Interface for SpatialEntityWatcher {
     type Vtable = ISpatialEntityWatcher_Vtbl;
@@ -1125,7 +1216,7 @@ impl SpatialLocation {
     }
 }
 impl windows_core::RuntimeType for SpatialLocation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialLocation>();
 }
 unsafe impl windows_core::Interface for SpatialLocation {
     type Vtable = ISpatialLocation_Vtbl;
@@ -1262,7 +1353,7 @@ impl SpatialLocator {
     }
 }
 impl windows_core::RuntimeType for SpatialLocator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialLocator>();
 }
 unsafe impl windows_core::Interface for SpatialLocator {
     type Vtable = ISpatialLocator_Vtbl;
@@ -1330,7 +1421,7 @@ impl SpatialLocatorAttachedFrameOfReference {
     }
 }
 impl windows_core::RuntimeType for SpatialLocatorAttachedFrameOfReference {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialLocatorAttachedFrameOfReference>();
 }
 unsafe impl windows_core::Interface for SpatialLocatorAttachedFrameOfReference {
     type Vtable = ISpatialLocatorAttachedFrameOfReference_Vtbl;
@@ -1359,7 +1450,7 @@ impl SpatialLocatorPositionalTrackingDeactivatingEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialLocatorPositionalTrackingDeactivatingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialLocatorPositionalTrackingDeactivatingEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialLocatorPositionalTrackingDeactivatingEventArgs {
     type Vtable = ISpatialLocatorPositionalTrackingDeactivatingEventArgs_Vtbl;
@@ -1448,7 +1539,7 @@ impl SpatialStageFrameOfReference {
     }
 }
 impl windows_core::RuntimeType for SpatialStageFrameOfReference {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialStageFrameOfReference>();
 }
 unsafe impl windows_core::Interface for SpatialStageFrameOfReference {
     type Vtable = ISpatialStageFrameOfReference_Vtbl;
@@ -1473,7 +1564,7 @@ impl SpatialStationaryFrameOfReference {
     }
 }
 impl windows_core::RuntimeType for SpatialStationaryFrameOfReference {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialStationaryFrameOfReference>();
 }
 unsafe impl windows_core::Interface for SpatialStationaryFrameOfReference {
     type Vtable = ISpatialStationaryFrameOfReference_Vtbl;

--- a/crates/libs/windows/src/Windows/Perception/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/mod.rs
@@ -5,6 +5,9 @@ pub mod People;
 #[cfg(feature = "Perception_Spatial")]
 pub mod Spatial;
 windows_core::imp::define_interface!(IPerceptionTimestamp, IPerceptionTimestamp_Vtbl, 0x87c24804_a22e_4adb_ba26_d78ef639bcf4);
+impl windows_core::RuntimeType for IPerceptionTimestamp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPerceptionTimestamp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,18 +15,27 @@ pub struct IPerceptionTimestamp_Vtbl {
     pub PredictionAmount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPerceptionTimestamp2, IPerceptionTimestamp2_Vtbl, 0xe354b7ed_2bd1_41b7_9ed0_74a15c354537);
+impl windows_core::RuntimeType for IPerceptionTimestamp2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPerceptionTimestamp2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SystemRelativeTargetTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPerceptionTimestampHelperStatics, IPerceptionTimestampHelperStatics_Vtbl, 0x47a611d4_a9df_4edc_855d_f4d339d967ac);
+impl windows_core::RuntimeType for IPerceptionTimestampHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPerceptionTimestampHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromHistoricalTargetTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::DateTime, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPerceptionTimestampHelperStatics2, IPerceptionTimestampHelperStatics2_Vtbl, 0x73d1a7fe_3fb9_4571_87d4_3c920a5e86eb);
+impl windows_core::RuntimeType for IPerceptionTimestampHelperStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPerceptionTimestampHelperStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,7 +69,7 @@ impl PerceptionTimestamp {
     }
 }
 impl windows_core::RuntimeType for PerceptionTimestamp {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPerceptionTimestamp>();
 }
 unsafe impl windows_core::Interface for PerceptionTimestamp {
     type Vtable = IPerceptionTimestamp_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/ApplicationModel/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IApplicationProfileStatics, IApplicationProfileStatics_Vtbl, 0xd5008ab4_7e7a_11e1_a7f2_b0a14824019b);
+impl windows_core::RuntimeType for IApplicationProfileStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationProfileStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Phone/Devices/Notification/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Devices/Notification/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IVibrationDevice, IVibrationDevice_Vtbl, 0x1b4a6595_cfcd_4e08_92fb_c1906d04498c);
+impl windows_core::RuntimeType for IVibrationDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVibrationDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IVibrationDevice_Vtbl {
     pub Cancel: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVibrationDeviceStatics, IVibrationDeviceStatics_Vtbl, 0x332fd2f1_1c69_4c91_949e_4bb67a85bdc7);
+impl windows_core::RuntimeType for IVibrationDeviceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVibrationDeviceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,7 +43,7 @@ impl VibrationDevice {
     }
 }
 impl windows_core::RuntimeType for VibrationDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVibrationDevice>();
 }
 unsafe impl windows_core::Interface for VibrationDevice {
     type Vtable = IVibrationDevice_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/Devices/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Devices/Power/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBattery, IBattery_Vtbl, 0x972adbdd_6720_4702_a476_b9d38a0070e3);
+impl windows_core::RuntimeType for IBattery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBattery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IBattery_Vtbl {
     pub RemoveRemainingChargePercentChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBatteryStatics, IBatteryStatics_Vtbl, 0xfaf5bc70_6369_11e1_b86c_0800200c9a66);
+impl windows_core::RuntimeType for IBatteryStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBatteryStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,7 +65,7 @@ impl Battery {
     }
 }
 impl windows_core::RuntimeType for Battery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBattery>();
 }
 unsafe impl windows_core::Interface for Battery {
     type Vtable = IBattery_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IEnterprise, IEnterprise_Vtbl, 0x96592f8d_856c_4426_a947_b06307718078);
+impl windows_core::RuntimeType for IEnterprise {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnterprise_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IEnterprise_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut EnterpriseStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEnterpriseEnrollmentManager, IEnterpriseEnrollmentManager_Vtbl, 0x20f9f390_2c69_41d8_88e6_e4b3884026cb);
+impl windows_core::RuntimeType for IEnterpriseEnrollmentManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnterpriseEnrollmentManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +29,9 @@ pub struct IEnterpriseEnrollmentManager_Vtbl {
     pub RequestUnenrollmentAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEnterpriseEnrollmentResult, IEnterpriseEnrollmentResult_Vtbl, 0x9ff71ce6_90db_4342_b326_1729aa91301c);
+impl windows_core::RuntimeType for IEnterpriseEnrollmentResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnterpriseEnrollmentResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +39,9 @@ pub struct IEnterpriseEnrollmentResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut EnterpriseEnrollmentStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInstallationManagerStatics, IInstallationManagerStatics_Vtbl, 0x929aa738_8d49_42ac_80c9_b4ad793c43f2);
+impl windows_core::RuntimeType for IInstallationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInstallationManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,6 +61,9 @@ pub struct IInstallationManagerStatics_Vtbl {
     FindPackages: usize,
 }
 windows_core::imp::define_interface!(IInstallationManagerStatics2, IInstallationManagerStatics2_Vtbl, 0x7c6c2cbd_fa4a_4c8e_ab97_d959452f19e5);
+impl windows_core::RuntimeType for IInstallationManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInstallationManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +81,9 @@ pub struct IInstallationManagerStatics2_Vtbl {
     FindPackagesByNamePublisher: usize,
 }
 windows_core::imp::define_interface!(IPackageInstallResult, IPackageInstallResult_Vtbl, 0x33e8eed5_0f7e_4473_967c_7d6e1c0e7de1);
+impl windows_core::RuntimeType for IPackageInstallResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageInstallResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +94,9 @@ pub struct IPackageInstallResult_Vtbl {
     InstallState: usize,
 }
 windows_core::imp::define_interface!(IPackageInstallResult2, IPackageInstallResult2_Vtbl, 0x7149d909_3ff9_41ed_a717_2bc65ffc61d2);
+impl windows_core::RuntimeType for IPackageInstallResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPackageInstallResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -130,7 +151,7 @@ impl Enterprise {
     }
 }
 impl windows_core::RuntimeType for Enterprise {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEnterprise>();
 }
 unsafe impl windows_core::Interface for Enterprise {
     type Vtable = IEnterprise_Vtbl;
@@ -207,7 +228,7 @@ impl EnterpriseEnrollmentResult {
     }
 }
 impl windows_core::RuntimeType for EnterpriseEnrollmentResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEnterpriseEnrollmentResult>();
 }
 unsafe impl windows_core::Interface for EnterpriseEnrollmentResult {
     type Vtable = IEnterpriseEnrollmentResult_Vtbl;
@@ -326,7 +347,7 @@ impl PackageInstallResult {
     }
 }
 impl windows_core::RuntimeType for PackageInstallResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPackageInstallResult>();
 }
 unsafe impl windows_core::Interface for PackageInstallResult {
     type Vtable = IPackageInstallResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAudioRoutingManager, IAudioRoutingManager_Vtbl, 0x79340d20_71cc_4526_9f29_fc8d2486418b);
+impl windows_core::RuntimeType for IAudioRoutingManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioRoutingManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IAudioRoutingManager_Vtbl {
     pub AvailableAudioEndpoints: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AvailableAudioRoutingEndpoints) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAudioRoutingManagerStatics, IAudioRoutingManagerStatics_Vtbl, 0x977fb2a4_5590_4a6f_adde_6a3d0ad58250);
+impl windows_core::RuntimeType for IAudioRoutingManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAudioRoutingManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,7 +70,7 @@ impl AudioRoutingManager {
     }
 }
 impl windows_core::RuntimeType for AudioRoutingManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAudioRoutingManager>();
 }
 unsafe impl windows_core::Interface for AudioRoutingManager {
     type Vtable = IAudioRoutingManager_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAccessoryManager, IAccessoryManager_Vtbl, 0x0d04a12c_883d_4aa7_bca7_fa4bb8bffee6);
+impl windows_core::RuntimeType for IAccessoryManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccessoryManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +60,9 @@ pub struct IAccessoryManager_Vtbl {
     GetAppIcon: usize,
 }
 windows_core::imp::define_interface!(IAccessoryManager2, IAccessoryManager2_Vtbl, 0xbacad44d_d393_46c6_b80c_15fdf44d5386);
+impl windows_core::RuntimeType for IAccessoryManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccessoryManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +95,9 @@ pub struct IAccessoryManager2_Vtbl {
     pub UpdateEmailReadStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccessoryManager3, IAccessoryManager3_Vtbl, 0x81f75137_edc7_47e0_b2f7_7e577c833f7d);
+impl windows_core::RuntimeType for IAccessoryManager3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccessoryManager3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,6 +163,9 @@ pub struct IAccessoryNotificationTriggerDetails_Vtbl {
     pub SetStartedProcessing: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAlarmNotificationTriggerDetails, IAlarmNotificationTriggerDetails_Vtbl, 0x38f5fa30_c738_4da2_908c_775d83c36abb);
+impl windows_core::RuntimeType for IAlarmNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAlarmNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -163,12 +175,18 @@ pub struct IAlarmNotificationTriggerDetails_Vtbl {
     pub ReminderState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ReminderState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAlarmNotificationTriggerDetails2, IAlarmNotificationTriggerDetails2_Vtbl, 0xcf16e06a_7155_40fe_a9c2_7bd2127ef853);
+impl windows_core::RuntimeType for IAlarmNotificationTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAlarmNotificationTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InstanceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppNotificationInfo, IAppNotificationInfo_Vtbl, 0x2157bea5_e286_45d3_9bea_f790fc216e0e);
+impl windows_core::RuntimeType for IAppNotificationInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppNotificationInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -176,6 +194,9 @@ pub struct IAppNotificationInfo_Vtbl {
     pub Name: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBinaryId, IBinaryId_Vtbl, 0x4f0da531_5595_44b4_9181_ce4efa3fc168);
+impl windows_core::RuntimeType for IBinaryId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBinaryId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +204,9 @@ pub struct IBinaryId_Vtbl {
     pub Length: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICalendarChangedNotificationTriggerDetails, ICalendarChangedNotificationTriggerDetails_Vtbl, 0x4b8a3bfc_279d_42ab_9c68_3e87977bf216);
+impl windows_core::RuntimeType for ICalendarChangedNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarChangedNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -190,6 +214,9 @@ pub struct ICalendarChangedNotificationTriggerDetails_Vtbl {
     pub ItemId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICortanaTileNotificationTriggerDetails, ICortanaTileNotificationTriggerDetails_Vtbl, 0xdc0f01d5_1489_46bb_b73b_7f90067ecf27);
+impl windows_core::RuntimeType for ICortanaTileNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICortanaTileNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -205,6 +232,9 @@ pub struct ICortanaTileNotificationTriggerDetails_Vtbl {
     pub Source: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailAccountInfo, IEmailAccountInfo_Vtbl, 0xdfbc02ab_bda0_4568_927e_b2ede35818a1);
+impl windows_core::RuntimeType for IEmailAccountInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailAccountInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -212,6 +242,9 @@ pub struct IEmailAccountInfo_Vtbl {
     pub IsNotificationEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailFolderInfo, IEmailFolderInfo_Vtbl, 0xc207150e_e237_46d6_90e6_4f529eeac1e2);
+impl windows_core::RuntimeType for IEmailFolderInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailFolderInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -219,6 +252,9 @@ pub struct IEmailFolderInfo_Vtbl {
     pub IsNotificationEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailNotificationTriggerDetails, IEmailNotificationTriggerDetails_Vtbl, 0xf3b82612_46cf_4e70_8e0d_7b2e04ab492b);
+impl windows_core::RuntimeType for IEmailNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -233,12 +269,18 @@ pub struct IEmailNotificationTriggerDetails_Vtbl {
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailNotificationTriggerDetails2, IEmailNotificationTriggerDetails2_Vtbl, 0x168067e3_c56f_4ec7_bed1_f734e08de5b2);
+impl windows_core::RuntimeType for IEmailNotificationTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailNotificationTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MessageEntryId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEmailReadNotificationTriggerDetails, IEmailReadNotificationTriggerDetails_Vtbl, 0xf5b7a087_06f3_4e3e_8c42_325e67010413);
+impl windows_core::RuntimeType for IEmailReadNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEmailReadNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +290,9 @@ pub struct IEmailReadNotificationTriggerDetails_Vtbl {
     pub IsRead: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaControlsTriggerDetails, IMediaControlsTriggerDetails_Vtbl, 0xfab4648b_ae45_4548_91ca_4ab0548e33b5);
+impl windows_core::RuntimeType for IMediaControlsTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaControlsTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -255,6 +300,9 @@ pub struct IMediaControlsTriggerDetails_Vtbl {
     pub MediaMetadata: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMediaMetadata, IMediaMetadata_Vtbl, 0x9b50ddf7_bb6c_4330_b3cd_0704a54cdb80);
+impl windows_core::RuntimeType for IMediaMetadata {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMediaMetadata_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -270,6 +318,9 @@ pub struct IMediaMetadata_Vtbl {
     Thumbnail: usize,
 }
 windows_core::imp::define_interface!(IPhoneCallDetails, IPhoneCallDetails_Vtbl, 0x0c1b6f53_f071_483e_bf33_ebd44b724447);
+impl windows_core::RuntimeType for IPhoneCallDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneCallDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,6 +341,9 @@ pub struct IPhoneCallDetails_Vtbl {
     PresetTextResponses: usize,
 }
 windows_core::imp::define_interface!(IPhoneLineDetails, IPhoneLineDetails_Vtbl, 0x47eb32dc_33ed_49b9_995c_a296bac82b77);
+impl windows_core::RuntimeType for IPhoneLineDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -301,12 +355,18 @@ pub struct IPhoneLineDetails_Vtbl {
     pub RegistrationState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PhoneLineRegistrationState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneLineDetails2, IPhoneLineDetails2_Vtbl, 0xb30cd77d_0147_498c_8241_bf0cabc60a25);
+impl windows_core::RuntimeType for IPhoneLineDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneLineDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MissedCallCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPhoneNotificationTriggerDetails, IPhoneNotificationTriggerDetails_Vtbl, 0xccc2fdf7_09c3_4118_91bc_ca6323a8d383);
+impl windows_core::RuntimeType for IPhoneNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPhoneNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -315,6 +375,9 @@ pub struct IPhoneNotificationTriggerDetails_Vtbl {
     pub PhoneLineChangedId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReminderNotificationTriggerDetails, IReminderNotificationTriggerDetails_Vtbl, 0x5bddaa5d_9f61_4bf0_9feb_10502bc0b0c2);
+impl windows_core::RuntimeType for IReminderNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReminderNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -330,12 +393,18 @@ pub struct IReminderNotificationTriggerDetails_Vtbl {
     pub ReminderState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ReminderState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IReminderNotificationTriggerDetails2, IReminderNotificationTriggerDetails2_Vtbl, 0xe715f9c0_504d_4c0f_a6b3_bcb9722c6cdd);
+impl windows_core::RuntimeType for IReminderNotificationTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IReminderNotificationTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InstanceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpeedDialEntry, ISpeedDialEntry_Vtbl, 0x9240b6db_872c_46dc_b62a_be4541b166f8);
+impl windows_core::RuntimeType for ISpeedDialEntry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpeedDialEntry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -344,6 +413,9 @@ pub struct ISpeedDialEntry_Vtbl {
     pub ContactName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextResponse, ITextResponse_Vtbl, 0xe9cb74c3_2457_4cdb_8110_72f5e8e883e8);
+impl windows_core::RuntimeType for ITextResponse {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextResponse_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -351,6 +423,9 @@ pub struct ITextResponse_Vtbl {
     pub Content: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationTriggerDetails, IToastNotificationTriggerDetails_Vtbl, 0xc9314895_4e6d_4e9d_afec_9e921b875ae8);
+impl windows_core::RuntimeType for IToastNotificationTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -361,12 +436,18 @@ pub struct IToastNotificationTriggerDetails_Vtbl {
     pub SuppressPopup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationTriggerDetails2, IToastNotificationTriggerDetails2_Vtbl, 0x3e0479dd_cac4_4f60_afa3_b925d9d83c93);
+impl windows_core::RuntimeType for IToastNotificationTriggerDetails2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationTriggerDetails2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InstanceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVolumeInfo, IVolumeInfo_Vtbl, 0x944dd118_7704_4481_b92e_d3ed3ece6322);
+impl windows_core::RuntimeType for IVolumeInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVolumeInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -750,7 +831,7 @@ impl AlarmNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for AlarmNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAlarmNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for AlarmNotificationTriggerDetails {
     type Vtable = IAlarmNotificationTriggerDetails_Vtbl;
@@ -780,7 +861,7 @@ impl AppNotificationInfo {
     }
 }
 impl windows_core::RuntimeType for AppNotificationInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppNotificationInfo>();
 }
 unsafe impl windows_core::Interface for AppNotificationInfo {
     type Vtable = IAppNotificationInfo_Vtbl;
@@ -810,7 +891,7 @@ impl BinaryId {
     }
 }
 impl windows_core::RuntimeType for BinaryId {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBinaryId>();
 }
 unsafe impl windows_core::Interface for BinaryId {
     type Vtable = IBinaryId_Vtbl;
@@ -880,7 +961,7 @@ impl CalendarChangedNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for CalendarChangedNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICalendarChangedNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for CalendarChangedNotificationTriggerDetails {
     type Vtable = ICalendarChangedNotificationTriggerDetails_Vtbl;
@@ -1006,7 +1087,7 @@ impl CortanaTileNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for CortanaTileNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICortanaTileNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for CortanaTileNotificationTriggerDetails {
     type Vtable = ICortanaTileNotificationTriggerDetails_Vtbl;
@@ -1036,7 +1117,7 @@ impl EmailAccountInfo {
     }
 }
 impl windows_core::RuntimeType for EmailAccountInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailAccountInfo>();
 }
 unsafe impl windows_core::Interface for EmailAccountInfo {
     type Vtable = IEmailAccountInfo_Vtbl;
@@ -1066,7 +1147,7 @@ impl EmailFolderInfo {
     }
 }
 impl windows_core::RuntimeType for EmailFolderInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailFolderInfo>();
 }
 unsafe impl windows_core::Interface for EmailFolderInfo {
     type Vtable = IEmailFolderInfo_Vtbl;
@@ -1172,7 +1253,7 @@ impl EmailNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for EmailNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for EmailNotificationTriggerDetails {
     type Vtable = IEmailNotificationTriggerDetails_Vtbl;
@@ -1256,7 +1337,7 @@ impl EmailReadNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for EmailReadNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEmailReadNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for EmailReadNotificationTriggerDetails {
     type Vtable = IEmailReadNotificationTriggerDetails_Vtbl;
@@ -1326,7 +1407,7 @@ impl MediaControlsTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for MediaControlsTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaControlsTriggerDetails>();
 }
 unsafe impl windows_core::Interface for MediaControlsTriggerDetails {
     type Vtable = IMediaControlsTriggerDetails_Vtbl;
@@ -1392,7 +1473,7 @@ impl MediaMetadata {
     }
 }
 impl windows_core::RuntimeType for MediaMetadata {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMediaMetadata>();
 }
 unsafe impl windows_core::Interface for MediaMetadata {
     type Vtable = IMediaMetadata_Vtbl;
@@ -1493,7 +1574,7 @@ impl PhoneCallDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneCallDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneCallDetails>();
 }
 unsafe impl windows_core::Interface for PhoneCallDetails {
     type Vtable = IPhoneCallDetails_Vtbl;
@@ -1558,7 +1639,7 @@ impl PhoneLineDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneLineDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneLineDetails>();
 }
 unsafe impl windows_core::Interface for PhoneLineDetails {
     type Vtable = IPhoneLineDetails_Vtbl;
@@ -1635,7 +1716,7 @@ impl PhoneNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for PhoneNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPhoneNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for PhoneNotificationTriggerDetails {
     type Vtable = IPhoneNotificationTriggerDetails_Vtbl;
@@ -1748,7 +1829,7 @@ impl ReminderNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for ReminderNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IReminderNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for ReminderNotificationTriggerDetails {
     type Vtable = IReminderNotificationTriggerDetails_Vtbl;
@@ -1785,7 +1866,7 @@ impl SpeedDialEntry {
     }
 }
 impl windows_core::RuntimeType for SpeedDialEntry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpeedDialEntry>();
 }
 unsafe impl windows_core::Interface for SpeedDialEntry {
     type Vtable = ISpeedDialEntry_Vtbl;
@@ -1815,7 +1896,7 @@ impl TextResponse {
     }
 }
 impl windows_core::RuntimeType for TextResponse {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITextResponse>();
 }
 unsafe impl windows_core::Interface for TextResponse {
     type Vtable = ITextResponse_Vtbl;
@@ -1913,7 +1994,7 @@ impl ToastNotificationTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotificationTriggerDetails>();
 }
 unsafe impl windows_core::Interface for ToastNotificationTriggerDetails {
     type Vtable = IToastNotificationTriggerDetails_Vtbl;
@@ -1964,7 +2045,7 @@ impl VolumeInfo {
     }
 }
 impl windows_core::RuntimeType for VolumeInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVolumeInfo>();
 }
 unsafe impl windows_core::Interface for VolumeInfo {
     type Vtable = IVolumeInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/PersonalInformation/Provisioning/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/PersonalInformation/Provisioning/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IContactPartnerProvisioningManagerStatics, IContactPartnerProvisioningManagerStatics_Vtbl, 0xc0d79a21_01af_4fd3_98cd_b3d656de15f4);
+impl windows_core::RuntimeType for IContactPartnerProvisioningManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPartnerProvisioningManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,12 +12,18 @@ pub struct IContactPartnerProvisioningManagerStatics_Vtbl {
     ImportVcardToSystemAsync: usize,
 }
 windows_core::imp::define_interface!(IContactPartnerProvisioningManagerStatics2, IContactPartnerProvisioningManagerStatics2_Vtbl, 0xc26155f7_55ed_475d_9334_c5d484c30f1a);
+impl windows_core::RuntimeType for IContactPartnerProvisioningManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactPartnerProvisioningManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AssociateSocialNetworkAccountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMessagePartnerProvisioningManagerStatics, IMessagePartnerProvisioningManagerStatics_Vtbl, 0x8a1b0850_73c5_457c_bc59_ed7d615c05a4);
+impl windows_core::RuntimeType for IMessagePartnerProvisioningManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessagePartnerProvisioningManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Phone_PersonalInformation_Provisioning")]
 pub mod Provisioning;
 windows_core::imp::define_interface!(IContactAddress, IContactAddress_Vtbl, 0x5f24f927_94a9_44a2_a155_2d0b37d1dccd);
+impl windows_core::RuntimeType for IContactAddress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactAddress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +19,9 @@ pub struct IContactAddress_Vtbl {
     pub SetStreetAddress: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactChangeRecord, IContactChangeRecord_Vtbl, 0xb9d3f78f_513b_4742_be00_cc5c5c236b04);
+impl windows_core::RuntimeType for IContactChangeRecord {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactChangeRecord_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -200,6 +206,9 @@ pub struct IContactInformation2_Vtbl {
     pub SetDisplayPictureDate: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactInformationStatics, IContactInformationStatics_Vtbl, 0x0f67bb29_03d0_4be6_b2a5_fb13859f1202);
+impl windows_core::RuntimeType for IContactInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -209,6 +218,9 @@ pub struct IContactInformationStatics_Vtbl {
     ParseVcardAsync: usize,
 }
 windows_core::imp::define_interface!(IContactQueryOptions, IContactQueryOptions_Vtbl, 0x580cab76_3f31_46c1_9a50_424a53dacae3);
+impl windows_core::RuntimeType for IContactQueryOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactQueryOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -220,6 +232,9 @@ pub struct IContactQueryOptions_Vtbl {
     pub SetOrderBy: unsafe extern "system" fn(*mut core::ffi::c_void, ContactQueryResultOrdering) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactQueryResult, IContactQueryResult_Vtbl, 0xc03db722_ecdb_4700_857e_3e786426b04b);
+impl windows_core::RuntimeType for IContactQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,6 +250,9 @@ pub struct IContactQueryResult_Vtbl {
     pub GetCurrentQueryOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactStore, IContactStore_Vtbl, 0xb2cd6fef_2bfd_4fad_8552_4e698097e8eb);
+impl windows_core::RuntimeType for IContactStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -259,12 +277,18 @@ pub struct IContactStore_Vtbl {
     SaveExtendedPropertiesAsync: usize,
 }
 windows_core::imp::define_interface!(IContactStore2, IContactStore2_Vtbl, 0x65f1b64f_d653_43a7_b236_b30c0f4d7269);
+impl windows_core::RuntimeType for IContactStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMeContactAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContactStoreStatics, IContactStoreStatics_Vtbl, 0xa804fe22_4beb_44cc_a572_67a5b92e8567);
+impl windows_core::RuntimeType for IContactStoreStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContactStoreStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +296,9 @@ pub struct IContactStoreStatics_Vtbl {
     pub CreateOrOpenWithOptionsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, ContactStoreSystemAccessMode, ContactStoreApplicationAccessMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownContactPropertiesStatics, IKnownContactPropertiesStatics_Vtbl, 0xd5812b01_2ced_4ee6_b1d6_094bf88ef0b6);
+impl windows_core::RuntimeType for IKnownContactPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownContactPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,6 +339,9 @@ pub struct IKnownContactPropertiesStatics_Vtbl {
     pub AlternateWorkTelephone: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoredContact, IStoredContact_Vtbl, 0xb070b7b1_263d_4e71_abe7_591d2466570e);
+impl windows_core::RuntimeType for IStoredContact {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoredContact_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -327,6 +357,9 @@ pub struct IStoredContact_Vtbl {
     pub ReplaceExistingContactAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoredContactFactory, IStoredContactFactory_Vtbl, 0x49ede921_c225_4fd9_89c5_cecc2c8a4b79);
+impl windows_core::RuntimeType for IStoredContactFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoredContactFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -402,7 +435,7 @@ impl ContactAddress {
     }
 }
 impl windows_core::RuntimeType for ContactAddress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactAddress>();
 }
 unsafe impl windows_core::Interface for ContactAddress {
     type Vtable = IContactAddress_Vtbl;
@@ -448,7 +481,7 @@ impl ContactChangeRecord {
     }
 }
 impl windows_core::RuntimeType for ContactChangeRecord {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactChangeRecord>();
 }
 unsafe impl windows_core::Interface for ContactChangeRecord {
     type Vtable = IContactChangeRecord_Vtbl;
@@ -595,7 +628,7 @@ impl ContactInformation {
     }
 }
 impl windows_core::RuntimeType for ContactInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactInformation>();
 }
 unsafe impl windows_core::Interface for ContactInformation {
     type Vtable = IContactInformation_Vtbl;
@@ -639,7 +672,7 @@ impl ContactQueryOptions {
     }
 }
 impl windows_core::RuntimeType for ContactQueryOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactQueryOptions>();
 }
 unsafe impl windows_core::Interface for ContactQueryOptions {
     type Vtable = IContactQueryOptions_Vtbl;
@@ -687,7 +720,7 @@ impl ContactQueryResult {
     }
 }
 impl windows_core::RuntimeType for ContactQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactQueryResult>();
 }
 unsafe impl windows_core::Interface for ContactQueryResult {
     type Vtable = IContactQueryResult_Vtbl;
@@ -808,7 +841,7 @@ impl ContactStore {
     }
 }
 impl windows_core::RuntimeType for ContactStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContactStore>();
 }
 unsafe impl windows_core::Interface for ContactStore {
     type Vtable = IContactStore_Vtbl;
@@ -1236,7 +1269,7 @@ impl StoredContact {
     }
 }
 impl windows_core::RuntimeType for StoredContact {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoredContact>();
 }
 unsafe impl windows_core::Interface for StoredContact {
     type Vtable = IStoredContact_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/StartScreen/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDualSimTile, IDualSimTile_Vtbl, 0x143ab213_d05f_4041_a18c_3e3fcb75b41e);
+impl windows_core::RuntimeType for IDualSimTile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDualSimTile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IDualSimTile_Vtbl {
     pub DeleteAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDualSimTileStatics, IDualSimTileStatics_Vtbl, 0x50567c9e_c58f_4dc9_b6e8_fa6777eeeb37);
+impl windows_core::RuntimeType for IDualSimTileStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDualSimTileStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,7 +181,7 @@ impl DualSimTile {
     }
 }
 impl windows_core::RuntimeType for DualSimTile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDualSimTile>();
 }
 unsafe impl windows_core::Interface for DualSimTile {
     type Vtable = IDualSimTile_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/Power/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPowerManagerStatics, IPowerManagerStatics_Vtbl, 0x25de8fd0_1c5b_11e1_bddb_0800200c9a66);
+impl windows_core::RuntimeType for IPowerManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPowerManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IPowerManagerStatics_Vtbl {
     pub RemovePowerSavingModeChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPowerManagerStatics2, IPowerManagerStatics2_Vtbl, 0x596236cf_1918_4551_a466_c51aae373bf8);
+impl windows_core::RuntimeType for IPowerManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPowerManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Phone/System/Profile/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/Profile/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IRetailModeStatics, IRetailModeStatics_Vtbl, 0xd7ded029_fdda_43e7_93fb_e53ab6e89ec3);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IRetailModeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IRetailModeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGameService, IGameService_Vtbl, 0x2e2d5098_48a9_4efc_afd6_8e6da09003fb);
+impl windows_core::RuntimeType for IGameService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +18,9 @@ pub struct IGameService_Vtbl {
     PostResult: usize,
 }
 windows_core::imp::define_interface!(IGameService2, IGameService2_Vtbl, 0xd2364ef6_ea17_4be5_8d8a_c860885e051f);
+impl windows_core::RuntimeType for IGameService2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameService2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +28,9 @@ pub struct IGameService2_Vtbl {
     pub GetAuthenticationStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGameServicePropertyCollection, IGameServicePropertyCollection_Vtbl, 0x07e57fc8_debb_4609_9cc8_529d16bc2bd9);
+impl windows_core::RuntimeType for IGameServicePropertyCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGameServicePropertyCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,7 +124,7 @@ impl GameServicePropertyCollection {
     }
 }
 impl windows_core::RuntimeType for GameServicePropertyCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGameServicePropertyCollection>();
 }
 unsafe impl windows_core::Interface for GameServicePropertyCollection {
     type Vtable = IGameServicePropertyCollection_Vtbl;

--- a/crates/libs/windows/src/Windows/Phone/System/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/mod.rs
@@ -5,12 +5,18 @@ pub mod Profile;
 #[cfg(feature = "Phone_System_UserProfile")]
 pub mod UserProfile;
 windows_core::imp::define_interface!(ISystemProtectionStatics, ISystemProtectionStatics_Vtbl, 0x49c36560_97e1_4d99_8bfb_befeaa6ace6d);
+impl windows_core::RuntimeType for ISystemProtectionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemProtectionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ScreenLocked: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemProtectionUnlockStatics, ISystemProtectionUnlockStatics_Vtbl, 0x0692fa3f_8f11_4c4b_aa0d_87d7af7b1779);
+impl windows_core::RuntimeType for ISystemProtectionUnlockStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemProtectionUnlockStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Phone/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/UI/Input/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBackPressedEventArgs, IBackPressedEventArgs_Vtbl, 0xf6f555ff_64ec_42a2_b93b_2fbc0c36a121);
+impl windows_core::RuntimeType for IBackPressedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackPressedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,11 +9,17 @@ pub struct IBackPressedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICameraEventArgs, ICameraEventArgs_Vtbl, 0xb4063bda_201f_473d_bc69_e9e4ac57c9d0);
+impl windows_core::RuntimeType for ICameraEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICameraEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IHardwareButtonsStatics, IHardwareButtonsStatics_Vtbl, 0x594b8780_da66_4fd8_a776_7506bd0cbfa7);
+impl windows_core::RuntimeType for IHardwareButtonsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHardwareButtonsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +27,9 @@ pub struct IHardwareButtonsStatics_Vtbl {
     pub RemoveBackPressed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHardwareButtonsStatics2, IHardwareButtonsStatics2_Vtbl, 0x39c6c274_993f_40dd_854c_831a8934b92e);
+impl windows_core::RuntimeType for IHardwareButtonsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHardwareButtonsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,7 +58,7 @@ impl BackPressedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BackPressedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackPressedEventArgs>();
 }
 unsafe impl windows_core::Interface for BackPressedEventArgs {
     type Vtable = IBackPressedEventArgs_Vtbl;
@@ -63,7 +75,7 @@ pub struct CameraEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(CameraEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl CameraEventArgs {}
 impl windows_core::RuntimeType for CameraEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICameraEventArgs>();
 }
 unsafe impl windows_core::Interface for CameraEventArgs {
     type Vtable = ICameraEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IMicrosoftAccountMultiFactorAuthenticationManager, IMicrosoftAccountMultiFactorAuthenticationManager_Vtbl, 0x0fd340a5_f574_4320_a08e_0a19a82322aa);
+impl windows_core::RuntimeType for IMicrosoftAccountMultiFactorAuthenticationManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMicrosoftAccountMultiFactorAuthenticationManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,12 +23,18 @@ pub struct IMicrosoftAccountMultiFactorAuthenticationManager_Vtbl {
     pub DenySessionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, MicrosoftAccountMultiFactorAuthenticationType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMicrosoftAccountMultiFactorAuthenticatorStatics, IMicrosoftAccountMultiFactorAuthenticatorStatics_Vtbl, 0xd964c2e6_f446_4c71_8b79_6ea4024aa9b8);
+impl windows_core::RuntimeType for IMicrosoftAccountMultiFactorAuthenticatorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMicrosoftAccountMultiFactorAuthenticatorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMicrosoftAccountMultiFactorGetSessionsResult, IMicrosoftAccountMultiFactorGetSessionsResult_Vtbl, 0x4e23a9a0_e9fa_497a_95de_6d5747bf974c);
+impl windows_core::RuntimeType for IMicrosoftAccountMultiFactorGetSessionsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMicrosoftAccountMultiFactorGetSessionsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +45,9 @@ pub struct IMicrosoftAccountMultiFactorGetSessionsResult_Vtbl {
     pub ServiceResponse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MicrosoftAccountMultiFactorServiceResponse) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMicrosoftAccountMultiFactorOneTimeCodedInfo, IMicrosoftAccountMultiFactorOneTimeCodedInfo_Vtbl, 0x82ba264b_d87c_4668_a976_40cfae547d08);
+impl windows_core::RuntimeType for IMicrosoftAccountMultiFactorOneTimeCodedInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMicrosoftAccountMultiFactorOneTimeCodedInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +57,9 @@ pub struct IMicrosoftAccountMultiFactorOneTimeCodedInfo_Vtbl {
     pub ServiceResponse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MicrosoftAccountMultiFactorServiceResponse) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMicrosoftAccountMultiFactorSessionInfo, IMicrosoftAccountMultiFactorSessionInfo_Vtbl, 0x5f7eabb4_a278_4635_b765_b494eb260af4);
+impl windows_core::RuntimeType for IMicrosoftAccountMultiFactorSessionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMicrosoftAccountMultiFactorSessionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +72,9 @@ pub struct IMicrosoftAccountMultiFactorSessionInfo_Vtbl {
     pub ExpirationTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo, IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo_Vtbl, 0xaa7ec5fb_da3f_4088_a20d_5618afadb2e5);
+impl windows_core::RuntimeType for IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,7 +190,7 @@ impl MicrosoftAccountMultiFactorAuthenticationManager {
     }
 }
 impl windows_core::RuntimeType for MicrosoftAccountMultiFactorAuthenticationManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMicrosoftAccountMultiFactorAuthenticationManager>();
 }
 unsafe impl windows_core::Interface for MicrosoftAccountMultiFactorAuthenticationManager {
     type Vtable = IMicrosoftAccountMultiFactorAuthenticationManager_Vtbl;
@@ -205,7 +223,7 @@ impl MicrosoftAccountMultiFactorGetSessionsResult {
     }
 }
 impl windows_core::RuntimeType for MicrosoftAccountMultiFactorGetSessionsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMicrosoftAccountMultiFactorGetSessionsResult>();
 }
 unsafe impl windows_core::Interface for MicrosoftAccountMultiFactorGetSessionsResult {
     type Vtable = IMicrosoftAccountMultiFactorGetSessionsResult_Vtbl;
@@ -251,7 +269,7 @@ impl MicrosoftAccountMultiFactorOneTimeCodedInfo {
     }
 }
 impl windows_core::RuntimeType for MicrosoftAccountMultiFactorOneTimeCodedInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMicrosoftAccountMultiFactorOneTimeCodedInfo>();
 }
 unsafe impl windows_core::Interface for MicrosoftAccountMultiFactorOneTimeCodedInfo {
     type Vtable = IMicrosoftAccountMultiFactorOneTimeCodedInfo_Vtbl;
@@ -318,7 +336,7 @@ impl MicrosoftAccountMultiFactorSessionInfo {
     }
 }
 impl windows_core::RuntimeType for MicrosoftAccountMultiFactorSessionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMicrosoftAccountMultiFactorSessionInfo>();
 }
 unsafe impl windows_core::Interface for MicrosoftAccountMultiFactorSessionInfo {
     type Vtable = IMicrosoftAccountMultiFactorSessionInfo_Vtbl;
@@ -359,7 +377,7 @@ impl MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {
     }
 }
 impl windows_core::RuntimeType for MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo>();
 }
 unsafe impl windows_core::Interface for MicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo {
     type Vtable = IMicrosoftAccountMultiFactorUnregisteredAccountsAndSessionInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Security_Authentication_Identity_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IEnterpriseKeyCredentialRegistrationInfo, IEnterpriseKeyCredentialRegistrationInfo_Vtbl, 0x38321acc_672b_4823_b603_6b3c753daf97);
+impl windows_core::RuntimeType for IEnterpriseKeyCredentialRegistrationInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnterpriseKeyCredentialRegistrationInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IEnterpriseKeyCredentialRegistrationInfo_Vtbl {
     pub KeyName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEnterpriseKeyCredentialRegistrationManager, IEnterpriseKeyCredentialRegistrationManager_Vtbl, 0x83f3be3f_a25f_4cba_bb8e_bdc32d03c297);
+impl windows_core::RuntimeType for IEnterpriseKeyCredentialRegistrationManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnterpriseKeyCredentialRegistrationManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct IEnterpriseKeyCredentialRegistrationManager_Vtbl {
     GetRegistrationsAsync: usize,
 }
 windows_core::imp::define_interface!(IEnterpriseKeyCredentialRegistrationManagerStatics, IEnterpriseKeyCredentialRegistrationManagerStatics_Vtbl, 0x77b85e9e_acf4_4bc0_bac2_40bb46efbb3f);
+impl windows_core::RuntimeType for IEnterpriseKeyCredentialRegistrationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnterpriseKeyCredentialRegistrationManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,7 +76,7 @@ impl EnterpriseKeyCredentialRegistrationInfo {
     }
 }
 impl windows_core::RuntimeType for EnterpriseKeyCredentialRegistrationInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEnterpriseKeyCredentialRegistrationInfo>();
 }
 unsafe impl windows_core::Interface for EnterpriseKeyCredentialRegistrationInfo {
     type Vtable = IEnterpriseKeyCredentialRegistrationInfo_Vtbl;
@@ -104,7 +113,7 @@ impl EnterpriseKeyCredentialRegistrationManager {
     }
 }
 impl windows_core::RuntimeType for EnterpriseKeyCredentialRegistrationManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEnterpriseKeyCredentialRegistrationManager>();
 }
 unsafe impl windows_core::Interface for EnterpriseKeyCredentialRegistrationManager {
     type Vtable = IEnterpriseKeyCredentialRegistrationManager_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IOnlineIdAuthenticator, IOnlineIdAuthenticator_Vtbl, 0xa003f58a_29ab_4817_b884_d7516dad18b9);
+impl windows_core::RuntimeType for IOnlineIdAuthenticator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdAuthenticator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +17,9 @@ pub struct IOnlineIdAuthenticator_Vtbl {
     pub AuthenticatedSafeCustomerId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOnlineIdServiceTicket, IOnlineIdServiceTicket_Vtbl, 0xc95c547f_d781_4a94_acb8_c59874238c26);
+impl windows_core::RuntimeType for IOnlineIdServiceTicket {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdServiceTicket_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +28,9 @@ pub struct IOnlineIdServiceTicket_Vtbl {
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOnlineIdServiceTicketRequest, IOnlineIdServiceTicketRequest_Vtbl, 0x297445d3_fb63_4135_8909_4e354c061466);
+impl windows_core::RuntimeType for IOnlineIdServiceTicketRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdServiceTicketRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +38,9 @@ pub struct IOnlineIdServiceTicketRequest_Vtbl {
     pub Policy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOnlineIdServiceTicketRequestFactory, IOnlineIdServiceTicketRequestFactory_Vtbl, 0xbebb0a08_9e73_4077_9614_08614c0bc245);
+impl windows_core::RuntimeType for IOnlineIdServiceTicketRequestFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdServiceTicketRequestFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +48,9 @@ pub struct IOnlineIdServiceTicketRequestFactory_Vtbl {
     pub CreateOnlineIdServiceTicketRequestAdvanced: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOnlineIdSystemAuthenticatorForUser, IOnlineIdSystemAuthenticatorForUser_Vtbl, 0x5798befb_1de4_4186_a2e6_b563f86aaf44);
+impl windows_core::RuntimeType for IOnlineIdSystemAuthenticatorForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdSystemAuthenticatorForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +63,9 @@ pub struct IOnlineIdSystemAuthenticatorForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IOnlineIdSystemAuthenticatorStatics, IOnlineIdSystemAuthenticatorStatics_Vtbl, 0x85047792_f634_41e3_96a4_5164e902c740);
+impl windows_core::RuntimeType for IOnlineIdSystemAuthenticatorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdSystemAuthenticatorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +76,9 @@ pub struct IOnlineIdSystemAuthenticatorStatics_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IOnlineIdSystemIdentity, IOnlineIdSystemIdentity_Vtbl, 0x743cd20d_b6ca_434d_8124_53ea12685307);
+impl windows_core::RuntimeType for IOnlineIdSystemIdentity {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdSystemIdentity_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -65,6 +86,9 @@ pub struct IOnlineIdSystemIdentity_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOnlineIdSystemTicketResult, IOnlineIdSystemTicketResult_Vtbl, 0xdb0a5ff8_b098_4acd_9d13_9e640652b5b6);
+impl windows_core::RuntimeType for IOnlineIdSystemTicketResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOnlineIdSystemTicketResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +97,9 @@ pub struct IOnlineIdSystemTicketResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserIdentity, IUserIdentity_Vtbl, 0x2146d9cd_0742_4be3_8a1c_7c7ae679aa88);
+impl windows_core::RuntimeType for IUserIdentity {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserIdentity_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -155,7 +182,7 @@ impl OnlineIdAuthenticator {
     }
 }
 impl windows_core::RuntimeType for OnlineIdAuthenticator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOnlineIdAuthenticator>();
 }
 unsafe impl windows_core::Interface for OnlineIdAuthenticator {
     type Vtable = IOnlineIdAuthenticator_Vtbl;
@@ -194,7 +221,7 @@ impl OnlineIdServiceTicket {
     }
 }
 impl windows_core::RuntimeType for OnlineIdServiceTicket {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOnlineIdServiceTicket>();
 }
 unsafe impl windows_core::Interface for OnlineIdServiceTicket {
     type Vtable = IOnlineIdServiceTicket_Vtbl;
@@ -243,7 +270,7 @@ impl OnlineIdServiceTicketRequest {
     }
 }
 impl windows_core::RuntimeType for OnlineIdServiceTicketRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOnlineIdServiceTicketRequest>();
 }
 unsafe impl windows_core::Interface for OnlineIdServiceTicketRequest {
     type Vtable = IOnlineIdServiceTicketRequest_Vtbl;
@@ -317,7 +344,7 @@ impl OnlineIdSystemAuthenticatorForUser {
     }
 }
 impl windows_core::RuntimeType for OnlineIdSystemAuthenticatorForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOnlineIdSystemAuthenticatorForUser>();
 }
 unsafe impl windows_core::Interface for OnlineIdSystemAuthenticatorForUser {
     type Vtable = IOnlineIdSystemAuthenticatorForUser_Vtbl;
@@ -349,7 +376,7 @@ impl OnlineIdSystemIdentity {
     }
 }
 impl windows_core::RuntimeType for OnlineIdSystemIdentity {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOnlineIdSystemIdentity>();
 }
 unsafe impl windows_core::Interface for OnlineIdSystemIdentity {
     type Vtable = IOnlineIdSystemIdentity_Vtbl;
@@ -388,7 +415,7 @@ impl OnlineIdSystemTicketResult {
     }
 }
 impl windows_core::RuntimeType for OnlineIdSystemTicketResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOnlineIdSystemTicketResult>();
 }
 unsafe impl windows_core::Interface for OnlineIdSystemTicketResult {
     type Vtable = IOnlineIdSystemTicketResult_Vtbl;
@@ -454,7 +481,7 @@ impl SignOutUserOperation {
     }
 }
 impl windows_core::RuntimeType for SignOutUserOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::IAsyncAction>();
 }
 unsafe impl windows_core::Interface for SignOutUserOperation {
     type Vtable = super::super::super::Foundation::IAsyncAction_Vtbl;
@@ -552,7 +579,7 @@ impl UserAuthenticationOperation {
     }
 }
 impl windows_core::RuntimeType for UserAuthenticationOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::IAsyncOperation<UserIdentity>>();
 }
 unsafe impl windows_core::Interface for UserAuthenticationOperation {
     type Vtable = super::super::super::Foundation::IAsyncOperation_Vtbl<UserIdentity>;
@@ -656,7 +683,7 @@ impl UserIdentity {
     }
 }
 impl windows_core::RuntimeType for UserIdentity {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserIdentity>();
 }
 unsafe impl windows_core::Interface for UserIdentity {
     type Vtable = IUserIdentity_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IFindAllAccountsResult, IFindAllAccountsResult_Vtbl, 0xa5812b5d_b72e_420c_86ab_aac0d7b7261f);
+impl windows_core::RuntimeType for IFindAllAccountsResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFindAllAccountsResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IFindAllAccountsResult_Vtbl {
     pub ProviderError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountEventArgs, IWebAccountEventArgs_Vtbl, 0x6fb7037d_424e_44ec_977c_ef2415462a5a);
+impl windows_core::RuntimeType for IWebAccountEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +25,9 @@ pub struct IWebAccountEventArgs_Vtbl {
     Account: usize,
 }
 windows_core::imp::define_interface!(IWebAccountMonitor, IWebAccountMonitor_Vtbl, 0x7445f5fd_aa9d_4619_8d5d_c138a4ede3e5);
+impl windows_core::RuntimeType for IWebAccountMonitor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountMonitor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +39,9 @@ pub struct IWebAccountMonitor_Vtbl {
     pub RemoveDefaultSignInAccountChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountMonitor2, IWebAccountMonitor2_Vtbl, 0xa7adc1f8_24b8_4f01_9ae5_24545e71233a);
+impl windows_core::RuntimeType for IWebAccountMonitor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountMonitor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +49,9 @@ pub struct IWebAccountMonitor2_Vtbl {
     pub RemoveAccountPictureUpdated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAuthenticationCoreManagerStatics, IWebAuthenticationCoreManagerStatics_Vtbl, 0x6aca7c92_a581_4479_9c10_752eff44fd34);
+impl windows_core::RuntimeType for IWebAuthenticationCoreManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationCoreManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,6 +79,9 @@ pub struct IWebAuthenticationCoreManagerStatics_Vtbl {
     FindAccountProviderWithAuthorityAsync: usize,
 }
 windows_core::imp::define_interface!(IWebAuthenticationCoreManagerStatics2, IWebAuthenticationCoreManagerStatics2_Vtbl, 0xf584184a_8b57_4820_b6a4_70a5b6fcf44a);
+impl windows_core::RuntimeType for IWebAuthenticationCoreManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationCoreManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +91,9 @@ pub struct IWebAuthenticationCoreManagerStatics2_Vtbl {
     FindAccountProviderWithAuthorityForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IWebAuthenticationCoreManagerStatics3, IWebAuthenticationCoreManagerStatics3_Vtbl, 0x2404eeb2_8924_4d93_ab3a_99688b419d56);
+impl windows_core::RuntimeType for IWebAuthenticationCoreManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationCoreManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -82,6 +103,9 @@ pub struct IWebAuthenticationCoreManagerStatics3_Vtbl {
     CreateWebAccountMonitor: usize,
 }
 windows_core::imp::define_interface!(IWebAuthenticationCoreManagerStatics4, IWebAuthenticationCoreManagerStatics4_Vtbl, 0x54e633fe_96e0_41e8_9832_1298897c2aaf);
+impl windows_core::RuntimeType for IWebAuthenticationCoreManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationCoreManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -107,6 +131,9 @@ pub struct IWebAuthenticationCoreManagerStatics4_Vtbl {
     FindSystemAccountProviderWithAuthorityForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IWebProviderError, IWebProviderError_Vtbl, 0xdb191bb1_50c5_4809_8dca_09c99410245c);
+impl windows_core::RuntimeType for IWebProviderError {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebProviderError_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,12 +145,18 @@ pub struct IWebProviderError_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IWebProviderErrorFactory, IWebProviderErrorFactory_Vtbl, 0xe3c40a2d_89ef_4e37_847f_a8b9d5a32910);
+impl windows_core::RuntimeType for IWebProviderErrorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebProviderErrorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebTokenRequest, IWebTokenRequest_Vtbl, 0xb77b4d68_adcb_4673_b364_0cf7b35caf97);
+impl windows_core::RuntimeType for IWebTokenRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebTokenRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +173,9 @@ pub struct IWebTokenRequest_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IWebTokenRequest2, IWebTokenRequest2_Vtbl, 0xd700c079_30c8_4397_9654_961c3be8b855);
+impl windows_core::RuntimeType for IWebTokenRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebTokenRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -149,6 +185,9 @@ pub struct IWebTokenRequest2_Vtbl {
     AppProperties: usize,
 }
 windows_core::imp::define_interface!(IWebTokenRequest3, IWebTokenRequest3_Vtbl, 0x5a755b51_3bb1_41a5_a63d_90bc32c7db9a);
+impl windows_core::RuntimeType for IWebTokenRequest3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebTokenRequest3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +195,9 @@ pub struct IWebTokenRequest3_Vtbl {
     pub SetCorrelationId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebTokenRequestFactory, IWebTokenRequestFactory_Vtbl, 0x6cf2141c_0ff0_4c67_b84f_99ddbe4a72c9);
+impl windows_core::RuntimeType for IWebTokenRequestFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebTokenRequestFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -177,6 +219,9 @@ pub struct IWebTokenRequestFactory_Vtbl {
     CreateWithScope: usize,
 }
 windows_core::imp::define_interface!(IWebTokenRequestResult, IWebTokenRequestResult_Vtbl, 0xc12a8305_d1f8_4483_8d54_38fe292784ff);
+impl windows_core::RuntimeType for IWebTokenRequestResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebTokenRequestResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +234,9 @@ pub struct IWebTokenRequestResult_Vtbl {
     pub InvalidateCacheAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebTokenResponse, IWebTokenResponse_Vtbl, 0x67a7c5ca_83f6_44c6_a3b1_0eb69e41fa8a);
+impl windows_core::RuntimeType for IWebTokenResponse {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebTokenResponse_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -204,6 +252,9 @@ pub struct IWebTokenResponse_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IWebTokenResponseFactory, IWebTokenResponseFactory_Vtbl, 0xab6bf7f8_5450_4ef6_97f7_052b0431c0f0);
+impl windows_core::RuntimeType for IWebTokenResponseFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebTokenResponseFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -246,7 +297,7 @@ impl FindAllAccountsResult {
     }
 }
 impl windows_core::RuntimeType for FindAllAccountsResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFindAllAccountsResult>();
 }
 unsafe impl windows_core::Interface for FindAllAccountsResult {
     type Vtable = IFindAllAccountsResult_Vtbl;
@@ -272,7 +323,7 @@ impl WebAccountEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebAccountEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountEventArgs>();
 }
 unsafe impl windows_core::Interface for WebAccountEventArgs {
     type Vtable = IWebAccountEventArgs_Vtbl;
@@ -346,7 +397,7 @@ impl WebAccountMonitor {
     }
 }
 impl windows_core::RuntimeType for WebAccountMonitor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountMonitor>();
 }
 unsafe impl windows_core::Interface for WebAccountMonitor {
     type Vtable = IWebAccountMonitor_Vtbl;
@@ -551,7 +602,7 @@ impl WebProviderError {
     }
 }
 impl windows_core::RuntimeType for WebProviderError {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebProviderError>();
 }
 unsafe impl windows_core::Interface for WebProviderError {
     type Vtable = IWebProviderError_Vtbl;
@@ -670,7 +721,7 @@ impl WebTokenRequest {
     }
 }
 impl windows_core::RuntimeType for WebTokenRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebTokenRequest>();
 }
 unsafe impl windows_core::Interface for WebTokenRequest {
     type Vtable = IWebTokenRequest_Vtbl;
@@ -717,7 +768,7 @@ impl WebTokenRequestResult {
     }
 }
 impl windows_core::RuntimeType for WebTokenRequestResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebTokenRequestResult>();
 }
 unsafe impl windows_core::Interface for WebTokenRequestResult {
     type Vtable = IWebTokenRequestResult_Vtbl;
@@ -804,7 +855,7 @@ impl WebTokenResponse {
     }
 }
 impl windows_core::RuntimeType for WebTokenResponse {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebTokenResponse>();
 }
 unsafe impl windows_core::Interface for WebTokenResponse {
     type Vtable = IWebTokenResponse_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IWebAccountClientView, IWebAccountClientView_Vtbl, 0xe7bd66ba_0bc7_4c66_bfd4_65d3082cbca8);
+impl windows_core::RuntimeType for IWebAccountClientView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountClientView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IWebAccountClientView_Vtbl {
     pub AccountPairwiseId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountClientViewFactory, IWebAccountClientViewFactory_Vtbl, 0x616d16a4_de22_4855_a326_06cebf2a3f23);
+impl windows_core::RuntimeType for IWebAccountClientViewFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountClientViewFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +20,9 @@ pub struct IWebAccountClientViewFactory_Vtbl {
     pub CreateWithPairwiseId: unsafe extern "system" fn(*mut core::ffi::c_void, WebAccountClientViewType, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountManagerStatics, IWebAccountManagerStatics_Vtbl, 0xb2e8e1a6_d49a_4032_84bf_1a2847747bf1);
+impl windows_core::RuntimeType for IWebAccountManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,12 +68,18 @@ pub struct IWebAccountManagerStatics_Vtbl {
     ClearWebAccountPictureAsync: usize,
 }
 windows_core::imp::define_interface!(IWebAccountManagerStatics2, IWebAccountManagerStatics2_Vtbl, 0x68a7a829_2d5f_4653_8bb0_bd2fa6bd2d87);
+impl windows_core::RuntimeType for IWebAccountManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PullCookiesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountManagerStatics3, IWebAccountManagerStatics3_Vtbl, 0xdd4523a6_8a4f_4aa2_b15e_03f550af1359);
+impl windows_core::RuntimeType for IWebAccountManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +101,9 @@ pub struct IWebAccountManagerStatics3_Vtbl {
     AddWebAccountWithScopeAndMapForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IWebAccountManagerStatics4, IWebAccountManagerStatics4_Vtbl, 0x59ebc2d2_f7db_412f_bc3f_f2fea04430b4);
+impl windows_core::RuntimeType for IWebAccountManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,6 +114,9 @@ pub struct IWebAccountManagerStatics4_Vtbl {
     InvalidateAppCacheForAccountAsync: usize,
 }
 windows_core::imp::define_interface!(IWebAccountMapManagerStatics, IWebAccountMapManagerStatics_Vtbl, 0xe8fa446f_3a1b_48a4_8e90_1e59ca6f54db);
+impl windows_core::RuntimeType for IWebAccountMapManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountMapManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +138,9 @@ pub struct IWebAccountMapManagerStatics_Vtbl {
     ClearPerUserFromPerAppAccountAsync: usize,
 }
 windows_core::imp::define_interface!(IWebAccountProviderAddAccountOperation, IWebAccountProviderAddAccountOperation_Vtbl, 0x73ebdccf_4378_4c79_9335_a5d7ab81594e);
+impl windows_core::RuntimeType for IWebAccountProviderAddAccountOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderAddAccountOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,6 +175,9 @@ pub struct IWebAccountProviderBaseReportOperation_Vtbl {
     ReportError: usize,
 }
 windows_core::imp::define_interface!(IWebAccountProviderDeleteAccountOperation, IWebAccountProviderDeleteAccountOperation_Vtbl, 0x0abb48b8_9e01_49c9_a355_7d48caf7d6ca);
+impl windows_core::RuntimeType for IWebAccountProviderDeleteAccountOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderDeleteAccountOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -160,6 +187,9 @@ pub struct IWebAccountProviderDeleteAccountOperation_Vtbl {
     WebAccount: usize,
 }
 windows_core::imp::define_interface!(IWebAccountProviderManageAccountOperation, IWebAccountProviderManageAccountOperation_Vtbl, 0xed20dc5c_d21b_463e_a9b7_c1fd0edae978);
+impl windows_core::RuntimeType for IWebAccountProviderManageAccountOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderManageAccountOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +219,9 @@ pub struct IWebAccountProviderOperation_Vtbl {
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WebAccountProviderOperationKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountProviderRetrieveCookiesOperation, IWebAccountProviderRetrieveCookiesOperation_Vtbl, 0x5a040441_0fa3_4ab1_a01c_20b110358594);
+impl windows_core::RuntimeType for IWebAccountProviderRetrieveCookiesOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderRetrieveCookiesOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -202,6 +235,9 @@ pub struct IWebAccountProviderRetrieveCookiesOperation_Vtbl {
     pub ApplicationCallbackUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountProviderSignOutAccountOperation, IWebAccountProviderSignOutAccountOperation_Vtbl, 0xb890e21d_0c55_47bc_8c72_04a6fc7cac07);
+impl windows_core::RuntimeType for IWebAccountProviderSignOutAccountOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderSignOutAccountOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -385,6 +421,9 @@ pub struct IWebAccountProviderUIReportOperation_Vtbl {
     pub ReportUserCanceled: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountScopeManagerStatics, IWebAccountScopeManagerStatics_Vtbl, 0x5c6ce37c_12b2_423a_bf3d_85b8d7e53656);
+impl windows_core::RuntimeType for IWebAccountScopeManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountScopeManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -402,6 +441,9 @@ pub struct IWebAccountScopeManagerStatics_Vtbl {
     GetScope: usize,
 }
 windows_core::imp::define_interface!(IWebProviderTokenRequest, IWebProviderTokenRequest_Vtbl, 0x1e18778b_8805_454b_9f11_468d2af1095a);
+impl windows_core::RuntimeType for IWebProviderTokenRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebProviderTokenRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -421,6 +463,9 @@ pub struct IWebProviderTokenRequest_Vtbl {
     GetApplicationTokenBindingKeyAsync: usize,
 }
 windows_core::imp::define_interface!(IWebProviderTokenRequest2, IWebProviderTokenRequest2_Vtbl, 0xb5d72e4c_10b1_4aa6_88b1_0b6c9e0c1e46);
+impl windows_core::RuntimeType for IWebProviderTokenRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebProviderTokenRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -430,6 +475,9 @@ pub struct IWebProviderTokenRequest2_Vtbl {
     GetApplicationTokenBindingKeyIdAsync: usize,
 }
 windows_core::imp::define_interface!(IWebProviderTokenRequest3, IWebProviderTokenRequest3_Vtbl, 0x1b2716aa_4289_446e_9256_dafb6f66a51e);
+impl windows_core::RuntimeType for IWebProviderTokenRequest3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebProviderTokenRequest3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -438,6 +486,9 @@ pub struct IWebProviderTokenRequest3_Vtbl {
     pub CheckApplicationForCapabilityAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebProviderTokenResponse, IWebProviderTokenResponse_Vtbl, 0xef213793_ef55_4186_b7ce_8cb2e7f9849e);
+impl windows_core::RuntimeType for IWebProviderTokenResponse {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebProviderTokenResponse_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -447,6 +498,9 @@ pub struct IWebProviderTokenResponse_Vtbl {
     ClientResponse: usize,
 }
 windows_core::imp::define_interface!(IWebProviderTokenResponseFactory, IWebProviderTokenResponseFactory_Vtbl, 0xfa49d99a_25ba_4077_9cfa_9db4dea7b71a);
+impl windows_core::RuntimeType for IWebProviderTokenResponseFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebProviderTokenResponseFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -506,7 +560,7 @@ impl WebAccountClientView {
     }
 }
 impl windows_core::RuntimeType for WebAccountClientView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountClientView>();
 }
 unsafe impl windows_core::Interface for WebAccountClientView {
     type Vtable = IWebAccountClientView_Vtbl;
@@ -809,7 +863,7 @@ impl WebAccountProviderAddAccountOperation {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderAddAccountOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderAddAccountOperation>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderAddAccountOperation {
     type Vtable = IWebAccountProviderAddAccountOperation_Vtbl;
@@ -855,7 +909,7 @@ impl WebAccountProviderDeleteAccountOperation {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderDeleteAccountOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderDeleteAccountOperation>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderDeleteAccountOperation {
     type Vtable = IWebAccountProviderDeleteAccountOperation_Vtbl;
@@ -931,7 +985,7 @@ impl WebAccountProviderGetTokenSilentOperation {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderGetTokenSilentOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderTokenOperation>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderGetTokenSilentOperation {
     type Vtable = IWebAccountProviderTokenOperation_Vtbl;
@@ -969,7 +1023,7 @@ impl WebAccountProviderManageAccountOperation {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderManageAccountOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderManageAccountOperation>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderManageAccountOperation {
     type Vtable = IWebAccountProviderManageAccountOperation_Vtbl;
@@ -1037,7 +1091,7 @@ impl WebAccountProviderRequestTokenOperation {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderRequestTokenOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderTokenOperation>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderRequestTokenOperation {
     type Vtable = IWebAccountProviderTokenOperation_Vtbl;
@@ -1111,7 +1165,7 @@ impl WebAccountProviderRetrieveCookiesOperation {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderRetrieveCookiesOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderRetrieveCookiesOperation>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderRetrieveCookiesOperation {
     type Vtable = IWebAccountProviderRetrieveCookiesOperation_Vtbl;
@@ -1171,7 +1225,7 @@ impl WebAccountProviderSignOutAccountOperation {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderSignOutAccountOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderSignOutAccountOperation>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderSignOutAccountOperation {
     type Vtable = IWebAccountProviderSignOutAccountOperation_Vtbl;
@@ -1205,7 +1259,7 @@ impl WebAccountProviderTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderTokenObjects>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderTriggerDetails {
     type Vtable = IWebAccountProviderTokenObjects_Vtbl;
@@ -1296,7 +1350,7 @@ impl WebProviderTokenRequest {
     }
 }
 impl windows_core::RuntimeType for WebProviderTokenRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebProviderTokenRequest>();
 }
 unsafe impl windows_core::Interface for WebProviderTokenRequest {
     type Vtable = IWebProviderTokenRequest_Vtbl;
@@ -1337,7 +1391,7 @@ impl WebProviderTokenResponse {
     }
 }
 impl windows_core::RuntimeType for WebProviderTokenResponse {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebProviderTokenResponse>();
 }
 unsafe impl windows_core::Interface for WebProviderTokenResponse {
     type Vtable = IWebProviderTokenResponse_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
@@ -3,6 +3,9 @@ pub mod Core;
 #[cfg(feature = "Security_Authentication_Web_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IWebAuthenticationBrokerStatics, IWebAuthenticationBrokerStatics_Vtbl, 0x2f149f1a_e673_40b5_bc22_201a6864a37b);
+impl windows_core::RuntimeType for IWebAuthenticationBrokerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationBrokerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IWebAuthenticationBrokerStatics_Vtbl {
     pub GetCurrentApplicationCallbackUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAuthenticationBrokerStatics2, IWebAuthenticationBrokerStatics2_Vtbl, 0x73cdfb9e_14e7_41da_a971_aaf4410b621e);
+impl windows_core::RuntimeType for IWebAuthenticationBrokerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationBrokerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,9 @@ pub struct IWebAuthenticationBrokerStatics2_Vtbl {
     pub AuthenticateSilentlyWithOptionsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, WebAuthenticationOptions, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAuthenticationResult, IWebAuthenticationResult_Vtbl, 0x64002b4b_ede9_470a_a5cd_0323faf6e262);
+impl windows_core::RuntimeType for IWebAuthenticationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAuthenticationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,7 +149,7 @@ impl WebAuthenticationResult {
     }
 }
 impl windows_core::RuntimeType for WebAuthenticationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAuthenticationResult>();
 }
 unsafe impl windows_core::Interface for WebAuthenticationResult {
     type Vtable = IWebAuthenticationResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAppCapability, IAppCapability_Vtbl, 0x4c49d915_8a2a_4295_9437_2df7c396aff4);
+impl windows_core::RuntimeType for IAppCapability {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCapability_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +16,9 @@ pub struct IAppCapability_Vtbl {
     pub RemoveAccessChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCapability2, IAppCapability2_Vtbl, 0x11c7ccb6_c74f_50a3_b960_88008767d939);
+impl windows_core::RuntimeType for IAppCapability2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCapability2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,11 +26,17 @@ pub struct IAppCapability2_Vtbl {
     pub SetDisplayMessage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppCapabilityAccessChangedEventArgs, IAppCapabilityAccessChangedEventArgs_Vtbl, 0x0a578d15_bdd7_457e_8cca_6f53bd2e5944);
+impl windows_core::RuntimeType for IAppCapabilityAccessChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCapabilityAccessChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IAppCapabilityStatics, IAppCapabilityStatics_Vtbl, 0x7c353e2a_46ee_44e5_af3d_6ad3fc49bd22);
+impl windows_core::RuntimeType for IAppCapabilityStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppCapabilityStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,7 +157,7 @@ impl AppCapability {
     }
 }
 impl windows_core::RuntimeType for AppCapability {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCapability>();
 }
 unsafe impl windows_core::Interface for AppCapability {
     type Vtable = IAppCapability_Vtbl;
@@ -162,7 +174,7 @@ pub struct AppCapabilityAccessChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AppCapabilityAccessChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl AppCapabilityAccessChangedEventArgs {}
 impl windows_core::RuntimeType for AppCapabilityAccessChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppCapabilityAccessChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppCapabilityAccessChangedEventArgs {
     type Vtable = IAppCapabilityAccessChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICredentialPickerOptions, ICredentialPickerOptions_Vtbl, 0x965a0b4c_95fa_467f_992b_0b22e5859bf6);
+impl windows_core::RuntimeType for ICredentialPickerOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICredentialPickerOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +33,9 @@ pub struct ICredentialPickerOptions_Vtbl {
     pub CredentialSaveOption: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CredentialSaveOption) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICredentialPickerResults, ICredentialPickerResults_Vtbl, 0x1948f99a_cc30_410c_9c38_cc0884c5b3d7);
+impl windows_core::RuntimeType for ICredentialPickerResults {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICredentialPickerResults_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +51,9 @@ pub struct ICredentialPickerResults_Vtbl {
     pub CredentialPassword: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICredentialPickerStatics, ICredentialPickerStatics_Vtbl, 0xaa3a5c73_c9ea_4782_99fb_e6d7e938e12d);
+impl windows_core::RuntimeType for ICredentialPickerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICredentialPickerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +62,9 @@ pub struct ICredentialPickerStatics_Vtbl {
     pub PickWithCaptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserConsentVerifierStatics, IUserConsentVerifierStatics_Vtbl, 0xaf4f3f91_564c_4ddc_b8b5_973447627c65);
+impl windows_core::RuntimeType for IUserConsentVerifierStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserConsentVerifierStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -220,7 +232,7 @@ impl CredentialPickerOptions {
     }
 }
 impl windows_core::RuntimeType for CredentialPickerOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICredentialPickerOptions>();
 }
 unsafe impl windows_core::Interface for CredentialPickerOptions {
     type Vtable = ICredentialPickerOptions_Vtbl;
@@ -286,7 +298,7 @@ impl CredentialPickerResults {
     }
 }
 impl windows_core::RuntimeType for CredentialPickerResults {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICredentialPickerResults>();
 }
 unsafe impl windows_core::Interface for CredentialPickerResults {
     type Vtable = ICredentialPickerResults_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
@@ -1,12 +1,18 @@
 #[cfg(feature = "Security_Credentials_UI")]
 pub mod UI;
 windows_core::imp::define_interface!(ICredentialFactory, ICredentialFactory_Vtbl, 0x54ef13a1_bf26_47b5_97dd_de779b7cad58);
+impl windows_core::RuntimeType for ICredentialFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICredentialFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreatePasswordCredential: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyCredential, IKeyCredential_Vtbl, 0x9585ef8d_457b_4847_b11a_fa960bbdb138);
+impl windows_core::RuntimeType for IKeyCredential {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyCredential_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +32,9 @@ pub struct IKeyCredential_Vtbl {
     pub GetAttestationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyCredentialAttestationResult, IKeyCredentialAttestationResult_Vtbl, 0x78aab3a1_a3c1_4103_b6cc_472c44171cbb);
+impl windows_core::RuntimeType for IKeyCredentialAttestationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyCredentialAttestationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +49,9 @@ pub struct IKeyCredentialAttestationResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut KeyCredentialAttestationStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyCredentialManagerStatics, IKeyCredentialManagerStatics_Vtbl, 0x6aac468b_0ef1_4ce0_8290_4106da6a63b5);
+impl windows_core::RuntimeType for IKeyCredentialManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyCredentialManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +62,9 @@ pub struct IKeyCredentialManagerStatics_Vtbl {
     pub DeleteAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyCredentialOperationResult, IKeyCredentialOperationResult_Vtbl, 0xf53786c1_5261_4cdd_976d_cc909ac71620);
+impl windows_core::RuntimeType for IKeyCredentialOperationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyCredentialOperationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +75,9 @@ pub struct IKeyCredentialOperationResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut KeyCredentialStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyCredentialRetrievalResult, IKeyCredentialRetrievalResult_Vtbl, 0x58cd7703_8d87_4249_9b58_f6598cc9644e);
+impl windows_core::RuntimeType for IKeyCredentialRetrievalResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyCredentialRetrievalResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +85,9 @@ pub struct IKeyCredentialRetrievalResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut KeyCredentialStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPasswordCredential, IPasswordCredential_Vtbl, 0x6ab18989_c720_41a7_a6c1_feadb36329a0);
+impl windows_core::RuntimeType for IPasswordCredential {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPasswordCredential_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,6 +104,9 @@ pub struct IPasswordCredential_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(IPasswordVault, IPasswordVault_Vtbl, 0x61fd2c0b_c8d4_48c1_a54f_bc5a64205af2);
+impl windows_core::RuntimeType for IPasswordVault {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPasswordVault_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -138,6 +162,9 @@ pub struct IWebAccount_Vtbl {
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WebAccountState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccount2, IWebAccount2_Vtbl, 0x7b56d6f8_990b_4eb5_94a7_5621f3a8b824);
+impl windows_core::RuntimeType for IWebAccount2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccount2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,12 +181,18 @@ pub struct IWebAccount2_Vtbl {
     pub SignOutWithClientIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountFactory, IWebAccountFactory_Vtbl, 0xac9afb39_1de9_4e92_b78f_0581a87f6e5c);
+impl windows_core::RuntimeType for IWebAccountFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWebAccount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, WebAccountState, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountProvider, IWebAccountProvider_Vtbl, 0x29dcc8c3_7ab9_4a7c_a336_b942f9dbf7c7);
+impl windows_core::RuntimeType for IWebAccountProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -171,6 +204,9 @@ pub struct IWebAccountProvider_Vtbl {
     IconUri: usize,
 }
 windows_core::imp::define_interface!(IWebAccountProvider2, IWebAccountProvider2_Vtbl, 0x4a01eb05_4e42_41d4_b518_e008a5163614);
+impl windows_core::RuntimeType for IWebAccountProvider2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProvider2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +214,9 @@ pub struct IWebAccountProvider2_Vtbl {
     pub Authority: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountProvider3, IWebAccountProvider3_Vtbl, 0xda1c518b_970d_4d49_825c_f2706f8ca7fe);
+impl windows_core::RuntimeType for IWebAccountProvider3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProvider3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -187,12 +226,18 @@ pub struct IWebAccountProvider3_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IWebAccountProvider4, IWebAccountProvider4_Vtbl, 0x718fd8db_e796_4210_b74e_84d29894b080);
+impl windows_core::RuntimeType for IWebAccountProvider4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProvider4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSystemProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountProviderFactory, IWebAccountProviderFactory_Vtbl, 0x1d767df1_e1e1_4b9a_a774_5c7c7e3bf371);
+impl windows_core::RuntimeType for IWebAccountProviderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -246,7 +291,7 @@ impl KeyCredential {
     }
 }
 impl windows_core::RuntimeType for KeyCredential {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyCredential>();
 }
 unsafe impl windows_core::Interface for KeyCredential {
     type Vtable = IKeyCredential_Vtbl;
@@ -287,7 +332,7 @@ impl KeyCredentialAttestationResult {
     }
 }
 impl windows_core::RuntimeType for KeyCredentialAttestationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyCredentialAttestationResult>();
 }
 unsafe impl windows_core::Interface for KeyCredentialAttestationResult {
     type Vtable = IKeyCredentialAttestationResult_Vtbl;
@@ -361,7 +406,7 @@ impl KeyCredentialOperationResult {
     }
 }
 impl windows_core::RuntimeType for KeyCredentialOperationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyCredentialOperationResult>();
 }
 unsafe impl windows_core::Interface for KeyCredentialOperationResult {
     type Vtable = IKeyCredentialOperationResult_Vtbl;
@@ -393,7 +438,7 @@ impl KeyCredentialRetrievalResult {
     }
 }
 impl windows_core::RuntimeType for KeyCredentialRetrievalResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyCredentialRetrievalResult>();
 }
 unsafe impl windows_core::Interface for KeyCredentialRetrievalResult {
     type Vtable = IKeyCredentialRetrievalResult_Vtbl;
@@ -474,7 +519,7 @@ impl PasswordCredential {
     }
 }
 impl windows_core::RuntimeType for PasswordCredential {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPasswordCredential>();
 }
 unsafe impl windows_core::Interface for PasswordCredential {
     type Vtable = IPasswordCredential_Vtbl;
@@ -582,7 +627,7 @@ impl PasswordCredentialPropertyStore {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for PasswordCredentialPropertyStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IPropertySet>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for PasswordCredentialPropertyStore {
@@ -672,7 +717,7 @@ impl PasswordVault {
     }
 }
 impl windows_core::RuntimeType for PasswordVault {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPasswordVault>();
 }
 unsafe impl windows_core::Interface for PasswordVault {
     type Vtable = IPasswordVault_Vtbl;
@@ -763,7 +808,7 @@ impl WebAccount {
     }
 }
 impl windows_core::RuntimeType for WebAccount {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccount>();
 }
 unsafe impl windows_core::Interface for WebAccount {
     type Vtable = IWebAccount_Vtbl;
@@ -846,7 +891,7 @@ impl WebAccountProvider {
     }
 }
 impl windows_core::RuntimeType for WebAccountProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProvider>();
 }
 unsafe impl windows_core::Interface for WebAccountProvider {
     type Vtable = IWebAccountProvider_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICertificate, ICertificate_Vtbl, 0x333f740c_04d8_43b3_b278_8c5fcc9be5a0);
+impl windows_core::RuntimeType for ICertificate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +34,9 @@ pub struct ICertificate_Vtbl {
     pub FriendlyName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificate2, ICertificate2_Vtbl, 0x17b8374c_8a25_4d96_a492_8fc29ac4fda6);
+impl windows_core::RuntimeType for ICertificate2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificate2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +48,9 @@ pub struct ICertificate2_Vtbl {
     pub SubjectAlternativeName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificate3, ICertificate3_Vtbl, 0xbe51a966_ae5f_4652_ace7_c6d7e7724cf3);
+impl windows_core::RuntimeType for ICertificate3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificate3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +59,9 @@ pub struct ICertificate3_Vtbl {
     pub KeyStorageProviderName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateChain, ICertificateChain_Vtbl, 0x20bf5385_3691_4501_a62c_fd97278b31ee);
+impl windows_core::RuntimeType for ICertificateChain {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateChain_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +73,9 @@ pub struct ICertificateChain_Vtbl {
     GetCertificates: usize,
 }
 windows_core::imp::define_interface!(ICertificateEnrollmentManagerStatics, ICertificateEnrollmentManagerStatics_Vtbl, 0x8846ef3f_a986_48fb_9fd7_9aec06935bf1);
+impl windows_core::RuntimeType for ICertificateEnrollmentManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateEnrollmentManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +84,9 @@ pub struct ICertificateEnrollmentManagerStatics_Vtbl {
     pub ImportPfxDataAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, ExportOption, KeyProtectionLevel, InstallOptions, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateEnrollmentManagerStatics2, ICertificateEnrollmentManagerStatics2_Vtbl, 0xdc5b1c33_6429_4014_999c_5d9735802d1d);
+impl windows_core::RuntimeType for ICertificateEnrollmentManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateEnrollmentManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,12 +94,18 @@ pub struct ICertificateEnrollmentManagerStatics2_Vtbl {
     pub ImportPfxDataToKspAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, ExportOption, KeyProtectionLevel, InstallOptions, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateEnrollmentManagerStatics3, ICertificateEnrollmentManagerStatics3_Vtbl, 0xfdec82be_617c_425a_b72d_398b26ac7264);
+impl windows_core::RuntimeType for ICertificateEnrollmentManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateEnrollmentManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ImportPfxDataToKspWithParametersAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateExtension, ICertificateExtension_Vtbl, 0x84cf0656_a9e6_454d_8e45_2ea7c4bcd53b);
+impl windows_core::RuntimeType for ICertificateExtension {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateExtension_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +118,9 @@ pub struct ICertificateExtension_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateFactory, ICertificateFactory_Vtbl, 0x17b4221c_4baf_44a2_9608_04fb62b16942);
+impl windows_core::RuntimeType for ICertificateFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,6 +130,9 @@ pub struct ICertificateFactory_Vtbl {
     CreateCertificate: usize,
 }
 windows_core::imp::define_interface!(ICertificateKeyUsages, ICertificateKeyUsages_Vtbl, 0x6ac6206f_e1cf_486a_b485_a69c83e46fd1);
+impl windows_core::RuntimeType for ICertificateKeyUsages {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateKeyUsages_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +154,9 @@ pub struct ICertificateKeyUsages_Vtbl {
     pub SetDigitalSignature: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateQuery, ICertificateQuery_Vtbl, 0x5b082a31_a728_4916_b5ee_ffcb8acf2417);
+impl windows_core::RuntimeType for ICertificateQuery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateQuery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,6 +174,9 @@ pub struct ICertificateQuery_Vtbl {
     pub SetHardwareOnly: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateQuery2, ICertificateQuery2_Vtbl, 0x935a0af7_0bd9_4f75_b8c2_e27a7f74eecd);
+impl windows_core::RuntimeType for ICertificateQuery2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateQuery2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,6 +188,9 @@ pub struct ICertificateQuery2_Vtbl {
     pub SetStoreName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateRequestProperties, ICertificateRequestProperties_Vtbl, 0x487e84f6_94e2_4dce_8833_1a700a37a29a);
+impl windows_core::RuntimeType for ICertificateRequestProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateRequestProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,6 +214,9 @@ pub struct ICertificateRequestProperties_Vtbl {
     pub SetKeyStorageProviderName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateRequestProperties2, ICertificateRequestProperties2_Vtbl, 0x3da0c954_d73f_4ff3_a0a6_0677c0ada05b);
+impl windows_core::RuntimeType for ICertificateRequestProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateRequestProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -186,6 +228,9 @@ pub struct ICertificateRequestProperties2_Vtbl {
     pub SetAttestationCredentialCertificate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateRequestProperties3, ICertificateRequestProperties3_Vtbl, 0xe687f616_734d_46b1_9d4c_6edfdbfc845b);
+impl windows_core::RuntimeType for ICertificateRequestProperties3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateRequestProperties3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -201,6 +246,9 @@ pub struct ICertificateRequestProperties3_Vtbl {
     pub SetUseExistingKey: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateRequestProperties4, ICertificateRequestProperties4_Vtbl, 0x4e429ad2_1c61_4fea_b8fe_135fb19cdce4);
+impl windows_core::RuntimeType for ICertificateRequestProperties4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateRequestProperties4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -215,6 +263,9 @@ pub struct ICertificateRequestProperties4_Vtbl {
     Extensions: usize,
 }
 windows_core::imp::define_interface!(ICertificateStore, ICertificateStore_Vtbl, 0xb0bff720_344e_4331_af14_a7f7a7ebc93a);
+impl windows_core::RuntimeType for ICertificateStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,12 +273,18 @@ pub struct ICertificateStore_Vtbl {
     pub Delete: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateStore2, ICertificateStore2_Vtbl, 0xc7e68e4a_417d_4d1a_babd_15687e549974);
+impl windows_core::RuntimeType for ICertificateStore2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateStore2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Name: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateStoresStatics, ICertificateStoresStatics_Vtbl, 0xfbecc739_c6fe_4de7_99cf_74c3e596e032);
+impl windows_core::RuntimeType for ICertificateStoresStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateStoresStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -244,12 +301,18 @@ pub struct ICertificateStoresStatics_Vtbl {
     pub GetStoreByName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICertificateStoresStatics2, ICertificateStoresStatics2_Vtbl, 0xfa900b79_a0d4_4b8c_bc55_c0a37eb141ed);
+impl windows_core::RuntimeType for ICertificateStoresStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICertificateStoresStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetUserStoreByName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IChainBuildingParameters, IChainBuildingParameters_Vtbl, 0x422ba922_7c8d_47b7_b59b_b12703733ac3);
+impl windows_core::RuntimeType for IChainBuildingParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChainBuildingParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -273,6 +336,9 @@ pub struct IChainBuildingParameters_Vtbl {
     ExclusiveTrustRoots: usize,
 }
 windows_core::imp::define_interface!(IChainValidationParameters, IChainValidationParameters_Vtbl, 0xc4743b4a_7eb0_4b56_a040_b9c8e655ddf3);
+impl windows_core::RuntimeType for IChainValidationParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IChainValidationParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -288,6 +354,9 @@ pub struct IChainValidationParameters_Vtbl {
     SetServerDnsName: usize,
 }
 windows_core::imp::define_interface!(ICmsAttachedSignature, ICmsAttachedSignature_Vtbl, 0x61899d9d_3757_4ecb_bddc_0ca357d7a936);
+impl windows_core::RuntimeType for ICmsAttachedSignature {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsAttachedSignature_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -303,6 +372,9 @@ pub struct ICmsAttachedSignature_Vtbl {
     pub VerifySignature: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SignatureValidationResult) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICmsAttachedSignatureFactory, ICmsAttachedSignatureFactory_Vtbl, 0xd0c8fc15_f757_4c64_a362_52cc1c77cffb);
+impl windows_core::RuntimeType for ICmsAttachedSignatureFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsAttachedSignatureFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,6 +384,9 @@ pub struct ICmsAttachedSignatureFactory_Vtbl {
     CreateCmsAttachedSignature: usize,
 }
 windows_core::imp::define_interface!(ICmsAttachedSignatureStatics, ICmsAttachedSignatureStatics_Vtbl, 0x87989c8e_b0ad_498d_a7f5_78b59bce4b36);
+impl windows_core::RuntimeType for ICmsAttachedSignatureStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsAttachedSignatureStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -321,6 +396,9 @@ pub struct ICmsAttachedSignatureStatics_Vtbl {
     GenerateSignatureAsync: usize,
 }
 windows_core::imp::define_interface!(ICmsDetachedSignature, ICmsDetachedSignature_Vtbl, 0x0f1ef154_f65e_4536_8339_5944081db2ca);
+impl windows_core::RuntimeType for ICmsDetachedSignature {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsDetachedSignature_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -338,6 +416,9 @@ pub struct ICmsDetachedSignature_Vtbl {
     VerifySignatureAsync: usize,
 }
 windows_core::imp::define_interface!(ICmsDetachedSignatureFactory, ICmsDetachedSignatureFactory_Vtbl, 0xc4ab3503_ae7f_4387_ad19_00f150e48ebb);
+impl windows_core::RuntimeType for ICmsDetachedSignatureFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsDetachedSignatureFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -347,6 +428,9 @@ pub struct ICmsDetachedSignatureFactory_Vtbl {
     CreateCmsDetachedSignature: usize,
 }
 windows_core::imp::define_interface!(ICmsDetachedSignatureStatics, ICmsDetachedSignatureStatics_Vtbl, 0x3d114cfd_bf9b_4682_9be6_91f57c053808);
+impl windows_core::RuntimeType for ICmsDetachedSignatureStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsDetachedSignatureStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -356,6 +440,9 @@ pub struct ICmsDetachedSignatureStatics_Vtbl {
     GenerateSignatureAsync: usize,
 }
 windows_core::imp::define_interface!(ICmsSignerInfo, ICmsSignerInfo_Vtbl, 0x50d020db_1d2f_4c1a_b5c5_d0188ff91f47);
+impl windows_core::RuntimeType for ICmsSignerInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsSignerInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -366,6 +453,9 @@ pub struct ICmsSignerInfo_Vtbl {
     pub TimestampInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICmsTimestampInfo, ICmsTimestampInfo_Vtbl, 0x2f5f00f2_2c18_4f88_8435_c534086076f5);
+impl windows_core::RuntimeType for ICmsTimestampInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICmsTimestampInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -377,6 +467,9 @@ pub struct ICmsTimestampInfo_Vtbl {
     pub Timestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyAlgorithmNamesStatics, IKeyAlgorithmNamesStatics_Vtbl, 0x479065d7_7ac7_4581_8c3b_d07027140448);
+impl windows_core::RuntimeType for IKeyAlgorithmNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyAlgorithmNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -390,6 +483,9 @@ pub struct IKeyAlgorithmNamesStatics_Vtbl {
     pub Ecdsa521: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyAlgorithmNamesStatics2, IKeyAlgorithmNamesStatics2_Vtbl, 0xc99b5686_e1fd_4a4a_893d_a26f33dd8bb4);
+impl windows_core::RuntimeType for IKeyAlgorithmNamesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyAlgorithmNamesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -397,6 +493,9 @@ pub struct IKeyAlgorithmNamesStatics2_Vtbl {
     pub Ecdh: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyAttestationHelperStatics, IKeyAttestationHelperStatics_Vtbl, 0x1648e246_f644_4326_88be_3af102d30e0c);
+impl windows_core::RuntimeType for IKeyAttestationHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyAttestationHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -404,12 +503,18 @@ pub struct IKeyAttestationHelperStatics_Vtbl {
     pub GetTpmAttestationCredentialId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyAttestationHelperStatics2, IKeyAttestationHelperStatics2_Vtbl, 0x9c590b2c_a6c6_4a5e_9e64_e85d5279df97);
+impl windows_core::RuntimeType for IKeyAttestationHelperStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyAttestationHelperStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DecryptTpmAttestationCredentialWithContainerNameAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyStorageProviderNamesStatics, IKeyStorageProviderNamesStatics_Vtbl, 0xaf186ae0_5529_4602_bd94_0aab91957b5c);
+impl windows_core::RuntimeType for IKeyStorageProviderNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyStorageProviderNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -418,12 +523,18 @@ pub struct IKeyStorageProviderNamesStatics_Vtbl {
     pub PlatformKeyStorageProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyStorageProviderNamesStatics2, IKeyStorageProviderNamesStatics2_Vtbl, 0x262d743d_9c2e_41cc_8812_c4d971dd7c60);
+impl windows_core::RuntimeType for IKeyStorageProviderNamesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyStorageProviderNamesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PassportKeyStorageProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPfxImportParameters, IPfxImportParameters_Vtbl, 0x680d3511_9a08_47c8_864a_2edd4d8eb46c);
+impl windows_core::RuntimeType for IPfxImportParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPfxImportParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -443,6 +554,9 @@ pub struct IPfxImportParameters_Vtbl {
     pub SetReaderName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStandardCertificateStoreNamesStatics, IStandardCertificateStoreNamesStatics_Vtbl, 0x0c154adb_a496_41f8_8fe5_9e96f36efbf8);
+impl windows_core::RuntimeType for IStandardCertificateStoreNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStandardCertificateStoreNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -451,6 +565,9 @@ pub struct IStandardCertificateStoreNamesStatics_Vtbl {
     pub IntermediateCertificationAuthorities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISubjectAlternativeNameInfo, ISubjectAlternativeNameInfo_Vtbl, 0x582859f1_569d_4c20_be7b_4e1c9a0bc52b);
+impl windows_core::RuntimeType for ISubjectAlternativeNameInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISubjectAlternativeNameInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -480,6 +597,9 @@ pub struct ISubjectAlternativeNameInfo_Vtbl {
     PrincipalName: usize,
 }
 windows_core::imp::define_interface!(ISubjectAlternativeNameInfo2, ISubjectAlternativeNameInfo2_Vtbl, 0x437a78c6_1c51_41ea_b34a_3d654398a370);
+impl windows_core::RuntimeType for ISubjectAlternativeNameInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISubjectAlternativeNameInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -510,6 +630,9 @@ pub struct ISubjectAlternativeNameInfo2_Vtbl {
     pub Extension: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserCertificateEnrollmentManager, IUserCertificateEnrollmentManager_Vtbl, 0x96313718_22e1_4819_b20b_ab46a6eca06e);
+impl windows_core::RuntimeType for IUserCertificateEnrollmentManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserCertificateEnrollmentManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -519,12 +642,18 @@ pub struct IUserCertificateEnrollmentManager_Vtbl {
     pub ImportPfxDataToKspAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, ExportOption, KeyProtectionLevel, InstallOptions, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserCertificateEnrollmentManager2, IUserCertificateEnrollmentManager2_Vtbl, 0x0dad9cb1_65de_492a_b86d_fc5c482c3747);
+impl windows_core::RuntimeType for IUserCertificateEnrollmentManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserCertificateEnrollmentManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ImportPfxDataToKspWithParametersAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserCertificateStore, IUserCertificateStore_Vtbl, 0xc9fb1d83_789f_4b4e_9180_045a757aac6d);
+impl windows_core::RuntimeType for IUserCertificateStore {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserCertificateStore_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -730,7 +859,7 @@ impl Certificate {
     }
 }
 impl windows_core::RuntimeType for Certificate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICertificate>();
 }
 unsafe impl windows_core::Interface for Certificate {
     type Vtable = ICertificate_Vtbl;
@@ -773,7 +902,7 @@ impl CertificateChain {
     }
 }
 impl windows_core::RuntimeType for CertificateChain {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICertificateChain>();
 }
 unsafe impl windows_core::Interface for CertificateChain {
     type Vtable = ICertificateChain_Vtbl;
@@ -898,7 +1027,7 @@ impl CertificateExtension {
     }
 }
 impl windows_core::RuntimeType for CertificateExtension {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICertificateExtension>();
 }
 unsafe impl windows_core::Interface for CertificateExtension {
     type Vtable = ICertificateExtension_Vtbl;
@@ -1011,7 +1140,7 @@ impl CertificateKeyUsages {
     }
 }
 impl windows_core::RuntimeType for CertificateKeyUsages {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICertificateKeyUsages>();
 }
 unsafe impl windows_core::Interface for CertificateKeyUsages {
     type Vtable = ICertificateKeyUsages_Vtbl;
@@ -1121,7 +1250,7 @@ impl CertificateQuery {
     }
 }
 impl windows_core::RuntimeType for CertificateQuery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICertificateQuery>();
 }
 unsafe impl windows_core::Interface for CertificateQuery {
     type Vtable = ICertificateQuery_Vtbl;
@@ -1362,7 +1491,7 @@ impl CertificateRequestProperties {
     }
 }
 impl windows_core::RuntimeType for CertificateRequestProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICertificateRequestProperties>();
 }
 unsafe impl windows_core::Interface for CertificateRequestProperties {
     type Vtable = ICertificateRequestProperties_Vtbl;
@@ -1401,7 +1530,7 @@ impl CertificateStore {
     }
 }
 impl windows_core::RuntimeType for CertificateStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICertificateStore>();
 }
 unsafe impl windows_core::Interface for CertificateStore {
     type Vtable = ICertificateStore_Vtbl;
@@ -1554,7 +1683,7 @@ impl ChainBuildingParameters {
     }
 }
 impl windows_core::RuntimeType for ChainBuildingParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChainBuildingParameters>();
 }
 unsafe impl windows_core::Interface for ChainBuildingParameters {
     type Vtable = IChainBuildingParameters_Vtbl;
@@ -1606,7 +1735,7 @@ impl ChainValidationParameters {
     }
 }
 impl windows_core::RuntimeType for ChainValidationParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IChainValidationParameters>();
 }
 unsafe impl windows_core::Interface for ChainValidationParameters {
     type Vtable = IChainValidationParameters_Vtbl;
@@ -1686,7 +1815,7 @@ impl CmsAttachedSignature {
     }
 }
 impl windows_core::RuntimeType for CmsAttachedSignature {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICmsAttachedSignature>();
 }
 unsafe impl windows_core::Interface for CmsAttachedSignature {
     type Vtable = ICmsAttachedSignature_Vtbl;
@@ -1763,7 +1892,7 @@ impl CmsDetachedSignature {
     }
 }
 impl windows_core::RuntimeType for CmsDetachedSignature {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICmsDetachedSignature>();
 }
 unsafe impl windows_core::Interface for CmsDetachedSignature {
     type Vtable = ICmsDetachedSignature_Vtbl;
@@ -1820,7 +1949,7 @@ impl CmsSignerInfo {
     }
 }
 impl windows_core::RuntimeType for CmsSignerInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICmsSignerInfo>();
 }
 unsafe impl windows_core::Interface for CmsSignerInfo {
     type Vtable = ICmsSignerInfo_Vtbl;
@@ -1860,7 +1989,7 @@ impl CmsTimestampInfo {
     }
 }
 impl windows_core::RuntimeType for CmsTimestampInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICmsTimestampInfo>();
 }
 unsafe impl windows_core::Interface for CmsTimestampInfo {
     type Vtable = ICmsTimestampInfo_Vtbl;
@@ -2112,7 +2241,7 @@ impl PfxImportParameters {
     }
 }
 impl windows_core::RuntimeType for PfxImportParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPfxImportParameters>();
 }
 unsafe impl windows_core::Interface for PfxImportParameters {
     type Vtable = IPfxImportParameters_Vtbl;
@@ -2269,7 +2398,7 @@ impl SubjectAlternativeNameInfo {
     }
 }
 impl windows_core::RuntimeType for SubjectAlternativeNameInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISubjectAlternativeNameInfo>();
 }
 unsafe impl windows_core::Interface for SubjectAlternativeNameInfo {
     type Vtable = ISubjectAlternativeNameInfo_Vtbl;
@@ -2328,7 +2457,7 @@ impl UserCertificateEnrollmentManager {
     }
 }
 impl windows_core::RuntimeType for UserCertificateEnrollmentManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserCertificateEnrollmentManager>();
 }
 unsafe impl windows_core::Interface for UserCertificateEnrollmentManager {
     type Vtable = IUserCertificateEnrollmentManager_Vtbl;
@@ -2373,7 +2502,7 @@ impl UserCertificateStore {
     }
 }
 impl windows_core::RuntimeType for UserCertificateStore {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserCertificateStore>();
 }
 unsafe impl windows_core::Interface for UserCertificateStore {
     type Vtable = IUserCertificateStore_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAsymmetricAlgorithmNamesStatics, IAsymmetricAlgorithmNamesStatics_Vtbl, 0xcaf6fce4_67c0_46aa_84f9_752e77449f9b);
+impl windows_core::RuntimeType for IAsymmetricAlgorithmNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAsymmetricAlgorithmNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +25,9 @@ pub struct IAsymmetricAlgorithmNamesStatics_Vtbl {
     pub RsaSignPssSha512: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAsymmetricAlgorithmNamesStatics2, IAsymmetricAlgorithmNamesStatics2_Vtbl, 0xf141c0d6_4bff_4f23_ba66_6045b137d5df);
+impl windows_core::RuntimeType for IAsymmetricAlgorithmNamesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAsymmetricAlgorithmNamesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +36,9 @@ pub struct IAsymmetricAlgorithmNamesStatics2_Vtbl {
     pub EcdsaSha512: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAsymmetricKeyAlgorithmProvider, IAsymmetricKeyAlgorithmProvider_Vtbl, 0xe8d2ff37_6259_4e88_b7e0_94191fde699e);
+impl windows_core::RuntimeType for IAsymmetricKeyAlgorithmProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAsymmetricKeyAlgorithmProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,6 +62,9 @@ pub struct IAsymmetricKeyAlgorithmProvider_Vtbl {
     ImportPublicKeyWithBlobType: usize,
 }
 windows_core::imp::define_interface!(IAsymmetricKeyAlgorithmProvider2, IAsymmetricKeyAlgorithmProvider2_Vtbl, 0x4e322a7e_7c4d_4997_ac4f_1b848b36306e);
+impl windows_core::RuntimeType for IAsymmetricKeyAlgorithmProvider2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAsymmetricKeyAlgorithmProvider2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,12 +72,18 @@ pub struct IAsymmetricKeyAlgorithmProvider2_Vtbl {
     pub CreateKeyPairWithCurveParameters: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAsymmetricKeyAlgorithmProviderStatics, IAsymmetricKeyAlgorithmProviderStatics_Vtbl, 0x425bde18_a7f3_47a6_a8d2_c48d6033a65c);
+impl windows_core::RuntimeType for IAsymmetricKeyAlgorithmProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAsymmetricKeyAlgorithmProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OpenAlgorithm: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICryptographicEngineStatics, ICryptographicEngineStatics_Vtbl, 0x9fea0639_6ff7_4c85_a095_95eb31715eb9);
+impl windows_core::RuntimeType for ICryptographicEngineStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICryptographicEngineStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +117,9 @@ pub struct ICryptographicEngineStatics_Vtbl {
     DeriveKeyMaterial: usize,
 }
 windows_core::imp::define_interface!(ICryptographicEngineStatics2, ICryptographicEngineStatics2_Vtbl, 0x675948fe_df9f_4191_92c7_6ce6f58420e0);
+impl windows_core::RuntimeType for ICryptographicEngineStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICryptographicEngineStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +145,9 @@ pub struct ICryptographicEngineStatics2_Vtbl {
     SignHashedDataAsync: usize,
 }
 windows_core::imp::define_interface!(ICryptographicKey, ICryptographicKey_Vtbl, 0xed2a3b70_8e7b_4009_8401_ffd1a62eeb27);
+impl windows_core::RuntimeType for ICryptographicKey {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICryptographicKey_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -146,6 +170,9 @@ pub struct ICryptographicKey_Vtbl {
     ExportPublicKeyWithBlobType: usize,
 }
 windows_core::imp::define_interface!(IEccCurveNamesStatics, IEccCurveNamesStatics_Vtbl, 0xb3ff930c_aeeb_409e_b7d4_9b95295aaecf);
+impl windows_core::RuntimeType for IEccCurveNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEccCurveNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -200,6 +227,9 @@ pub struct IEccCurveNamesStatics_Vtbl {
     AllEccCurveNames: usize,
 }
 windows_core::imp::define_interface!(IEncryptedAndAuthenticatedData, IEncryptedAndAuthenticatedData_Vtbl, 0x6fa42fe7_1ecb_4b00_bea5_60b83f862f17);
+impl windows_core::RuntimeType for IEncryptedAndAuthenticatedData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEncryptedAndAuthenticatedData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -213,6 +243,9 @@ pub struct IEncryptedAndAuthenticatedData_Vtbl {
     AuthenticationTag: usize,
 }
 windows_core::imp::define_interface!(IHashAlgorithmNamesStatics, IHashAlgorithmNamesStatics_Vtbl, 0x6b5e0516_de96_4f0a_8d57_dcc9dae36c76);
+impl windows_core::RuntimeType for IHashAlgorithmNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHashAlgorithmNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -223,6 +256,9 @@ pub struct IHashAlgorithmNamesStatics_Vtbl {
     pub Sha512: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHashAlgorithmProvider, IHashAlgorithmProvider_Vtbl, 0xbe9b3080_b2c3_422b_bce1_ec90efb5d7b5);
+impl windows_core::RuntimeType for IHashAlgorithmProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHashAlgorithmProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,12 +271,18 @@ pub struct IHashAlgorithmProvider_Vtbl {
     pub CreateHash: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHashAlgorithmProviderStatics, IHashAlgorithmProviderStatics_Vtbl, 0x9fac9741_5cc4_4336_ae38_6212b75a915a);
+impl windows_core::RuntimeType for IHashAlgorithmProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHashAlgorithmProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OpenAlgorithm: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHashComputation, IHashComputation_Vtbl, 0x5904d1b6_ad31_4603_a3a4_b1bda98e2562);
+impl windows_core::RuntimeType for IHashComputation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHashComputation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +296,9 @@ pub struct IHashComputation_Vtbl {
     GetValueAndReset: usize,
 }
 windows_core::imp::define_interface!(IKeyDerivationAlgorithmNamesStatics, IKeyDerivationAlgorithmNamesStatics_Vtbl, 0x7b6e363e_94d2_4739_a57b_022e0c3a402a);
+impl windows_core::RuntimeType for IKeyDerivationAlgorithmNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationAlgorithmNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +319,9 @@ pub struct IKeyDerivationAlgorithmNamesStatics_Vtbl {
     pub Sp80056aConcatSha512: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyDerivationAlgorithmNamesStatics2, IKeyDerivationAlgorithmNamesStatics2_Vtbl, 0x57953fab_6044_466f_97f4_337b7808384d);
+impl windows_core::RuntimeType for IKeyDerivationAlgorithmNamesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationAlgorithmNamesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -284,6 +332,9 @@ pub struct IKeyDerivationAlgorithmNamesStatics2_Vtbl {
     pub CapiKdfSha512: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyDerivationAlgorithmProvider, IKeyDerivationAlgorithmProvider_Vtbl, 0xe1fba83b_4671_43b7_9158_763aaa98b6bf);
+impl windows_core::RuntimeType for IKeyDerivationAlgorithmProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationAlgorithmProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,12 +345,18 @@ pub struct IKeyDerivationAlgorithmProvider_Vtbl {
     CreateKey: usize,
 }
 windows_core::imp::define_interface!(IKeyDerivationAlgorithmProviderStatics, IKeyDerivationAlgorithmProviderStatics_Vtbl, 0x0a22097a_0a1c_443b_9418_b9498aeb1603);
+impl windows_core::RuntimeType for IKeyDerivationAlgorithmProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationAlgorithmProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OpenAlgorithm: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyDerivationParameters, IKeyDerivationParameters_Vtbl, 0x7bf05967_047b_4a8c_964a_469ffd5522e2);
+impl windows_core::RuntimeType for IKeyDerivationParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +371,9 @@ pub struct IKeyDerivationParameters_Vtbl {
     pub IterationCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyDerivationParameters2, IKeyDerivationParameters2_Vtbl, 0xcd4166d1_417e_4f4c_b666_c0d879f3f8e0);
+impl windows_core::RuntimeType for IKeyDerivationParameters2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationParameters2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -321,6 +381,9 @@ pub struct IKeyDerivationParameters2_Vtbl {
     pub SetCapi1KdfTargetAlgorithm: unsafe extern "system" fn(*mut core::ffi::c_void, Capi1KdfTargetAlgorithm) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyDerivationParametersStatics, IKeyDerivationParametersStatics_Vtbl, 0xea961fbe_f37f_4146_9dfe_a456f1735f4b);
+impl windows_core::RuntimeType for IKeyDerivationParametersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationParametersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -338,12 +401,18 @@ pub struct IKeyDerivationParametersStatics_Vtbl {
     BuildForSP80056a: usize,
 }
 windows_core::imp::define_interface!(IKeyDerivationParametersStatics2, IKeyDerivationParametersStatics2_Vtbl, 0xa5783dd5_58e3_4efb_b283_a1653126e1be);
+impl windows_core::RuntimeType for IKeyDerivationParametersStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyDerivationParametersStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub BuildForCapi1Kdf: unsafe extern "system" fn(*mut core::ffi::c_void, Capi1KdfTargetAlgorithm, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMacAlgorithmNamesStatics, IMacAlgorithmNamesStatics_Vtbl, 0x41412678_fb1e_43a4_895e_a9026e4390a3);
+impl windows_core::RuntimeType for IMacAlgorithmNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMacAlgorithmNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -355,6 +424,9 @@ pub struct IMacAlgorithmNamesStatics_Vtbl {
     pub AesCmac: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMacAlgorithmProvider, IMacAlgorithmProvider_Vtbl, 0x4a3fc5c3_1cbd_41ce_a092_aa0bc5d2d2f5);
+impl windows_core::RuntimeType for IMacAlgorithmProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMacAlgorithmProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -366,6 +438,9 @@ pub struct IMacAlgorithmProvider_Vtbl {
     CreateKey: usize,
 }
 windows_core::imp::define_interface!(IMacAlgorithmProvider2, IMacAlgorithmProvider2_Vtbl, 0x6da32a15_d931_42ed_8e7e_c301caee119c);
+impl windows_core::RuntimeType for IMacAlgorithmProvider2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMacAlgorithmProvider2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -375,12 +450,18 @@ pub struct IMacAlgorithmProvider2_Vtbl {
     CreateHash: usize,
 }
 windows_core::imp::define_interface!(IMacAlgorithmProviderStatics, IMacAlgorithmProviderStatics_Vtbl, 0xc9bdc147_cc77_4df0_9e4e_b921e080644c);
+impl windows_core::RuntimeType for IMacAlgorithmProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMacAlgorithmProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OpenAlgorithm: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPersistedKeyProviderStatics, IPersistedKeyProviderStatics_Vtbl, 0x77274814_d9d4_4cf5_b668_e0457df30894);
+impl windows_core::RuntimeType for IPersistedKeyProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPersistedKeyProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -394,6 +475,9 @@ pub struct IPersistedKeyProviderStatics_Vtbl {
     OpenPublicKeyFromCertificate: usize,
 }
 windows_core::imp::define_interface!(ISymmetricAlgorithmNamesStatics, ISymmetricAlgorithmNamesStatics_Vtbl, 0x6870727b_c996_4eae_84d7_79b2aeb73b9c);
+impl windows_core::RuntimeType for ISymmetricAlgorithmNamesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISymmetricAlgorithmNamesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -418,6 +502,9 @@ pub struct ISymmetricAlgorithmNamesStatics_Vtbl {
     pub Rc4: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISymmetricKeyAlgorithmProvider, ISymmetricKeyAlgorithmProvider_Vtbl, 0x3d7e4a33_3bd0_4902_8ac8_470d50d21376);
+impl windows_core::RuntimeType for ISymmetricKeyAlgorithmProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISymmetricKeyAlgorithmProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -429,6 +516,9 @@ pub struct ISymmetricKeyAlgorithmProvider_Vtbl {
     CreateSymmetricKey: usize,
 }
 windows_core::imp::define_interface!(ISymmetricKeyAlgorithmProviderStatics, ISymmetricKeyAlgorithmProviderStatics_Vtbl, 0x8d3b2326_1f37_491f_b60e_f5431b26b483);
+impl windows_core::RuntimeType for ISymmetricKeyAlgorithmProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISymmetricKeyAlgorithmProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -666,7 +756,7 @@ impl AsymmetricKeyAlgorithmProvider {
     }
 }
 impl windows_core::RuntimeType for AsymmetricKeyAlgorithmProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAsymmetricKeyAlgorithmProvider>();
 }
 unsafe impl windows_core::Interface for AsymmetricKeyAlgorithmProvider {
     type Vtable = IAsymmetricKeyAlgorithmProvider_Vtbl;
@@ -858,7 +948,7 @@ impl CryptographicHash {
     }
 }
 impl windows_core::RuntimeType for CryptographicHash {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHashComputation>();
 }
 unsafe impl windows_core::Interface for CryptographicHash {
     type Vtable = IHashComputation_Vtbl;
@@ -915,7 +1005,7 @@ impl CryptographicKey {
     }
 }
 impl windows_core::RuntimeType for CryptographicKey {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICryptographicKey>();
 }
 unsafe impl windows_core::Interface for CryptographicKey {
     type Vtable = ICryptographicKey_Vtbl;
@@ -1237,7 +1327,7 @@ impl EncryptedAndAuthenticatedData {
     }
 }
 impl windows_core::RuntimeType for EncryptedAndAuthenticatedData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEncryptedAndAuthenticatedData>();
 }
 unsafe impl windows_core::Interface for EncryptedAndAuthenticatedData {
     type Vtable = IEncryptedAndAuthenticatedData_Vtbl;
@@ -1339,7 +1429,7 @@ impl HashAlgorithmProvider {
     }
 }
 impl windows_core::RuntimeType for HashAlgorithmProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHashAlgorithmProvider>();
 }
 unsafe impl windows_core::Interface for HashAlgorithmProvider {
     type Vtable = IHashAlgorithmProvider_Vtbl;
@@ -1522,7 +1612,7 @@ impl KeyDerivationAlgorithmProvider {
     }
 }
 impl windows_core::RuntimeType for KeyDerivationAlgorithmProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyDerivationAlgorithmProvider>();
 }
 unsafe impl windows_core::Interface for KeyDerivationAlgorithmProvider {
     type Vtable = IKeyDerivationAlgorithmProvider_Vtbl;
@@ -1625,7 +1715,7 @@ impl KeyDerivationParameters {
     }
 }
 impl windows_core::RuntimeType for KeyDerivationParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyDerivationParameters>();
 }
 unsafe impl windows_core::Interface for KeyDerivationParameters {
     type Vtable = IKeyDerivationParameters_Vtbl;
@@ -1737,7 +1827,7 @@ impl MacAlgorithmProvider {
     }
 }
 impl windows_core::RuntimeType for MacAlgorithmProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMacAlgorithmProvider>();
 }
 unsafe impl windows_core::Interface for MacAlgorithmProvider {
     type Vtable = IMacAlgorithmProvider_Vtbl;
@@ -1947,7 +2037,7 @@ impl SymmetricKeyAlgorithmProvider {
     }
 }
 impl windows_core::RuntimeType for SymmetricKeyAlgorithmProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISymmetricKeyAlgorithmProvider>();
 }
 unsafe impl windows_core::Interface for SymmetricKeyAlgorithmProvider {
     type Vtable = ISymmetricKeyAlgorithmProvider_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Cryptography/DataProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/DataProtection/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDataProtectionProvider, IDataProtectionProvider_Vtbl, 0x09639948_ed22_4270_bd1c_6d72c00f8787);
+impl windows_core::RuntimeType for IDataProtectionProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataProtectionProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +23,9 @@ pub struct IDataProtectionProvider_Vtbl {
     UnprotectStreamAsync: usize,
 }
 windows_core::imp::define_interface!(IDataProtectionProviderFactory, IDataProtectionProviderFactory_Vtbl, 0xadf33dac_4932_4cdf_ac41_7214333514ca);
+impl windows_core::RuntimeType for IDataProtectionProviderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataProtectionProviderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,7 +102,7 @@ impl DataProtectionProvider {
     }
 }
 impl windows_core::RuntimeType for DataProtectionProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataProtectionProvider>();
 }
 unsafe impl windows_core::Interface for DataProtectionProvider {
     type Vtable = IDataProtectionProvider_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/mod.rs
@@ -5,6 +5,9 @@ pub mod Core;
 #[cfg(feature = "Security_Cryptography_DataProtection")]
 pub mod DataProtection;
 windows_core::imp::define_interface!(ICryptographicBufferStatics, ICryptographicBufferStatics_Vtbl, 0x320b7e22_3cb0_4cdf_8663_1d28910065eb);
+impl windows_core::RuntimeType for ICryptographicBufferStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICryptographicBufferStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IUserDataAvailabilityStateChangedEventArgs, IUserDataAvailabilityStateChangedEventArgs_Vtbl, 0xa76582c9_06a2_4273_a803_834c9f87fbeb);
+impl windows_core::RuntimeType for IUserDataAvailabilityStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataAvailabilityStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataBufferUnprotectResult, IUserDataBufferUnprotectResult_Vtbl, 0x8efd0e90_fa9a_46a4_a377_01cebf1e74d8);
+impl windows_core::RuntimeType for IUserDataBufferUnprotectResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataBufferUnprotectResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +21,9 @@ pub struct IUserDataBufferUnprotectResult_Vtbl {
     UnprotectedBuffer: usize,
 }
 windows_core::imp::define_interface!(IUserDataProtectionManager, IUserDataProtectionManager_Vtbl, 0x1f13237d_b42e_4a88_9480_0f240924c876);
+impl windows_core::RuntimeType for IUserDataProtectionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataProtectionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +48,9 @@ pub struct IUserDataProtectionManager_Vtbl {
     pub RemoveDataAvailabilityStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataProtectionManagerStatics, IUserDataProtectionManagerStatics_Vtbl, 0x977780e8_6dce_4fae_af85_782ac2cf4572);
+impl windows_core::RuntimeType for IUserDataProtectionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataProtectionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,6 +61,9 @@ pub struct IUserDataProtectionManagerStatics_Vtbl {
     TryGetForUser: usize,
 }
 windows_core::imp::define_interface!(IUserDataStorageItemProtectionInfo, IUserDataStorageItemProtectionInfo_Vtbl, 0x5b6680f6_e87f_40a1_b19d_a6187a0c662f);
+impl windows_core::RuntimeType for IUserDataStorageItemProtectionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataStorageItemProtectionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,7 +83,7 @@ impl UserDataAvailabilityStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDataAvailabilityStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataAvailabilityStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDataAvailabilityStateChangedEventArgs {
     type Vtable = IUserDataAvailabilityStateChangedEventArgs_Vtbl;
@@ -101,7 +116,7 @@ impl UserDataBufferUnprotectResult {
     }
 }
 impl windows_core::RuntimeType for UserDataBufferUnprotectResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataBufferUnprotectResult>();
 }
 unsafe impl windows_core::Interface for UserDataBufferUnprotectResult {
     type Vtable = IUserDataBufferUnprotectResult_Vtbl;
@@ -205,7 +220,7 @@ impl UserDataProtectionManager {
     }
 }
 impl windows_core::RuntimeType for UserDataProtectionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataProtectionManager>();
 }
 unsafe impl windows_core::Interface for UserDataProtectionManager {
     type Vtable = IUserDataProtectionManager_Vtbl;
@@ -230,7 +245,7 @@ impl UserDataStorageItemProtectionInfo {
     }
 }
 impl windows_core::RuntimeType for UserDataStorageItemProtectionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataStorageItemProtectionInfo>();
 }
 unsafe impl windows_core::Interface for UserDataStorageItemProtectionInfo {
     type Vtable = IUserDataStorageItemProtectionInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBufferProtectUnprotectResult, IBufferProtectUnprotectResult_Vtbl, 0x47995edc_6cec_4e3a_b251_9e7485d79e7a);
+impl windows_core::RuntimeType for IBufferProtectUnprotectResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBufferProtectUnprotectResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IBufferProtectUnprotectResult_Vtbl {
     pub ProtectionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataProtectionInfo, IDataProtectionInfo_Vtbl, 0x8420b0c1_5e31_4405_9540_3f943af0cb26);
+impl windows_core::RuntimeType for IDataProtectionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataProtectionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +22,9 @@ pub struct IDataProtectionInfo_Vtbl {
     pub Identity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataProtectionManagerStatics, IDataProtectionManagerStatics_Vtbl, 0xb6149b74_9144_4ee4_8a8a_30b5f361430e);
+impl windows_core::RuntimeType for IDataProtectionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataProtectionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +54,9 @@ pub struct IDataProtectionManagerStatics_Vtbl {
     GetStreamProtectionInfoAsync: usize,
 }
 windows_core::imp::define_interface!(IFileProtectionInfo, IFileProtectionInfo_Vtbl, 0x4ee96486_147e_4dd0_8faf_5253ed91ad0c);
+impl windows_core::RuntimeType for IFileProtectionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileProtectionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,12 +65,18 @@ pub struct IFileProtectionInfo_Vtbl {
     pub Identity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileProtectionInfo2, IFileProtectionInfo2_Vtbl, 0x82123a4c_557a_498d_8e94_944cd5836432);
+impl windows_core::RuntimeType for IFileProtectionInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileProtectionInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsProtectWhileOpenSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileProtectionManagerStatics, IFileProtectionManagerStatics_Vtbl, 0x5846fc9b_e613_426b_bb38_88cba1dc9adb);
+impl windows_core::RuntimeType for IFileProtectionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileProtectionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,6 +110,9 @@ pub struct IFileProtectionManagerStatics_Vtbl {
     CreateProtectedAndOpenAsync: usize,
 }
 windows_core::imp::define_interface!(IFileProtectionManagerStatics2, IFileProtectionManagerStatics2_Vtbl, 0x83d2a745_0483_41ab_b2d5_bc7f23d74ebb);
+impl windows_core::RuntimeType for IFileProtectionManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileProtectionManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,6 +130,9 @@ pub struct IFileProtectionManagerStatics2_Vtbl {
     SaveFileAsContainerWithSharingAsync: usize,
 }
 windows_core::imp::define_interface!(IFileProtectionManagerStatics3, IFileProtectionManagerStatics3_Vtbl, 0x6918849a_624f_46d6_b241_e9cd5fdf3e3f);
+impl windows_core::RuntimeType for IFileProtectionManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileProtectionManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -123,6 +147,10 @@ pub struct IFileProtectionManagerStatics3_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IFileRevocationManagerStatics, IFileRevocationManagerStatics_Vtbl, 0x256bbc3d_1c5d_4260_8c75_9144cfb78ba9);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IFileRevocationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IFileRevocationManagerStatics_Vtbl {
@@ -145,6 +173,9 @@ pub struct IFileRevocationManagerStatics_Vtbl {
     GetStatusAsync: usize,
 }
 windows_core::imp::define_interface!(IFileUnprotectOptions, IFileUnprotectOptions_Vtbl, 0x7d1312f1_3b0d_4dd8_a1f8_1ec53822e2f3);
+impl windows_core::RuntimeType for IFileUnprotectOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileUnprotectOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,12 +183,18 @@ pub struct IFileUnprotectOptions_Vtbl {
     pub Audit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileUnprotectOptionsFactory, IFileUnprotectOptionsFactory_Vtbl, 0x51aeb39c_da8c_4c3f_9bfb_cb73a7cce0dd);
+impl windows_core::RuntimeType for IFileUnprotectOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileUnprotectOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, bool, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectedAccessResumedEventArgs, IProtectedAccessResumedEventArgs_Vtbl, 0xac4dca59_5d80_4e95_8c5f_8539450eebe0);
+impl windows_core::RuntimeType for IProtectedAccessResumedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectedAccessResumedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -167,6 +204,9 @@ pub struct IProtectedAccessResumedEventArgs_Vtbl {
     Identities: usize,
 }
 windows_core::imp::define_interface!(IProtectedAccessSuspendingEventArgs, IProtectedAccessSuspendingEventArgs_Vtbl, 0x75a193e0_a344_429f_b975_04fc1f88c185);
+impl windows_core::RuntimeType for IProtectedAccessSuspendingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectedAccessSuspendingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +218,9 @@ pub struct IProtectedAccessSuspendingEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectedContainerExportResult, IProtectedContainerExportResult_Vtbl, 0x3948ef95_f7fb_4b42_afb0_df70b41543c1);
+impl windows_core::RuntimeType for IProtectedContainerExportResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectedContainerExportResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +231,9 @@ pub struct IProtectedContainerExportResult_Vtbl {
     File: usize,
 }
 windows_core::imp::define_interface!(IProtectedContainerImportResult, IProtectedContainerImportResult_Vtbl, 0xcdb780d1_e7bb_4d1a_9339_34dc41149f9b);
+impl windows_core::RuntimeType for IProtectedContainerImportResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectedContainerImportResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,6 +244,9 @@ pub struct IProtectedContainerImportResult_Vtbl {
     File: usize,
 }
 windows_core::imp::define_interface!(IProtectedContentRevokedEventArgs, IProtectedContentRevokedEventArgs_Vtbl, 0x63686821_58b9_47ee_93d9_f0f741cf43f0);
+impl windows_core::RuntimeType for IProtectedContentRevokedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectedContentRevokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,6 +256,9 @@ pub struct IProtectedContentRevokedEventArgs_Vtbl {
     Identities: usize,
 }
 windows_core::imp::define_interface!(IProtectedFileCreateResult, IProtectedFileCreateResult_Vtbl, 0x28e3ed6a_e9e7_4a03_9f53_bdb16172699b);
+impl windows_core::RuntimeType for IProtectedFileCreateResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectedFileCreateResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +273,9 @@ pub struct IProtectedFileCreateResult_Vtbl {
     pub ProtectionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyAuditInfo, IProtectionPolicyAuditInfo_Vtbl, 0x425ab7e4_feb7_44fc_b3bb_c3c4d7ecbebb);
+impl windows_core::RuntimeType for IProtectionPolicyAuditInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyAuditInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -234,6 +289,9 @@ pub struct IProtectionPolicyAuditInfo_Vtbl {
     pub TargetDescription: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyAuditInfoFactory, IProtectionPolicyAuditInfoFactory_Vtbl, 0x7ed4180b_92e8_42d5_83d4_25440b423549);
+impl windows_core::RuntimeType for IProtectionPolicyAuditInfoFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyAuditInfoFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -241,6 +299,9 @@ pub struct IProtectionPolicyAuditInfoFactory_Vtbl {
     pub CreateWithActionAndDataDescription: unsafe extern "system" fn(*mut core::ffi::c_void, ProtectionPolicyAuditAction, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyManager, IProtectionPolicyManager_Vtbl, 0xd5703e18_a08d_47e6_a240_9934d7165eb5);
+impl windows_core::RuntimeType for IProtectionPolicyManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +309,9 @@ pub struct IProtectionPolicyManager_Vtbl {
     pub Identity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyManager2, IProtectionPolicyManager2_Vtbl, 0xabf7527a_8435_417f_99b6_51beaf365888);
+impl windows_core::RuntimeType for IProtectionPolicyManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -255,6 +319,9 @@ pub struct IProtectionPolicyManager2_Vtbl {
     pub ShowEnterpriseIndicator: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyManagerStatics, IProtectionPolicyManagerStatics_Vtbl, 0xc0bffc66_8c3d_4d56_8804_c68f0ad32ec5);
+impl windows_core::RuntimeType for IProtectionPolicyManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -278,6 +345,9 @@ pub struct IProtectionPolicyManagerStatics_Vtbl {
     pub RequestAccessAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyManagerStatics2, IProtectionPolicyManagerStatics2_Vtbl, 0xb68f9a8c_39e0_4649_b2e4_070ab8a579b3);
+impl windows_core::RuntimeType for IProtectionPolicyManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -292,6 +362,9 @@ pub struct IProtectionPolicyManagerStatics2_Vtbl {
     pub IsProtectionEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyManagerStatics3, IProtectionPolicyManagerStatics3_Vtbl, 0x48ff9e8c_6a6f_4d9f_bced_18ab537aa015);
+impl windows_core::RuntimeType for IProtectionPolicyManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -302,6 +375,9 @@ pub struct IProtectionPolicyManagerStatics3_Vtbl {
     pub LogAuditEvent: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtectionPolicyManagerStatics4, IProtectionPolicyManagerStatics4_Vtbl, 0x20b794db_ccbd_490f_8c83_49ccb77aea6c);
+impl windows_core::RuntimeType for IProtectionPolicyManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtectionPolicyManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -336,6 +412,9 @@ pub struct IProtectionPolicyManagerStatics4_Vtbl {
     pub GetPrimaryManagedIdentityForIdentity: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IThreadNetworkContext, IThreadNetworkContext_Vtbl, 0xfa4ea8e9_ef13_405a_b12c_d7348c6f41fc);
+impl windows_core::RuntimeType for IThreadNetworkContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IThreadNetworkContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -362,7 +441,7 @@ impl BufferProtectUnprotectResult {
     }
 }
 impl windows_core::RuntimeType for BufferProtectUnprotectResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBufferProtectUnprotectResult>();
 }
 unsafe impl windows_core::Interface for BufferProtectUnprotectResult {
     type Vtable = IBufferProtectUnprotectResult_Vtbl;
@@ -394,7 +473,7 @@ impl DataProtectionInfo {
     }
 }
 impl windows_core::RuntimeType for DataProtectionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataProtectionInfo>();
 }
 unsafe impl windows_core::Interface for DataProtectionInfo {
     type Vtable = IDataProtectionInfo_Vtbl;
@@ -513,7 +592,7 @@ impl FileProtectionInfo {
     }
 }
 impl windows_core::RuntimeType for FileProtectionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileProtectionInfo>();
 }
 unsafe impl windows_core::Interface for FileProtectionInfo {
     type Vtable = IFileProtectionInfo_Vtbl;
@@ -749,7 +828,7 @@ impl FileUnprotectOptions {
     }
 }
 impl windows_core::RuntimeType for FileUnprotectOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileUnprotectOptions>();
 }
 unsafe impl windows_core::Interface for FileUnprotectOptions {
     type Vtable = IFileUnprotectOptions_Vtbl;
@@ -775,7 +854,7 @@ impl ProtectedAccessResumedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ProtectedAccessResumedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectedAccessResumedEventArgs>();
 }
 unsafe impl windows_core::Interface for ProtectedAccessResumedEventArgs {
     type Vtable = IProtectedAccessResumedEventArgs_Vtbl;
@@ -815,7 +894,7 @@ impl ProtectedAccessSuspendingEventArgs {
     }
 }
 impl windows_core::RuntimeType for ProtectedAccessSuspendingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectedAccessSuspendingEventArgs>();
 }
 unsafe impl windows_core::Interface for ProtectedAccessSuspendingEventArgs {
     type Vtable = IProtectedAccessSuspendingEventArgs_Vtbl;
@@ -848,7 +927,7 @@ impl ProtectedContainerExportResult {
     }
 }
 impl windows_core::RuntimeType for ProtectedContainerExportResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectedContainerExportResult>();
 }
 unsafe impl windows_core::Interface for ProtectedContainerExportResult {
     type Vtable = IProtectedContainerExportResult_Vtbl;
@@ -881,7 +960,7 @@ impl ProtectedContainerImportResult {
     }
 }
 impl windows_core::RuntimeType for ProtectedContainerImportResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectedContainerImportResult>();
 }
 unsafe impl windows_core::Interface for ProtectedContainerImportResult {
     type Vtable = IProtectedContainerImportResult_Vtbl;
@@ -907,7 +986,7 @@ impl ProtectedContentRevokedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ProtectedContentRevokedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectedContentRevokedEventArgs>();
 }
 unsafe impl windows_core::Interface for ProtectedContentRevokedEventArgs {
     type Vtable = IProtectedContentRevokedEventArgs_Vtbl;
@@ -948,7 +1027,7 @@ impl ProtectedFileCreateResult {
     }
 }
 impl windows_core::RuntimeType for ProtectedFileCreateResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectedFileCreateResult>();
 }
 unsafe impl windows_core::Interface for ProtectedFileCreateResult {
     type Vtable = IProtectedFileCreateResult_Vtbl;
@@ -1027,7 +1106,7 @@ impl ProtectionPolicyAuditInfo {
     }
 }
 impl windows_core::RuntimeType for ProtectionPolicyAuditInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectionPolicyAuditInfo>();
 }
 unsafe impl windows_core::Interface for ProtectionPolicyAuditInfo {
     type Vtable = IProtectionPolicyAuditInfo_Vtbl;
@@ -1371,7 +1450,7 @@ impl ProtectionPolicyManager {
     }
 }
 impl windows_core::RuntimeType for ProtectionPolicyManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtectionPolicyManager>();
 }
 unsafe impl windows_core::Interface for ProtectionPolicyManager {
     type Vtable = IProtectionPolicyManager_Vtbl;
@@ -1394,7 +1473,7 @@ impl ThreadNetworkContext {
     }
 }
 impl windows_core::RuntimeType for ThreadNetworkContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IThreadNetworkContext>();
 }
 unsafe impl windows_core::Interface for ThreadNetworkContext {
     type Vtable = IThreadNetworkContext_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IEasClientDeviceInformation, IEasClientDeviceInformation_Vtbl, 0x54dfd981_1968_4ca3_b958_e595d16505eb);
+impl windows_core::RuntimeType for IEasClientDeviceInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEasClientDeviceInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IEasClientDeviceInformation_Vtbl {
     pub SystemSku: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEasClientDeviceInformation2, IEasClientDeviceInformation2_Vtbl, 0xffb35923_bb26_4d6a_81bc_165aee0ad754);
+impl windows_core::RuntimeType for IEasClientDeviceInformation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEasClientDeviceInformation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IEasClientDeviceInformation2_Vtbl {
     pub SystemFirmwareVersion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEasClientSecurityPolicy, IEasClientSecurityPolicy_Vtbl, 0x45b72362_dfba_4a9b_aced_6fe2adcb6420);
+impl windows_core::RuntimeType for IEasClientSecurityPolicy {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEasClientSecurityPolicy_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +49,9 @@ pub struct IEasClientSecurityPolicy_Vtbl {
     pub ApplyAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEasComplianceResults, IEasComplianceResults_Vtbl, 0x463c299c_7f19_4c66_b403_cb45dd57a2b3);
+impl windows_core::RuntimeType for IEasComplianceResults {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEasComplianceResults_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +66,9 @@ pub struct IEasComplianceResults_Vtbl {
     pub MaxInactivityTimeLockResult: unsafe extern "system" fn(*mut core::ffi::c_void, *mut EasMaxInactivityTimeLockResult) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEasComplianceResults2, IEasComplianceResults2_Vtbl, 0x2fbe60c9_1aa8_47f5_88bb_cb3ef0bffb15);
+impl windows_core::RuntimeType for IEasComplianceResults2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEasComplianceResults2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,7 +144,7 @@ impl EasClientDeviceInformation {
     }
 }
 impl windows_core::RuntimeType for EasClientDeviceInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEasClientDeviceInformation>();
 }
 unsafe impl windows_core::Interface for EasClientDeviceInformation {
     type Vtable = IEasClientDeviceInformation_Vtbl;
@@ -254,7 +269,7 @@ impl EasClientSecurityPolicy {
     }
 }
 impl windows_core::RuntimeType for EasClientSecurityPolicy {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEasClientSecurityPolicy>();
 }
 unsafe impl windows_core::Interface for EasClientSecurityPolicy {
     type Vtable = IEasClientSecurityPolicy_Vtbl;
@@ -340,7 +355,7 @@ impl EasComplianceResults {
     }
 }
 impl windows_core::RuntimeType for EasComplianceResults {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEasComplianceResults>();
 }
 unsafe impl windows_core::Interface for EasComplianceResults {
     type Vtable = IEasComplianceResults_Vtbl;

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironment, IIsolatedWindowsEnvironment_Vtbl, 0x41d24597_c328_4467_b37f_4dfc6f60b6bc);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +21,9 @@ pub struct IIsolatedWindowsEnvironment_Vtbl {
     pub UnregisterMessageReceiver: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironment2, IIsolatedWindowsEnvironment2_Vtbl, 0x2d365f39_88bd_4ab4_93cf_7e2bcef337c0);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironment2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironment2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +37,9 @@ pub struct IIsolatedWindowsEnvironment2_Vtbl {
     PostMessageToReceiverWithTelemetryAsync: usize,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironment3, IIsolatedWindowsEnvironment3_Vtbl, 0xcb7fc7d2_d06e_4c26_8ada_dacdaaad03f5);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironment3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironment3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,12 +48,18 @@ pub struct IIsolatedWindowsEnvironment3_Vtbl {
     pub ShareFileWithTelemetryAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironment4, IIsolatedWindowsEnvironment4_Vtbl, 0x11e3701a_dd9e_4f1b_812c_4020f307f93c);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironment4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironment4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ChangePriority: unsafe extern "system" fn(*mut core::ffi::c_void, IsolatedWindowsEnvironmentCreationPriority) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentCreateResult, IIsolatedWindowsEnvironmentCreateResult_Vtbl, 0xef9a5e58_dcd7_45c2_9c85_ab642a715e8e);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentCreateResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentCreateResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -53,12 +68,18 @@ pub struct IIsolatedWindowsEnvironmentCreateResult_Vtbl {
     pub Environment: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentCreateResult2, IIsolatedWindowsEnvironmentCreateResult2_Vtbl, 0xa547dbc7_61d4_4fb8_ab5c_edefa3d388ad);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentCreateResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentCreateResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ChangeCreationPriority: unsafe extern "system" fn(*mut core::ffi::c_void, IsolatedWindowsEnvironmentCreationPriority) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentFactory, IIsolatedWindowsEnvironmentFactory_Vtbl, 0x1aca93e7_e804_454d_8466_f9897c20b0f6);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +92,9 @@ pub struct IIsolatedWindowsEnvironmentFactory_Vtbl {
     FindByOwnerId: usize,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentFile, IIsolatedWindowsEnvironmentFile_Vtbl, 0x4d5ae1ef_029f_4101_8c35_fe91bf9cd5f0);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentFile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentFile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +103,9 @@ pub struct IIsolatedWindowsEnvironmentFile_Vtbl {
     pub Close: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentFile2, IIsolatedWindowsEnvironmentFile2_Vtbl, 0x4eeb8dec_ad5d_4b0a_b754_f36c3d46d684);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentFile2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentFile2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +113,9 @@ pub struct IIsolatedWindowsEnvironmentFile2_Vtbl {
     pub IsReadOnly: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentHostStatics, IIsolatedWindowsEnvironmentHostStatics_Vtbl, 0x2c0e22c7_05a0_517a_b81c_6ee8790c381f);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentHostStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentHostStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,6 +126,9 @@ pub struct IIsolatedWindowsEnvironmentHostStatics_Vtbl {
     HostErrors: usize,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentLaunchFileResult, IIsolatedWindowsEnvironmentLaunchFileResult_Vtbl, 0x685d4176_f6e0_4569_b1aa_215c0ff5b257);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentLaunchFileResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentLaunchFileResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -104,6 +137,9 @@ pub struct IIsolatedWindowsEnvironmentLaunchFileResult_Vtbl {
     pub File: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentOptions, IIsolatedWindowsEnvironmentOptions_Vtbl, 0xb71d98f7_61f0_4008_b207_0bf9eb2d76f2);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,6 +162,9 @@ pub struct IIsolatedWindowsEnvironmentOptions_Vtbl {
     pub SetAllowCameraAndMicrophoneAccess: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentOptions2, IIsolatedWindowsEnvironmentOptions2_Vtbl, 0x10d7cc31_8b8f_4b9d_b22c_617103b55b08);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,6 +172,9 @@ pub struct IIsolatedWindowsEnvironmentOptions2_Vtbl {
     pub SetWindowAnnotationOverride: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentOptions3, IIsolatedWindowsEnvironmentOptions3_Vtbl, 0x98d5aa23_161f_4cd9_8a9c_269b30122b0d);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentOptions3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentOptions3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -144,6 +186,9 @@ pub struct IIsolatedWindowsEnvironmentOptions3_Vtbl {
     pub SetCreationPriority: unsafe extern "system" fn(*mut core::ffi::c_void, IsolatedWindowsEnvironmentCreationPriority) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentOwnerRegistrationData, IIsolatedWindowsEnvironmentOwnerRegistrationData_Vtbl, 0xf888ec22_e8cf_56c0_b1df_90af4ad80e84);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentOwnerRegistrationData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentOwnerRegistrationData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +210,9 @@ pub struct IIsolatedWindowsEnvironmentOwnerRegistrationData_Vtbl {
     ActivationFileExtensions: usize,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentOwnerRegistrationResult, IIsolatedWindowsEnvironmentOwnerRegistrationResult_Vtbl, 0x6dab9451_6169_55df_8f51_790e99d7277d);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentOwnerRegistrationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentOwnerRegistrationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,6 +220,9 @@ pub struct IIsolatedWindowsEnvironmentOwnerRegistrationResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentOwnerRegistrationStatics, IIsolatedWindowsEnvironmentOwnerRegistrationStatics_Vtbl, 0x10951754_204b_5ec9_9de3_df792d074a61);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentOwnerRegistrationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentOwnerRegistrationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,6 +230,9 @@ pub struct IIsolatedWindowsEnvironmentOwnerRegistrationStatics_Vtbl {
     pub Unregister: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentPostMessageResult, IIsolatedWindowsEnvironmentPostMessageResult_Vtbl, 0x0dfa28fa_2ef0_4d8f_b341_3171b2df93b1);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentPostMessageResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentPostMessageResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -186,6 +240,9 @@ pub struct IIsolatedWindowsEnvironmentPostMessageResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentProcess, IIsolatedWindowsEnvironmentProcess_Vtbl, 0xa858c3ef_8172_4f10_af93_cbe60af88d09);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentProcess {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentProcess_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -196,6 +253,9 @@ pub struct IIsolatedWindowsEnvironmentProcess_Vtbl {
     pub WaitForExitAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentShareFileRequestOptions, IIsolatedWindowsEnvironmentShareFileRequestOptions_Vtbl, 0xc9190ed8_0fd0_4946_bb88_117a60737b61);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentShareFileRequestOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentShareFileRequestOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,6 +263,9 @@ pub struct IIsolatedWindowsEnvironmentShareFileRequestOptions_Vtbl {
     pub SetAllowWrite: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentShareFileResult, IIsolatedWindowsEnvironmentShareFileResult_Vtbl, 0xaec7caa7_9ac6_4bf5_8b91_5c1adf0d7d00);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentShareFileResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentShareFileResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -211,6 +274,9 @@ pub struct IIsolatedWindowsEnvironmentShareFileResult_Vtbl {
     pub File: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentShareFolderRequestOptions, IIsolatedWindowsEnvironmentShareFolderRequestOptions_Vtbl, 0xc405eb7d_7053_4f6a_9b87_746846ed19b2);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentShareFolderRequestOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentShareFolderRequestOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -218,6 +284,9 @@ pub struct IIsolatedWindowsEnvironmentShareFolderRequestOptions_Vtbl {
     pub SetAllowWrite: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentShareFolderResult, IIsolatedWindowsEnvironmentShareFolderResult_Vtbl, 0x556ba72e_ca9d_4211_b143_1cedc86eb2fe);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentShareFolderResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentShareFolderResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -225,6 +294,9 @@ pub struct IIsolatedWindowsEnvironmentShareFolderResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentStartProcessResult, IIsolatedWindowsEnvironmentStartProcessResult_Vtbl, 0x8fa1dc2f_57da_4bb5_9c06_fa072d2032e2);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentStartProcessResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentStartProcessResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -233,6 +305,9 @@ pub struct IIsolatedWindowsEnvironmentStartProcessResult_Vtbl {
     pub Process: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentTelemetryParameters, IIsolatedWindowsEnvironmentTelemetryParameters_Vtbl, 0xebdb3cab_7a3a_4524_a0f4_f96e284d33cd);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentTelemetryParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentTelemetryParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,6 +315,9 @@ pub struct IIsolatedWindowsEnvironmentTelemetryParameters_Vtbl {
     pub SetCorrelationId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentUserInfo, IIsolatedWindowsEnvironmentUserInfo_Vtbl, 0x8a9c75ae_69ba_4001_96fc_19a02703b340);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentUserInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentUserInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,12 +326,18 @@ pub struct IIsolatedWindowsEnvironmentUserInfo_Vtbl {
     pub TryWaitForSignInAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsEnvironmentUserInfo2, IIsolatedWindowsEnvironmentUserInfo2_Vtbl, 0xb0bdd5dd_91d7_481e_94f2_2a5a6bdf9383);
+impl windows_core::RuntimeType for IIsolatedWindowsEnvironmentUserInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsEnvironmentUserInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryWaitForSignInWithProgressAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsHostMessengerStatics, IIsolatedWindowsHostMessengerStatics_Vtbl, 0x06e444bb_53c0_4889_8fa3_53592e37cf21);
+impl windows_core::RuntimeType for IIsolatedWindowsHostMessengerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsHostMessengerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -264,6 +348,9 @@ pub struct IIsolatedWindowsHostMessengerStatics_Vtbl {
     pub GetFileId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIsolatedWindowsHostMessengerStatics2, IIsolatedWindowsHostMessengerStatics2_Vtbl, 0x55ef9ebc_0444_42ad_832d_1b89c089d1ca);
+impl windows_core::RuntimeType for IIsolatedWindowsHostMessengerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIsolatedWindowsHostMessengerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -463,7 +550,7 @@ impl IsolatedWindowsEnvironment {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironment>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironment {
     type Vtable = IIsolatedWindowsEnvironment_Vtbl;
@@ -506,7 +593,7 @@ impl IsolatedWindowsEnvironmentCreateResult {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentCreateResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentCreateResult>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentCreateResult {
     type Vtable = IIsolatedWindowsEnvironmentCreateResult_Vtbl;
@@ -556,7 +643,7 @@ impl IsolatedWindowsEnvironmentFile {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentFile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentFile>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentFile {
     type Vtable = IIsolatedWindowsEnvironmentFile_Vtbl;
@@ -619,7 +706,7 @@ impl IsolatedWindowsEnvironmentLaunchFileResult {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentLaunchFileResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentLaunchFileResult>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentLaunchFileResult {
     type Vtable = IIsolatedWindowsEnvironmentLaunchFileResult_Vtbl;
@@ -783,7 +870,7 @@ impl IsolatedWindowsEnvironmentOptions {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentOptions>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentOptions {
     type Vtable = IIsolatedWindowsEnvironmentOptions_Vtbl;
@@ -863,7 +950,7 @@ impl IsolatedWindowsEnvironmentOwnerRegistrationData {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentOwnerRegistrationData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentOwnerRegistrationData>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentOwnerRegistrationData {
     type Vtable = IIsolatedWindowsEnvironmentOwnerRegistrationData_Vtbl;
@@ -895,7 +982,7 @@ impl IsolatedWindowsEnvironmentOwnerRegistrationResult {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentOwnerRegistrationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentOwnerRegistrationResult>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentOwnerRegistrationResult {
     type Vtable = IIsolatedWindowsEnvironmentOwnerRegistrationResult_Vtbl;
@@ -927,7 +1014,7 @@ impl IsolatedWindowsEnvironmentPostMessageResult {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentPostMessageResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentPostMessageResult>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentPostMessageResult {
     type Vtable = IIsolatedWindowsEnvironmentPostMessageResult_Vtbl;
@@ -974,7 +1061,7 @@ impl IsolatedWindowsEnvironmentProcess {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentProcess {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentProcess>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentProcess {
     type Vtable = IIsolatedWindowsEnvironmentProcess_Vtbl;
@@ -1010,7 +1097,7 @@ impl IsolatedWindowsEnvironmentShareFileRequestOptions {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentShareFileRequestOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentShareFileRequestOptions>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentShareFileRequestOptions {
     type Vtable = IIsolatedWindowsEnvironmentShareFileRequestOptions_Vtbl;
@@ -1049,7 +1136,7 @@ impl IsolatedWindowsEnvironmentShareFileResult {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentShareFileResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentShareFileResult>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentShareFileResult {
     type Vtable = IIsolatedWindowsEnvironmentShareFileResult_Vtbl;
@@ -1085,7 +1172,7 @@ impl IsolatedWindowsEnvironmentShareFolderRequestOptions {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentShareFolderRequestOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentShareFolderRequestOptions>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentShareFolderRequestOptions {
     type Vtable = IIsolatedWindowsEnvironmentShareFolderRequestOptions_Vtbl;
@@ -1117,7 +1204,7 @@ impl IsolatedWindowsEnvironmentShareFolderResult {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentShareFolderResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentShareFolderResult>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentShareFolderResult {
     type Vtable = IIsolatedWindowsEnvironmentShareFolderResult_Vtbl;
@@ -1156,7 +1243,7 @@ impl IsolatedWindowsEnvironmentStartProcessResult {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentStartProcessResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentStartProcessResult>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentStartProcessResult {
     type Vtable = IIsolatedWindowsEnvironmentStartProcessResult_Vtbl;
@@ -1192,7 +1279,7 @@ impl IsolatedWindowsEnvironmentTelemetryParameters {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentTelemetryParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentTelemetryParameters>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentTelemetryParameters {
     type Vtable = IIsolatedWindowsEnvironmentTelemetryParameters_Vtbl;
@@ -1238,7 +1325,7 @@ impl IsolatedWindowsEnvironmentUserInfo {
     }
 }
 impl windows_core::RuntimeType for IsolatedWindowsEnvironmentUserInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIsolatedWindowsEnvironmentUserInfo>();
 }
 unsafe impl windows_core::Interface for IsolatedWindowsEnvironmentUserInfo {
     type Vtable = IIsolatedWindowsEnvironmentUserInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IGuidanceAudioNotificationRequestedEventArgs, IGuidanceAudioNotificationRequestedEventArgs_Vtbl, 0xca2aa24a_c7c2_4d4c_9d7c_499576bceddb);
+impl windows_core::RuntimeType for IGuidanceAudioNotificationRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceAudioNotificationRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IGuidanceAudioNotificationRequestedEventArgs_Vtbl {
     pub AudioText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceLaneInfo, IGuidanceLaneInfo_Vtbl, 0x8404d114_6581_43b7_ac15_c9079bf90df1);
+impl windows_core::RuntimeType for IGuidanceLaneInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceLaneInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IGuidanceLaneInfo_Vtbl {
     pub IsOnRoute: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceManeuver, IGuidanceManeuver_Vtbl, 0xfc09326c_ecc9_4928_a2a1_7232b99b94a1);
+impl windows_core::RuntimeType for IGuidanceManeuver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceManeuver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +46,9 @@ pub struct IGuidanceManeuver_Vtbl {
     pub InstructionText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceMapMatchedCoordinate, IGuidanceMapMatchedCoordinate_Vtbl, 0xb7acb168_2912_4a99_aff1_798609b981fe);
+impl windows_core::RuntimeType for IGuidanceMapMatchedCoordinate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceMapMatchedCoordinate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -50,6 +62,9 @@ pub struct IGuidanceMapMatchedCoordinate_Vtbl {
     pub Road: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceNavigator, IGuidanceNavigator_Vtbl, 0x08f17ef7_8e3f_4d9a_be8a_108f9a012c67);
+impl windows_core::RuntimeType for IGuidanceNavigator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceNavigator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,6 +104,9 @@ pub struct IGuidanceNavigator_Vtbl {
     UpdateUserLocationWithPositionOverride: usize,
 }
 windows_core::imp::define_interface!(IGuidanceNavigator2, IGuidanceNavigator2_Vtbl, 0x6cdc50d1_041c_4bf3_b633_a101fc2f6b57);
+impl windows_core::RuntimeType for IGuidanceNavigator2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceNavigator2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,24 +116,36 @@ pub struct IGuidanceNavigator2_Vtbl {
     pub SetIsGuidanceAudioMuted: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceNavigatorStatics, IGuidanceNavigatorStatics_Vtbl, 0x00fd9513_4456_4e66_a143_3add6be08426);
+impl windows_core::RuntimeType for IGuidanceNavigatorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceNavigatorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceNavigatorStatics2, IGuidanceNavigatorStatics2_Vtbl, 0x54c5c3e2_7784_4c85_8c95_d0c6efb43965);
+impl windows_core::RuntimeType for IGuidanceNavigatorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceNavigatorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub UseAppProvidedVoice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceReroutedEventArgs, IGuidanceReroutedEventArgs_Vtbl, 0x115d4008_d528_454e_bb94_a50341d2c9f1);
+impl windows_core::RuntimeType for IGuidanceReroutedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceReroutedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Route: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceRoadSegment, IGuidanceRoadSegment_Vtbl, 0xb32758a6_be78_4c63_afe7_6c2957479b3e);
+impl windows_core::RuntimeType for IGuidanceRoadSegment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceRoadSegment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,12 +163,18 @@ pub struct IGuidanceRoadSegment_Vtbl {
     pub IsTollRoad: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceRoadSegment2, IGuidanceRoadSegment2_Vtbl, 0x2474a61d_1723_49f1_895b_47a2c4aa9c55);
+impl windows_core::RuntimeType for IGuidanceRoadSegment2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceRoadSegment2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsScenic: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceRoadSignpost, IGuidanceRoadSignpost_Vtbl, 0xf1a728b6_f77a_4742_8312_53300f9845f0);
+impl windows_core::RuntimeType for IGuidanceRoadSignpost {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceRoadSignpost_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +194,9 @@ pub struct IGuidanceRoadSignpost_Vtbl {
     ExitDirections: usize,
 }
 windows_core::imp::define_interface!(IGuidanceRoute, IGuidanceRoute_Vtbl, 0x3a14545d_801a_40bd_a286_afb2010cce6c);
+impl windows_core::RuntimeType for IGuidanceRoute {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceRoute_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -182,6 +221,9 @@ pub struct IGuidanceRoute_Vtbl {
     pub ConvertToMapRoute: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceRouteStatics, IGuidanceRouteStatics_Vtbl, 0xf56d926a_55ed_49c1_b09c_4b8223b50db3);
+impl windows_core::RuntimeType for IGuidanceRouteStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceRouteStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +231,9 @@ pub struct IGuidanceRouteStatics_Vtbl {
     pub TryCreateFromMapRoute: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceTelemetryCollector, IGuidanceTelemetryCollector_Vtbl, 0xdb1f8da5_b878_4d92_98dd_347d23d38262);
+impl windows_core::RuntimeType for IGuidanceTelemetryCollector {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceTelemetryCollector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -201,12 +246,18 @@ pub struct IGuidanceTelemetryCollector_Vtbl {
     pub SetUploadFrequency: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceTelemetryCollectorStatics, IGuidanceTelemetryCollectorStatics_Vtbl, 0x36532047_f160_44fb_b578_94577ca05990);
+impl windows_core::RuntimeType for IGuidanceTelemetryCollectorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceTelemetryCollectorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetCurrent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGuidanceUpdatedEventArgs, IGuidanceUpdatedEventArgs_Vtbl, 0xfdac160b_9e8d_4de3_a9fa_b06321d18db9);
+impl windows_core::RuntimeType for IGuidanceUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGuidanceUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -257,7 +308,7 @@ impl GuidanceAudioNotificationRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GuidanceAudioNotificationRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceAudioNotificationRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for GuidanceAudioNotificationRequestedEventArgs {
     type Vtable = IGuidanceAudioNotificationRequestedEventArgs_Vtbl;
@@ -289,7 +340,7 @@ impl GuidanceLaneInfo {
     }
 }
 impl windows_core::RuntimeType for GuidanceLaneInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceLaneInfo>();
 }
 unsafe impl windows_core::Interface for GuidanceLaneInfo {
     type Vtable = IGuidanceLaneInfo_Vtbl;
@@ -392,7 +443,7 @@ impl GuidanceManeuver {
     }
 }
 impl windows_core::RuntimeType for GuidanceManeuver {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceManeuver>();
 }
 unsafe impl windows_core::Interface for GuidanceManeuver {
     type Vtable = IGuidanceManeuver_Vtbl;
@@ -446,7 +497,7 @@ impl GuidanceMapMatchedCoordinate {
     }
 }
 impl windows_core::RuntimeType for GuidanceMapMatchedCoordinate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceMapMatchedCoordinate>();
 }
 unsafe impl windows_core::Interface for GuidanceMapMatchedCoordinate {
     type Vtable = IGuidanceMapMatchedCoordinate_Vtbl;
@@ -685,7 +736,7 @@ impl GuidanceNavigator {
     }
 }
 impl windows_core::RuntimeType for GuidanceNavigator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceNavigator>();
 }
 unsafe impl windows_core::Interface for GuidanceNavigator {
     type Vtable = IGuidanceNavigator_Vtbl;
@@ -710,7 +761,7 @@ impl GuidanceReroutedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GuidanceReroutedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceReroutedEventArgs>();
 }
 unsafe impl windows_core::Interface for GuidanceReroutedEventArgs {
     type Vtable = IGuidanceReroutedEventArgs_Vtbl;
@@ -799,7 +850,7 @@ impl GuidanceRoadSegment {
     }
 }
 impl windows_core::RuntimeType for GuidanceRoadSegment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceRoadSegment>();
 }
 unsafe impl windows_core::Interface for GuidanceRoadSegment {
     type Vtable = IGuidanceRoadSegment_Vtbl;
@@ -855,7 +906,7 @@ impl GuidanceRoadSignpost {
     }
 }
 impl windows_core::RuntimeType for GuidanceRoadSignpost {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceRoadSignpost>();
 }
 unsafe impl windows_core::Interface for GuidanceRoadSignpost {
     type Vtable = IGuidanceRoadSignpost_Vtbl;
@@ -949,7 +1000,7 @@ impl GuidanceRoute {
     }
 }
 impl windows_core::RuntimeType for GuidanceRoute {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceRoute>();
 }
 unsafe impl windows_core::Interface for GuidanceRoute {
     type Vtable = IGuidanceRoute_Vtbl;
@@ -1015,7 +1066,7 @@ impl GuidanceTelemetryCollector {
     }
 }
 impl windows_core::RuntimeType for GuidanceTelemetryCollector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceTelemetryCollector>();
 }
 unsafe impl windows_core::Interface for GuidanceTelemetryCollector {
     type Vtable = IGuidanceTelemetryCollector_Vtbl;
@@ -1132,7 +1183,7 @@ impl GuidanceUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for GuidanceUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGuidanceUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for GuidanceUpdatedEventArgs {
     type Vtable = IGuidanceUpdatedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ILocalCategoriesStatics, ILocalCategoriesStatics_Vtbl, 0xf49399f5_8261_4321_9974_ef92d49a8dca);
+impl windows_core::RuntimeType for ILocalCategoriesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalCategoriesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct ILocalCategoriesStatics_Vtbl {
     pub Shop: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILocalLocation, ILocalLocation_Vtbl, 0xbb0fe9ab_4502_4f2c_94a9_0d60de0e2163);
+impl windows_core::RuntimeType for ILocalLocation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalLocation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +33,9 @@ pub struct ILocalLocation_Vtbl {
     pub DataAttribution: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILocalLocation2, ILocalLocation2_Vtbl, 0x6e9e307c_ecb5_4ffc_bb8c_ba50ba8c2dc6);
+impl windows_core::RuntimeType for ILocalLocation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalLocation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,6 +47,9 @@ pub struct ILocalLocation2_Vtbl {
     HoursOfOperation: usize,
 }
 windows_core::imp::define_interface!(ILocalLocationFinderResult, ILocalLocationFinderResult_Vtbl, 0xd09b6cc6_f338_4191_9fd8_5440b9a68f52);
+impl windows_core::RuntimeType for ILocalLocationFinderResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalLocationFinderResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +60,9 @@ pub struct ILocalLocationFinderResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut LocalLocationFinderStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILocalLocationFinderStatics, ILocalLocationFinderStatics_Vtbl, 0xd2ef7344_a0de_48ca_81a8_07c7dcfd37ab);
+impl windows_core::RuntimeType for ILocalLocationFinderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalLocationFinderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +72,9 @@ pub struct ILocalLocationFinderStatics_Vtbl {
     FindLocalLocationsAsync: usize,
 }
 windows_core::imp::define_interface!(ILocalLocationHoursOfOperationItem, ILocalLocationHoursOfOperationItem_Vtbl, 0x23548c72_a1c7_43f1_a4f0_1091c39ec640);
+impl windows_core::RuntimeType for ILocalLocationHoursOfOperationItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalLocationHoursOfOperationItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,6 +86,9 @@ pub struct ILocalLocationHoursOfOperationItem_Vtbl {
     pub Span: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILocalLocationRatingInfo, ILocalLocationRatingInfo_Vtbl, 0xcb1dab56_3354_4311_8bc0_a2d4d5eb806e);
+impl windows_core::RuntimeType for ILocalLocationRatingInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILocalLocationRatingInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +97,9 @@ pub struct ILocalLocationRatingInfo_Vtbl {
     pub ProviderIdentifier: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaceInfoHelperStatics, IPlaceInfoHelperStatics_Vtbl, 0xdd1ca9a7_a9c6_491b_bc09_e80fcea48ee6);
+impl windows_core::RuntimeType for IPlaceInfoHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaceInfoHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -219,7 +243,7 @@ impl LocalLocation {
     }
 }
 impl windows_core::RuntimeType for LocalLocation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILocalLocation>();
 }
 unsafe impl windows_core::Interface for LocalLocation {
     type Vtable = ILocalLocation_Vtbl;
@@ -273,7 +297,7 @@ impl LocalLocationFinderResult {
     }
 }
 impl windows_core::RuntimeType for LocalLocationFinderResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILocalLocationFinderResult>();
 }
 unsafe impl windows_core::Interface for LocalLocationFinderResult {
     type Vtable = ILocalLocationFinderResult_Vtbl;
@@ -313,7 +337,7 @@ impl LocalLocationHoursOfOperationItem {
     }
 }
 impl windows_core::RuntimeType for LocalLocationHoursOfOperationItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILocalLocationHoursOfOperationItem>();
 }
 unsafe impl windows_core::Interface for LocalLocationHoursOfOperationItem {
     type Vtable = ILocalLocationHoursOfOperationItem_Vtbl;
@@ -352,7 +376,7 @@ impl LocalLocationRatingInfo {
     }
 }
 impl windows_core::RuntimeType for LocalLocationRatingInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILocalLocationRatingInfo>();
 }
 unsafe impl windows_core::Interface for LocalLocationRatingInfo {
     type Vtable = ILocalLocationRatingInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IOfflineMapPackage, IOfflineMapPackage_Vtbl, 0xa797673b_a5b5_4144_b525_e68c8862664b);
+impl windows_core::RuntimeType for IOfflineMapPackage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOfflineMapPackage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IOfflineMapPackage_Vtbl {
     pub RequestStartDownloadAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOfflineMapPackageQueryResult, IOfflineMapPackageQueryResult_Vtbl, 0x55585411_39e1_4e41_a4e1_5f4872bee199);
+impl windows_core::RuntimeType for IOfflineMapPackageQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOfflineMapPackageQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,12 +27,18 @@ pub struct IOfflineMapPackageQueryResult_Vtbl {
     Packages: usize,
 }
 windows_core::imp::define_interface!(IOfflineMapPackageStartDownloadResult, IOfflineMapPackageStartDownloadResult_Vtbl, 0xd965b918_d4d6_4afe_9378_3ec71ef11c3d);
+impl windows_core::RuntimeType for IOfflineMapPackageStartDownloadResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOfflineMapPackageStartDownloadResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut OfflineMapPackageStartDownloadStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOfflineMapPackageStatics, IOfflineMapPackageStatics_Vtbl, 0x185e7922_a831_4ab0_941f_6998fa929285);
+impl windows_core::RuntimeType for IOfflineMapPackageStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOfflineMapPackageStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -134,7 +146,7 @@ impl OfflineMapPackage {
     }
 }
 impl windows_core::RuntimeType for OfflineMapPackage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOfflineMapPackage>();
 }
 unsafe impl windows_core::Interface for OfflineMapPackage {
     type Vtable = IOfflineMapPackage_Vtbl;
@@ -167,7 +179,7 @@ impl OfflineMapPackageQueryResult {
     }
 }
 impl windows_core::RuntimeType for OfflineMapPackageQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOfflineMapPackageQueryResult>();
 }
 unsafe impl windows_core::Interface for OfflineMapPackageQueryResult {
     type Vtable = IOfflineMapPackageQueryResult_Vtbl;
@@ -192,7 +204,7 @@ impl OfflineMapPackageStartDownloadResult {
     }
 }
 impl windows_core::RuntimeType for OfflineMapPackageStartDownloadResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOfflineMapPackageStartDownloadResult>();
 }
 unsafe impl windows_core::Interface for OfflineMapPackageStartDownloadResult {
     type Vtable = IOfflineMapPackageStartDownloadResult_Vtbl;

--- a/crates/libs/windows/src/Windows/Services/Maps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/mod.rs
@@ -5,6 +5,9 @@ pub mod LocalSearch;
 #[cfg(feature = "Services_Maps_OfflineMaps")]
 pub mod OfflineMaps;
 windows_core::imp::define_interface!(IEnhancedWaypoint, IEnhancedWaypoint_Vtbl, 0xed268c74_5913_11e6_8b77_86f30ca893d3);
+impl windows_core::RuntimeType for IEnhancedWaypoint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnhancedWaypoint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +18,9 @@ pub struct IEnhancedWaypoint_Vtbl {
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WaypointKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEnhancedWaypointFactory, IEnhancedWaypointFactory_Vtbl, 0xaf868477_a2aa_46dd_b645_23b31b8aa6c7);
+impl windows_core::RuntimeType for IEnhancedWaypointFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEnhancedWaypointFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,9 @@ pub struct IEnhancedWaypointFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IManeuverWarning, IManeuverWarning_Vtbl, 0xc1a36d8a_2630_4378_9e4a_6e44253dceba);
+impl windows_core::RuntimeType for IManeuverWarning {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManeuverWarning_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +40,9 @@ pub struct IManeuverWarning_Vtbl {
     pub Severity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ManeuverWarningSeverity) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapAddress, IMapAddress_Vtbl, 0xcfa7a973_a3b4_4494_b3ff_cba94db69699);
+impl windows_core::RuntimeType for IMapAddress {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapAddress_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,12 +63,18 @@ pub struct IMapAddress_Vtbl {
     pub Continent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapAddress2, IMapAddress2_Vtbl, 0x75cd6df1_e5ad_45a9_bf40_6cf256c1dd13);
+impl windows_core::RuntimeType for IMapAddress2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapAddress2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FormattedAddress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapLocation, IMapLocation_Vtbl, 0x3c073f57_0da4_42e8_9ee2_a96fcf2371dc);
+impl windows_core::RuntimeType for IMapLocation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapLocation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +87,9 @@ pub struct IMapLocation_Vtbl {
     pub Address: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapLocationFinderResult, IMapLocationFinderResult_Vtbl, 0x43f1f179_e8cc_45f6_bed2_54ccbf965d9a);
+impl windows_core::RuntimeType for IMapLocationFinderResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapLocationFinderResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +100,9 @@ pub struct IMapLocationFinderResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MapLocationFinderStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapLocationFinderStatics, IMapLocationFinderStatics_Vtbl, 0x318adb5d_1c5d_4f35_a2df_aaca94959517);
+impl windows_core::RuntimeType for IMapLocationFinderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapLocationFinderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,6 +120,9 @@ pub struct IMapLocationFinderStatics_Vtbl {
     FindLocationsWithMaxCountAsync: usize,
 }
 windows_core::imp::define_interface!(IMapLocationFinderStatics2, IMapLocationFinderStatics2_Vtbl, 0x959a8b96_6485_4dfd_851a_33ac317e3af6);
+impl windows_core::RuntimeType for IMapLocationFinderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapLocationFinderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,6 +132,9 @@ pub struct IMapLocationFinderStatics2_Vtbl {
     FindLocationsAtWithAccuracyAsync: usize,
 }
 windows_core::imp::define_interface!(IMapManagerStatics, IMapManagerStatics_Vtbl, 0x37e3e515_82b4_4d54_8fd9_af2624b3011c);
+impl windows_core::RuntimeType for IMapManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -112,6 +142,9 @@ pub struct IMapManagerStatics_Vtbl {
     pub ShowMapsUpdateUI: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRoute, IMapRoute_Vtbl, 0xfb07b732_584d_4583_9c60_641fea274349);
+impl windows_core::RuntimeType for IMapRoute {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRoute_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -132,6 +165,9 @@ pub struct IMapRoute_Vtbl {
     pub IsTrafficBased: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRoute2, IMapRoute2_Vtbl, 0xd1c5d40c_2213_4ab0_a260_46b38169beac);
+impl windows_core::RuntimeType for IMapRoute2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRoute2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +175,9 @@ pub struct IMapRoute2_Vtbl {
     pub HasBlockedRoads: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRoute3, IMapRoute3_Vtbl, 0x858d1eae_f2ad_429f_bb37_cd21094ffc92);
+impl windows_core::RuntimeType for IMapRoute3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRoute3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -146,12 +185,18 @@ pub struct IMapRoute3_Vtbl {
     pub TrafficCongestion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut TrafficCongestion) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRoute4, IMapRoute4_Vtbl, 0x366c8ca5_3053_4fa1_80ff_d475f3ed1e6e);
+impl windows_core::RuntimeType for IMapRoute4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRoute4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsScenic: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRouteDrivingOptions, IMapRouteDrivingOptions_Vtbl, 0x6815364d_c6dc_4697_a452_b18f8f0b67a1);
+impl windows_core::RuntimeType for IMapRouteDrivingOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteDrivingOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +210,9 @@ pub struct IMapRouteDrivingOptions_Vtbl {
     pub SetRouteRestrictions: unsafe extern "system" fn(*mut core::ffi::c_void, MapRouteRestrictions) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRouteDrivingOptions2, IMapRouteDrivingOptions2_Vtbl, 0x35dc8670_c298_48d0_b5ad_825460645603);
+impl windows_core::RuntimeType for IMapRouteDrivingOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteDrivingOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,6 +220,9 @@ pub struct IMapRouteDrivingOptions2_Vtbl {
     pub SetDepartureTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRouteFinderResult, IMapRouteFinderResult_Vtbl, 0xa868a31a_9422_46ac_8ca1_b1614d4bfbe2);
+impl windows_core::RuntimeType for IMapRouteFinderResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteFinderResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,6 +230,9 @@ pub struct IMapRouteFinderResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MapRouteFinderStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRouteFinderResult2, IMapRouteFinderResult2_Vtbl, 0x20709c6d_d90c_46c8_91c6_7d4be4efb215);
+impl windows_core::RuntimeType for IMapRouteFinderResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteFinderResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +242,9 @@ pub struct IMapRouteFinderResult2_Vtbl {
     AlternateRoutes: usize,
 }
 windows_core::imp::define_interface!(IMapRouteFinderStatics, IMapRouteFinderStatics_Vtbl, 0xb8a5c50f_1c64_4c3a_81eb_1f7c152afbbb);
+impl windows_core::RuntimeType for IMapRouteFinderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteFinderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -233,6 +290,9 @@ pub struct IMapRouteFinderStatics_Vtbl {
     GetWalkingRouteFromWaypointsAsync: usize,
 }
 windows_core::imp::define_interface!(IMapRouteFinderStatics2, IMapRouteFinderStatics2_Vtbl, 0xafcc2c73_7760_49af_b3bd_baf135b703e1);
+impl windows_core::RuntimeType for IMapRouteFinderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteFinderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -242,6 +302,9 @@ pub struct IMapRouteFinderStatics2_Vtbl {
     GetDrivingRouteWithOptionsAsync: usize,
 }
 windows_core::imp::define_interface!(IMapRouteFinderStatics3, IMapRouteFinderStatics3_Vtbl, 0xf6098134_5913_11e6_8b77_86f30ca893d3);
+impl windows_core::RuntimeType for IMapRouteFinderStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteFinderStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -255,6 +318,9 @@ pub struct IMapRouteFinderStatics3_Vtbl {
     GetDrivingRouteFromEnhancedWaypointsWithOptionsAsync: usize,
 }
 windows_core::imp::define_interface!(IMapRouteLeg, IMapRouteLeg_Vtbl, 0x96f8b2f6_5bba_4d17_9db6_1a263fec7471);
+impl windows_core::RuntimeType for IMapRouteLeg {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteLeg_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +340,9 @@ pub struct IMapRouteLeg_Vtbl {
     Maneuvers: usize,
 }
 windows_core::imp::define_interface!(IMapRouteLeg2, IMapRouteLeg2_Vtbl, 0x02e2062d_c9c6_45b8_8e54_1a10b57a17e8);
+impl windows_core::RuntimeType for IMapRouteLeg2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteLeg2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +350,9 @@ pub struct IMapRouteLeg2_Vtbl {
     pub TrafficCongestion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut TrafficCongestion) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRouteManeuver, IMapRouteManeuver_Vtbl, 0xed5c17f0_a6ab_4d65_a086_fa8a7e340df2);
+impl windows_core::RuntimeType for IMapRouteManeuver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteManeuver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -295,6 +367,9 @@ pub struct IMapRouteManeuver_Vtbl {
     pub ManeuverNotices: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MapManeuverNotices) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRouteManeuver2, IMapRouteManeuver2_Vtbl, 0x5d7bcd9c_7c9b_41df_838b_eae21e4b05a9);
+impl windows_core::RuntimeType for IMapRouteManeuver2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteManeuver2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -303,6 +378,9 @@ pub struct IMapRouteManeuver2_Vtbl {
     pub StreetName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapRouteManeuver3, IMapRouteManeuver3_Vtbl, 0xa6a138df_0483_4166_85be_b99336c11875);
+impl windows_core::RuntimeType for IMapRouteManeuver3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapRouteManeuver3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,6 +390,9 @@ pub struct IMapRouteManeuver3_Vtbl {
     Warnings: usize,
 }
 windows_core::imp::define_interface!(IMapServiceStatics, IMapServiceStatics_Vtbl, 0x0144ad85_c04c_4cdd_871a_a0726d097cd4);
+impl windows_core::RuntimeType for IMapServiceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapServiceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -319,18 +400,27 @@ pub struct IMapServiceStatics_Vtbl {
     pub ServiceToken: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapServiceStatics2, IMapServiceStatics2_Vtbl, 0xf8193eed_9c85_40a9_8896_0fc3fd2b7c2a);
+impl windows_core::RuntimeType for IMapServiceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapServiceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub WorldViewRegionCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapServiceStatics3, IMapServiceStatics3_Vtbl, 0x0a11ce20_63a7_4854_b355_d6dcda223d1b);
+impl windows_core::RuntimeType for IMapServiceStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapServiceStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DataAttributions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMapServiceStatics4, IMapServiceStatics4_Vtbl, 0x088a2862_6abc_420e_945f_4cfd89c67356);
+impl windows_core::RuntimeType for IMapServiceStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMapServiceStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -338,6 +428,9 @@ pub struct IMapServiceStatics4_Vtbl {
     pub DataUsagePreference: unsafe extern "system" fn(*mut core::ffi::c_void, *mut MapServiceDataUsagePreference) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaceInfo, IPlaceInfo_Vtbl, 0x9a0810b6_31c8_4f6a_9f18_950b4c38951a);
+impl windows_core::RuntimeType for IPlaceInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaceInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -355,6 +448,9 @@ pub struct IPlaceInfo_Vtbl {
     Geoshape: usize,
 }
 windows_core::imp::define_interface!(IPlaceInfoCreateOptions, IPlaceInfoCreateOptions_Vtbl, 0xcd33c125_67f1_4bb3_9907_ecce939b0399);
+impl windows_core::RuntimeType for IPlaceInfoCreateOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaceInfoCreateOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -364,6 +460,9 @@ pub struct IPlaceInfoCreateOptions_Vtbl {
     pub DisplayAddress: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaceInfoStatics, IPlaceInfoStatics_Vtbl, 0x82b9ff71_6cd0_48a4_afd9_5ed82097936b);
+impl windows_core::RuntimeType for IPlaceInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaceInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -384,6 +483,9 @@ pub struct IPlaceInfoStatics_Vtbl {
     pub IsShowSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlaceInfoStatics2, IPlaceInfoStatics2_Vtbl, 0x730f0249_4047_44a3_8f81_2550a5216370);
+impl windows_core::RuntimeType for IPlaceInfoStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlaceInfoStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -427,7 +529,7 @@ impl EnhancedWaypoint {
     }
 }
 impl windows_core::RuntimeType for EnhancedWaypoint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEnhancedWaypoint>();
 }
 unsafe impl windows_core::Interface for EnhancedWaypoint {
     type Vtable = IEnhancedWaypoint_Vtbl;
@@ -459,7 +561,7 @@ impl ManeuverWarning {
     }
 }
 impl windows_core::RuntimeType for ManeuverWarning {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IManeuverWarning>();
 }
 unsafe impl windows_core::Interface for ManeuverWarning {
     type Vtable = IManeuverWarning_Vtbl;
@@ -589,7 +691,7 @@ impl MapAddress {
     }
 }
 impl windows_core::RuntimeType for MapAddress {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapAddress>();
 }
 unsafe impl windows_core::Interface for MapAddress {
     type Vtable = IMapAddress_Vtbl;
@@ -636,7 +738,7 @@ impl MapLocation {
     }
 }
 impl windows_core::RuntimeType for MapLocation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapLocation>();
 }
 unsafe impl windows_core::Interface for MapLocation {
     type Vtable = IMapLocation_Vtbl;
@@ -725,7 +827,7 @@ impl MapLocationFinderResult {
     }
 }
 impl windows_core::RuntimeType for MapLocationFinderResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapLocationFinderResult>();
 }
 unsafe impl windows_core::Interface for MapLocationFinderResult {
     type Vtable = IMapLocationFinderResult_Vtbl;
@@ -840,7 +942,7 @@ impl MapRoute {
     }
 }
 impl windows_core::RuntimeType for MapRoute {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapRoute>();
 }
 unsafe impl windows_core::Interface for MapRoute {
     type Vtable = IMapRoute_Vtbl;
@@ -926,7 +1028,7 @@ impl MapRouteDrivingOptions {
     }
 }
 impl windows_core::RuntimeType for MapRouteDrivingOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapRouteDrivingOptions>();
 }
 unsafe impl windows_core::Interface for MapRouteDrivingOptions {
     type Vtable = IMapRouteDrivingOptions_Vtbl;
@@ -1125,7 +1227,7 @@ impl MapRouteFinderResult {
     }
 }
 impl windows_core::RuntimeType for MapRouteFinderResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapRouteFinderResult>();
 }
 unsafe impl windows_core::Interface for MapRouteFinderResult {
     type Vtable = IMapRouteFinderResult_Vtbl;
@@ -1195,7 +1297,7 @@ impl MapRouteLeg {
     }
 }
 impl windows_core::RuntimeType for MapRouteLeg {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapRouteLeg>();
 }
 unsafe impl windows_core::Interface for MapRouteLeg {
     type Vtable = IMapRouteLeg_Vtbl;
@@ -1285,7 +1387,7 @@ impl MapRouteManeuver {
     }
 }
 impl windows_core::RuntimeType for MapRouteManeuver {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMapRouteManeuver>();
 }
 unsafe impl windows_core::Interface for MapRouteManeuver {
     type Vtable = IMapRouteManeuver_Vtbl;
@@ -1472,7 +1574,7 @@ impl PlaceInfo {
     }
 }
 impl windows_core::RuntimeType for PlaceInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaceInfo>();
 }
 unsafe impl windows_core::Interface for PlaceInfo {
     type Vtable = IPlaceInfo_Vtbl;
@@ -1519,7 +1621,7 @@ impl PlaceInfoCreateOptions {
     }
 }
 impl windows_core::RuntimeType for PlaceInfoCreateOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlaceInfoCreateOptions>();
 }
 unsafe impl windows_core::Interface for PlaceInfoCreateOptions {
     type Vtable = IPlaceInfoCreateOptions_Vtbl;

--- a/crates/libs/windows/src/Windows/Services/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Store/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IStoreAcquireLicenseResult, IStoreAcquireLicenseResult_Vtbl, 0xfbd7946d_f040_4cb3_9a39_29bcecdbe22d);
+impl windows_core::RuntimeType for IStoreAcquireLicenseResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreAcquireLicenseResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IStoreAcquireLicenseResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreAppLicense, IStoreAppLicense_Vtbl, 0xf389f9de_73c0_45ce_9bab_b2fe3e5eafd3);
+impl windows_core::RuntimeType for IStoreAppLicense {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreAppLicense_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,12 +29,18 @@ pub struct IStoreAppLicense_Vtbl {
     pub TrialUniqueId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreAppLicense2, IStoreAppLicense2_Vtbl, 0xb4666e91_4443_40b3_993f_28904435bdc6);
+impl windows_core::RuntimeType for IStoreAppLicense2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreAppLicense2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsDiscLicense: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreAvailability, IStoreAvailability_Vtbl, 0xfa060325_0ffd_4493_ad43_f1f9918f69fa);
+impl windows_core::RuntimeType for IStoreAvailability {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreAvailability_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +52,9 @@ pub struct IStoreAvailability_Vtbl {
     pub RequestPurchaseWithPurchasePropertiesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreCanAcquireLicenseResult, IStoreCanAcquireLicenseResult_Vtbl, 0x3a693db3_0088_482f_86d5_bd46522663ad);
+impl windows_core::RuntimeType for IStoreCanAcquireLicenseResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreCanAcquireLicenseResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -48,6 +63,9 @@ pub struct IStoreCanAcquireLicenseResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut StoreCanLicenseStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreCollectionData, IStoreCollectionData_Vtbl, 0x8aa4c3b3_5bb3_441a_2ab4_4dab73d5ce67);
+impl windows_core::RuntimeType for IStoreCollectionData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreCollectionData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +79,9 @@ pub struct IStoreCollectionData_Vtbl {
     pub ExtendedJsonData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreConsumableResult, IStoreConsumableResult_Vtbl, 0xea5dab72_6a00_4052_be5b_bfdab4433352);
+impl windows_core::RuntimeType for IStoreConsumableResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreConsumableResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -70,6 +91,9 @@ pub struct IStoreConsumableResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreContext, IStoreContext_Vtbl, 0xac98b6be_f4fd_4912_babd_5035e5e8bcab);
+impl windows_core::RuntimeType for IStoreContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,6 +153,9 @@ pub struct IStoreContext_Vtbl {
     RequestDownloadAndInstallStorePackagesAsync: usize,
 }
 windows_core::imp::define_interface!(IStoreContext2, IStoreContext2_Vtbl, 0x18bc54da_7bd9_452c_9116_3bbd06ffc63a);
+impl windows_core::RuntimeType for IStoreContext2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreContext2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -138,6 +165,9 @@ pub struct IStoreContext2_Vtbl {
     FindStoreProductForPackageAsync: usize,
 }
 windows_core::imp::define_interface!(IStoreContext3, IStoreContext3_Vtbl, 0xe26226ca_1a01_4730_85a6_ecc896e4ae38);
+impl windows_core::RuntimeType for IStoreContext3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreContext3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -187,6 +217,9 @@ pub struct IStoreContext3_Vtbl {
     pub UninstallStorePackageByStoreIdAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreContext4, IStoreContext4_Vtbl, 0xaf9c6f69_bea1_4bf4_8e74_ae03e206c6b0);
+impl windows_core::RuntimeType for IStoreContext4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreContext4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,6 +230,9 @@ pub struct IStoreContext4_Vtbl {
     SetInstallOrderForAssociatedStoreQueueItemsAsync: usize,
 }
 windows_core::imp::define_interface!(IStoreContext5, IStoreContext5_Vtbl, 0x6de6c52b_c43a_5953_b39a_71643c57d96e);
+impl windows_core::RuntimeType for IStoreContext5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreContext5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -211,6 +247,9 @@ pub struct IStoreContext5_Vtbl {
     pub RequestPurchaseByInAppOfferTokenAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreContextStatics, IStoreContextStatics_Vtbl, 0x9c06ee5f_15c0_4e72_9330_d6191cebd19c);
+impl windows_core::RuntimeType for IStoreContextStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreContextStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +260,9 @@ pub struct IStoreContextStatics_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IStoreImage, IStoreImage_Vtbl, 0x081fd248_adb4_4b64_a993_784789926ed5);
+impl windows_core::RuntimeType for IStoreImage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreImage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -231,6 +273,9 @@ pub struct IStoreImage_Vtbl {
     pub Caption: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreLicense, IStoreLicense_Vtbl, 0x26dc9579_4c4f_4f30_bc89_649f60e36055);
+impl windows_core::RuntimeType for IStoreLicense {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreLicense_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -241,6 +286,9 @@ pub struct IStoreLicense_Vtbl {
     pub InAppOfferToken: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePackageInstallOptions, IStorePackageInstallOptions_Vtbl, 0x1d3d630c_0ccd_44dd_8c59_80810a729973);
+impl windows_core::RuntimeType for IStorePackageInstallOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePackageInstallOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +296,9 @@ pub struct IStorePackageInstallOptions_Vtbl {
     pub SetAllowForcedAppRestart: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePackageLicense, IStorePackageLicense_Vtbl, 0x0c465714_14e1_4973_bd14_f77724271e99);
+impl windows_core::RuntimeType for IStorePackageLicense {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePackageLicense_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -261,6 +312,9 @@ pub struct IStorePackageLicense_Vtbl {
     pub ReleaseLicense: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePackageUpdate, IStorePackageUpdate_Vtbl, 0x140fa150_3cbf_4a35_b91f_48271c31b072);
+impl windows_core::RuntimeType for IStorePackageUpdate {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePackageUpdate_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -271,6 +325,9 @@ pub struct IStorePackageUpdate_Vtbl {
     pub Mandatory: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePackageUpdateResult, IStorePackageUpdateResult_Vtbl, 0xe79142ed_61f9_4893_b4fe_cf191603af7b);
+impl windows_core::RuntimeType for IStorePackageUpdateResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePackageUpdateResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +338,9 @@ pub struct IStorePackageUpdateResult_Vtbl {
     StorePackageUpdateStatuses: usize,
 }
 windows_core::imp::define_interface!(IStorePackageUpdateResult2, IStorePackageUpdateResult2_Vtbl, 0x071d012e_bc62_4f2e_87ea_99d801aeaf98);
+impl windows_core::RuntimeType for IStorePackageUpdateResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePackageUpdateResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,6 +350,9 @@ pub struct IStorePackageUpdateResult2_Vtbl {
     StoreQueueItems: usize,
 }
 windows_core::imp::define_interface!(IStorePrice, IStorePrice_Vtbl, 0x55ba94c4_15f1_407c_8f06_006380f4df0b);
+impl windows_core::RuntimeType for IStorePrice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePrice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -301,6 +364,9 @@ pub struct IStorePrice_Vtbl {
     pub FormattedRecurrencePrice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePrice2, IStorePrice2_Vtbl, 0xf711573c_40e6_5641_b063_f1df42b2b12a);
+impl windows_core::RuntimeType for IStorePrice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePrice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -309,6 +375,9 @@ pub struct IStorePrice2_Vtbl {
     pub UnformattedRecurrencePrice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreProduct, IStoreProduct_Vtbl, 0x320e2c52_d760_450a_a42b_67d1e901ac90);
+impl windows_core::RuntimeType for IStoreProduct {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreProduct_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -344,6 +413,9 @@ pub struct IStoreProduct_Vtbl {
     pub InAppOfferToken: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreProductOptions, IStoreProductOptions_Vtbl, 0x5b34a0f9_a113_4811_8326_16199c927f31);
+impl windows_core::RuntimeType for IStoreProductOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreProductOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -353,6 +425,9 @@ pub struct IStoreProductOptions_Vtbl {
     ActionFilters: usize,
 }
 windows_core::imp::define_interface!(IStoreProductPagedQueryResult, IStoreProductPagedQueryResult_Vtbl, 0xc92718c5_4dd5_4869_a462_ecc6872e43c5);
+impl windows_core::RuntimeType for IStoreProductPagedQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreProductPagedQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -365,6 +440,9 @@ pub struct IStoreProductPagedQueryResult_Vtbl {
     pub GetNextAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreProductQueryResult, IStoreProductQueryResult_Vtbl, 0xd805e6c5_d456_4ff6_8049_9076d5165f73);
+impl windows_core::RuntimeType for IStoreProductQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreProductQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -375,6 +453,9 @@ pub struct IStoreProductQueryResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreProductResult, IStoreProductResult_Vtbl, 0xb7674f73_3c87_4ee1_8201_f428359bd3af);
+impl windows_core::RuntimeType for IStoreProductResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreProductResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -382,6 +463,9 @@ pub struct IStoreProductResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePurchaseProperties, IStorePurchaseProperties_Vtbl, 0x836278f3_ff87_4364_a5b4_fd2153ebe43b);
+impl windows_core::RuntimeType for IStorePurchaseProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePurchaseProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -391,12 +475,18 @@ pub struct IStorePurchaseProperties_Vtbl {
     pub SetExtendedJsonData: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePurchasePropertiesFactory, IStorePurchasePropertiesFactory_Vtbl, 0xa768f59e_fefd_489f_9a17_22a593e68b9d);
+impl windows_core::RuntimeType for IStorePurchasePropertiesFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePurchasePropertiesFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorePurchaseResult, IStorePurchaseResult_Vtbl, 0xadd28552_f96a_463d_a7bb_c20b4fca6952);
+impl windows_core::RuntimeType for IStorePurchaseResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorePurchaseResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -404,6 +494,9 @@ pub struct IStorePurchaseResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreQueueItem, IStoreQueueItem_Vtbl, 0x56d5c32b_f830_4293_9188_cad2dcde7357);
+impl windows_core::RuntimeType for IStoreQueueItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreQueueItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -417,6 +510,9 @@ pub struct IStoreQueueItem_Vtbl {
     pub RemoveStatusChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreQueueItem2, IStoreQueueItem2_Vtbl, 0x69491ca8_1ad4_447c_ad8c_a95035f64d82);
+impl windows_core::RuntimeType for IStoreQueueItem2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreQueueItem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -425,12 +521,18 @@ pub struct IStoreQueueItem2_Vtbl {
     pub ResumeInstallAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreQueueItemCompletedEventArgs, IStoreQueueItemCompletedEventArgs_Vtbl, 0x1247df6c_b44a_439b_bb07_1d3003d005c2);
+impl windows_core::RuntimeType for IStoreQueueItemCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreQueueItemCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreQueueItemStatus, IStoreQueueItemStatus_Vtbl, 0x9bd6796f_9cc3_4ec3_b2ef_7be433b30174);
+impl windows_core::RuntimeType for IStoreQueueItemStatus {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreQueueItemStatus_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -440,6 +542,9 @@ pub struct IStoreQueueItemStatus_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreRateAndReviewResult, IStoreRateAndReviewResult_Vtbl, 0x9d209d56_a6b5_4121_9b61_ee6d0fbdbdbb);
+impl windows_core::RuntimeType for IStoreRateAndReviewResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreRateAndReviewResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -449,12 +554,18 @@ pub struct IStoreRateAndReviewResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut StoreRateAndReviewStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreRequestHelperStatics, IStoreRequestHelperStatics_Vtbl, 0x6ce5e5f9_a0c9_4b2c_96a6_a171c630038d);
+impl windows_core::RuntimeType for IStoreRequestHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreRequestHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SendRequestAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreSendRequestResult, IStoreSendRequestResult_Vtbl, 0xc73abe60_8272_4502_8a69_6e75153a4299);
+impl windows_core::RuntimeType for IStoreSendRequestResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreSendRequestResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -462,6 +573,9 @@ pub struct IStoreSendRequestResult_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreSendRequestResult2, IStoreSendRequestResult2_Vtbl, 0x2901296f_c0b0_49d0_8e8d_aa940af9c10b);
+impl windows_core::RuntimeType for IStoreSendRequestResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreSendRequestResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -471,6 +585,9 @@ pub struct IStoreSendRequestResult2_Vtbl {
     HttpStatusCode: usize,
 }
 windows_core::imp::define_interface!(IStoreSku, IStoreSku_Vtbl, 0x397e6f55_4440_4f03_863c_91f3fec83d79);
+impl windows_core::RuntimeType for IStoreSku {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreSku_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -507,6 +624,9 @@ pub struct IStoreSku_Vtbl {
     pub SubscriptionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreSubscriptionInfo, IStoreSubscriptionInfo_Vtbl, 0x4189776a_0559_43ac_a9c6_3ab0011fb8eb);
+impl windows_core::RuntimeType for IStoreSubscriptionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreSubscriptionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -517,6 +637,9 @@ pub struct IStoreSubscriptionInfo_Vtbl {
     pub TrialPeriodUnit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut StoreDurationUnit) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreUninstallStorePackageResult, IStoreUninstallStorePackageResult_Vtbl, 0x9fca39fd_126f_4cda_b801_1346b8d0a260);
+impl windows_core::RuntimeType for IStoreUninstallStorePackageResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreUninstallStorePackageResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -524,6 +647,9 @@ pub struct IStoreUninstallStorePackageResult_Vtbl {
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut StoreUninstallStorePackageStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStoreVideo, IStoreVideo_Vtbl, 0xf26cb184_6f5e_4dc2_886c_3c63083c2f94);
+impl windows_core::RuntimeType for IStoreVideo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStoreVideo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -555,7 +681,7 @@ impl StoreAcquireLicenseResult {
     }
 }
 impl windows_core::RuntimeType for StoreAcquireLicenseResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreAcquireLicenseResult>();
 }
 unsafe impl windows_core::Interface for StoreAcquireLicenseResult {
     type Vtable = IStoreAcquireLicenseResult_Vtbl;
@@ -644,7 +770,7 @@ impl StoreAppLicense {
     }
 }
 impl windows_core::RuntimeType for StoreAppLicense {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreAppLicense>();
 }
 unsafe impl windows_core::Interface for StoreAppLicense {
     type Vtable = IStoreAppLicense_Vtbl;
@@ -707,7 +833,7 @@ impl StoreAvailability {
     }
 }
 impl windows_core::RuntimeType for StoreAvailability {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreAvailability>();
 }
 unsafe impl windows_core::Interface for StoreAvailability {
     type Vtable = IStoreAvailability_Vtbl;
@@ -746,7 +872,7 @@ impl StoreCanAcquireLicenseResult {
     }
 }
 impl windows_core::RuntimeType for StoreCanAcquireLicenseResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreCanAcquireLicenseResult>();
 }
 unsafe impl windows_core::Interface for StoreCanAcquireLicenseResult {
     type Vtable = IStoreCanAcquireLicenseResult_Vtbl;
@@ -820,7 +946,7 @@ impl StoreCollectionData {
     }
 }
 impl windows_core::RuntimeType for StoreCollectionData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreCollectionData>();
 }
 unsafe impl windows_core::Interface for StoreCollectionData {
     type Vtable = IStoreCollectionData_Vtbl;
@@ -866,7 +992,7 @@ impl StoreConsumableResult {
     }
 }
 impl windows_core::RuntimeType for StoreConsumableResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreConsumableResult>();
 }
 unsafe impl windows_core::Interface for StoreConsumableResult {
     type Vtable = IStoreConsumableResult_Vtbl;
@@ -1291,7 +1417,7 @@ impl StoreContext {
     }
 }
 impl windows_core::RuntimeType for StoreContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreContext>();
 }
 unsafe impl windows_core::Interface for StoreContext {
     type Vtable = IStoreContext_Vtbl;
@@ -1344,7 +1470,7 @@ impl StoreImage {
     }
 }
 impl windows_core::RuntimeType for StoreImage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreImage>();
 }
 unsafe impl windows_core::Interface for StoreImage {
     type Vtable = IStoreImage_Vtbl;
@@ -1397,7 +1523,7 @@ impl StoreLicense {
     }
 }
 impl windows_core::RuntimeType for StoreLicense {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreLicense>();
 }
 unsafe impl windows_core::Interface for StoreLicense {
     type Vtable = IStoreLicense_Vtbl;
@@ -1433,7 +1559,7 @@ impl StorePackageInstallOptions {
     }
 }
 impl windows_core::RuntimeType for StorePackageInstallOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePackageInstallOptions>();
 }
 unsafe impl windows_core::Interface for StorePackageInstallOptions {
     type Vtable = IStorePackageInstallOptions_Vtbl;
@@ -1489,7 +1615,7 @@ impl StorePackageLicense {
     }
 }
 impl windows_core::RuntimeType for StorePackageLicense {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePackageLicense>();
 }
 unsafe impl windows_core::Interface for StorePackageLicense {
     type Vtable = IStorePackageLicense_Vtbl;
@@ -1522,7 +1648,7 @@ impl StorePackageUpdate {
     }
 }
 impl windows_core::RuntimeType for StorePackageUpdate {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePackageUpdate>();
 }
 unsafe impl windows_core::Interface for StorePackageUpdate {
     type Vtable = IStorePackageUpdate_Vtbl;
@@ -1563,7 +1689,7 @@ impl StorePackageUpdateResult {
     }
 }
 impl windows_core::RuntimeType for StorePackageUpdateResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePackageUpdateResult>();
 }
 unsafe impl windows_core::Interface for StorePackageUpdateResult {
     type Vtable = IStorePackageUpdateResult_Vtbl;
@@ -1644,7 +1770,7 @@ impl StorePrice {
     }
 }
 impl windows_core::RuntimeType for StorePrice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePrice>();
 }
 unsafe impl windows_core::Interface for StorePrice {
     type Vtable = IStorePrice_Vtbl;
@@ -1795,7 +1921,7 @@ impl StoreProduct {
     }
 }
 impl windows_core::RuntimeType for StoreProduct {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreProduct>();
 }
 unsafe impl windows_core::Interface for StoreProduct {
     type Vtable = IStoreProduct_Vtbl;
@@ -1828,7 +1954,7 @@ impl StoreProductOptions {
     }
 }
 impl windows_core::RuntimeType for StoreProductOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreProductOptions>();
 }
 unsafe impl windows_core::Interface for StoreProductOptions {
     type Vtable = IStoreProductOptions_Vtbl;
@@ -1875,7 +2001,7 @@ impl StoreProductPagedQueryResult {
     }
 }
 impl windows_core::RuntimeType for StoreProductPagedQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreProductPagedQueryResult>();
 }
 unsafe impl windows_core::Interface for StoreProductPagedQueryResult {
     type Vtable = IStoreProductPagedQueryResult_Vtbl;
@@ -1908,7 +2034,7 @@ impl StoreProductQueryResult {
     }
 }
 impl windows_core::RuntimeType for StoreProductQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreProductQueryResult>();
 }
 unsafe impl windows_core::Interface for StoreProductQueryResult {
     type Vtable = IStoreProductQueryResult_Vtbl;
@@ -1940,7 +2066,7 @@ impl StoreProductResult {
     }
 }
 impl windows_core::RuntimeType for StoreProductResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreProductResult>();
 }
 unsafe impl windows_core::Interface for StoreProductResult {
     type Vtable = IStoreProductResult_Vtbl;
@@ -1998,7 +2124,7 @@ impl StorePurchaseProperties {
     }
 }
 impl windows_core::RuntimeType for StorePurchaseProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePurchaseProperties>();
 }
 unsafe impl windows_core::Interface for StorePurchaseProperties {
     type Vtable = IStorePurchaseProperties_Vtbl;
@@ -2030,7 +2156,7 @@ impl StorePurchaseResult {
     }
 }
 impl windows_core::RuntimeType for StorePurchaseResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorePurchaseResult>();
 }
 unsafe impl windows_core::Interface for StorePurchaseResult {
     type Vtable = IStorePurchaseResult_Vtbl;
@@ -2125,7 +2251,7 @@ impl StoreQueueItem {
     }
 }
 impl windows_core::RuntimeType for StoreQueueItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreQueueItem>();
 }
 unsafe impl windows_core::Interface for StoreQueueItem {
     type Vtable = IStoreQueueItem_Vtbl;
@@ -2150,7 +2276,7 @@ impl StoreQueueItemCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for StoreQueueItemCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreQueueItemCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for StoreQueueItemCompletedEventArgs {
     type Vtable = IStoreQueueItemCompletedEventArgs_Vtbl;
@@ -2196,7 +2322,7 @@ impl StoreQueueItemStatus {
     }
 }
 impl windows_core::RuntimeType for StoreQueueItemStatus {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreQueueItemStatus>();
 }
 unsafe impl windows_core::Interface for StoreQueueItemStatus {
     type Vtable = IStoreQueueItemStatus_Vtbl;
@@ -2242,7 +2368,7 @@ impl StoreRateAndReviewResult {
     }
 }
 impl windows_core::RuntimeType for StoreRateAndReviewResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreRateAndReviewResult>();
 }
 unsafe impl windows_core::Interface for StoreRateAndReviewResult {
     type Vtable = IStoreRateAndReviewResult_Vtbl;
@@ -2302,7 +2428,7 @@ impl StoreSendRequestResult {
     }
 }
 impl windows_core::RuntimeType for StoreSendRequestResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreSendRequestResult>();
 }
 unsafe impl windows_core::Interface for StoreSendRequestResult {
     type Vtable = IStoreSendRequestResult_Vtbl;
@@ -2460,7 +2586,7 @@ impl StoreSku {
     }
 }
 impl windows_core::RuntimeType for StoreSku {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreSku>();
 }
 unsafe impl windows_core::Interface for StoreSku {
     type Vtable = IStoreSku_Vtbl;
@@ -2513,7 +2639,7 @@ impl StoreSubscriptionInfo {
     }
 }
 impl windows_core::RuntimeType for StoreSubscriptionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreSubscriptionInfo>();
 }
 unsafe impl windows_core::Interface for StoreSubscriptionInfo {
     type Vtable = IStoreSubscriptionInfo_Vtbl;
@@ -2545,7 +2671,7 @@ impl StoreUninstallStorePackageResult {
     }
 }
 impl windows_core::RuntimeType for StoreUninstallStorePackageResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreUninstallStorePackageResult>();
 }
 unsafe impl windows_core::Interface for StoreUninstallStorePackageResult {
     type Vtable = IStoreUninstallStorePackageResult_Vtbl;
@@ -2605,7 +2731,7 @@ impl StoreVideo {
     }
 }
 impl windows_core::RuntimeType for StoreVideo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStoreVideo>();
 }
 unsafe impl windows_core::Interface for StoreVideo {
     type Vtable = IStoreVideo_Vtbl;

--- a/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
@@ -1,16 +1,25 @@
 windows_core::imp::define_interface!(ITargetedContentAction, ITargetedContentAction_Vtbl, 0xd75b691e_6cd6_4ca0_9d8f_4728b0b7e6b6);
+impl windows_core::RuntimeType for ITargetedContentAction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentAction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InvokeAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentAvailabilityChangedEventArgs, ITargetedContentAvailabilityChangedEventArgs_Vtbl, 0xe0f59d26_5927_4450_965c_1ceb7becde65);
+impl windows_core::RuntimeType for ITargetedContentAvailabilityChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentAvailabilityChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentChangedEventArgs, ITargetedContentChangedEventArgs_Vtbl, 0x99d488c9_587e_4586_8ef7_b54ca9453a16);
+impl windows_core::RuntimeType for ITargetedContentChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +27,9 @@ pub struct ITargetedContentChangedEventArgs_Vtbl {
     pub HasPreviousContentExpired: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentCollection, ITargetedContentCollection_Vtbl, 0x2d4b66c5_f163_44ba_9f6e_e1a4c2bb559d);
+impl windows_core::RuntimeType for ITargetedContentCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +51,9 @@ pub struct ITargetedContentCollection_Vtbl {
     Items: usize,
 }
 windows_core::imp::define_interface!(ITargetedContentContainer, ITargetedContentContainer_Vtbl, 0xbc2494c9_8837_47c2_850f_d79d64595926);
+impl windows_core::RuntimeType for ITargetedContentContainer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentContainer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,12 +64,18 @@ pub struct ITargetedContentContainer_Vtbl {
     pub SelectSingleObject: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentContainerStatics, ITargetedContentContainerStatics_Vtbl, 0x5b47e7fb_2140_4c1f_a736_c59583f227d8);
+impl windows_core::RuntimeType for ITargetedContentContainerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentContainerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentImage, ITargetedContentImage_Vtbl, 0xa7a585d9_779f_4b1e_bbb1_8eaf53fbeab2);
+impl windows_core::RuntimeType for ITargetedContentImage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentImage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +83,9 @@ pub struct ITargetedContentImage_Vtbl {
     pub Width: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentItem, ITargetedContentItem_Vtbl, 0x38168dc4_276c_4c32_96ba_565c6e406e74);
+impl windows_core::RuntimeType for ITargetedContentItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +103,9 @@ pub struct ITargetedContentItem_Vtbl {
     Collections: usize,
 }
 windows_core::imp::define_interface!(ITargetedContentItemState, ITargetedContentItemState_Vtbl, 0x73935454_4c65_4b47_a441_472de53c79b6);
+impl windows_core::RuntimeType for ITargetedContentItemState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentItemState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +113,9 @@ pub struct ITargetedContentItemState_Vtbl {
     pub AppInstallationState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut TargetedContentAppInstallationState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentObject, ITargetedContentObject_Vtbl, 0x041d7969_2212_42d1_9dfa_88a8e3033aa3);
+impl windows_core::RuntimeType for ITargetedContentObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,12 +125,18 @@ pub struct ITargetedContentObject_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentStateChangedEventArgs, ITargetedContentStateChangedEventArgs_Vtbl, 0x9a1cef3d_8073_4416_8df2_546835a6414f);
+impl windows_core::RuntimeType for ITargetedContentStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentSubscription, ITargetedContentSubscription_Vtbl, 0x882c2c49_c652_4c7a_acad_1f7fa2986c73);
+impl windows_core::RuntimeType for ITargetedContentSubscription {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentSubscription_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +150,9 @@ pub struct ITargetedContentSubscription_Vtbl {
     pub RemoveStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentSubscriptionOptions, ITargetedContentSubscriptionOptions_Vtbl, 0x61ee6ad0_2c83_421b_8467_413eaf1aeb97);
+impl windows_core::RuntimeType for ITargetedContentSubscriptionOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentSubscriptionOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -131,6 +170,9 @@ pub struct ITargetedContentSubscriptionOptions_Vtbl {
     pub Update: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentSubscriptionStatics, ITargetedContentSubscriptionStatics_Vtbl, 0xfaddfe80_360d_4916_b53c_7ea27090d02a);
+impl windows_core::RuntimeType for ITargetedContentSubscriptionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentSubscriptionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -138,6 +180,9 @@ pub struct ITargetedContentSubscriptionStatics_Vtbl {
     pub GetOptions: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetedContentValue, ITargetedContentValue_Vtbl, 0xaafde4b3_4215_4bf8_867f_43f04865f9bf);
+impl windows_core::RuntimeType for ITargetedContentValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetedContentValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -196,7 +241,7 @@ impl TargetedContentAction {
     }
 }
 impl windows_core::RuntimeType for TargetedContentAction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentAction>();
 }
 unsafe impl windows_core::Interface for TargetedContentAction {
     type Vtable = ITargetedContentAction_Vtbl;
@@ -221,7 +266,7 @@ impl TargetedContentAvailabilityChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TargetedContentAvailabilityChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentAvailabilityChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for TargetedContentAvailabilityChangedEventArgs {
     type Vtable = ITargetedContentAvailabilityChangedEventArgs_Vtbl;
@@ -253,7 +298,7 @@ impl TargetedContentChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TargetedContentChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for TargetedContentChangedEventArgs {
     type Vtable = ITargetedContentChangedEventArgs_Vtbl;
@@ -317,7 +362,7 @@ impl TargetedContentCollection {
     }
 }
 impl windows_core::RuntimeType for TargetedContentCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentCollection>();
 }
 unsafe impl windows_core::Interface for TargetedContentCollection {
     type Vtable = ITargetedContentCollection_Vtbl;
@@ -381,7 +426,7 @@ impl TargetedContentContainer {
     }
 }
 impl windows_core::RuntimeType for TargetedContentContainer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentContainer>();
 }
 unsafe impl windows_core::Interface for TargetedContentContainer {
     type Vtable = ITargetedContentContainer_Vtbl;
@@ -413,7 +458,7 @@ impl TargetedContentFile {
 }
 #[cfg(feature = "Storage_Streams")]
 impl windows_core::RuntimeType for TargetedContentFile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Storage::Streams::IRandomAccessStreamReference>();
 }
 #[cfg(feature = "Storage_Streams")]
 unsafe impl windows_core::Interface for TargetedContentFile {
@@ -459,7 +504,7 @@ impl TargetedContentImage {
     }
 }
 impl windows_core::RuntimeType for TargetedContentImage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentImage>();
 }
 unsafe impl windows_core::Interface for TargetedContentImage {
     type Vtable = ITargetedContentImage_Vtbl;
@@ -515,7 +560,7 @@ impl TargetedContentItem {
     }
 }
 impl windows_core::RuntimeType for TargetedContentItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentItem>();
 }
 unsafe impl windows_core::Interface for TargetedContentItem {
     type Vtable = ITargetedContentItem_Vtbl;
@@ -547,7 +592,7 @@ impl TargetedContentItemState {
     }
 }
 impl windows_core::RuntimeType for TargetedContentItemState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentItemState>();
 }
 unsafe impl windows_core::Interface for TargetedContentItemState {
     type Vtable = ITargetedContentItemState_Vtbl;
@@ -593,7 +638,7 @@ impl TargetedContentObject {
     }
 }
 impl windows_core::RuntimeType for TargetedContentObject {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentObject>();
 }
 unsafe impl windows_core::Interface for TargetedContentObject {
     type Vtable = ITargetedContentObject_Vtbl;
@@ -618,7 +663,7 @@ impl TargetedContentStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TargetedContentStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for TargetedContentStateChangedEventArgs {
     type Vtable = ITargetedContentStateChangedEventArgs_Vtbl;
@@ -709,7 +754,7 @@ impl TargetedContentSubscription {
     }
 }
 impl windows_core::RuntimeType for TargetedContentSubscription {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentSubscription>();
 }
 unsafe impl windows_core::Interface for TargetedContentSubscription {
     type Vtable = ITargetedContentSubscription_Vtbl;
@@ -765,7 +810,7 @@ impl TargetedContentSubscriptionOptions {
     }
 }
 impl windows_core::RuntimeType for TargetedContentSubscriptionOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentSubscriptionOptions>();
 }
 unsafe impl windows_core::Interface for TargetedContentSubscriptionOptions {
     type Vtable = ITargetedContentSubscriptionOptions_Vtbl;
@@ -903,7 +948,7 @@ impl TargetedContentValue {
     }
 }
 impl windows_core::RuntimeType for TargetedContentValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetedContentValue>();
 }
 unsafe impl windows_core::Interface for TargetedContentValue {
     type Vtable = ITargetedContentValue_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IItemRemovedEventArgs, IItemRemovedEventArgs_Vtbl, 0x59677e5c_55be_4c66_ba66_5eaea79d2631);
+impl windows_core::RuntimeType for IItemRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IItemRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemovedEntry: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<AccessListEntry>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageApplicationPermissionsStatics, IStorageApplicationPermissionsStatics_Vtbl, 0x4391dfaa_d033_48f9_8060_3ec847d2e3f1);
+impl windows_core::RuntimeType for IStorageApplicationPermissionsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageApplicationPermissionsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +18,9 @@ pub struct IStorageApplicationPermissionsStatics_Vtbl {
     pub MostRecentlyUsedList: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageApplicationPermissionsStatics2, IStorageApplicationPermissionsStatics2_Vtbl, 0x072716ec_aa05_4294_9a11_1a3d04519ad0);
+impl windows_core::RuntimeType for IStorageApplicationPermissionsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageApplicationPermissionsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -171,6 +180,9 @@ pub struct IStorageItemAccessList_Vtbl {
     pub MaximumItemsAllowed: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageItemMostRecentlyUsedList, IStorageItemMostRecentlyUsedList_Vtbl, 0x016239d5_510d_411e_8cf1_c3d1effa4c33);
+impl windows_core::RuntimeType for IStorageItemMostRecentlyUsedList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageItemMostRecentlyUsedList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -178,6 +190,9 @@ pub struct IStorageItemMostRecentlyUsedList_Vtbl {
     pub RemoveItemRemoved: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageItemMostRecentlyUsedList2, IStorageItemMostRecentlyUsedList2_Vtbl, 0xda481ea0_ed8d_4731_a1db_e44ee2204093);
+impl windows_core::RuntimeType for IStorageItemMostRecentlyUsedList2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageItemMostRecentlyUsedList2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,7 +255,7 @@ impl AccessListEntryView {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for AccessListEntryView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVectorView<AccessListEntry>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for AccessListEntryView {
@@ -281,7 +296,7 @@ impl ItemRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ItemRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IItemRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for ItemRemovedEventArgs {
     type Vtable = IItemRemovedEventArgs_Vtbl;
@@ -462,7 +477,7 @@ impl StorageItemAccessList {
     }
 }
 impl windows_core::RuntimeType for StorageItemAccessList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageItemAccessList>();
 }
 unsafe impl windows_core::Interface for StorageItemAccessList {
     type Vtable = IStorageItemAccessList_Vtbl;
@@ -626,7 +641,7 @@ impl StorageItemMostRecentlyUsedList {
     }
 }
 impl windows_core::RuntimeType for StorageItemMostRecentlyUsedList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageItemMostRecentlyUsedList>();
 }
 unsafe impl windows_core::Interface for StorageItemMostRecentlyUsedList {
     type Vtable = IStorageItemMostRecentlyUsedList_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/BulkAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/BulkAccess/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IFileInformationFactory, IFileInformationFactory_Vtbl, 0x401d88be_960f_4d6d_a7d0_1a3861e76c83);
+impl windows_core::RuntimeType for IFileInformationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileInformationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +34,9 @@ pub struct IFileInformationFactory_Vtbl {
     pub GetVirtualizedFoldersVector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileInformationFactoryFactory, IFileInformationFactoryFactory_Vtbl, 0x84ea0e7d_e4a2_4f00_8afa_af5e0f826bd5);
+impl windows_core::RuntimeType for IFileInformationFactoryFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileInformationFactoryFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -546,7 +552,7 @@ impl FileInformation {
     }
 }
 impl windows_core::RuntimeType for FileInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageItemInformation>();
 }
 unsafe impl windows_core::Interface for FileInformation {
     type Vtable = IStorageItemInformation_Vtbl;
@@ -676,7 +682,7 @@ impl FileInformationFactory {
     }
 }
 impl windows_core::RuntimeType for FileInformationFactory {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileInformationFactory>();
 }
 unsafe impl windows_core::Interface for FileInformationFactory {
     type Vtable = IFileInformationFactory_Vtbl;
@@ -1148,7 +1154,7 @@ impl FolderInformation {
     }
 }
 impl windows_core::RuntimeType for FolderInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageItemInformation>();
 }
 unsafe impl windows_core::Interface for FolderInformation {
     type Vtable = IStorageItemInformation_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICompressor, ICompressor_Vtbl, 0x0ac3645a_57ac_4ee1_b702_84d39d5424e0);
+impl windows_core::RuntimeType for ICompressor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompressor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct ICompressor_Vtbl {
     DetachStream: usize,
 }
 windows_core::imp::define_interface!(ICompressorFactory, ICompressorFactory_Vtbl, 0x5f3d96a4_2cfb_442c_a8ba_d7d11b039da0);
+impl windows_core::RuntimeType for ICompressorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompressorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -22,6 +28,9 @@ pub struct ICompressorFactory_Vtbl {
     CreateCompressorEx: usize,
 }
 windows_core::imp::define_interface!(IDecompressor, IDecompressor_Vtbl, 0xb883fe46_d68a_4c8b_ada0_4ee813fc5283);
+impl windows_core::RuntimeType for IDecompressor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDecompressor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +40,9 @@ pub struct IDecompressor_Vtbl {
     DetachStream: usize,
 }
 windows_core::imp::define_interface!(IDecompressorFactory, IDecompressorFactory_Vtbl, 0x5337e252_1da2_42e1_8834_0379d28d742f);
+impl windows_core::RuntimeType for IDecompressorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDecompressorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -111,7 +123,7 @@ impl Compressor {
     }
 }
 impl windows_core::RuntimeType for Compressor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompressor>();
 }
 unsafe impl windows_core::Interface for Compressor {
     type Vtable = ICompressor_Vtbl;
@@ -169,7 +181,7 @@ impl Decompressor {
     }
 }
 impl windows_core::RuntimeType for Decompressor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDecompressor>();
 }
 unsafe impl windows_core::Interface for Decompressor {
     type Vtable = IDecompressor_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IBasicProperties, IBasicProperties_Vtbl, 0xd05d55db_785e_4a66_be02_9beec58aea81);
+impl windows_core::RuntimeType for IBasicProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBasicProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,6 +10,9 @@ pub struct IBasicProperties_Vtbl {
     pub ItemDate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDocumentProperties, IDocumentProperties_Vtbl, 0x7eab19bc_1821_4923_b4a9_0aea404d0070);
+impl windows_core::RuntimeType for IDocumentProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDocumentProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,9 @@ pub struct IDocumentProperties_Vtbl {
     pub SetComment: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGeotagHelperStatics, IGeotagHelperStatics_Vtbl, 0x41493244_2524_4655_86a6_ed16f5fc716b);
+impl windows_core::RuntimeType for IGeotagHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGeotagHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +50,9 @@ pub struct IGeotagHelperStatics_Vtbl {
     SetGeotagAsync: usize,
 }
 windows_core::imp::define_interface!(IImageProperties, IImageProperties_Vtbl, 0x523c9424_fcff_4275_afee_ecdb9ab47973);
+impl windows_core::RuntimeType for IImageProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImageProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -69,6 +81,9 @@ pub struct IImageProperties_Vtbl {
     PeopleNames: usize,
 }
 windows_core::imp::define_interface!(IMusicProperties, IMusicProperties_Vtbl, 0xbc8aab62_66ec_419a_bc5d_ca65a4cb46da);
+impl windows_core::RuntimeType for IMusicProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMusicProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +129,9 @@ pub struct IMusicProperties_Vtbl {
     pub SetYear: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageItemContentProperties, IStorageItemContentProperties_Vtbl, 0x05294bad_bc38_48bf_85d7_770e0e2ae0ba);
+impl windows_core::RuntimeType for IStorageItemContentProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageItemContentProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,6 +190,9 @@ pub struct IStorageItemExtraProperties_Vtbl {
     pub SavePropertiesAsyncOverloadDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IThumbnailProperties, IThumbnailProperties_Vtbl, 0x693dd42f_dbe7_49b5_b3b3_2893ac5d3423);
+impl windows_core::RuntimeType for IThumbnailProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IThumbnailProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,6 +202,9 @@ pub struct IThumbnailProperties_Vtbl {
     pub Type: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ThumbnailType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVideoProperties, IVideoProperties_Vtbl, 0x719ae507_68de_4db8_97de_49998c059f2f);
+impl windows_core::RuntimeType for IVideoProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVideoProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -276,7 +300,7 @@ impl BasicProperties {
     }
 }
 impl windows_core::RuntimeType for BasicProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBasicProperties>();
 }
 unsafe impl windows_core::Interface for BasicProperties {
     type Vtable = IBasicProperties_Vtbl;
@@ -360,7 +384,7 @@ impl DocumentProperties {
     }
 }
 impl windows_core::RuntimeType for DocumentProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDocumentProperties>();
 }
 unsafe impl windows_core::Interface for DocumentProperties {
     type Vtable = IDocumentProperties_Vtbl;
@@ -555,7 +579,7 @@ impl ImageProperties {
     }
 }
 impl windows_core::RuntimeType for ImageProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImageProperties>();
 }
 unsafe impl windows_core::Interface for ImageProperties {
     type Vtable = IImageProperties_Vtbl;
@@ -754,7 +778,7 @@ impl MusicProperties {
     }
 }
 impl windows_core::RuntimeType for MusicProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMusicProperties>();
 }
 unsafe impl windows_core::Interface for MusicProperties {
     type Vtable = IMusicProperties_Vtbl;
@@ -828,7 +852,7 @@ impl StorageItemContentProperties {
     }
 }
 impl windows_core::RuntimeType for StorageItemContentProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageItemContentProperties>();
 }
 unsafe impl windows_core::Interface for StorageItemContentProperties {
     type Vtable = IStorageItemContentProperties_Vtbl;
@@ -986,7 +1010,7 @@ impl StorageItemThumbnail {
 }
 #[cfg(feature = "Storage_Streams")]
 impl windows_core::RuntimeType for StorageItemThumbnail {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::Streams::IRandomAccessStreamWithContentType>();
 }
 #[cfg(feature = "Storage_Streams")]
 unsafe impl windows_core::Interface for StorageItemThumbnail {
@@ -1170,7 +1194,7 @@ impl VideoProperties {
     }
 }
 impl windows_core::RuntimeType for VideoProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVideoProperties>();
 }
 unsafe impl windows_core::Interface for VideoProperties {
     type Vtable = IVideoProperties_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IFileOpenPickerUI, IFileOpenPickerUI_Vtbl, 0xdda45a10_f9d4_40c4_8af5_c5b6b5a61d1d);
+impl windows_core::RuntimeType for IFileOpenPickerUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileOpenPickerUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +31,10 @@ pub struct IFileOpenPickerUI_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IFileRemovedEventArgs, IFileRemovedEventArgs_Vtbl, 0x13043da7_7fca_4c2b_9eca_6890f9f00185);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IFileRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IFileRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +44,9 @@ pub struct IFileRemovedEventArgs_Vtbl {
     Id: usize,
 }
 windows_core::imp::define_interface!(IFileSavePickerUI, IFileSavePickerUI_Vtbl, 0x9656c1e7_3e56_43cc_8a39_33c73d9d542b);
+impl windows_core::RuntimeType for IFileSavePickerUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileSavePickerUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,12 +65,18 @@ pub struct IFileSavePickerUI_Vtbl {
     pub RemoveTargetFileRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPickerClosingDeferral, IPickerClosingDeferral_Vtbl, 0x7af7f71e_1a67_4a31_ae80_e907708a619b);
+impl windows_core::RuntimeType for IPickerClosingDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPickerClosingDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPickerClosingEventArgs, IPickerClosingEventArgs_Vtbl, 0x7e59f224_b332_4f12_8b9f_a8c2f06b32cd);
+impl windows_core::RuntimeType for IPickerClosingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPickerClosingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -68,6 +84,9 @@ pub struct IPickerClosingEventArgs_Vtbl {
     pub IsCanceled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPickerClosingOperation, IPickerClosingOperation_Vtbl, 0x4ce9fb84_beee_4e39_a773_fc5f0eae328d);
+impl windows_core::RuntimeType for IPickerClosingOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPickerClosingOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +94,9 @@ pub struct IPickerClosingOperation_Vtbl {
     pub Deadline: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetFileRequest, ITargetFileRequest_Vtbl, 0x42bd3355_7f88_478b_8e81_690b20340678);
+impl windows_core::RuntimeType for ITargetFileRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetFileRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,12 +105,18 @@ pub struct ITargetFileRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetFileRequestDeferral, ITargetFileRequestDeferral_Vtbl, 0x4aee9d91_bf15_4da9_95f6_f6b7d558225b);
+impl windows_core::RuntimeType for ITargetFileRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetFileRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITargetFileRequestedEventArgs, ITargetFileRequestedEventArgs_Vtbl, 0xb163dbc1_1b51_4c89_a591_0fd40b3c57c9);
+impl windows_core::RuntimeType for ITargetFileRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITargetFileRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -195,7 +223,7 @@ impl FileOpenPickerUI {
     }
 }
 impl windows_core::RuntimeType for FileOpenPickerUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileOpenPickerUI>();
 }
 unsafe impl windows_core::Interface for FileOpenPickerUI {
     type Vtable = IFileOpenPickerUI_Vtbl;
@@ -223,7 +251,7 @@ impl FileRemovedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for FileRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileRemovedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for FileRemovedEventArgs {
@@ -309,7 +337,7 @@ impl FileSavePickerUI {
     }
 }
 impl windows_core::RuntimeType for FileSavePickerUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileSavePickerUI>();
 }
 unsafe impl windows_core::Interface for FileSavePickerUI {
     type Vtable = IFileSavePickerUI_Vtbl;
@@ -329,7 +357,7 @@ impl PickerClosingDeferral {
     }
 }
 impl windows_core::RuntimeType for PickerClosingDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPickerClosingDeferral>();
 }
 unsafe impl windows_core::Interface for PickerClosingDeferral {
     type Vtable = IPickerClosingDeferral_Vtbl;
@@ -359,7 +387,7 @@ impl PickerClosingEventArgs {
     }
 }
 impl windows_core::RuntimeType for PickerClosingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPickerClosingEventArgs>();
 }
 unsafe impl windows_core::Interface for PickerClosingEventArgs {
     type Vtable = IPickerClosingEventArgs_Vtbl;
@@ -389,7 +417,7 @@ impl PickerClosingOperation {
     }
 }
 impl windows_core::RuntimeType for PickerClosingOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPickerClosingOperation>();
 }
 unsafe impl windows_core::Interface for PickerClosingOperation {
     type Vtable = IPickerClosingOperation_Vtbl;
@@ -426,7 +454,7 @@ impl TargetFileRequest {
     }
 }
 impl windows_core::RuntimeType for TargetFileRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetFileRequest>();
 }
 unsafe impl windows_core::Interface for TargetFileRequest {
     type Vtable = ITargetFileRequest_Vtbl;
@@ -446,7 +474,7 @@ impl TargetFileRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for TargetFileRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetFileRequestDeferral>();
 }
 unsafe impl windows_core::Interface for TargetFileRequestDeferral {
     type Vtable = ITargetFileRequestDeferral_Vtbl;
@@ -469,7 +497,7 @@ impl TargetFileRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TargetFileRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITargetFileRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for TargetFileRequestedEventArgs {
     type Vtable = ITargetFileRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "Storage_Pickers_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IFileOpenPicker, IFileOpenPicker_Vtbl, 0x2ca8278a_12c5_4c5f_8977_94547793c241);
+impl windows_core::RuntimeType for IFileOpenPicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileOpenPicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +26,9 @@ pub struct IFileOpenPicker_Vtbl {
     PickMultipleFilesAsync: usize,
 }
 windows_core::imp::define_interface!(IFileOpenPicker2, IFileOpenPicker2_Vtbl, 0x8ceb6cd2_b446_46f7_b265_90f8e55ad650);
+impl windows_core::RuntimeType for IFileOpenPicker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileOpenPicker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +46,9 @@ pub struct IFileOpenPicker2_Vtbl {
     PickMultipleFilesAndContinue: usize,
 }
 windows_core::imp::define_interface!(IFileOpenPicker3, IFileOpenPicker3_Vtbl, 0xd9a5c5b3_c5dc_5b98_bd80_a8d0ca0584d8);
+impl windows_core::RuntimeType for IFileOpenPicker3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileOpenPicker3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,6 +58,9 @@ pub struct IFileOpenPicker3_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IFileOpenPickerStatics, IFileOpenPickerStatics_Vtbl, 0x6821573b_2f02_4833_96d4_abbfad72b67b);
+impl windows_core::RuntimeType for IFileOpenPickerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileOpenPickerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +70,9 @@ pub struct IFileOpenPickerStatics_Vtbl {
     ResumePickSingleFileAsync: usize,
 }
 windows_core::imp::define_interface!(IFileOpenPickerStatics2, IFileOpenPickerStatics2_Vtbl, 0xe8917415_eddd_5c98_b6f3_366fdfcad392);
+impl windows_core::RuntimeType for IFileOpenPickerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileOpenPickerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,12 +82,18 @@ pub struct IFileOpenPickerStatics2_Vtbl {
     CreateForUser: usize,
 }
 windows_core::imp::define_interface!(IFileOpenPickerWithOperationId, IFileOpenPickerWithOperationId_Vtbl, 0x3f57b569_2522_4ca5_aa73_a15509f1fcbf);
+impl windows_core::RuntimeType for IFileOpenPickerWithOperationId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileOpenPickerWithOperationId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PickSingleFileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileSavePicker, IFileSavePicker_Vtbl, 0x3286ffcb_617f_4cc5_af6a_b3fdf29ad145);
+impl windows_core::RuntimeType for IFileSavePicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileSavePicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,6 +116,9 @@ pub struct IFileSavePicker_Vtbl {
     pub PickSaveFileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileSavePicker2, IFileSavePicker2_Vtbl, 0x0ec313a2_d24b_449a_8197_e89104fd42cc);
+impl windows_core::RuntimeType for IFileSavePicker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileSavePicker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +132,9 @@ pub struct IFileSavePicker2_Vtbl {
     PickSaveFileAndContinue: usize,
 }
 windows_core::imp::define_interface!(IFileSavePicker3, IFileSavePicker3_Vtbl, 0x698aec69_ba3c_4e51_bd90_4abcbbf4cfaf);
+impl windows_core::RuntimeType for IFileSavePicker3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileSavePicker3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,6 +142,9 @@ pub struct IFileSavePicker3_Vtbl {
     pub SetEnterpriseId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileSavePicker4, IFileSavePicker4_Vtbl, 0xe7d83a5a_ddfa_5de0_8b70_c842c21988ec);
+impl windows_core::RuntimeType for IFileSavePicker4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileSavePicker4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +154,9 @@ pub struct IFileSavePicker4_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IFileSavePickerStatics, IFileSavePickerStatics_Vtbl, 0x28e3cf9e_961c_5e2c_aed7_e64737f4ce37);
+impl windows_core::RuntimeType for IFileSavePickerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileSavePickerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,6 +166,9 @@ pub struct IFileSavePickerStatics_Vtbl {
     CreateForUser: usize,
 }
 windows_core::imp::define_interface!(IFolderPicker, IFolderPicker_Vtbl, 0x084f7799_f3fb_400a_99b1_7b4a772fd60d);
+impl windows_core::RuntimeType for IFolderPicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFolderPicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,6 +187,9 @@ pub struct IFolderPicker_Vtbl {
     pub PickSingleFolderAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFolderPicker2, IFolderPicker2_Vtbl, 0x8eb3ba97_dc85_4616_be94_9660881f2f5d);
+impl windows_core::RuntimeType for IFolderPicker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFolderPicker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -164,6 +203,9 @@ pub struct IFolderPicker2_Vtbl {
     PickFolderAndContinue: usize,
 }
 windows_core::imp::define_interface!(IFolderPicker3, IFolderPicker3_Vtbl, 0x673b1e29_d326_53c0_bd24_a25c714cee36);
+impl windows_core::RuntimeType for IFolderPicker3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFolderPicker3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,6 +215,9 @@ pub struct IFolderPicker3_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IFolderPickerStatics, IFolderPickerStatics_Vtbl, 0x9be34740_7ca1_5942_a3c8_46f2551ecff3);
+impl windows_core::RuntimeType for IFolderPickerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFolderPickerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -277,7 +322,7 @@ impl FileExtensionVector {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for FileExtensionVector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVector<windows_core::HSTRING>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for FileExtensionVector {
@@ -449,7 +494,7 @@ impl FileOpenPicker {
     }
 }
 impl windows_core::RuntimeType for FileOpenPicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileOpenPicker>();
 }
 unsafe impl windows_core::Interface for FileOpenPicker {
     type Vtable = IFileOpenPicker_Vtbl;
@@ -534,7 +579,7 @@ impl FilePickerFileTypesOrderedMap {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for FilePickerFileTypesOrderedMap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IMap<windows_core::HSTRING, super::super::Foundation::Collections::IVector<windows_core::HSTRING>>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for FilePickerFileTypesOrderedMap {
@@ -621,7 +666,7 @@ impl FilePickerSelectedFilesArray {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for FilePickerSelectedFilesArray {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVectorView<super::StorageFile>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for FilePickerSelectedFilesArray {
@@ -797,7 +842,7 @@ impl FileSavePicker {
     }
 }
 impl windows_core::RuntimeType for FileSavePicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileSavePicker>();
 }
 unsafe impl windows_core::Interface for FileSavePicker {
     type Vtable = IFileSavePicker_Vtbl;
@@ -917,7 +962,7 @@ impl FolderPicker {
     }
 }
 impl windows_core::RuntimeType for FolderPicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFolderPicker>();
 }
 unsafe impl windows_core::Interface for FolderPicker {
     type Vtable = IFolderPicker_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(ICachedFileUpdaterStatics, ICachedFileUpdaterStatics_Vtbl, 0x9fc90920_7bcf_4888_a81e_102d7034d7ce);
+impl windows_core::RuntimeType for ICachedFileUpdaterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICachedFileUpdaterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetUpdateInformation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, ReadActivationMode, WriteActivationMode, CachedFileOptions) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICachedFileUpdaterUI, ICachedFileUpdaterUI_Vtbl, 0x9e6f41e6_baf2_4a97_b600_9333f5df80fd);
+impl windows_core::RuntimeType for ICachedFileUpdaterUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICachedFileUpdaterUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +24,9 @@ pub struct ICachedFileUpdaterUI_Vtbl {
     pub UIStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UIStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICachedFileUpdaterUI2, ICachedFileUpdaterUI2_Vtbl, 0x8856a21c_8699_4340_9f49_f7cad7fe8991);
+impl windows_core::RuntimeType for ICachedFileUpdaterUI2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICachedFileUpdaterUI2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +34,9 @@ pub struct ICachedFileUpdaterUI2_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileUpdateRequest, IFileUpdateRequest_Vtbl, 0x40c82536_c1fe_4d93_a792_1e736bc70837);
+impl windows_core::RuntimeType for IFileUpdateRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileUpdateRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +48,9 @@ pub struct IFileUpdateRequest_Vtbl {
     pub UpdateLocalFile: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileUpdateRequest2, IFileUpdateRequest2_Vtbl, 0x82484648_bdbe_447b_a2ee_7afe6a032a94);
+impl windows_core::RuntimeType for IFileUpdateRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileUpdateRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,18 +58,27 @@ pub struct IFileUpdateRequest2_Vtbl {
     pub SetUserInputNeededMessage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileUpdateRequestDeferral, IFileUpdateRequestDeferral_Vtbl, 0xffcedb2b_8ade_44a5_bb00_164c4e72f13a);
+impl windows_core::RuntimeType for IFileUpdateRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileUpdateRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileUpdateRequestedEventArgs, IFileUpdateRequestedEventArgs_Vtbl, 0x7b0a9342_3905_438d_aaef_78ae265f8dd2);
+impl windows_core::RuntimeType for IFileUpdateRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileUpdateRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderFileTypeInfo, IStorageProviderFileTypeInfo_Vtbl, 0x1955b9c1_0184_5a88_87df_4544f464365d);
+impl windows_core::RuntimeType for IStorageProviderFileTypeInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderFileTypeInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,12 +86,18 @@ pub struct IStorageProviderFileTypeInfo_Vtbl {
     pub IconResource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderFileTypeInfoFactory, IStorageProviderFileTypeInfoFactory_Vtbl, 0x3fa12c6f_cce6_5d5d_80b1_389e7cf92dbf);
+impl windows_core::RuntimeType for IStorageProviderFileTypeInfoFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderFileTypeInfoFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderGetContentInfoForPathResult, IStorageProviderGetContentInfoForPathResult_Vtbl, 0x2564711d_aa89_4d12_82e3_f72a92e33966);
+impl windows_core::RuntimeType for IStorageProviderGetContentInfoForPathResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderGetContentInfoForPathResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +109,9 @@ pub struct IStorageProviderGetContentInfoForPathResult_Vtbl {
     pub SetContentId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderGetPathForContentUriResult, IStorageProviderGetPathForContentUriResult_Vtbl, 0x63711a9d_4118_45a6_acb6_22c49d019f40);
+impl windows_core::RuntimeType for IStorageProviderGetPathForContentUriResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderGetPathForContentUriResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -88,6 +121,9 @@ pub struct IStorageProviderGetPathForContentUriResult_Vtbl {
     pub SetPath: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderItemPropertiesStatics, IStorageProviderItemPropertiesStatics_Vtbl, 0x2d2c1c97_2704_4729_8fa9_7e6b8e158c2f);
+impl windows_core::RuntimeType for IStorageProviderItemPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderItemPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -97,6 +133,9 @@ pub struct IStorageProviderItemPropertiesStatics_Vtbl {
     SetAsync: usize,
 }
 windows_core::imp::define_interface!(IStorageProviderItemProperty, IStorageProviderItemProperty_Vtbl, 0x476cb558_730b_4188_b7b5_63b716ed476d);
+impl windows_core::RuntimeType for IStorageProviderItemProperty {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderItemProperty_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +147,9 @@ pub struct IStorageProviderItemProperty_Vtbl {
     pub IconResource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderItemPropertyDefinition, IStorageProviderItemPropertyDefinition_Vtbl, 0xc5b383bb_ff1f_4298_831e_ff1c08089690);
+impl windows_core::RuntimeType for IStorageProviderItemPropertyDefinition {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderItemPropertyDefinition_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +182,9 @@ pub struct IStorageProviderItemPropertySource_Vtbl {
     GetItemProperties: usize,
 }
 windows_core::imp::define_interface!(IStorageProviderKnownFolderEntry, IStorageProviderKnownFolderEntry_Vtbl, 0xeffa7db0_1d44_596b_8464_928800c5e2d8);
+impl windows_core::RuntimeType for IStorageProviderKnownFolderEntry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderKnownFolderEntry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -149,6 +194,9 @@ pub struct IStorageProviderKnownFolderEntry_Vtbl {
     pub SetStatus: unsafe extern "system" fn(*mut core::ffi::c_void, StorageProviderKnownFolderSyncStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderKnownFolderSyncInfo, IStorageProviderKnownFolderSyncInfo_Vtbl, 0x98b017ce_ffc1_5b11_ae77_cc17afec1049);
+impl windows_core::RuntimeType for IStorageProviderKnownFolderSyncInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderKnownFolderSyncInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -216,6 +264,9 @@ pub struct IStorageProviderKnownFolderSyncInfoSourceFactory_Vtbl {
     pub GetKnownFolderSyncInfoSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderKnownFolderSyncRequestArgs, IStorageProviderKnownFolderSyncRequestArgs_Vtbl, 0xeda6d569_b4e8_542f_ab8d_f3613f250a4a);
+impl windows_core::RuntimeType for IStorageProviderKnownFolderSyncRequestArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderKnownFolderSyncRequestArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -226,6 +277,9 @@ pub struct IStorageProviderKnownFolderSyncRequestArgs_Vtbl {
     pub Source: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderMoreInfoUI, IStorageProviderMoreInfoUI_Vtbl, 0xef38e591_a7cb_5e7d_9b5e_22749842697c);
+impl windows_core::RuntimeType for IStorageProviderMoreInfoUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderMoreInfoUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +308,9 @@ pub struct IStorageProviderPropertyCapabilities_Vtbl {
     pub IsPropertySupported: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderQuotaUI, IStorageProviderQuotaUI_Vtbl, 0xba6295c3_312e_544f_9fd5_1f81b21f3649);
+impl windows_core::RuntimeType for IStorageProviderQuotaUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderQuotaUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -273,6 +330,9 @@ pub struct IStorageProviderQuotaUI_Vtbl {
     SetQuotaUsedColor: usize,
 }
 windows_core::imp::define_interface!(IStorageProviderStatusUI, IStorageProviderStatusUI_Vtbl, 0xd6b6a758_198d_5b80_977f_5ff73da33118);
+impl windows_core::RuntimeType for IStorageProviderStatusUI {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderStatusUI_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -354,6 +414,9 @@ pub struct IStorageProviderStatusUISourceFactory_Vtbl {
     pub GetStatusUISource: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderSyncRootInfo, IStorageProviderSyncRootInfo_Vtbl, 0x7c1305c4_99f9_41ac_8904_ab055d654926);
+impl windows_core::RuntimeType for IStorageProviderSyncRootInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderSyncRootInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -399,6 +462,9 @@ pub struct IStorageProviderSyncRootInfo_Vtbl {
     pub SetRecycleBinUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderSyncRootInfo2, IStorageProviderSyncRootInfo2_Vtbl, 0xcf51b023_7cf1_5166_bdba_efd95f529e31);
+impl windows_core::RuntimeType for IStorageProviderSyncRootInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderSyncRootInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -406,6 +472,9 @@ pub struct IStorageProviderSyncRootInfo2_Vtbl {
     pub SetProviderId: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProviderSyncRootInfo3, IStorageProviderSyncRootInfo3_Vtbl, 0x507a6617_bef6_56fd_855e_75ace2e45cf5);
+impl windows_core::RuntimeType for IStorageProviderSyncRootInfo3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderSyncRootInfo3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -415,6 +484,9 @@ pub struct IStorageProviderSyncRootInfo3_Vtbl {
     FallbackFileTypeInfo: usize,
 }
 windows_core::imp::define_interface!(IStorageProviderSyncRootManagerStatics, IStorageProviderSyncRootManagerStatics_Vtbl, 0x3e99fbbf_8fe3_4b40_abc7_f6fc3d74c98e);
+impl windows_core::RuntimeType for IStorageProviderSyncRootManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderSyncRootManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -428,6 +500,9 @@ pub struct IStorageProviderSyncRootManagerStatics_Vtbl {
     GetCurrentSyncRoots: usize,
 }
 windows_core::imp::define_interface!(IStorageProviderSyncRootManagerStatics2, IStorageProviderSyncRootManagerStatics2_Vtbl, 0xefb6cfee_1374_544e_9df1_5598d2e9cfdd);
+impl windows_core::RuntimeType for IStorageProviderSyncRootManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProviderSyncRootManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -599,7 +674,7 @@ impl CachedFileUpdaterUI {
     }
 }
 impl windows_core::RuntimeType for CachedFileUpdaterUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICachedFileUpdaterUI>();
 }
 unsafe impl windows_core::Interface for CachedFileUpdaterUI {
     type Vtable = ICachedFileUpdaterUI_Vtbl;
@@ -665,7 +740,7 @@ impl FileUpdateRequest {
     }
 }
 impl windows_core::RuntimeType for FileUpdateRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileUpdateRequest>();
 }
 unsafe impl windows_core::Interface for FileUpdateRequest {
     type Vtable = IFileUpdateRequest_Vtbl;
@@ -685,7 +760,7 @@ impl FileUpdateRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for FileUpdateRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileUpdateRequestDeferral>();
 }
 unsafe impl windows_core::Interface for FileUpdateRequestDeferral {
     type Vtable = IFileUpdateRequestDeferral_Vtbl;
@@ -708,7 +783,7 @@ impl FileUpdateRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for FileUpdateRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFileUpdateRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for FileUpdateRequestedEventArgs {
     type Vtable = IFileUpdateRequestedEventArgs_Vtbl;
@@ -749,7 +824,7 @@ impl StorageProviderFileTypeInfo {
     }
 }
 impl windows_core::RuntimeType for StorageProviderFileTypeInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderFileTypeInfo>();
 }
 unsafe impl windows_core::Interface for StorageProviderFileTypeInfo {
     type Vtable = IStorageProviderFileTypeInfo_Vtbl;
@@ -807,7 +882,7 @@ impl StorageProviderGetContentInfoForPathResult {
     }
 }
 impl windows_core::RuntimeType for StorageProviderGetContentInfoForPathResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderGetContentInfoForPathResult>();
 }
 unsafe impl windows_core::Interface for StorageProviderGetContentInfoForPathResult {
     type Vtable = IStorageProviderGetContentInfoForPathResult_Vtbl;
@@ -854,7 +929,7 @@ impl StorageProviderGetPathForContentUriResult {
     }
 }
 impl windows_core::RuntimeType for StorageProviderGetPathForContentUriResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderGetPathForContentUriResult>();
 }
 unsafe impl windows_core::Interface for StorageProviderGetPathForContentUriResult {
     type Vtable = IStorageProviderGetPathForContentUriResult_Vtbl;
@@ -934,7 +1009,7 @@ impl StorageProviderItemProperty {
     }
 }
 impl windows_core::RuntimeType for StorageProviderItemProperty {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderItemProperty>();
 }
 unsafe impl windows_core::Interface for StorageProviderItemProperty {
     type Vtable = IStorageProviderItemProperty_Vtbl;
@@ -981,7 +1056,7 @@ impl StorageProviderItemPropertyDefinition {
     }
 }
 impl windows_core::RuntimeType for StorageProviderItemPropertyDefinition {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderItemPropertyDefinition>();
 }
 unsafe impl windows_core::Interface for StorageProviderItemPropertyDefinition {
     type Vtable = IStorageProviderItemPropertyDefinition_Vtbl;
@@ -1028,7 +1103,7 @@ impl StorageProviderKnownFolderEntry {
     }
 }
 impl windows_core::RuntimeType for StorageProviderKnownFolderEntry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderKnownFolderEntry>();
 }
 unsafe impl windows_core::Interface for StorageProviderKnownFolderEntry {
     type Vtable = IStorageProviderKnownFolderEntry_Vtbl;
@@ -1086,7 +1161,7 @@ impl StorageProviderKnownFolderSyncInfo {
     }
 }
 impl windows_core::RuntimeType for StorageProviderKnownFolderSyncInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderKnownFolderSyncInfo>();
 }
 unsafe impl windows_core::Interface for StorageProviderKnownFolderSyncInfo {
     type Vtable = IStorageProviderKnownFolderSyncInfo_Vtbl;
@@ -1119,7 +1194,7 @@ impl StorageProviderKnownFolderSyncRequestArgs {
     }
 }
 impl windows_core::RuntimeType for StorageProviderKnownFolderSyncRequestArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderKnownFolderSyncRequestArgs>();
 }
 unsafe impl windows_core::Interface for StorageProviderKnownFolderSyncRequestArgs {
     type Vtable = IStorageProviderKnownFolderSyncRequestArgs_Vtbl;
@@ -1169,7 +1244,7 @@ impl StorageProviderMoreInfoUI {
     }
 }
 impl windows_core::RuntimeType for StorageProviderMoreInfoUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderMoreInfoUI>();
 }
 unsafe impl windows_core::Interface for StorageProviderMoreInfoUI {
     type Vtable = IStorageProviderMoreInfoUI_Vtbl;
@@ -1243,7 +1318,7 @@ impl StorageProviderQuotaUI {
     }
 }
 impl windows_core::RuntimeType for StorageProviderQuotaUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderQuotaUI>();
 }
 unsafe impl windows_core::Interface for StorageProviderQuotaUI {
     type Vtable = IStorageProviderQuotaUI_Vtbl;
@@ -1376,7 +1451,7 @@ impl StorageProviderStatusUI {
     }
 }
 impl windows_core::RuntimeType for StorageProviderStatusUI {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderStatusUI>();
 }
 unsafe impl windows_core::Interface for StorageProviderStatusUI {
     type Vtable = IStorageProviderStatusUI_Vtbl;
@@ -1604,7 +1679,7 @@ impl StorageProviderSyncRootInfo {
     }
 }
 impl windows_core::RuntimeType for StorageProviderSyncRootInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProviderSyncRootInfo>();
 }
 unsafe impl windows_core::Interface for StorageProviderSyncRootInfo {
     type Vtable = IStorageProviderSyncRootInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Search/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IContentIndexer, IContentIndexer_Vtbl, 0xb1767f8d_f698_4982_b05f_3a6e8cab01a2);
+impl windows_core::RuntimeType for IContentIndexer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentIndexer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +20,9 @@ pub struct IContentIndexer_Vtbl {
     pub Revision: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContentIndexerQuery, IContentIndexerQuery_Vtbl, 0x70e3b0f8_4bfc_428a_8889_cc51da9a7b9d);
+impl windows_core::RuntimeType for IContentIndexerQuery {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentIndexerQuery_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +46,9 @@ pub struct IContentIndexerQuery_Vtbl {
     pub QueryFolder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContentIndexerQueryOperations, IContentIndexerQueryOperations_Vtbl, 0x28823e10_4786_42f1_9730_792b3566b150);
+impl windows_core::RuntimeType for IContentIndexerQueryOperations {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentIndexerQueryOperations_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,6 +66,9 @@ pub struct IContentIndexerQueryOperations_Vtbl {
     CreateQuery: usize,
 }
 windows_core::imp::define_interface!(IContentIndexerStatics, IContentIndexerStatics_Vtbl, 0x8c488375_b37e_4c60_9ba8_b760fda3e59d);
+impl windows_core::RuntimeType for IContentIndexerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentIndexerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -137,6 +149,9 @@ pub struct IIndexableContent_Vtbl {
     pub SetStreamContentType: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IQueryOptions, IQueryOptions_Vtbl, 0x1e5e46ee_0f45_4838_a8e9_d0479d446c30);
+impl windows_core::RuntimeType for IQueryOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IQueryOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,6 +187,9 @@ pub struct IQueryOptions_Vtbl {
     SetPropertyPrefetch: usize,
 }
 windows_core::imp::define_interface!(IQueryOptionsFactory, IQueryOptionsFactory_Vtbl, 0x032e1f8c_a9c1_4e71_8011_0dee9d4811a3);
+impl windows_core::RuntimeType for IQueryOptionsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IQueryOptionsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -182,6 +200,9 @@ pub struct IQueryOptionsFactory_Vtbl {
     pub CreateCommonFolderQuery: unsafe extern "system" fn(*mut core::ffi::c_void, CommonFolderQuery, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IQueryOptionsWithProviderFilter, IQueryOptionsWithProviderFilter_Vtbl, 0x5b9d1026_15c4_44dd_b89a_47a59b7d7c4f);
+impl windows_core::RuntimeType for IQueryOptionsWithProviderFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IQueryOptionsWithProviderFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -191,6 +212,9 @@ pub struct IQueryOptionsWithProviderFilter_Vtbl {
     StorageProviderIdFilter: usize,
 }
 windows_core::imp::define_interface!(IStorageFileQueryResult, IStorageFileQueryResult_Vtbl, 0x52fda447_2baa_412c_b29f_d4b1778efa1e);
+impl windows_core::RuntimeType for IStorageFileQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFileQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -204,6 +228,9 @@ pub struct IStorageFileQueryResult_Vtbl {
     GetFilesAsyncDefaultStartAndCount: usize,
 }
 windows_core::imp::define_interface!(IStorageFileQueryResult2, IStorageFileQueryResult2_Vtbl, 0x4e5db9dd_7141_46c4_8be3_e9dc9e27275c);
+impl windows_core::RuntimeType for IStorageFileQueryResult2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFileQueryResult2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -392,6 +419,9 @@ pub struct IStorageFolderQueryOperations_Vtbl {
     pub IsCommonFileQuerySupported: unsafe extern "system" fn(*mut core::ffi::c_void, CommonFileQuery, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageFolderQueryResult, IStorageFolderQueryResult_Vtbl, 0x6654c911_7d66_46fa_aecf_e4a4baa93ab8);
+impl windows_core::RuntimeType for IStorageFolderQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFolderQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -405,6 +435,9 @@ pub struct IStorageFolderQueryResult_Vtbl {
     GetFoldersAsyncDefaultStartAndCount: usize,
 }
 windows_core::imp::define_interface!(IStorageItemQueryResult, IStorageItemQueryResult_Vtbl, 0xe8948079_9d58_47b8_b2b2_41b07f4795f9);
+impl windows_core::RuntimeType for IStorageItemQueryResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageItemQueryResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -418,6 +451,9 @@ pub struct IStorageItemQueryResult_Vtbl {
     GetItemsAsyncDefaultStartAndCount: usize,
 }
 windows_core::imp::define_interface!(IStorageLibraryChangeTrackerTriggerDetails, IStorageLibraryChangeTrackerTriggerDetails_Vtbl, 0x1dc7a369_b7a3_4df2_9d61_eba85a0343d2);
+impl windows_core::RuntimeType for IStorageLibraryChangeTrackerTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChangeTrackerTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -425,6 +461,9 @@ pub struct IStorageLibraryChangeTrackerTriggerDetails_Vtbl {
     pub ChangeTracker: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryContentChangedTriggerDetails, IStorageLibraryContentChangedTriggerDetails_Vtbl, 0x2a371977_abbf_4e1d_8aa5_6385d8884799);
+impl windows_core::RuntimeType for IStorageLibraryContentChangedTriggerDetails {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryContentChangedTriggerDetails_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -518,6 +557,9 @@ pub struct IStorageQueryResultBase_Vtbl {
     pub ApplyNewQueryOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IValueAndLanguage, IValueAndLanguage_Vtbl, 0xb9914881_a1ee_4bc4_92a5_466968e30436);
+impl windows_core::RuntimeType for IValueAndLanguage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IValueAndLanguage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -648,7 +690,7 @@ impl ContentIndexer {
     }
 }
 impl windows_core::RuntimeType for ContentIndexer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContentIndexer>();
 }
 unsafe impl windows_core::Interface for ContentIndexer {
     type Vtable = IContentIndexer_Vtbl;
@@ -712,7 +754,7 @@ impl ContentIndexerQuery {
     }
 }
 impl windows_core::RuntimeType for ContentIndexerQuery {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContentIndexerQuery>();
 }
 unsafe impl windows_core::Interface for ContentIndexerQuery {
     type Vtable = IContentIndexerQuery_Vtbl;
@@ -784,7 +826,7 @@ impl IndexableContent {
     }
 }
 impl windows_core::RuntimeType for IndexableContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIndexableContent>();
 }
 unsafe impl windows_core::Interface for IndexableContent {
     type Vtable = IIndexableContent_Vtbl;
@@ -947,7 +989,7 @@ impl QueryOptions {
     }
 }
 impl windows_core::RuntimeType for QueryOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IQueryOptions>();
 }
 unsafe impl windows_core::Interface for QueryOptions {
     type Vtable = IQueryOptions_Vtbl;
@@ -1066,7 +1108,7 @@ impl SortEntryVector {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for SortEntryVector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVector<SortEntry>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for SortEntryVector {
@@ -1194,7 +1236,7 @@ impl StorageFileQueryResult {
     }
 }
 impl windows_core::RuntimeType for StorageFileQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageFileQueryResult>();
 }
 unsafe impl windows_core::Interface for StorageFileQueryResult {
     type Vtable = IStorageFileQueryResult_Vtbl;
@@ -1293,7 +1335,7 @@ impl StorageFolderQueryResult {
     }
 }
 impl windows_core::RuntimeType for StorageFolderQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageFolderQueryResult>();
 }
 unsafe impl windows_core::Interface for StorageFolderQueryResult {
     type Vtable = IStorageFolderQueryResult_Vtbl;
@@ -1392,7 +1434,7 @@ impl StorageItemQueryResult {
     }
 }
 impl windows_core::RuntimeType for StorageItemQueryResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageItemQueryResult>();
 }
 unsafe impl windows_core::Interface for StorageItemQueryResult {
     type Vtable = IStorageItemQueryResult_Vtbl;
@@ -1422,7 +1464,7 @@ impl StorageLibraryChangeTrackerTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryChangeTrackerTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryChangeTrackerTriggerDetails>();
 }
 unsafe impl windows_core::Interface for StorageLibraryChangeTrackerTriggerDetails {
     type Vtable = IStorageLibraryChangeTrackerTriggerDetails_Vtbl;
@@ -1452,7 +1494,7 @@ impl StorageLibraryContentChangedTriggerDetails {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryContentChangedTriggerDetails {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryContentChangedTriggerDetails>();
 }
 unsafe impl windows_core::Interface for StorageLibraryContentChangedTriggerDetails {
     type Vtable = IStorageLibraryContentChangedTriggerDetails_Vtbl;
@@ -1500,7 +1542,7 @@ impl ValueAndLanguage {
     }
 }
 impl windows_core::RuntimeType for ValueAndLanguage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IValueAndLanguage>();
 }
 unsafe impl windows_core::Interface for ValueAndLanguage {
     type Vtable = IValueAndLanguage_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -31,12 +31,18 @@ pub struct IBuffer_Vtbl {
     pub SetLength: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBufferFactory, IBufferFactory_Vtbl, 0x71af914d_c10f_484b_bc50_14bc623b3a27);
+impl windows_core::RuntimeType for IBufferFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBufferFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBufferStatics, IBufferStatics_Vtbl, 0xe901e65b_d716_475a_a90a_af7229b1e741);
+impl windows_core::RuntimeType for IBufferStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBufferStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -270,12 +276,18 @@ pub struct IDataReader_Vtbl {
     pub DetachStream: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataReaderFactory, IDataReaderFactory_Vtbl, 0xd7527847_57da_4e15_914c_06806699a098);
+impl windows_core::RuntimeType for IDataReaderFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataReaderFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateDataReader: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataReaderStatics, IDataReaderStatics_Vtbl, 0x11fcbfc8_f93a_471b_b121_f379e349313c);
+impl windows_core::RuntimeType for IDataReaderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataReaderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -461,12 +473,18 @@ pub struct IDataWriter_Vtbl {
     pub DetachStream: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDataWriterFactory, IDataWriterFactory_Vtbl, 0x338c67c2_8b84_4c2b_9c50_7b8767847a1f);
+impl windows_core::RuntimeType for IDataWriterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDataWriterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateDataWriter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFileRandomAccessStreamStatics, IFileRandomAccessStreamStatics_Vtbl, 0x73550107_3b57_4b5d_8345_554d2fc621f0);
+impl windows_core::RuntimeType for IFileRandomAccessStreamStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileRandomAccessStreamStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -740,6 +758,9 @@ pub struct IRandomAccessStreamReference_Vtbl {
     pub OpenReadAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRandomAccessStreamReferenceStatics, IRandomAccessStreamReferenceStatics_Vtbl, 0x857309dc_3fbf_4e7d_986f_ef3b1a07a964);
+impl windows_core::RuntimeType for IRandomAccessStreamReferenceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRandomAccessStreamReferenceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -748,6 +769,9 @@ pub struct IRandomAccessStreamReferenceStatics_Vtbl {
     pub CreateFromStream: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRandomAccessStreamStatics, IRandomAccessStreamStatics_Vtbl, 0x524cedcf_6e29_4ce5_9573_6b753db66c3a);
+impl windows_core::RuntimeType for IRandomAccessStreamStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRandomAccessStreamStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -922,7 +946,7 @@ impl Buffer {
     }
 }
 impl windows_core::RuntimeType for Buffer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBuffer>();
 }
 unsafe impl windows_core::Interface for Buffer {
     type Vtable = IBuffer_Vtbl;
@@ -1143,7 +1167,7 @@ impl DataReader {
     }
 }
 impl windows_core::RuntimeType for DataReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataReader>();
 }
 unsafe impl windows_core::Interface for DataReader {
     type Vtable = IDataReader_Vtbl;
@@ -1212,7 +1236,7 @@ impl DataReaderLoadOperation {
     }
 }
 impl windows_core::RuntimeType for DataReaderLoadOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncOperation<u32>>();
 }
 unsafe impl windows_core::Interface for DataReaderLoadOperation {
     type Vtable = super::super::Foundation::IAsyncOperation_Vtbl<u32>;
@@ -1426,7 +1450,7 @@ impl DataWriter {
     }
 }
 impl windows_core::RuntimeType for DataWriter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDataWriter>();
 }
 unsafe impl windows_core::Interface for DataWriter {
     type Vtable = IDataWriter_Vtbl;
@@ -1495,7 +1519,7 @@ impl DataWriterStoreOperation {
     }
 }
 impl windows_core::RuntimeType for DataWriterStoreOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::IAsyncOperation<u32>>();
 }
 unsafe impl windows_core::Interface for DataWriterStoreOperation {
     type Vtable = super::super::Foundation::IAsyncOperation_Vtbl<u32>;
@@ -1557,7 +1581,7 @@ impl FileInputStream {
     }
 }
 impl windows_core::RuntimeType for FileInputStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputStream>();
 }
 unsafe impl windows_core::Interface for FileInputStream {
     type Vtable = IInputStream_Vtbl;
@@ -1597,7 +1621,7 @@ impl FileOutputStream {
     }
 }
 impl windows_core::RuntimeType for FileOutputStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOutputStream>();
 }
 unsafe impl windows_core::Interface for FileOutputStream {
     type Vtable = IOutputStream_Vtbl;
@@ -1773,7 +1797,7 @@ impl FileRandomAccessStream {
     }
 }
 impl windows_core::RuntimeType for FileRandomAccessStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRandomAccessStream>();
 }
 unsafe impl windows_core::Interface for FileRandomAccessStream {
     type Vtable = IRandomAccessStream_Vtbl;
@@ -1887,7 +1911,7 @@ impl InMemoryRandomAccessStream {
     }
 }
 impl windows_core::RuntimeType for InMemoryRandomAccessStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRandomAccessStream>();
 }
 unsafe impl windows_core::Interface for InMemoryRandomAccessStream {
     type Vtable = IRandomAccessStream_Vtbl;
@@ -1920,7 +1944,7 @@ impl InputStreamOverStream {
     }
 }
 impl windows_core::RuntimeType for InputStreamOverStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputStream>();
 }
 unsafe impl windows_core::Interface for InputStreamOverStream {
     type Vtable = IInputStream_Vtbl;
@@ -1960,7 +1984,7 @@ impl OutputStreamOverStream {
     }
 }
 impl windows_core::RuntimeType for OutputStreamOverStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOutputStream>();
 }
 unsafe impl windows_core::Interface for OutputStreamOverStream {
     type Vtable = IOutputStream_Vtbl;
@@ -2108,7 +2132,7 @@ impl RandomAccessStreamOverStream {
     }
 }
 impl windows_core::RuntimeType for RandomAccessStreamOverStream {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRandomAccessStream>();
 }
 unsafe impl windows_core::Interface for RandomAccessStreamOverStream {
     type Vtable = IRandomAccessStream_Vtbl;
@@ -2166,7 +2190,7 @@ impl RandomAccessStreamReference {
     }
 }
 impl windows_core::RuntimeType for RandomAccessStreamReference {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRandomAccessStreamReference>();
 }
 unsafe impl windows_core::Interface for RandomAccessStreamReference {
     type Vtable = IRandomAccessStreamReference_Vtbl;

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -15,6 +15,9 @@ pub mod Search;
 #[cfg(feature = "Storage_Streams")]
 pub mod Streams;
 windows_core::imp::define_interface!(IAppDataPaths, IAppDataPaths_Vtbl, 0x7301d60a_79a2_48c9_9ec0_3fda092f79e1);
+impl windows_core::RuntimeType for IAppDataPaths {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDataPaths_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +32,9 @@ pub struct IAppDataPaths_Vtbl {
     pub RoamingAppData: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppDataPathsStatics, IAppDataPathsStatics_Vtbl, 0xd8eb2afe_a9d9_4b14_b999_e3921379d903);
+impl windows_core::RuntimeType for IAppDataPathsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDataPathsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +45,9 @@ pub struct IAppDataPathsStatics_Vtbl {
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationData, IApplicationData_Vtbl, 0xc3da6fb7_b744_4b45_b0b8_223a0938d0dc);
+impl windows_core::RuntimeType for IApplicationData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -57,12 +66,18 @@ pub struct IApplicationData_Vtbl {
     pub RoamingStorageQuota: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationData2, IApplicationData2_Vtbl, 0x9e65cd69_0ba3_4e32_be29_b02de6607638);
+impl windows_core::RuntimeType for IApplicationData2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationData2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LocalCacheFolder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationData3, IApplicationData3_Vtbl, 0xdc222cf4_2772_4c1d_aa2c_c9f743ade8d1);
+impl windows_core::RuntimeType for IApplicationData3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationData3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +86,9 @@ pub struct IApplicationData3_Vtbl {
     pub SharedLocalFolder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationDataContainer, IApplicationDataContainer_Vtbl, 0xc5aefd1e_f467_40ba_8566_ab640a441e1d);
+impl windows_core::RuntimeType for IApplicationDataContainer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationDataContainer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -88,12 +106,18 @@ pub struct IApplicationDataContainer_Vtbl {
     pub DeleteContainer: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationDataStatics, IApplicationDataStatics_Vtbl, 0x5612147b_e843_45e3_94d8_06169e3c8e17);
+impl windows_core::RuntimeType for IApplicationDataStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationDataStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationDataStatics2, IApplicationDataStatics2_Vtbl, 0xcd606211_cf49_40a4_a47c_c7f0dbba8107);
+impl windows_core::RuntimeType for IApplicationDataStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationDataStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -103,6 +127,9 @@ pub struct IApplicationDataStatics2_Vtbl {
     GetForUserAsync: usize,
 }
 windows_core::imp::define_interface!(ICachedFileManagerStatics, ICachedFileManagerStatics_Vtbl, 0x8ffc224a_e782_495d_b614_654c4f0b2370);
+impl windows_core::RuntimeType for ICachedFileManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICachedFileManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -113,6 +140,9 @@ pub struct ICachedFileManagerStatics_Vtbl {
     CompleteUpdatesAsync: usize,
 }
 windows_core::imp::define_interface!(IDownloadsFolderStatics, IDownloadsFolderStatics_Vtbl, 0x27862ed0_404e_47df_a1e2_e37308be7b37);
+impl windows_core::RuntimeType for IDownloadsFolderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDownloadsFolderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,6 +152,9 @@ pub struct IDownloadsFolderStatics_Vtbl {
     pub CreateFolderWithCollisionOptionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, CreationCollisionOption, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDownloadsFolderStatics2, IDownloadsFolderStatics2_Vtbl, 0xe93045bd_8ef8_4f8e_8d15_ac0e265f390d);
+impl windows_core::RuntimeType for IDownloadsFolderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDownloadsFolderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -143,6 +176,9 @@ pub struct IDownloadsFolderStatics2_Vtbl {
     CreateFolderForUserWithCollisionOptionAsync: usize,
 }
 windows_core::imp::define_interface!(IFileIOStatics, IFileIOStatics_Vtbl, 0x887411eb_7f54_4732_a5f0_5e43e3b8c2f5);
+impl windows_core::RuntimeType for IFileIOStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFileIOStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -196,24 +232,36 @@ pub struct IFileIOStatics_Vtbl {
     pub WriteBytesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownFoldersCameraRollStatics, IKnownFoldersCameraRollStatics_Vtbl, 0x5d115e66_27e8_492f_b8e5_2f90896cd4cd);
+impl windows_core::RuntimeType for IKnownFoldersCameraRollStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownFoldersCameraRollStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CameraRoll: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownFoldersPlaylistsStatics, IKnownFoldersPlaylistsStatics_Vtbl, 0xdad5ecd6_306f_4d6a_b496_46ba8eb106ce);
+impl windows_core::RuntimeType for IKnownFoldersPlaylistsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownFoldersPlaylistsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Playlists: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownFoldersSavedPicturesStatics, IKnownFoldersSavedPicturesStatics_Vtbl, 0x055c93ea_253d_467c_b6ca_a97da1e9a18d);
+impl windows_core::RuntimeType for IKnownFoldersSavedPicturesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownFoldersSavedPicturesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SavedPictures: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownFoldersStatics, IKnownFoldersStatics_Vtbl, 0x5a2a7520_4802_452d_9ad9_4351ada7ec35);
+impl windows_core::RuntimeType for IKnownFoldersStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownFoldersStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -226,6 +274,9 @@ pub struct IKnownFoldersStatics_Vtbl {
     pub MediaServerDevices: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownFoldersStatics2, IKnownFoldersStatics2_Vtbl, 0x194bd0cd_cf6e_4d07_9d53_e9163a2536e9);
+impl windows_core::RuntimeType for IKnownFoldersStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownFoldersStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -234,6 +285,9 @@ pub struct IKnownFoldersStatics2_Vtbl {
     pub RecordedCalls: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownFoldersStatics3, IKnownFoldersStatics3_Vtbl, 0xc5194341_9742_4ed5_823d_fc1401148764);
+impl windows_core::RuntimeType for IKnownFoldersStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownFoldersStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -243,6 +297,9 @@ pub struct IKnownFoldersStatics3_Vtbl {
     GetFolderForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IKnownFoldersStatics4, IKnownFoldersStatics4_Vtbl, 0x1722e6bf_9ff9_4b21_bed5_90ecb13a192e);
+impl windows_core::RuntimeType for IKnownFoldersStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownFoldersStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +311,9 @@ pub struct IKnownFoldersStatics4_Vtbl {
     pub GetFolderAsync: unsafe extern "system" fn(*mut core::ffi::c_void, KnownFolderId, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPathIOStatics, IPathIOStatics_Vtbl, 0x0f2f3758_8ec7_4381_922b_8f6c07d288f3);
+impl windows_core::RuntimeType for IPathIOStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPathIOStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -307,12 +367,18 @@ pub struct IPathIOStatics_Vtbl {
     pub WriteBytesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISetVersionDeferral, ISetVersionDeferral_Vtbl, 0x033508a2_781a_437a_b078_3f32badcfe47);
+impl windows_core::RuntimeType for ISetVersionDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISetVersionDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISetVersionRequest, ISetVersionRequest_Vtbl, 0xb9c76b9b_1056_4e69_8330_162619956f9b);
+impl windows_core::RuntimeType for ISetVersionRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISetVersionRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -595,6 +661,9 @@ pub struct IStorageFilePropertiesWithAvailability_Vtbl {
     pub IsAvailable: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageFileStatics, IStorageFileStatics_Vtbl, 0x5984c710_daf2_43c8_8bb4_a4d3eacfd03f);
+impl windows_core::RuntimeType for IStorageFileStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFileStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -618,6 +687,9 @@ pub struct IStorageFileStatics_Vtbl {
     ReplaceWithStreamedFileFromUriAsync: usize,
 }
 windows_core::imp::define_interface!(IStorageFileStatics2, IStorageFileStatics2_Vtbl, 0x5c76a781_212e_4af9_8f04_740cae108974);
+impl windows_core::RuntimeType for IStorageFileStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFileStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -821,18 +893,27 @@ pub struct IStorageFolder2_Vtbl {
     pub TryGetItemAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageFolder3, IStorageFolder3_Vtbl, 0x9f617899_bde1_4124_aeb3_b06ad96f98d4);
+impl windows_core::RuntimeType for IStorageFolder3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFolder3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryGetChangeTracker: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageFolderStatics, IStorageFolderStatics_Vtbl, 0x08f327ff_85d5_48b9_aee9_28511e339f9f);
+impl windows_core::RuntimeType for IStorageFolderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFolderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetFolderFromPathAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageFolderStatics2, IStorageFolderStatics2_Vtbl, 0xb4656dc3_71d2_467d_8b29_371f0f62bf6f);
+impl windows_core::RuntimeType for IStorageFolderStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageFolderStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1296,6 +1377,9 @@ pub struct IStorageItemPropertiesWithProvider_Vtbl {
     pub Provider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibrary, IStorageLibrary_Vtbl, 0x1edd7103_0e5e_4d6c_b5e8_9318983d6a03);
+impl windows_core::RuntimeType for IStorageLibrary {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibrary_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1310,18 +1394,27 @@ pub struct IStorageLibrary_Vtbl {
     pub RemoveDefinitionChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibrary2, IStorageLibrary2_Vtbl, 0x5b0ce348_fcb3_4031_afb0_a68d7bd44534);
+impl windows_core::RuntimeType for IStorageLibrary2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibrary2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ChangeTracker: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibrary3, IStorageLibrary3_Vtbl, 0x8a281291_2154_4201_8113_d2c05ce1ad23);
+impl windows_core::RuntimeType for IStorageLibrary3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibrary3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AreFolderSuggestionsAvailableAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryChange, IStorageLibraryChange_Vtbl, 0x00980b23_2be2_4909_aa48_159f5203a51e);
+impl windows_core::RuntimeType for IStorageLibraryChange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1332,6 +1425,9 @@ pub struct IStorageLibraryChange_Vtbl {
     pub GetStorageItemAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryChangeReader, IStorageLibraryChangeReader_Vtbl, 0xf205bc83_fca2_41f9_8954_ee2e991eb96f);
+impl windows_core::RuntimeType for IStorageLibraryChangeReader {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChangeReader_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1342,12 +1438,18 @@ pub struct IStorageLibraryChangeReader_Vtbl {
     pub AcceptChangesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryChangeReader2, IStorageLibraryChangeReader2_Vtbl, 0xabf4868b_fbcc_4a4f_999e_e7ab7c646dbe);
+impl windows_core::RuntimeType for IStorageLibraryChangeReader2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChangeReader2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetLastChangeId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryChangeTracker, IStorageLibraryChangeTracker_Vtbl, 0x9e157316_6073_44f6_9681_7492d1286c90);
+impl windows_core::RuntimeType for IStorageLibraryChangeTracker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChangeTracker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1356,6 +1458,9 @@ pub struct IStorageLibraryChangeTracker_Vtbl {
     pub Reset: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryChangeTracker2, IStorageLibraryChangeTracker2_Vtbl, 0xcd051c3b_0f9f_42f9_8fb3_158d82e13821);
+impl windows_core::RuntimeType for IStorageLibraryChangeTracker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChangeTracker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1363,6 +1468,9 @@ pub struct IStorageLibraryChangeTracker2_Vtbl {
     pub Disable: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryChangeTrackerOptions, IStorageLibraryChangeTrackerOptions_Vtbl, 0xbb52bcd4_1a6d_59c0_ad2a_823a20532483);
+impl windows_core::RuntimeType for IStorageLibraryChangeTrackerOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryChangeTrackerOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1370,23 +1478,35 @@ pub struct IStorageLibraryChangeTrackerOptions_Vtbl {
     pub SetTrackChangeDetails: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryLastChangeId, IStorageLibraryLastChangeId_Vtbl, 0x5281826a_bbe1_53bc_82ca_81cc7f039329);
+impl windows_core::RuntimeType for IStorageLibraryLastChangeId {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryLastChangeId_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IStorageLibraryLastChangeIdStatics, IStorageLibraryLastChangeIdStatics_Vtbl, 0x81a49128_2ca3_5309_b0d1_cf0788e40762);
+impl windows_core::RuntimeType for IStorageLibraryLastChangeIdStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryLastChangeIdStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Unknown: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryStatics, IStorageLibraryStatics_Vtbl, 0x4208a6db_684a_49c6_9e59_90121ee050d6);
+impl windows_core::RuntimeType for IStorageLibraryStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetLibraryAsync: unsafe extern "system" fn(*mut core::ffi::c_void, KnownLibraryId, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageLibraryStatics2, IStorageLibraryStatics2_Vtbl, 0xffb08ddc_fa75_4695_b9d1_7f81f97832e3);
+impl windows_core::RuntimeType for IStorageLibraryStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageLibraryStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1396,6 +1516,9 @@ pub struct IStorageLibraryStatics2_Vtbl {
     GetLibraryForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IStorageProvider, IStorageProvider_Vtbl, 0xe705eed4_d478_47d6_ba46_1a8ebe114a20);
+impl windows_core::RuntimeType for IStorageProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1403,12 +1526,18 @@ pub struct IStorageProvider_Vtbl {
     pub DisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageProvider2, IStorageProvider2_Vtbl, 0x010d1917_3404_414b_9fd7_cd44472eaa39);
+impl windows_core::RuntimeType for IStorageProvider2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageProvider2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsPropertySupportedForPartialFileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStorageStreamTransaction, IStorageStreamTransaction_Vtbl, 0xf67cf363_a53d_4d94_ae2c_67232d93acdd);
+impl windows_core::RuntimeType for IStorageStreamTransaction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStorageStreamTransaction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1435,12 +1564,18 @@ pub struct IStreamedFileDataRequest_Vtbl {
     pub FailAndClose: unsafe extern "system" fn(*mut core::ffi::c_void, StreamedFileFailureMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemAudioProperties, ISystemAudioProperties_Vtbl, 0x3f8f38b7_308c_47e1_924d_8645348e5db7);
+impl windows_core::RuntimeType for ISystemAudioProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemAudioProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub EncodingBitrate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemDataPaths, ISystemDataPaths_Vtbl, 0xe32abf70_d8fa_45ec_a942_d2e26fb60ba5);
+impl windows_core::RuntimeType for ISystemDataPaths {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemDataPaths_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1462,12 +1597,18 @@ pub struct ISystemDataPaths_Vtbl {
     pub Windows: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemDataPathsStatics, ISystemDataPathsStatics_Vtbl, 0xe0f96fd0_9920_4bca_b379_f96fdf7caad8);
+impl windows_core::RuntimeType for ISystemDataPathsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemDataPathsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemGPSProperties, ISystemGPSProperties_Vtbl, 0xc0f46eb4_c174_481a_bc25_921986f6a6f3);
+impl windows_core::RuntimeType for ISystemGPSProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemGPSProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1475,6 +1616,9 @@ pub struct ISystemGPSProperties_Vtbl {
     pub LongitudeDecimal: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemImageProperties, ISystemImageProperties_Vtbl, 0x011b2e30_8b39_4308_bea1_e8aa61e47826);
+impl windows_core::RuntimeType for ISystemImageProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemImageProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1482,6 +1626,9 @@ pub struct ISystemImageProperties_Vtbl {
     pub VerticalSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMediaProperties, ISystemMediaProperties_Vtbl, 0xa42b3316_8415_40dc_8c44_98361d235430);
+impl windows_core::RuntimeType for ISystemMediaProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMediaProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1493,6 +1640,9 @@ pub struct ISystemMediaProperties_Vtbl {
     pub Year: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMusicProperties, ISystemMusicProperties_Vtbl, 0xb47988d5_67af_4bc3_8d39_5b89022026a1);
+impl windows_core::RuntimeType for ISystemMusicProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMusicProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1506,6 +1656,9 @@ pub struct ISystemMusicProperties_Vtbl {
     pub TrackNumber: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemPhotoProperties, ISystemPhotoProperties_Vtbl, 0x4734fc3d_ab21_4424_b735_f4353a56c8fc);
+impl windows_core::RuntimeType for ISystemPhotoProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemPhotoProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1516,6 +1669,9 @@ pub struct ISystemPhotoProperties_Vtbl {
     pub PeopleNames: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemProperties, ISystemProperties_Vtbl, 0x917a71c1_85f3_4dd1_b001_a50bfd21c8d2);
+impl windows_core::RuntimeType for ISystemProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1534,6 +1690,9 @@ pub struct ISystemProperties_Vtbl {
     pub Image: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemVideoProperties, ISystemVideoProperties_Vtbl, 0x2040f715_67f8_4322_9b80_4fa9fefb83e8);
+impl windows_core::RuntimeType for ISystemVideoProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemVideoProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1544,6 +1703,9 @@ pub struct ISystemVideoProperties_Vtbl {
     pub TotalBitrate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataPaths, IUserDataPaths_Vtbl, 0xf9c53912_abc4_46ff_8a2b_dc9d7fa6e52f);
+impl windows_core::RuntimeType for IUserDataPaths {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataPaths_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1568,6 +1730,9 @@ pub struct IUserDataPaths_Vtbl {
     pub Videos: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDataPathsStatics, IUserDataPathsStatics_Vtbl, 0x01b29def_e062_48a1_8b0c_f2c7a9ca56c0);
+impl windows_core::RuntimeType for IUserDataPathsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDataPathsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1668,7 +1833,7 @@ impl AppDataPaths {
     }
 }
 impl windows_core::RuntimeType for AppDataPaths {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppDataPaths>();
 }
 unsafe impl windows_core::Interface for AppDataPaths {
     type Vtable = IAppDataPaths_Vtbl;
@@ -1836,7 +2001,7 @@ impl ApplicationData {
     }
 }
 impl windows_core::RuntimeType for ApplicationData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationData>();
 }
 unsafe impl windows_core::Interface for ApplicationData {
     type Vtable = IApplicationData_Vtbl;
@@ -1944,7 +2109,7 @@ impl ApplicationDataCompositeValue {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ApplicationDataCompositeValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::Foundation::Collections::IPropertySet>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ApplicationDataCompositeValue {
@@ -2028,7 +2193,7 @@ impl ApplicationDataContainer {
     }
 }
 impl windows_core::RuntimeType for ApplicationDataContainer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationDataContainer>();
 }
 unsafe impl windows_core::Interface for ApplicationDataContainer {
     type Vtable = IApplicationDataContainer_Vtbl;
@@ -2129,7 +2294,7 @@ impl ApplicationDataContainerSettings {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for ApplicationDataContainerSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::Foundation::Collections::IPropertySet>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for ApplicationDataContainerSettings {
@@ -2718,7 +2883,7 @@ impl SetVersionDeferral {
     }
 }
 impl windows_core::RuntimeType for SetVersionDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISetVersionDeferral>();
 }
 unsafe impl windows_core::Interface for SetVersionDeferral {
     type Vtable = ISetVersionDeferral_Vtbl;
@@ -2757,7 +2922,7 @@ impl SetVersionRequest {
     }
 }
 impl windows_core::RuntimeType for SetVersionRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISetVersionRequest>();
 }
 unsafe impl windows_core::Interface for SetVersionRequest {
     type Vtable = ISetVersionRequest_Vtbl;
@@ -3177,7 +3342,7 @@ impl StorageFile {
     }
 }
 impl windows_core::RuntimeType for StorageFile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageFile>();
 }
 unsafe impl windows_core::Interface for StorageFile {
     type Vtable = IStorageFile_Vtbl;
@@ -3628,7 +3793,7 @@ impl StorageFolder {
     }
 }
 impl windows_core::RuntimeType for StorageFolder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageFolder>();
 }
 unsafe impl windows_core::Interface for StorageFolder {
     type Vtable = IStorageFolder_Vtbl;
@@ -3730,7 +3895,7 @@ impl StorageLibrary {
     }
 }
 impl windows_core::RuntimeType for StorageLibrary {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibrary>();
 }
 unsafe impl windows_core::Interface for StorageLibrary {
     type Vtable = IStorageLibrary_Vtbl;
@@ -3781,7 +3946,7 @@ impl StorageLibraryChange {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryChange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryChange>();
 }
 unsafe impl windows_core::Interface for StorageLibraryChange {
     type Vtable = IStorageLibraryChange_Vtbl;
@@ -3821,7 +3986,7 @@ impl StorageLibraryChangeReader {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryChangeReader {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryChangeReader>();
 }
 unsafe impl windows_core::Interface for StorageLibraryChangeReader {
     type Vtable = IStorageLibraryChangeReader_Vtbl;
@@ -3865,7 +4030,7 @@ impl StorageLibraryChangeTracker {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryChangeTracker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryChangeTracker>();
 }
 unsafe impl windows_core::Interface for StorageLibraryChangeTracker {
     type Vtable = IStorageLibraryChangeTracker_Vtbl;
@@ -3901,7 +4066,7 @@ impl StorageLibraryChangeTrackerOptions {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryChangeTrackerOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryChangeTrackerOptions>();
 }
 unsafe impl windows_core::Interface for StorageLibraryChangeTrackerOptions {
     type Vtable = IStorageLibraryChangeTrackerOptions_Vtbl;
@@ -3930,7 +4095,7 @@ impl StorageLibraryLastChangeId {
     }
 }
 impl windows_core::RuntimeType for StorageLibraryLastChangeId {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageLibraryLastChangeId>();
 }
 unsafe impl windows_core::Interface for StorageLibraryLastChangeId {
     type Vtable = IStorageLibraryLastChangeId_Vtbl;
@@ -3969,7 +4134,7 @@ impl StorageProvider {
     }
 }
 impl windows_core::RuntimeType for StorageProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageProvider>();
 }
 unsafe impl windows_core::Interface for StorageProvider {
     type Vtable = IStorageProvider_Vtbl;
@@ -4005,7 +4170,7 @@ impl StorageStreamTransaction {
     }
 }
 impl windows_core::RuntimeType for StorageStreamTransaction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStorageStreamTransaction>();
 }
 unsafe impl windows_core::Interface for StorageStreamTransaction {
     type Vtable = IStorageStreamTransaction_Vtbl;
@@ -4054,7 +4219,7 @@ impl StreamedFileDataRequest {
 }
 #[cfg(feature = "Storage_Streams")]
 impl windows_core::RuntimeType for StreamedFileDataRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, Streams::IOutputStream>();
 }
 #[cfg(feature = "Storage_Streams")]
 unsafe impl windows_core::Interface for StreamedFileDataRequest {
@@ -4079,7 +4244,7 @@ impl SystemAudioProperties {
     }
 }
 impl windows_core::RuntimeType for SystemAudioProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemAudioProperties>();
 }
 unsafe impl windows_core::Interface for SystemAudioProperties {
     type Vtable = ISystemAudioProperties_Vtbl;
@@ -4220,7 +4385,7 @@ impl SystemDataPaths {
     }
 }
 impl windows_core::RuntimeType for SystemDataPaths {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemDataPaths>();
 }
 unsafe impl windows_core::Interface for SystemDataPaths {
     type Vtable = ISystemDataPaths_Vtbl;
@@ -4252,7 +4417,7 @@ impl SystemGPSProperties {
     }
 }
 impl windows_core::RuntimeType for SystemGPSProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemGPSProperties>();
 }
 unsafe impl windows_core::Interface for SystemGPSProperties {
     type Vtable = ISystemGPSProperties_Vtbl;
@@ -4284,7 +4449,7 @@ impl SystemImageProperties {
     }
 }
 impl windows_core::RuntimeType for SystemImageProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemImageProperties>();
 }
 unsafe impl windows_core::Interface for SystemImageProperties {
     type Vtable = ISystemImageProperties_Vtbl;
@@ -4344,7 +4509,7 @@ impl SystemMediaProperties {
     }
 }
 impl windows_core::RuntimeType for SystemMediaProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMediaProperties>();
 }
 unsafe impl windows_core::Interface for SystemMediaProperties {
     type Vtable = ISystemMediaProperties_Vtbl;
@@ -4418,7 +4583,7 @@ impl SystemMusicProperties {
     }
 }
 impl windows_core::RuntimeType for SystemMusicProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMusicProperties>();
 }
 unsafe impl windows_core::Interface for SystemMusicProperties {
     type Vtable = ISystemMusicProperties_Vtbl;
@@ -4471,7 +4636,7 @@ impl SystemPhotoProperties {
     }
 }
 impl windows_core::RuntimeType for SystemPhotoProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemPhotoProperties>();
 }
 unsafe impl windows_core::Interface for SystemPhotoProperties {
     type Vtable = ISystemPhotoProperties_Vtbl;
@@ -4613,7 +4778,7 @@ impl SystemVideoProperties {
     }
 }
 impl windows_core::RuntimeType for SystemVideoProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemVideoProperties>();
 }
 unsafe impl windows_core::Interface for SystemVideoProperties {
     type Vtable = ISystemVideoProperties_Vtbl;
@@ -4785,7 +4950,7 @@ impl UserDataPaths {
     }
 }
 impl windows_core::RuntimeType for UserDataPaths {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDataPaths>();
 }
 unsafe impl windows_core::Interface for UserDataPaths {
     type Vtable = IUserDataPaths_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDevicePortalConnection, IDevicePortalConnection_Vtbl, 0x0f447f51_1198_4da1_8d54_bdef393e09b6);
+impl windows_core::RuntimeType for IDevicePortalConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePortalConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct IDevicePortalConnection_Vtbl {
     pub RemoveRequestReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDevicePortalConnectionClosedEventArgs, IDevicePortalConnectionClosedEventArgs_Vtbl, 0xfcf70e38_7032_428c_9f50_945c15a9f0cb);
+impl windows_core::RuntimeType for IDevicePortalConnectionClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePortalConnectionClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DevicePortalConnectionClosedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDevicePortalConnectionRequestReceivedEventArgs, IDevicePortalConnectionRequestReceivedEventArgs_Vtbl, 0x64dae045_6fda_4459_9ebd_ecce22e38559);
+impl windows_core::RuntimeType for IDevicePortalConnectionRequestReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePortalConnectionRequestReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +36,9 @@ pub struct IDevicePortalConnectionRequestReceivedEventArgs_Vtbl {
     ResponseMessage: usize,
 }
 windows_core::imp::define_interface!(IDevicePortalConnectionStatics, IDevicePortalConnectionStatics_Vtbl, 0x4bbe31e7_e9b9_4645_8fed_a53eea0edbd6);
+impl windows_core::RuntimeType for IDevicePortalConnectionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePortalConnectionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +48,9 @@ pub struct IDevicePortalConnectionStatics_Vtbl {
     GetForAppServiceConnection: usize,
 }
 windows_core::imp::define_interface!(IDevicePortalWebSocketConnection, IDevicePortalWebSocketConnection_Vtbl, 0x67657920_d65a_42f0_aef4_787808098b7b);
+impl windows_core::RuntimeType for IDevicePortalWebSocketConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePortalWebSocketConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -61,6 +76,9 @@ pub struct IDevicePortalWebSocketConnection_Vtbl {
     GetServerStreamWebSocketForRequest2: usize,
 }
 windows_core::imp::define_interface!(IDevicePortalWebSocketConnectionRequestReceivedEventArgs, IDevicePortalWebSocketConnectionRequestReceivedEventArgs_Vtbl, 0x79fdcaba_175c_4739_9f74_dda797c35b3f);
+impl windows_core::RuntimeType for IDevicePortalWebSocketConnectionRequestReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDevicePortalWebSocketConnectionRequestReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -176,7 +194,7 @@ impl DevicePortalConnection {
     }
 }
 impl windows_core::RuntimeType for DevicePortalConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePortalConnection>();
 }
 unsafe impl windows_core::Interface for DevicePortalConnection {
     type Vtable = IDevicePortalConnection_Vtbl;
@@ -201,7 +219,7 @@ impl DevicePortalConnectionClosedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DevicePortalConnectionClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePortalConnectionClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for DevicePortalConnectionClosedEventArgs {
     type Vtable = IDevicePortalConnectionClosedEventArgs_Vtbl;
@@ -257,7 +275,7 @@ impl DevicePortalConnectionRequestReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for DevicePortalConnectionRequestReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDevicePortalConnectionRequestReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for DevicePortalConnectionRequestReceivedEventArgs {
     type Vtable = IDevicePortalConnectionRequestReceivedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPlatformTelemetryClientStatics, IPlatformTelemetryClientStatics_Vtbl, 0x9bf3f25d_d5c3_4eea_8dbe_9c8dbb0d9d8f);
+impl windows_core::RuntimeType for IPlatformTelemetryClientStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlatformTelemetryClientStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,12 +9,18 @@ pub struct IPlatformTelemetryClientStatics_Vtbl {
     pub RegisterWithSettings: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlatformTelemetryRegistrationResult, IPlatformTelemetryRegistrationResult_Vtbl, 0x4d8518ab_2292_49bd_a15a_3d71d2145112);
+impl windows_core::RuntimeType for IPlatformTelemetryRegistrationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlatformTelemetryRegistrationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PlatformTelemetryRegistrationStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlatformTelemetryRegistrationSettings, IPlatformTelemetryRegistrationSettings_Vtbl, 0x819a8582_ca19_415e_bb79_9c224bfa3a73);
+impl windows_core::RuntimeType for IPlatformTelemetryRegistrationSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlatformTelemetryRegistrationSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,7 +69,7 @@ impl PlatformTelemetryRegistrationResult {
     }
 }
 impl windows_core::RuntimeType for PlatformTelemetryRegistrationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlatformTelemetryRegistrationResult>();
 }
 unsafe impl windows_core::Interface for PlatformTelemetryRegistrationResult {
     type Vtable = IPlatformTelemetryRegistrationResult_Vtbl;
@@ -107,7 +116,7 @@ impl PlatformTelemetryRegistrationSettings {
     }
 }
 impl windows_core::RuntimeType for PlatformTelemetryRegistrationSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlatformTelemetryRegistrationSettings>();
 }
 unsafe impl windows_core::Interface for PlatformTelemetryRegistrationSettings {
     type Vtable = IPlatformTelemetryRegistrationSettings_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IPlatformDiagnosticActionsStatics, IPlatformDiagnosticActionsStatics_Vtbl, 0xc1145cfa_9292_4267_890a_9ea3ed072312);
+impl windows_core::RuntimeType for IPlatformDiagnosticActionsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlatformDiagnosticActionsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +24,9 @@ pub struct IPlatformDiagnosticActionsStatics_Vtbl {
     GetKnownTraceList: usize,
 }
 windows_core::imp::define_interface!(IPlatformDiagnosticTraceInfo, IPlatformDiagnosticTraceInfo_Vtbl, 0xf870ed97_d597_4bf7_88dc_cf5c7dc2a1d2);
+impl windows_core::RuntimeType for IPlatformDiagnosticTraceInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlatformDiagnosticTraceInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +38,9 @@ pub struct IPlatformDiagnosticTraceInfo_Vtbl {
     pub Priority: unsafe extern "system" fn(*mut core::ffi::c_void, *mut PlatformDiagnosticTracePriority) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlatformDiagnosticTraceRuntimeInfo, IPlatformDiagnosticTraceRuntimeInfo_Vtbl, 0x3d4d5e2d_01d8_4768_8554_1eb1ca610986);
+impl windows_core::RuntimeType for IPlatformDiagnosticTraceRuntimeInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlatformDiagnosticTraceRuntimeInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,7 +161,7 @@ impl PlatformDiagnosticTraceInfo {
     }
 }
 impl windows_core::RuntimeType for PlatformDiagnosticTraceInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlatformDiagnosticTraceInfo>();
 }
 unsafe impl windows_core::Interface for PlatformDiagnosticTraceInfo {
     type Vtable = IPlatformDiagnosticTraceInfo_Vtbl;
@@ -184,7 +193,7 @@ impl PlatformDiagnosticTraceRuntimeInfo {
     }
 }
 impl windows_core::RuntimeType for PlatformDiagnosticTraceRuntimeInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPlatformDiagnosticTraceRuntimeInfo>();
 }
 unsafe impl windows_core::Interface for PlatformDiagnosticTraceRuntimeInfo {
     type Vtable = IPlatformDiagnosticTraceRuntimeInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
@@ -5,6 +5,9 @@ pub mod Telemetry;
 #[cfg(feature = "System_Diagnostics_TraceReporting")]
 pub mod TraceReporting;
 windows_core::imp::define_interface!(IDiagnosticActionResult, IDiagnosticActionResult_Vtbl, 0xc265a296_e73b_4097_b28f_3442f03dd831);
+impl windows_core::RuntimeType for IDiagnosticActionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDiagnosticActionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +18,9 @@ pub struct IDiagnosticActionResult_Vtbl {
     Results: usize,
 }
 windows_core::imp::define_interface!(IDiagnosticInvoker, IDiagnosticInvoker_Vtbl, 0x187b270a_02e3_4f86_84fc_fdd892b5940f);
+impl windows_core::RuntimeType for IDiagnosticInvoker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDiagnosticInvoker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,12 +30,18 @@ pub struct IDiagnosticInvoker_Vtbl {
     RunDiagnosticActionAsync: usize,
 }
 windows_core::imp::define_interface!(IDiagnosticInvoker2, IDiagnosticInvoker2_Vtbl, 0xe3bf945c_155a_4b52_a8ec_070c44f95000);
+impl windows_core::RuntimeType for IDiagnosticInvoker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDiagnosticInvoker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RunDiagnosticActionFromStringAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDiagnosticInvokerStatics, IDiagnosticInvokerStatics_Vtbl, 0x5cfad8de_f15c_4554_a813_c113c3881b09);
+impl windows_core::RuntimeType for IDiagnosticInvokerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDiagnosticInvokerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,12 +50,18 @@ pub struct IDiagnosticInvokerStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessCpuUsage, IProcessCpuUsage_Vtbl, 0x0bbb2472_c8bf_423a_a810_b559ae4354e2);
+impl windows_core::RuntimeType for IProcessCpuUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessCpuUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetReport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessCpuUsageReport, IProcessCpuUsageReport_Vtbl, 0x8a6d9cac_3987_4e2f_a119_6b5fa214f1b4);
+impl windows_core::RuntimeType for IProcessCpuUsageReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessCpuUsageReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,6 +69,9 @@ pub struct IProcessCpuUsageReport_Vtbl {
     pub UserTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessDiagnosticInfo, IProcessDiagnosticInfo_Vtbl, 0xe830b04b_300e_4ee6_a0ab_5b5f5231b434);
+impl windows_core::RuntimeType for IProcessDiagnosticInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessDiagnosticInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +84,9 @@ pub struct IProcessDiagnosticInfo_Vtbl {
     pub CpuUsage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessDiagnosticInfo2, IProcessDiagnosticInfo2_Vtbl, 0x9558cb1a_3d0b_49ec_ab70_4f7a112805de);
+impl windows_core::RuntimeType for IProcessDiagnosticInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessDiagnosticInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +97,9 @@ pub struct IProcessDiagnosticInfo2_Vtbl {
     pub IsPackaged: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessDiagnosticInfoStatics, IProcessDiagnosticInfoStatics_Vtbl, 0x2f41b260_b49f_428c_aa0e_84744f49ca95);
+impl windows_core::RuntimeType for IProcessDiagnosticInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessDiagnosticInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -83,18 +110,27 @@ pub struct IProcessDiagnosticInfoStatics_Vtbl {
     pub GetForCurrentProcess: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessDiagnosticInfoStatics2, IProcessDiagnosticInfoStatics2_Vtbl, 0x4a869897_9899_4a44_a29b_091663be09b6);
+impl windows_core::RuntimeType for IProcessDiagnosticInfoStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessDiagnosticInfoStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryGetForProcessId: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessDiskUsage, IProcessDiskUsage_Vtbl, 0x5ad78bfd_7e51_4e53_bfaa_5a6ee1aabbf8);
+impl windows_core::RuntimeType for IProcessDiskUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessDiskUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetReport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessDiskUsageReport, IProcessDiskUsageReport_Vtbl, 0x401627fd_535d_4c1f_81b8_da54e1be635e);
+impl windows_core::RuntimeType for IProcessDiskUsageReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessDiskUsageReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,12 +142,18 @@ pub struct IProcessDiskUsageReport_Vtbl {
     pub OtherBytesCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessMemoryUsage, IProcessMemoryUsage_Vtbl, 0xf50b229b_827c_42b7_b07c_0e32627e6b3e);
+impl windows_core::RuntimeType for IProcessMemoryUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessMemoryUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetReport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessMemoryUsageReport, IProcessMemoryUsageReport_Vtbl, 0xc2c77cba_1951_4685_8532_7e749ecf8eeb);
+impl windows_core::RuntimeType for IProcessMemoryUsageReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessMemoryUsageReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -129,12 +171,18 @@ pub struct IProcessMemoryUsageReport_Vtbl {
     pub WorkingSetSizeInBytes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemCpuUsage, ISystemCpuUsage_Vtbl, 0x6037b3ac_02d6_4234_8362_7fe3adc81f5f);
+impl windows_core::RuntimeType for ISystemCpuUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemCpuUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetReport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemCpuUsageReport, ISystemCpuUsageReport_Vtbl, 0x2c26d0b2_9483_4f62_ab57_82b29d9719b8);
+impl windows_core::RuntimeType for ISystemCpuUsageReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemCpuUsageReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -143,6 +191,9 @@ pub struct ISystemCpuUsageReport_Vtbl {
     pub IdleTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemDiagnosticInfo, ISystemDiagnosticInfo_Vtbl, 0xa290fe05_dff3_407f_9a1b_0b2b317ca800);
+impl windows_core::RuntimeType for ISystemDiagnosticInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemDiagnosticInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -150,12 +201,18 @@ pub struct ISystemDiagnosticInfo_Vtbl {
     pub CpuUsage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemDiagnosticInfoStatics, ISystemDiagnosticInfoStatics_Vtbl, 0xd404ac21_fc7d_45f0_9a3f_39203aed9f7e);
+impl windows_core::RuntimeType for ISystemDiagnosticInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemDiagnosticInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentSystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemDiagnosticInfoStatics2, ISystemDiagnosticInfoStatics2_Vtbl, 0x79ded189_6af9_4da9_a422_15f73255b3eb);
+impl windows_core::RuntimeType for ISystemDiagnosticInfoStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemDiagnosticInfoStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -163,12 +220,18 @@ pub struct ISystemDiagnosticInfoStatics2_Vtbl {
     pub PreferredArchitecture: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::ProcessorArchitecture) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMemoryUsage, ISystemMemoryUsage_Vtbl, 0x17ffc595_1702_49cf_aa27_2f0a32591404);
+impl windows_core::RuntimeType for ISystemMemoryUsage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMemoryUsage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetReport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemMemoryUsageReport, ISystemMemoryUsageReport_Vtbl, 0x38663c87_2a9f_403a_bd19_2cf3e8169500);
+impl windows_core::RuntimeType for ISystemMemoryUsageReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemMemoryUsageReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,7 +261,7 @@ impl DiagnosticActionResult {
     }
 }
 impl windows_core::RuntimeType for DiagnosticActionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDiagnosticActionResult>();
 }
 unsafe impl windows_core::Interface for DiagnosticActionResult {
     type Vtable = IDiagnosticActionResult_Vtbl;
@@ -260,7 +323,7 @@ impl DiagnosticInvoker {
     }
 }
 impl windows_core::RuntimeType for DiagnosticInvoker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDiagnosticInvoker>();
 }
 unsafe impl windows_core::Interface for DiagnosticInvoker {
     type Vtable = IDiagnosticInvoker_Vtbl;
@@ -285,7 +348,7 @@ impl ProcessCpuUsage {
     }
 }
 impl windows_core::RuntimeType for ProcessCpuUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessCpuUsage>();
 }
 unsafe impl windows_core::Interface for ProcessCpuUsage {
     type Vtable = IProcessCpuUsage_Vtbl;
@@ -317,7 +380,7 @@ impl ProcessCpuUsageReport {
     }
 }
 impl windows_core::RuntimeType for ProcessCpuUsageReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessCpuUsageReport>();
 }
 unsafe impl windows_core::Interface for ProcessCpuUsageReport {
     type Vtable = IProcessCpuUsageReport_Vtbl;
@@ -428,7 +491,7 @@ impl ProcessDiagnosticInfo {
     }
 }
 impl windows_core::RuntimeType for ProcessDiagnosticInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessDiagnosticInfo>();
 }
 unsafe impl windows_core::Interface for ProcessDiagnosticInfo {
     type Vtable = IProcessDiagnosticInfo_Vtbl;
@@ -453,7 +516,7 @@ impl ProcessDiskUsage {
     }
 }
 impl windows_core::RuntimeType for ProcessDiskUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessDiskUsage>();
 }
 unsafe impl windows_core::Interface for ProcessDiskUsage {
     type Vtable = IProcessDiskUsage_Vtbl;
@@ -513,7 +576,7 @@ impl ProcessDiskUsageReport {
     }
 }
 impl windows_core::RuntimeType for ProcessDiskUsageReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessDiskUsageReport>();
 }
 unsafe impl windows_core::Interface for ProcessDiskUsageReport {
     type Vtable = IProcessDiskUsageReport_Vtbl;
@@ -538,7 +601,7 @@ impl ProcessMemoryUsage {
     }
 }
 impl windows_core::RuntimeType for ProcessMemoryUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessMemoryUsage>();
 }
 unsafe impl windows_core::Interface for ProcessMemoryUsage {
     type Vtable = IProcessMemoryUsage_Vtbl;
@@ -640,7 +703,7 @@ impl ProcessMemoryUsageReport {
     }
 }
 impl windows_core::RuntimeType for ProcessMemoryUsageReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessMemoryUsageReport>();
 }
 unsafe impl windows_core::Interface for ProcessMemoryUsageReport {
     type Vtable = IProcessMemoryUsageReport_Vtbl;
@@ -665,7 +728,7 @@ impl SystemCpuUsage {
     }
 }
 impl windows_core::RuntimeType for SystemCpuUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemCpuUsage>();
 }
 unsafe impl windows_core::Interface for SystemCpuUsage {
     type Vtable = ISystemCpuUsage_Vtbl;
@@ -704,7 +767,7 @@ impl SystemCpuUsageReport {
     }
 }
 impl windows_core::RuntimeType for SystemCpuUsageReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemCpuUsageReport>();
 }
 unsafe impl windows_core::Interface for SystemCpuUsageReport {
     type Vtable = ISystemCpuUsageReport_Vtbl;
@@ -764,7 +827,7 @@ impl SystemDiagnosticInfo {
     }
 }
 impl windows_core::RuntimeType for SystemDiagnosticInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemDiagnosticInfo>();
 }
 unsafe impl windows_core::Interface for SystemDiagnosticInfo {
     type Vtable = ISystemDiagnosticInfo_Vtbl;
@@ -789,7 +852,7 @@ impl SystemMemoryUsage {
     }
 }
 impl windows_core::RuntimeType for SystemMemoryUsage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMemoryUsage>();
 }
 unsafe impl windows_core::Interface for SystemMemoryUsage {
     type Vtable = ISystemMemoryUsage_Vtbl;
@@ -828,7 +891,7 @@ impl SystemMemoryUsageReport {
     }
 }
 impl windows_core::RuntimeType for SystemMemoryUsageReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemMemoryUsageReport>();
 }
 unsafe impl windows_core::Interface for SystemMemoryUsageReport {
     type Vtable = ISystemMemoryUsageReport_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Display/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDisplayRequest, IDisplayRequest_Vtbl, 0xe5732044_f49f_4b60_8dd4_5e7e3a632ac0);
+impl windows_core::RuntimeType for IDisplayRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,7 +30,7 @@ impl DisplayRequest {
     }
 }
 impl windows_core::RuntimeType for DisplayRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayRequest>();
 }
 unsafe impl windows_core::Interface for DisplayRequest {
     type Vtable = IDisplayRequest_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Implementation/FileExplorer/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(ISysStorageProviderEventReceivedEventArgs, ISysStorageProviderEventReceivedEventArgs_Vtbl, 0xe132d1b9_7b9d_5820_9728_4262b5289142);
+impl windows_core::RuntimeType for ISysStorageProviderEventReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISysStorageProviderEventReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Json: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISysStorageProviderEventReceivedEventArgsFactory, ISysStorageProviderEventReceivedEventArgsFactory_Vtbl, 0xde1a780e_e975_5f68_bcc6_fb46281c6a61);
+impl windows_core::RuntimeType for ISysStorageProviderEventReceivedEventArgsFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISysStorageProviderEventReceivedEventArgsFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,7 +121,7 @@ impl SysStorageProviderEventReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SysStorageProviderEventReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISysStorageProviderEventReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for SysStorageProviderEventReceivedEventArgs {
     type Vtable = ISysStorageProviderEventReceivedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Inventory/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Inventory/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IInstalledDesktopApp, IInstalledDesktopApp_Vtbl, 0x75eab8ed_c0bc_5364_4c28_166e0545167a);
+impl windows_core::RuntimeType for IInstalledDesktopApp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInstalledDesktopApp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IInstalledDesktopApp_Vtbl {
     pub DisplayVersion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInstalledDesktopAppStatics, IInstalledDesktopAppStatics_Vtbl, 0x264cf74e_21cd_5f9b_6056_7866ad72489a);
+impl windows_core::RuntimeType for IInstalledDesktopAppStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInstalledDesktopAppStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,7 +77,7 @@ impl InstalledDesktopApp {
     }
 }
 impl windows_core::RuntimeType for InstalledDesktopApp {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInstalledDesktopApp>();
 }
 unsafe impl windows_core::Interface for InstalledDesktopApp {
     type Vtable = IInstalledDesktopApp_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Power/mod.rs
@@ -1,6 +1,10 @@
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IBackgroundEnergyManagerStatics, IBackgroundEnergyManagerStatics_Vtbl, 0xb3161d95_1180_4376_96e1_4095568147ce);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IBackgroundEnergyManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IBackgroundEnergyManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +60,10 @@ pub struct IBackgroundEnergyManagerStatics_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IForegroundEnergyManagerStatics, IForegroundEnergyManagerStatics_Vtbl, 0x9ff86872_e677_4814_9a20_5337ca732b98);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IForegroundEnergyManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IForegroundEnergyManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,6 +109,9 @@ pub struct IForegroundEnergyManagerStatics_Vtbl {
     RemoveRecentEnergyUsageReturnedToLow: usize,
 }
 windows_core::imp::define_interface!(IPowerManagerStatics, IPowerManagerStatics_Vtbl, 0x1394825d_62ce_4364_98d5_aa28c7fbd15b);
+impl windows_core::RuntimeType for IPowerManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPowerManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/System/Profile/SystemManufacturers/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/SystemManufacturers/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IOemSupportInfo, IOemSupportInfo_Vtbl, 0x8d2eae55_87ef_4266_86d0_c4afbeb29bb9);
+impl windows_core::RuntimeType for IOemSupportInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOemSupportInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -7,12 +10,18 @@ pub struct IOemSupportInfo_Vtbl {
     pub SupportProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmbiosInformationStatics, ISmbiosInformationStatics_Vtbl, 0x080cca7c_637c_48c4_b728_f9273812db8e);
+impl windows_core::RuntimeType for ISmbiosInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmbiosInformationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SerialNumber: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemSupportDeviceInfo, ISystemSupportDeviceInfo_Vtbl, 0x05880b99_8247_441b_a996_a1784bab79a8);
+impl windows_core::RuntimeType for ISystemSupportDeviceInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemSupportDeviceInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +34,9 @@ pub struct ISystemSupportDeviceInfo_Vtbl {
     pub SystemFirmwareVersion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemSupportInfoStatics, ISystemSupportInfoStatics_Vtbl, 0xef750974_c422_45d7_a44d_5c1c0043a2b3);
+impl windows_core::RuntimeType for ISystemSupportInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemSupportInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +44,9 @@ pub struct ISystemSupportInfoStatics_Vtbl {
     pub OemSupportInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemSupportInfoStatics2, ISystemSupportInfoStatics2_Vtbl, 0x33f349a4_3fa1_4986_aa4b_057420455e6d);
+impl windows_core::RuntimeType for ISystemSupportInfoStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemSupportInfoStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -65,7 +80,7 @@ impl OemSupportInfo {
     }
 }
 impl windows_core::RuntimeType for OemSupportInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOemSupportInfo>();
 }
 unsafe impl windows_core::Interface for OemSupportInfo {
     type Vtable = IOemSupportInfo_Vtbl;
@@ -149,7 +164,7 @@ impl SystemSupportDeviceInfo {
     }
 }
 impl windows_core::RuntimeType for SystemSupportDeviceInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemSupportDeviceInfo>();
 }
 unsafe impl windows_core::Interface for SystemSupportDeviceInfo {
     type Vtable = ISystemSupportDeviceInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Profile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "System_Profile_SystemManufacturers")]
 pub mod SystemManufacturers;
 windows_core::imp::define_interface!(IAnalyticsInfoStatics, IAnalyticsInfoStatics_Vtbl, 0x1d5ee066_188d_5ba9_4387_acaeb0e7e305);
+impl windows_core::RuntimeType for IAnalyticsInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnalyticsInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IAnalyticsInfoStatics_Vtbl {
     pub DeviceForm: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAnalyticsInfoStatics2, IAnalyticsInfoStatics2_Vtbl, 0x101704ea_a7f9_46d2_ab94_016865afdb25);
+impl windows_core::RuntimeType for IAnalyticsInfoStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnalyticsInfoStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IAnalyticsInfoStatics2_Vtbl {
     GetSystemPropertiesAsync: usize,
 }
 windows_core::imp::define_interface!(IAnalyticsVersionInfo, IAnalyticsVersionInfo_Vtbl, 0x926130b8_9955_4c74_bdc1_7cd0decf9b03);
+impl windows_core::RuntimeType for IAnalyticsVersionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnalyticsVersionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,12 +33,18 @@ pub struct IAnalyticsVersionInfo_Vtbl {
     pub DeviceFamilyVersion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAnalyticsVersionInfo2, IAnalyticsVersionInfo2_Vtbl, 0x76e915b1_ff36_407c_9f57_160d3e540747);
+impl windows_core::RuntimeType for IAnalyticsVersionInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnalyticsVersionInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ProductName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppApplicabilityStatics, IAppApplicabilityStatics_Vtbl, 0x1664a082_0f38_5c99_83e4_48995970861c);
+impl windows_core::RuntimeType for IAppApplicabilityStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppApplicabilityStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,12 +54,18 @@ pub struct IAppApplicabilityStatics_Vtbl {
     GetUnsupportedAppRequirements: usize,
 }
 windows_core::imp::define_interface!(IEducationSettingsStatics, IEducationSettingsStatics_Vtbl, 0xfc53f0ef_4d3e_4e13_9b23_505f4d091e92);
+impl windows_core::RuntimeType for IEducationSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEducationSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsEducationEnvironment: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHardwareIdentificationStatics, IHardwareIdentificationStatics_Vtbl, 0x971260e0_f170_4a42_bd55_a900b212dae2);
+impl windows_core::RuntimeType for IHardwareIdentificationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHardwareIdentificationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +75,9 @@ pub struct IHardwareIdentificationStatics_Vtbl {
     GetPackageSpecificToken: usize,
 }
 windows_core::imp::define_interface!(IHardwareToken, IHardwareToken_Vtbl, 0x28f6d4c0_fb12_40a4_8167_7f4e03d2724c);
+impl windows_core::RuntimeType for IHardwareToken {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHardwareToken_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +95,9 @@ pub struct IHardwareToken_Vtbl {
     Certificate: usize,
 }
 windows_core::imp::define_interface!(IKnownRetailInfoPropertiesStatics, IKnownRetailInfoPropertiesStatics_Vtbl, 0x99571178_500f_487e_8e75_29e551728712);
+impl windows_core::RuntimeType for IKnownRetailInfoPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownRetailInfoPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,6 +125,9 @@ pub struct IKnownRetailInfoPropertiesStatics_Vtbl {
     pub WindowsEdition: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPlatformDiagnosticsAndUsageDataSettingsStatics, IPlatformDiagnosticsAndUsageDataSettingsStatics_Vtbl, 0xb6e24c1b_7b1c_4b32_8c62_a66597ce723a);
+impl windows_core::RuntimeType for IPlatformDiagnosticsAndUsageDataSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPlatformDiagnosticsAndUsageDataSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -107,6 +137,9 @@ pub struct IPlatformDiagnosticsAndUsageDataSettingsStatics_Vtbl {
     pub CanCollectDiagnostics: unsafe extern "system" fn(*mut core::ffi::c_void, PlatformDataCollectionLevel, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRetailInfoStatics, IRetailInfoStatics_Vtbl, 0x0712c6b8_8b92_4f2a_8499_031f1798d6ef);
+impl windows_core::RuntimeType for IRetailInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRetailInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,18 +150,27 @@ pub struct IRetailInfoStatics_Vtbl {
     Properties: usize,
 }
 windows_core::imp::define_interface!(ISharedModeSettingsStatics, ISharedModeSettingsStatics_Vtbl, 0x893df40e_cad6_4d50_8c49_6fcfc03edb29);
+impl windows_core::RuntimeType for ISharedModeSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedModeSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISharedModeSettingsStatics2, ISharedModeSettingsStatics2_Vtbl, 0x608988a4_ccf1_4ee8_a5e2_fd6a1d0cfac8);
+impl windows_core::RuntimeType for ISharedModeSettingsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISharedModeSettingsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ShouldAvoidLocalStorage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISmartAppControlPolicyStatics, ISmartAppControlPolicyStatics_Vtbl, 0x5ff8c75b_073e_5015_8d98_5ff224180a0b);
+impl windows_core::RuntimeType for ISmartAppControlPolicyStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISmartAppControlPolicyStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -137,6 +179,9 @@ pub struct ISmartAppControlPolicyStatics_Vtbl {
     pub RemoveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemIdentificationInfo, ISystemIdentificationInfo_Vtbl, 0x0c659e7d_c3c2_4d33_a2df_21bc41916eb3);
+impl windows_core::RuntimeType for ISystemIdentificationInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemIdentificationInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -147,6 +192,9 @@ pub struct ISystemIdentificationInfo_Vtbl {
     pub Source: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SystemIdentificationSource) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemIdentificationStatics, ISystemIdentificationStatics_Vtbl, 0x5581f42a_d3df_4d93_a37d_c41a616c6d01);
+impl windows_core::RuntimeType for ISystemIdentificationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemIdentificationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -154,6 +202,9 @@ pub struct ISystemIdentificationStatics_Vtbl {
     pub GetSystemIdForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemSetupInfoStatics, ISystemSetupInfoStatics_Vtbl, 0xb8366a4b_fb6a_4571_be0a_9a0f67954123);
+impl windows_core::RuntimeType for ISystemSetupInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemSetupInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -162,6 +213,9 @@ pub struct ISystemSetupInfoStatics_Vtbl {
     pub RemoveOutOfBoxExperienceStateChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUnsupportedAppRequirement, IUnsupportedAppRequirement_Vtbl, 0x6182445c_894b_5cbc_8976_a98e0a9b998d);
+impl windows_core::RuntimeType for IUnsupportedAppRequirement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUnsupportedAppRequirement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,6 +223,9 @@ pub struct IUnsupportedAppRequirement_Vtbl {
     pub Reasons: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UnsupportedAppRequirementReasons) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowsIntegrityPolicyStatics, IWindowsIntegrityPolicyStatics_Vtbl, 0x7d1d81db_8d63_4789_9ea5_ddcf65a94f3c);
+impl windows_core::RuntimeType for IWindowsIntegrityPolicyStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowsIntegrityPolicyStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -245,7 +302,7 @@ impl AnalyticsVersionInfo {
     }
 }
 impl windows_core::RuntimeType for AnalyticsVersionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAnalyticsVersionInfo>();
 }
 unsafe impl windows_core::Interface for AnalyticsVersionInfo {
     type Vtable = IAnalyticsVersionInfo_Vtbl;
@@ -346,7 +403,7 @@ impl HardwareToken {
     }
 }
 impl windows_core::RuntimeType for HardwareToken {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHardwareToken>();
 }
 unsafe impl windows_core::Interface for HardwareToken {
     type Vtable = IHardwareToken_Vtbl;
@@ -664,7 +721,7 @@ impl SystemIdentificationInfo {
     }
 }
 impl windows_core::RuntimeType for SystemIdentificationInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemIdentificationInfo>();
 }
 unsafe impl windows_core::Interface for SystemIdentificationInfo {
     type Vtable = ISystemIdentificationInfo_Vtbl;
@@ -725,7 +782,7 @@ impl UnsupportedAppRequirement {
     }
 }
 impl windows_core::RuntimeType for UnsupportedAppRequirement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUnsupportedAppRequirement>();
 }
 unsafe impl windows_core::Interface for UnsupportedAppRequirement {
     type Vtable = IUnsupportedAppRequirement_Vtbl;

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Input/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IRemoteTextConnection, IRemoteTextConnection_Vtbl, 0x4e7bb02a_183e_5e66_b5e4_3e6e5c570cf1);
+impl windows_core::RuntimeType for IRemoteTextConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteTextConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IRemoteTextConnection_Vtbl {
     pub ReportDataReceived: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteTextConnectionFactory, IRemoteTextConnectionFactory_Vtbl, 0x88e075c2_0cae_596c_850f_78d345cd728b);
+impl windows_core::RuntimeType for IRemoteTextConnectionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteTextConnectionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,7 +69,7 @@ impl RemoteTextConnection {
     }
 }
 impl windows_core::RuntimeType for RemoteTextConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteTextConnection>();
 }
 unsafe impl windows_core::Interface for RemoteTextConnection {
     type Vtable = IRemoteTextConnection_Vtbl;

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/Provider/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IPerformLocalActionRequestedEventArgs, IPerformLocalActionRequestedEventArgs_Vtbl, 0x59359f4f_0862_53a3_a3b3_c932fb718cdc);
+impl windows_core::RuntimeType for IPerformLocalActionRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPerformLocalActionRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Action: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RemoteDesktopLocalAction) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteDesktopConnectionInfo, IRemoteDesktopConnectionInfo_Vtbl, 0x68bd69d6_6dea_543b_b737_f347919f5093);
+impl windows_core::RuntimeType for IRemoteDesktopConnectionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteDesktopConnectionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +18,9 @@ pub struct IRemoteDesktopConnectionInfo_Vtbl {
     pub SwitchToLocalSession: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteDesktopConnectionInfoStatics, IRemoteDesktopConnectionInfoStatics_Vtbl, 0x4a7dc5a1_3368_5a75_bb78_807df7ebc439);
+impl windows_core::RuntimeType for IRemoteDesktopConnectionInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteDesktopConnectionInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +30,9 @@ pub struct IRemoteDesktopConnectionInfoStatics_Vtbl {
     GetForLaunchUri: usize,
 }
 windows_core::imp::define_interface!(IRemoteDesktopConnectionRemoteInfo, IRemoteDesktopConnectionRemoteInfo_Vtbl, 0x2a3dfa7e_a7ab_547e_9a6a_4c565bbb8d71);
+impl windows_core::RuntimeType for IRemoteDesktopConnectionRemoteInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteDesktopConnectionRemoteInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +43,9 @@ pub struct IRemoteDesktopConnectionRemoteInfo_Vtbl {
     pub RemovePerformLocalActionRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteDesktopConnectionRemoteInfoStatics, IRemoteDesktopConnectionRemoteInfoStatics_Vtbl, 0xb590e64a_e4c9_53e8_b83d_a0db3676246a);
+impl windows_core::RuntimeType for IRemoteDesktopConnectionRemoteInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteDesktopConnectionRemoteInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,6 +53,9 @@ pub struct IRemoteDesktopConnectionRemoteInfoStatics_Vtbl {
     pub GetForLaunchUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteDesktopInfo, IRemoteDesktopInfo_Vtbl, 0xd185bb25_2f1e_5098_b9e0_f46d6358c5c4);
+impl windows_core::RuntimeType for IRemoteDesktopInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteDesktopInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,12 +63,18 @@ pub struct IRemoteDesktopInfo_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteDesktopInfoFactory, IRemoteDesktopInfoFactory_Vtbl, 0xad0e8d58_b56f_5a8b_b419_8002ee0c5ee9);
+impl windows_core::RuntimeType for IRemoteDesktopInfoFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteDesktopInfoFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteDesktopRegistrarStatics, IRemoteDesktopRegistrarStatics_Vtbl, 0x687c2750_46d9_5de3_8dc3_84a9202cecfb);
+impl windows_core::RuntimeType for IRemoteDesktopRegistrarStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteDesktopRegistrarStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -74,7 +98,7 @@ impl PerformLocalActionRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for PerformLocalActionRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPerformLocalActionRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for PerformLocalActionRequestedEventArgs {
     type Vtable = IPerformLocalActionRequestedEventArgs_Vtbl;
@@ -115,7 +139,7 @@ impl RemoteDesktopConnectionInfo {
     }
 }
 impl windows_core::RuntimeType for RemoteDesktopConnectionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteDesktopConnectionInfo>();
 }
 unsafe impl windows_core::Interface for RemoteDesktopConnectionInfo {
     type Vtable = IRemoteDesktopConnectionInfo_Vtbl;
@@ -190,7 +214,7 @@ impl RemoteDesktopConnectionRemoteInfo {
     }
 }
 impl windows_core::RuntimeType for RemoteDesktopConnectionRemoteInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteDesktopConnectionRemoteInfo>();
 }
 unsafe impl windows_core::Interface for RemoteDesktopConnectionRemoteInfo {
     type Vtable = IRemoteDesktopConnectionRemoteInfo_Vtbl;
@@ -233,7 +257,7 @@ impl RemoteDesktopInfo {
     }
 }
 impl windows_core::RuntimeType for RemoteDesktopInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteDesktopInfo>();
 }
 unsafe impl windows_core::Interface for RemoteDesktopInfo {
     type Vtable = IRemoteDesktopInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteDesktop/mod.rs
@@ -3,6 +3,9 @@ pub mod Input;
 #[cfg(feature = "System_RemoteDesktop_Provider")]
 pub mod Provider;
 windows_core::imp::define_interface!(IInteractiveSessionStatics, IInteractiveSessionStatics_Vtbl, 0x60884631_dd3a_4576_9c8d_e8027618bdce);
+impl windows_core::RuntimeType for IInteractiveSessionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractiveSessionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IKnownRemoteSystemCapabilitiesStatics, IKnownRemoteSystemCapabilitiesStatics_Vtbl, 0x8108e380_7f8a_44e4_92cd_03b6469b94a3);
+impl windows_core::RuntimeType for IKnownRemoteSystemCapabilitiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownRemoteSystemCapabilitiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct IKnownRemoteSystemCapabilitiesStatics_Vtbl {
     pub SpatialEntity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystem, IRemoteSystem_Vtbl, 0xed5838cd_1e10_4a8c_b4a6_4e5fd6f97721);
+impl windows_core::RuntimeType for IRemoteSystem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +24,9 @@ pub struct IRemoteSystem_Vtbl {
     pub IsAvailableByProximity: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystem2, IRemoteSystem2_Vtbl, 0x09dfe4ec_fb8b_4a08_a758_6876435d769e);
+impl windows_core::RuntimeType for IRemoteSystem2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystem2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +34,9 @@ pub struct IRemoteSystem2_Vtbl {
     pub GetCapabilitySupportedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystem3, IRemoteSystem3_Vtbl, 0x72b4b495_b7c6_40be_831b_73562f12ffa8);
+impl windows_core::RuntimeType for IRemoteSystem3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystem3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,12 +44,18 @@ pub struct IRemoteSystem3_Vtbl {
     pub ModelDisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystem4, IRemoteSystem4_Vtbl, 0xf164ffe5_b987_4ca5_9926_fa0438be6273);
+impl windows_core::RuntimeType for IRemoteSystem4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystem4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Platform: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RemoteSystemPlatform) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystem5, IRemoteSystem5_Vtbl, 0xeb2ad723_e5e2_4ae2_a7a7_a1097a098e90);
+impl windows_core::RuntimeType for IRemoteSystem5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystem5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,18 +65,27 @@ pub struct IRemoteSystem5_Vtbl {
     Apps: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystem6, IRemoteSystem6_Vtbl, 0xd4cda942_c027_533e_9384_3a19b4f7eef3);
+impl windows_core::RuntimeType for IRemoteSystem6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystem6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub User: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemAddedEventArgs, IRemoteSystemAddedEventArgs_Vtbl, 0x8f39560f_e534_4697_8836_7abea151516e);
+impl windows_core::RuntimeType for IRemoteSystemAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemApp, IRemoteSystemApp_Vtbl, 0x80e5bcbd_d54d_41b1_9b16_6810a871ed4f);
+impl windows_core::RuntimeType for IRemoteSystemApp {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemApp_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,6 +99,9 @@ pub struct IRemoteSystemApp_Vtbl {
     Attributes: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemApp2, IRemoteSystemApp2_Vtbl, 0x6369bf15_0a96_577a_8ff6_c35904dfa8f3);
+impl windows_core::RuntimeType for IRemoteSystemApp2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemApp2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +109,9 @@ pub struct IRemoteSystemApp2_Vtbl {
     pub ConnectionToken: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemAppRegistration, IRemoteSystemAppRegistration_Vtbl, 0xb47947b5_7035_4a5a_b8df_962d8f8431f4);
+impl windows_core::RuntimeType for IRemoteSystemAppRegistration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemAppRegistration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,6 +123,9 @@ pub struct IRemoteSystemAppRegistration_Vtbl {
     pub SaveAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemAppRegistrationStatics, IRemoteSystemAppRegistrationStatics_Vtbl, 0x01b99840_cfd2_453f_ae25_c2539f086afd);
+impl windows_core::RuntimeType for IRemoteSystemAppRegistrationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemAppRegistrationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -97,24 +133,36 @@ pub struct IRemoteSystemAppRegistrationStatics_Vtbl {
     pub GetForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemAuthorizationKindFilter, IRemoteSystemAuthorizationKindFilter_Vtbl, 0x6b0dde8e_04d0_40f4_a27f_c2acbbd6b734);
+impl windows_core::RuntimeType for IRemoteSystemAuthorizationKindFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemAuthorizationKindFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystemAuthorizationKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RemoteSystemAuthorizationKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemAuthorizationKindFilterFactory, IRemoteSystemAuthorizationKindFilterFactory_Vtbl, 0xad65df4d_b66a_45a4_8177_8caed75d9e5a);
+impl windows_core::RuntimeType for IRemoteSystemAuthorizationKindFilterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemAuthorizationKindFilterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, RemoteSystemAuthorizationKind, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionInfo, IRemoteSystemConnectionInfo_Vtbl, 0x23278bc3_0d09_52cb_9c6a_eed2940bee43);
+impl windows_core::RuntimeType for IRemoteSystemConnectionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsProximal: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionInfoStatics, IRemoteSystemConnectionInfoStatics_Vtbl, 0xac831e2d_66c5_56d7_a4ce_705d94925ad6);
+impl windows_core::RuntimeType for IRemoteSystemConnectionInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,36 +172,54 @@ pub struct IRemoteSystemConnectionInfoStatics_Vtbl {
     TryCreateFromAppServiceConnection: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionRequest, IRemoteSystemConnectionRequest_Vtbl, 0x84ed4104_8d5e_4d72_8238_7621576c7a67);
+impl windows_core::RuntimeType for IRemoteSystemConnectionRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionRequest2, IRemoteSystemConnectionRequest2_Vtbl, 0x12df6d6f_bffc_483a_8abe_d34a6c19f92b);
+impl windows_core::RuntimeType for IRemoteSystemConnectionRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystemApp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionRequest3, IRemoteSystemConnectionRequest3_Vtbl, 0xde86c3e7_c9cc_5a50_b8d9_ba7b34bb8d0e);
+impl windows_core::RuntimeType for IRemoteSystemConnectionRequest3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionRequest3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ConnectionToken: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionRequestFactory, IRemoteSystemConnectionRequestFactory_Vtbl, 0xaa0a0a20_baeb_4575_b530_810bb9786334);
+impl windows_core::RuntimeType for IRemoteSystemConnectionRequestFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionRequestFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionRequestStatics, IRemoteSystemConnectionRequestStatics_Vtbl, 0x86ca143d_8214_425c_8932_db49032d1306);
+impl windows_core::RuntimeType for IRemoteSystemConnectionRequestStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionRequestStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateForApp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemConnectionRequestStatics2, IRemoteSystemConnectionRequestStatics2_Vtbl, 0x460f1027_64ec_598e_a800_4f2ee58def19);
+impl windows_core::RuntimeType for IRemoteSystemConnectionRequestStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemConnectionRequestStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,18 +227,27 @@ pub struct IRemoteSystemConnectionRequestStatics2_Vtbl {
     pub CreateFromConnectionTokenForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemDiscoveryTypeFilter, IRemoteSystemDiscoveryTypeFilter_Vtbl, 0x42d9041f_ee5a_43da_ac6a_6fee25460741);
+impl windows_core::RuntimeType for IRemoteSystemDiscoveryTypeFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemDiscoveryTypeFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystemDiscoveryType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RemoteSystemDiscoveryType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemDiscoveryTypeFilterFactory, IRemoteSystemDiscoveryTypeFilterFactory_Vtbl, 0x9f9eb993_c260_4161_92f2_9c021f23fe5d);
+impl windows_core::RuntimeType for IRemoteSystemDiscoveryTypeFilterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemDiscoveryTypeFilterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, RemoteSystemDiscoveryType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemEnumerationCompletedEventArgs, IRemoteSystemEnumerationCompletedEventArgs_Vtbl, 0xc6e83d5f_4030_4354_a060_14f1b22c545d);
+impl windows_core::RuntimeType for IRemoteSystemEnumerationCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemEnumerationCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -188,6 +263,9 @@ pub struct IRemoteSystemFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IRemoteSystemKindFilter, IRemoteSystemKindFilter_Vtbl, 0x38e1c9ec_22c3_4ef6_901a_bbb1c7aad4ed);
+impl windows_core::RuntimeType for IRemoteSystemKindFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemKindFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,6 +275,9 @@ pub struct IRemoteSystemKindFilter_Vtbl {
     RemoteSystemKinds: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemKindFilterFactory, IRemoteSystemKindFilterFactory_Vtbl, 0xa1fb18ee_99ea_40bc_9a39_c670aa804a28);
+impl windows_core::RuntimeType for IRemoteSystemKindFilterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemKindFilterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -206,6 +287,9 @@ pub struct IRemoteSystemKindFilterFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemKindStatics, IRemoteSystemKindStatics_Vtbl, 0xf6317633_ab14_41d0_9553_796aadb882db);
+impl windows_core::RuntimeType for IRemoteSystemKindStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemKindStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -216,6 +300,9 @@ pub struct IRemoteSystemKindStatics_Vtbl {
     pub Xbox: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemKindStatics2, IRemoteSystemKindStatics2_Vtbl, 0xb9e3a3d0_0466_4749_91e8_65f9d19a96a5);
+impl windows_core::RuntimeType for IRemoteSystemKindStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemKindStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -224,12 +311,18 @@ pub struct IRemoteSystemKindStatics2_Vtbl {
     pub Laptop: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemRemovedEventArgs, IRemoteSystemRemovedEventArgs_Vtbl, 0x8b3d16bb_7306_49ea_b7df_67d5714cb013);
+impl windows_core::RuntimeType for IRemoteSystemRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystemId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSession, IRemoteSystemSession_Vtbl, 0x69476a01_9ada_490f_9549_d31cb14c9e95);
+impl windows_core::RuntimeType for IRemoteSystemSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -242,12 +335,18 @@ pub struct IRemoteSystemSession_Vtbl {
     pub SendInvitationAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionAddedEventArgs, IRemoteSystemSessionAddedEventArgs_Vtbl, 0xd585d754_bc97_4c39_99b4_beca76e04c3f);
+impl windows_core::RuntimeType for IRemoteSystemSessionAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SessionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionController, IRemoteSystemSessionController_Vtbl, 0xe48b2dd2_6820_4867_b425_d89c0a3ef7ba);
+impl windows_core::RuntimeType for IRemoteSystemSessionController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -257,6 +356,9 @@ pub struct IRemoteSystemSessionController_Vtbl {
     pub CreateSessionAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionControllerFactory, IRemoteSystemSessionControllerFactory_Vtbl, 0xbfcc2f6b_ac3d_4199_82cd_6670a773ef2e);
+impl windows_core::RuntimeType for IRemoteSystemSessionControllerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionControllerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -264,6 +366,9 @@ pub struct IRemoteSystemSessionControllerFactory_Vtbl {
     pub CreateControllerWithSessionOptions: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionCreationResult, IRemoteSystemSessionCreationResult_Vtbl, 0xa79812c2_37de_448c_8b83_a30aa3c4ead6);
+impl windows_core::RuntimeType for IRemoteSystemSessionCreationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionCreationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -271,12 +376,18 @@ pub struct IRemoteSystemSessionCreationResult_Vtbl {
     pub Session: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionDisconnectedEventArgs, IRemoteSystemSessionDisconnectedEventArgs_Vtbl, 0xde0bc69b_77c5_461c_8209_7c6c5d3111ab);
+impl windows_core::RuntimeType for IRemoteSystemSessionDisconnectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionDisconnectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RemoteSystemSessionDisconnectedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionInfo, IRemoteSystemSessionInfo_Vtbl, 0xff4df648_8b0a_4e9a_9905_69e4b841c588);
+impl windows_core::RuntimeType for IRemoteSystemSessionInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -285,6 +396,9 @@ pub struct IRemoteSystemSessionInfo_Vtbl {
     pub JoinAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionInvitation, IRemoteSystemSessionInvitation_Vtbl, 0x3e32cc91_51d7_4766_a121_25516c3b8294);
+impl windows_core::RuntimeType for IRemoteSystemSessionInvitation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionInvitation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -292,6 +406,9 @@ pub struct IRemoteSystemSessionInvitation_Vtbl {
     pub SessionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionInvitationListener, IRemoteSystemSessionInvitationListener_Vtbl, 0x08f4003f_bc71_49e1_874a_31ddff9a27b9);
+impl windows_core::RuntimeType for IRemoteSystemSessionInvitationListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionInvitationListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -299,12 +416,18 @@ pub struct IRemoteSystemSessionInvitationListener_Vtbl {
     pub RemoveInvitationReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionInvitationReceivedEventArgs, IRemoteSystemSessionInvitationReceivedEventArgs_Vtbl, 0x5e964a2d_a10d_4edb_8dea_54d20ac19543);
+impl windows_core::RuntimeType for IRemoteSystemSessionInvitationReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionInvitationReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Invitation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionJoinRequest, IRemoteSystemSessionJoinRequest_Vtbl, 0x20600068_7994_4331_86d1_d89d882585ee);
+impl windows_core::RuntimeType for IRemoteSystemSessionJoinRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionJoinRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,6 +435,9 @@ pub struct IRemoteSystemSessionJoinRequest_Vtbl {
     pub Accept: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionJoinRequestedEventArgs, IRemoteSystemSessionJoinRequestedEventArgs_Vtbl, 0xdbca4fc3_82b9_4816_9c24_e40e61774bd8);
+impl windows_core::RuntimeType for IRemoteSystemSessionJoinRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionJoinRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -319,6 +445,9 @@ pub struct IRemoteSystemSessionJoinRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionJoinResult, IRemoteSystemSessionJoinResult_Vtbl, 0xce7b1f04_a03e_41a4_900b_1e79328c1267);
+impl windows_core::RuntimeType for IRemoteSystemSessionJoinResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionJoinResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -326,6 +455,9 @@ pub struct IRemoteSystemSessionJoinResult_Vtbl {
     pub Session: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionMessageChannel, IRemoteSystemSessionMessageChannel_Vtbl, 0x9524d12a_73d9_4c10_b751_c26784437127);
+impl windows_core::RuntimeType for IRemoteSystemSessionMessageChannel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionMessageChannel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -346,6 +478,9 @@ pub struct IRemoteSystemSessionMessageChannel_Vtbl {
     pub RemoveValueSetReceived: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionMessageChannelFactory, IRemoteSystemSessionMessageChannelFactory_Vtbl, 0x295e1c4a_bd16_4298_b7ce_415482b0e11d);
+impl windows_core::RuntimeType for IRemoteSystemSessionMessageChannelFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionMessageChannelFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -353,6 +488,9 @@ pub struct IRemoteSystemSessionMessageChannelFactory_Vtbl {
     pub CreateWithReliability: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, RemoteSystemSessionMessageChannelReliability, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionOptions, IRemoteSystemSessionOptions_Vtbl, 0x740ed755_8418_4f01_9353_e21c9ecc6cfc);
+impl windows_core::RuntimeType for IRemoteSystemSessionOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -360,6 +498,9 @@ pub struct IRemoteSystemSessionOptions_Vtbl {
     pub SetIsInviteOnly: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionParticipant, IRemoteSystemSessionParticipant_Vtbl, 0x7e90058c_acf9_4729_8a17_44e7baed5dcc);
+impl windows_core::RuntimeType for IRemoteSystemSessionParticipant {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionParticipant_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -370,18 +511,27 @@ pub struct IRemoteSystemSessionParticipant_Vtbl {
     GetHostNames: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionParticipantAddedEventArgs, IRemoteSystemSessionParticipantAddedEventArgs_Vtbl, 0xd35a57d8_c9a1_4bb7_b6b0_79bb91adf93d);
+impl windows_core::RuntimeType for IRemoteSystemSessionParticipantAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionParticipantAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Participant: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionParticipantRemovedEventArgs, IRemoteSystemSessionParticipantRemovedEventArgs_Vtbl, 0x866ef088_de68_4abf_88a1_f90d16274192);
+impl windows_core::RuntimeType for IRemoteSystemSessionParticipantRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionParticipantRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Participant: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionParticipantWatcher, IRemoteSystemSessionParticipantWatcher_Vtbl, 0xdcdd02cc_aa87_4d79_b6cc_4459b3e92075);
+impl windows_core::RuntimeType for IRemoteSystemSessionParticipantWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionParticipantWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -396,24 +546,36 @@ pub struct IRemoteSystemSessionParticipantWatcher_Vtbl {
     pub RemoveEnumerationCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionRemovedEventArgs, IRemoteSystemSessionRemovedEventArgs_Vtbl, 0xaf82914e_39a1_4dea_9d63_43798d5bbbd0);
+impl windows_core::RuntimeType for IRemoteSystemSessionRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SessionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionStatics, IRemoteSystemSessionStatics_Vtbl, 0x8524899f_fd20_44e3_9565_e75a3b14c66e);
+impl windows_core::RuntimeType for IRemoteSystemSessionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWatcher: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionUpdatedEventArgs, IRemoteSystemSessionUpdatedEventArgs_Vtbl, 0x16875069_231e_4c91_8ec8_b3a39d9e55a3);
+impl windows_core::RuntimeType for IRemoteSystemSessionUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SessionInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionValueSetReceivedEventArgs, IRemoteSystemSessionValueSetReceivedEventArgs_Vtbl, 0x06f31785_2da5_4e58_a78f_9e8d0784ee25);
+impl windows_core::RuntimeType for IRemoteSystemSessionValueSetReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionValueSetReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -424,6 +586,9 @@ pub struct IRemoteSystemSessionValueSetReceivedEventArgs_Vtbl {
     Message: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemSessionWatcher, IRemoteSystemSessionWatcher_Vtbl, 0x8003e340_0c41_4a62_b6d7_bdbe2b19be2d);
+impl windows_core::RuntimeType for IRemoteSystemSessionWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemSessionWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -438,6 +603,9 @@ pub struct IRemoteSystemSessionWatcher_Vtbl {
     pub RemoveRemoved: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemStatics, IRemoteSystemStatics_Vtbl, 0xa485b392_ff2b_4b47_be62_743f2f140f30);
+impl windows_core::RuntimeType for IRemoteSystemStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -453,12 +621,18 @@ pub struct IRemoteSystemStatics_Vtbl {
     pub RequestAccessAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemStatics2, IRemoteSystemStatics2_Vtbl, 0x0c98edca_6f99_4c52_a272_ea4f36471744);
+impl windows_core::RuntimeType for IRemoteSystemStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsAuthorizationKindEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, RemoteSystemAuthorizationKind, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemStatics3, IRemoteSystemStatics3_Vtbl, 0x9995f16f_0b3c_5ac5_b325_cc73f437dfcd);
+impl windows_core::RuntimeType for IRemoteSystemStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -469,24 +643,36 @@ pub struct IRemoteSystemStatics3_Vtbl {
     CreateWatcherWithFiltersForUser: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemStatusTypeFilter, IRemoteSystemStatusTypeFilter_Vtbl, 0x0c39514e_cbb6_4777_8534_2e0c521affa2);
+impl windows_core::RuntimeType for IRemoteSystemStatusTypeFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemStatusTypeFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystemStatusType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RemoteSystemStatusType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemStatusTypeFilterFactory, IRemoteSystemStatusTypeFilterFactory_Vtbl, 0x33cf78fa_d724_4125_ac7a_8d281e44c949);
+impl windows_core::RuntimeType for IRemoteSystemStatusTypeFilterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemStatusTypeFilterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, RemoteSystemStatusType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemUpdatedEventArgs, IRemoteSystemUpdatedEventArgs_Vtbl, 0x7502ff0e_dbcb_4155_b4ca_b30a04f27627);
+impl windows_core::RuntimeType for IRemoteSystemUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RemoteSystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemWatcher, IRemoteSystemWatcher_Vtbl, 0x5d600c7e_2c07_48c5_889c_455d2b099771);
+impl windows_core::RuntimeType for IRemoteSystemWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -500,6 +686,9 @@ pub struct IRemoteSystemWatcher_Vtbl {
     pub RemoveRemoteSystemRemoved: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemWatcher2, IRemoteSystemWatcher2_Vtbl, 0x73436700_19ca_48f9_a4cd_780f7ad58c71);
+impl windows_core::RuntimeType for IRemoteSystemWatcher2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemWatcher2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -509,18 +698,27 @@ pub struct IRemoteSystemWatcher2_Vtbl {
     pub RemoveErrorOccurred: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemWatcher3, IRemoteSystemWatcher3_Vtbl, 0xf79c0fcf_a913_55d3_8413_418fcf15ba54);
+impl windows_core::RuntimeType for IRemoteSystemWatcher3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemWatcher3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub User: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemWatcherErrorOccurredEventArgs, IRemoteSystemWatcherErrorOccurredEventArgs_Vtbl, 0x74c5c6af_5114_4426_9216_20d81f8519ae);
+impl windows_core::RuntimeType for IRemoteSystemWatcherErrorOccurredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemWatcherErrorOccurredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Error: unsafe extern "system" fn(*mut core::ffi::c_void, *mut RemoteSystemWatcherError) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteSystemWebAccountFilter, IRemoteSystemWebAccountFilter_Vtbl, 0x3fb75873_87c8_5d8f_977e_f69f96d67238);
+impl windows_core::RuntimeType for IRemoteSystemWebAccountFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemWebAccountFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -530,6 +728,9 @@ pub struct IRemoteSystemWebAccountFilter_Vtbl {
     Account: usize,
 }
 windows_core::imp::define_interface!(IRemoteSystemWebAccountFilterFactory, IRemoteSystemWebAccountFilterFactory_Vtbl, 0x348a2709_5f4d_5127_b4a7_bf99d5252b1b);
+impl windows_core::RuntimeType for IRemoteSystemWebAccountFilterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteSystemWebAccountFilterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -738,7 +939,7 @@ impl RemoteSystem {
     }
 }
 impl windows_core::RuntimeType for RemoteSystem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystem>();
 }
 unsafe impl windows_core::Interface for RemoteSystem {
     type Vtable = IRemoteSystem_Vtbl;
@@ -763,7 +964,7 @@ impl RemoteSystemAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemAddedEventArgs {
     type Vtable = IRemoteSystemAddedEventArgs_Vtbl;
@@ -831,7 +1032,7 @@ impl RemoteSystemApp {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemApp {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemApp>();
 }
 unsafe impl windows_core::Interface for RemoteSystemApp {
     type Vtable = IRemoteSystemApp_Vtbl;
@@ -891,7 +1092,7 @@ impl RemoteSystemAppRegistration {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemAppRegistration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemAppRegistration>();
 }
 unsafe impl windows_core::Interface for RemoteSystemAppRegistration {
     type Vtable = IRemoteSystemAppRegistration_Vtbl;
@@ -928,7 +1129,7 @@ impl RemoteSystemAuthorizationKindFilter {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemAuthorizationKindFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemAuthorizationKindFilter>();
 }
 unsafe impl windows_core::Interface for RemoteSystemAuthorizationKindFilter {
     type Vtable = IRemoteSystemAuthorizationKindFilter_Vtbl;
@@ -968,7 +1169,7 @@ impl RemoteSystemConnectionInfo {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemConnectionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemConnectionInfo>();
 }
 unsafe impl windows_core::Interface for RemoteSystemConnectionInfo {
     type Vtable = IRemoteSystemConnectionInfo_Vtbl;
@@ -1055,7 +1256,7 @@ impl RemoteSystemConnectionRequest {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemConnectionRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemConnectionRequest>();
 }
 unsafe impl windows_core::Interface for RemoteSystemConnectionRequest {
     type Vtable = IRemoteSystemConnectionRequest_Vtbl;
@@ -1092,7 +1293,7 @@ impl RemoteSystemDiscoveryTypeFilter {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemDiscoveryTypeFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemDiscoveryTypeFilter>();
 }
 unsafe impl windows_core::Interface for RemoteSystemDiscoveryTypeFilter {
     type Vtable = IRemoteSystemDiscoveryTypeFilter_Vtbl;
@@ -1109,7 +1310,7 @@ pub struct RemoteSystemEnumerationCompletedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(RemoteSystemEnumerationCompletedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl RemoteSystemEnumerationCompletedEventArgs {}
 impl windows_core::RuntimeType for RemoteSystemEnumerationCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemEnumerationCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemEnumerationCompletedEventArgs {
     type Vtable = IRemoteSystemEnumerationCompletedEventArgs_Vtbl;
@@ -1151,7 +1352,7 @@ impl RemoteSystemKindFilter {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemKindFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemKindFilter>();
 }
 unsafe impl windows_core::Interface for RemoteSystemKindFilter {
     type Vtable = IRemoteSystemKindFilter_Vtbl;
@@ -1240,7 +1441,7 @@ impl RemoteSystemRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemRemovedEventArgs {
     type Vtable = IRemoteSystemRemovedEventArgs_Vtbl;
@@ -1326,7 +1527,7 @@ impl RemoteSystemSession {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSession>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSession {
     type Vtable = IRemoteSystemSession_Vtbl;
@@ -1351,7 +1552,7 @@ impl RemoteSystemSessionAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionAddedEventArgs {
     type Vtable = IRemoteSystemSessionAddedEventArgs_Vtbl;
@@ -1420,7 +1621,7 @@ impl RemoteSystemSessionController {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionController>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionController {
     type Vtable = IRemoteSystemSessionController_Vtbl;
@@ -1452,7 +1653,7 @@ impl RemoteSystemSessionCreationResult {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionCreationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionCreationResult>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionCreationResult {
     type Vtable = IRemoteSystemSessionCreationResult_Vtbl;
@@ -1477,7 +1678,7 @@ impl RemoteSystemSessionDisconnectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionDisconnectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionDisconnectedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionDisconnectedEventArgs {
     type Vtable = IRemoteSystemSessionDisconnectedEventArgs_Vtbl;
@@ -1516,7 +1717,7 @@ impl RemoteSystemSessionInfo {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionInfo>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionInfo {
     type Vtable = IRemoteSystemSessionInfo_Vtbl;
@@ -1548,7 +1749,7 @@ impl RemoteSystemSessionInvitation {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionInvitation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionInvitation>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionInvitation {
     type Vtable = IRemoteSystemSessionInvitation_Vtbl;
@@ -1587,7 +1788,7 @@ impl RemoteSystemSessionInvitationListener {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionInvitationListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionInvitationListener>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionInvitationListener {
     type Vtable = IRemoteSystemSessionInvitationListener_Vtbl;
@@ -1612,7 +1813,7 @@ impl RemoteSystemSessionInvitationReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionInvitationReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionInvitationReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionInvitationReceivedEventArgs {
     type Vtable = IRemoteSystemSessionInvitationReceivedEventArgs_Vtbl;
@@ -1641,7 +1842,7 @@ impl RemoteSystemSessionJoinRequest {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionJoinRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionJoinRequest>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionJoinRequest {
     type Vtable = IRemoteSystemSessionJoinRequest_Vtbl;
@@ -1673,7 +1874,7 @@ impl RemoteSystemSessionJoinRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionJoinRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionJoinRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionJoinRequestedEventArgs {
     type Vtable = IRemoteSystemSessionJoinRequestedEventArgs_Vtbl;
@@ -1705,7 +1906,7 @@ impl RemoteSystemSessionJoinResult {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionJoinResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionJoinResult>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionJoinResult {
     type Vtable = IRemoteSystemSessionJoinResult_Vtbl;
@@ -1802,7 +2003,7 @@ impl RemoteSystemSessionMessageChannel {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionMessageChannel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionMessageChannel>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionMessageChannel {
     type Vtable = IRemoteSystemSessionMessageChannel_Vtbl;
@@ -1838,7 +2039,7 @@ impl RemoteSystemSessionOptions {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionOptions>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionOptions {
     type Vtable = IRemoteSystemSessionOptions_Vtbl;
@@ -1871,7 +2072,7 @@ impl RemoteSystemSessionParticipant {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionParticipant {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionParticipant>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionParticipant {
     type Vtable = IRemoteSystemSessionParticipant_Vtbl;
@@ -1896,7 +2097,7 @@ impl RemoteSystemSessionParticipantAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionParticipantAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionParticipantAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionParticipantAddedEventArgs {
     type Vtable = IRemoteSystemSessionParticipantAddedEventArgs_Vtbl;
@@ -1921,7 +2122,7 @@ impl RemoteSystemSessionParticipantRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionParticipantRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionParticipantRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionParticipantRemovedEventArgs {
     type Vtable = IRemoteSystemSessionParticipantRemovedEventArgs_Vtbl;
@@ -1996,7 +2197,7 @@ impl RemoteSystemSessionParticipantWatcher {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionParticipantWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionParticipantWatcher>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionParticipantWatcher {
     type Vtable = IRemoteSystemSessionParticipantWatcher_Vtbl;
@@ -2021,7 +2222,7 @@ impl RemoteSystemSessionRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionRemovedEventArgs {
     type Vtable = IRemoteSystemSessionRemovedEventArgs_Vtbl;
@@ -2046,7 +2247,7 @@ impl RemoteSystemSessionUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionUpdatedEventArgs {
     type Vtable = IRemoteSystemSessionUpdatedEventArgs_Vtbl;
@@ -2079,7 +2280,7 @@ impl RemoteSystemSessionValueSetReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionValueSetReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionValueSetReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionValueSetReceivedEventArgs {
     type Vtable = IRemoteSystemSessionValueSetReceivedEventArgs_Vtbl;
@@ -2154,7 +2355,7 @@ impl RemoteSystemSessionWatcher {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemSessionWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemSessionWatcher>();
 }
 unsafe impl windows_core::Interface for RemoteSystemSessionWatcher {
     type Vtable = IRemoteSystemSessionWatcher_Vtbl;
@@ -2191,7 +2392,7 @@ impl RemoteSystemStatusTypeFilter {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemStatusTypeFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemStatusTypeFilter>();
 }
 unsafe impl windows_core::Interface for RemoteSystemStatusTypeFilter {
     type Vtable = IRemoteSystemStatusTypeFilter_Vtbl;
@@ -2216,7 +2417,7 @@ impl RemoteSystemUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemUpdatedEventArgs {
     type Vtable = IRemoteSystemUpdatedEventArgs_Vtbl;
@@ -2319,7 +2520,7 @@ impl RemoteSystemWatcher {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemWatcher>();
 }
 unsafe impl windows_core::Interface for RemoteSystemWatcher {
     type Vtable = IRemoteSystemWatcher_Vtbl;
@@ -2344,7 +2545,7 @@ impl RemoteSystemWatcherErrorOccurredEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemWatcherErrorOccurredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemWatcherErrorOccurredEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteSystemWatcherErrorOccurredEventArgs {
     type Vtable = IRemoteSystemWatcherErrorOccurredEventArgs_Vtbl;
@@ -2386,7 +2587,7 @@ impl RemoteSystemWebAccountFilter {
     }
 }
 impl windows_core::RuntimeType for RemoteSystemWebAccountFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteSystemWebAccountFilter>();
 }
 unsafe impl windows_core::Interface for RemoteSystemWebAccountFilter {
     type Vtable = IRemoteSystemWebAccountFilter_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/Core/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IPreallocatedWorkItem, IPreallocatedWorkItem_Vtbl, 0xb6daa9fc_bc5b_401a_a8b2_6e754d14daa6);
+impl windows_core::RuntimeType for IPreallocatedWorkItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPreallocatedWorkItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RunAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPreallocatedWorkItemFactory, IPreallocatedWorkItemFactory_Vtbl, 0xe3d32b45_dfea_469b_82c5_f6e3cefdeafb);
+impl windows_core::RuntimeType for IPreallocatedWorkItemFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPreallocatedWorkItemFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +19,9 @@ pub struct IPreallocatedWorkItemFactory_Vtbl {
     pub CreateWorkItemWithPriorityAndOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, super::WorkItemPriority, super::WorkItemOptions, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISignalNotifier, ISignalNotifier_Vtbl, 0x14285e06_63a7_4713_b6d9_62f64b56fb8b);
+impl windows_core::RuntimeType for ISignalNotifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISignalNotifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +29,9 @@ pub struct ISignalNotifier_Vtbl {
     pub Terminate: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISignalNotifierStatics, ISignalNotifierStatics_Vtbl, 0x1c4e4566_8400_46d3_a115_7d0c0dfc9f62);
+impl windows_core::RuntimeType for ISignalNotifierStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISignalNotifierStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -74,7 +86,7 @@ impl PreallocatedWorkItem {
     }
 }
 impl windows_core::RuntimeType for PreallocatedWorkItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPreallocatedWorkItem>();
 }
 unsafe impl windows_core::Interface for PreallocatedWorkItem {
     type Vtable = IPreallocatedWorkItem_Vtbl;
@@ -141,7 +153,7 @@ impl SignalNotifier {
     }
 }
 impl windows_core::RuntimeType for SignalNotifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISignalNotifier>();
 }
 unsafe impl windows_core::Interface for SignalNotifier {
     type Vtable = ISignalNotifier_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "System_Threading_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IThreadPoolStatics, IThreadPoolStatics_Vtbl, 0xb6bf67dd_84bd_44f8_ac1c_93ebcb9dba91);
+impl windows_core::RuntimeType for IThreadPoolStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IThreadPoolStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IThreadPoolStatics_Vtbl {
     pub RunWithPriorityAndOptionsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, WorkItemPriority, WorkItemOptions, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IThreadPoolTimer, IThreadPoolTimer_Vtbl, 0x594ebe78_55ea_4a88_a50d_3402ae1f9cf2);
+impl windows_core::RuntimeType for IThreadPoolTimer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IThreadPoolTimer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct IThreadPoolTimer_Vtbl {
     pub Cancel: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IThreadPoolTimerStatics, IThreadPoolTimerStatics_Vtbl, 0x1a8a9d02_e482_461b_b8c7_8efad1cce590);
+impl windows_core::RuntimeType for IThreadPoolTimerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IThreadPoolTimerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -131,7 +140,7 @@ impl ThreadPoolTimer {
     }
 }
 impl windows_core::RuntimeType for ThreadPoolTimer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IThreadPoolTimer>();
 }
 unsafe impl windows_core::Interface for ThreadPoolTimer {
     type Vtable = IThreadPoolTimer_Vtbl;

--- a/crates/libs/windows/src/Windows/System/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Update/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISystemUpdateItem, ISystemUpdateItem_Vtbl, 0x779740eb_5624_519e_a8e2_09e9173b3fb7);
+impl windows_core::RuntimeType for ISystemUpdateItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemUpdateItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct ISystemUpdateItem_Vtbl {
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemUpdateLastErrorInfo, ISystemUpdateLastErrorInfo_Vtbl, 0x7ee887f7_8a44_5b6e_bd07_7aece4116ea9);
+impl windows_core::RuntimeType for ISystemUpdateLastErrorInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemUpdateLastErrorInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +26,9 @@ pub struct ISystemUpdateLastErrorInfo_Vtbl {
     pub IsInteractive: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemUpdateManagerStatics, ISystemUpdateManagerStatics_Vtbl, 0xb2d3fcef_2971_51be_b41a_8bd703bb701a);
+impl windows_core::RuntimeType for ISystemUpdateManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemUpdateManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,7 +126,7 @@ impl SystemUpdateItem {
     }
 }
 impl windows_core::RuntimeType for SystemUpdateItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemUpdateItem>();
 }
 unsafe impl windows_core::Interface for SystemUpdateItem {
     type Vtable = ISystemUpdateItem_Vtbl;
@@ -156,7 +165,7 @@ impl SystemUpdateLastErrorInfo {
     }
 }
 impl windows_core::RuntimeType for SystemUpdateLastErrorInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemUpdateLastErrorInfo>();
 }
 unsafe impl windows_core::Interface for SystemUpdateLastErrorInfo {
     type Vtable = ISystemUpdateLastErrorInfo_Vtbl;

--- a/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAdvertisingManagerForUser, IAdvertisingManagerForUser_Vtbl, 0x928bf3d0_cf7c_4ab0_a7dc_6dc5bcd44252);
+impl windows_core::RuntimeType for IAdvertisingManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvertisingManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,18 +9,27 @@ pub struct IAdvertisingManagerForUser_Vtbl {
     pub User: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvertisingManagerStatics, IAdvertisingManagerStatics_Vtbl, 0xadd3468c_a273_48cb_b346_3544522d5581);
+impl windows_core::RuntimeType for IAdvertisingManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvertisingManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AdvertisingId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAdvertisingManagerStatics2, IAdvertisingManagerStatics2_Vtbl, 0xdd0947af_1a6d_46b0_95bc_f3f9d6beb9fb);
+impl windows_core::RuntimeType for IAdvertisingManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdvertisingManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAssignedAccessSettings, IAssignedAccessSettings_Vtbl, 0x1bc57f1c_e971_5757_b8e0_512f8b8c46d2);
+impl windows_core::RuntimeType for IAssignedAccessSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAssignedAccessSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +38,9 @@ pub struct IAssignedAccessSettings_Vtbl {
     pub User: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAssignedAccessSettingsStatics, IAssignedAccessSettingsStatics_Vtbl, 0x34a81d0d_8a29_5ef3_a7be_618e6ac3bd01);
+impl windows_core::RuntimeType for IAssignedAccessSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAssignedAccessSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +48,9 @@ pub struct IAssignedAccessSettingsStatics_Vtbl {
     pub GetForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDiagnosticsSettings, IDiagnosticsSettings_Vtbl, 0xe5e9eccd_2711_44e0_973c_491d78048d24);
+impl windows_core::RuntimeType for IDiagnosticsSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDiagnosticsSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -40,6 +58,9 @@ pub struct IDiagnosticsSettings_Vtbl {
     pub User: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDiagnosticsSettingsStatics, IDiagnosticsSettingsStatics_Vtbl, 0x72d2e80f_5390_4793_990b_3ccc7d6ac9c8);
+impl windows_core::RuntimeType for IDiagnosticsSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDiagnosticsSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,17 +68,26 @@ pub struct IDiagnosticsSettingsStatics_Vtbl {
     pub GetForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFirstSignInSettings, IFirstSignInSettings_Vtbl, 0x3e945153_3a5e_452e_a601_f5baad2a4870);
+impl windows_core::RuntimeType for IFirstSignInSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFirstSignInSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IFirstSignInSettingsStatics, IFirstSignInSettingsStatics_Vtbl, 0x1ce18f0f_1c41_4ea0_b7a2_6f0c1c7e8438);
+impl windows_core::RuntimeType for IFirstSignInSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFirstSignInSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGlobalizationPreferencesForUser, IGlobalizationPreferencesForUser_Vtbl, 0x150f0795_4f6e_40ba_a010_e27d81bda7f5);
+impl windows_core::RuntimeType for IGlobalizationPreferencesForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalizationPreferencesForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,6 +115,9 @@ pub struct IGlobalizationPreferencesForUser_Vtbl {
     WeekStartsOn: usize,
 }
 windows_core::imp::define_interface!(IGlobalizationPreferencesStatics, IGlobalizationPreferencesStatics_Vtbl, 0x01bf4326_ed37_4e96_b0e9_c1340d1ea158);
+impl windows_core::RuntimeType for IGlobalizationPreferencesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalizationPreferencesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -111,6 +144,9 @@ pub struct IGlobalizationPreferencesStatics_Vtbl {
     WeekStartsOn: usize,
 }
 windows_core::imp::define_interface!(IGlobalizationPreferencesStatics2, IGlobalizationPreferencesStatics2_Vtbl, 0xfcce85f1_4300_4cd0_9cac_1a8e7b7e18f4);
+impl windows_core::RuntimeType for IGlobalizationPreferencesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalizationPreferencesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -121,12 +157,18 @@ pub struct IGlobalizationPreferencesStatics2_Vtbl {
     TrySetLanguages: usize,
 }
 windows_core::imp::define_interface!(IGlobalizationPreferencesStatics3, IGlobalizationPreferencesStatics3_Vtbl, 0x1e059733_35f5_40d8_b9e8_aef3ef856fce);
+impl windows_core::RuntimeType for IGlobalizationPreferencesStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGlobalizationPreferencesStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenImageFeedStatics, ILockScreenImageFeedStatics_Vtbl, 0x2c0d73f6_03a9_41a6_9b01_495251ff51d5);
+impl windows_core::RuntimeType for ILockScreenImageFeedStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenImageFeedStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -134,6 +176,9 @@ pub struct ILockScreenImageFeedStatics_Vtbl {
     pub TryRemoveImageFeed: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILockScreenStatics, ILockScreenStatics_Vtbl, 0x3ee9d3ad_b607_40ae_b426_7631d9821269);
+impl windows_core::RuntimeType for ILockScreenStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILockScreenStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -153,6 +198,10 @@ pub struct ILockScreenStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IUserInformationStatics, IUserInformationStatics_Vtbl, 0x77f3a910_48fa_489c_934e_2ae85ba8f772);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IUserInformationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IUserInformationStatics_Vtbl {
@@ -219,6 +268,9 @@ pub struct IUserInformationStatics_Vtbl {
     GetDomainNameAsync: usize,
 }
 windows_core::imp::define_interface!(IUserProfilePersonalizationSettings, IUserProfilePersonalizationSettings_Vtbl, 0x8ceddab4_7998_46d5_8dd3_184f1c5f9ab9);
+impl windows_core::RuntimeType for IUserProfilePersonalizationSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserProfilePersonalizationSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -232,6 +284,9 @@ pub struct IUserProfilePersonalizationSettings_Vtbl {
     TrySetWallpaperImageAsync: usize,
 }
 windows_core::imp::define_interface!(IUserProfilePersonalizationSettingsStatics, IUserProfilePersonalizationSettingsStatics_Vtbl, 0x91acb841_5037_454b_9883_bb772d08dd16);
+impl windows_core::RuntimeType for IUserProfilePersonalizationSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserProfilePersonalizationSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,7 +345,7 @@ impl AdvertisingManagerForUser {
     }
 }
 impl windows_core::RuntimeType for AdvertisingManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdvertisingManagerForUser>();
 }
 unsafe impl windows_core::Interface for AdvertisingManagerForUser {
     type Vtable = IAdvertisingManagerForUser_Vtbl;
@@ -349,7 +404,7 @@ impl AssignedAccessSettings {
     }
 }
 impl windows_core::RuntimeType for AssignedAccessSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAssignedAccessSettings>();
 }
 unsafe impl windows_core::Interface for AssignedAccessSettings {
     type Vtable = IAssignedAccessSettings_Vtbl;
@@ -401,7 +456,7 @@ impl DiagnosticsSettings {
     }
 }
 impl windows_core::RuntimeType for DiagnosticsSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDiagnosticsSettings>();
 }
 unsafe impl windows_core::Interface for DiagnosticsSettings {
     type Vtable = IDiagnosticsSettings_Vtbl;
@@ -469,7 +524,7 @@ impl FirstSignInSettings {
     }
 }
 impl windows_core::RuntimeType for FirstSignInSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFirstSignInSettings>();
 }
 unsafe impl windows_core::Interface for FirstSignInSettings {
     type Vtable = IFirstSignInSettings_Vtbl;
@@ -644,7 +699,7 @@ impl GlobalizationPreferencesForUser {
     }
 }
 impl windows_core::RuntimeType for GlobalizationPreferencesForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGlobalizationPreferencesForUser>();
 }
 unsafe impl windows_core::Interface for GlobalizationPreferencesForUser {
     type Vtable = IGlobalizationPreferencesForUser_Vtbl;
@@ -901,7 +956,7 @@ impl UserProfilePersonalizationSettings {
     }
 }
 impl windows_core::RuntimeType for UserProfilePersonalizationSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserProfilePersonalizationSettings>();
 }
 unsafe impl windows_core::Interface for UserProfilePersonalizationSettings {
     type Vtable = IUserProfilePersonalizationSettings_Vtbl;

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -21,6 +21,9 @@ pub mod Update;
 #[cfg(feature = "System_UserProfile")]
 pub mod UserProfile;
 windows_core::imp::define_interface!(IAppActivationResult, IAppActivationResult_Vtbl, 0x6b528900_f46e_4eb0_aa6c_38af557cf9ed);
+impl windows_core::RuntimeType for IAppActivationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppActivationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +31,9 @@ pub struct IAppActivationResult_Vtbl {
     pub AppResourceGroupInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppDiagnosticInfo, IAppDiagnosticInfo_Vtbl, 0xe348a69a_8889_4ca3_be07_d5ffff5f0804);
+impl windows_core::RuntimeType for IAppDiagnosticInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDiagnosticInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +43,9 @@ pub struct IAppDiagnosticInfo_Vtbl {
     AppInfo: usize,
 }
 windows_core::imp::define_interface!(IAppDiagnosticInfo2, IAppDiagnosticInfo2_Vtbl, 0xdf46fbd7_191a_446c_9473_8fbc2374a354);
+impl windows_core::RuntimeType for IAppDiagnosticInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDiagnosticInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -47,12 +56,18 @@ pub struct IAppDiagnosticInfo2_Vtbl {
     pub CreateResourceGroupWatcher: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppDiagnosticInfo3, IAppDiagnosticInfo3_Vtbl, 0xc895c63d_dd61_4c65_babd_81a10b4f9815);
+impl windows_core::RuntimeType for IAppDiagnosticInfo3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDiagnosticInfo3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LaunchAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppDiagnosticInfoStatics, IAppDiagnosticInfoStatics_Vtbl, 0xce6925bf_10ca_40c8_a9ca_c5c96501866e);
+impl windows_core::RuntimeType for IAppDiagnosticInfoStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDiagnosticInfoStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,6 +77,9 @@ pub struct IAppDiagnosticInfoStatics_Vtbl {
     RequestInfoAsync: usize,
 }
 windows_core::imp::define_interface!(IAppDiagnosticInfoStatics2, IAppDiagnosticInfoStatics2_Vtbl, 0x05b24b86_1000_4c90_bb9f_7235071c50fe);
+impl windows_core::RuntimeType for IAppDiagnosticInfoStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDiagnosticInfoStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -81,6 +99,9 @@ pub struct IAppDiagnosticInfoStatics2_Vtbl {
     RequestInfoForAppUserModelId: usize,
 }
 windows_core::imp::define_interface!(IAppDiagnosticInfoWatcher, IAppDiagnosticInfoWatcher_Vtbl, 0x75575070_01d3_489a_9325_52f9cc6ede0a);
+impl windows_core::RuntimeType for IAppDiagnosticInfoWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDiagnosticInfoWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -97,18 +118,27 @@ pub struct IAppDiagnosticInfoWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppDiagnosticInfoWatcherEventArgs, IAppDiagnosticInfoWatcherEventArgs_Vtbl, 0x7017c716_e1da_4c65_99df_046dff5be71a);
+impl windows_core::RuntimeType for IAppDiagnosticInfoWatcherEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppDiagnosticInfoWatcherEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AppDiagnosticInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppExecutionStateChangeResult, IAppExecutionStateChangeResult_Vtbl, 0x6f039bf0_f91b_4df8_ae77_3033ccb69114);
+impl windows_core::RuntimeType for IAppExecutionStateChangeResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppExecutionStateChangeResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExtendedError: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppMemoryReport, IAppMemoryReport_Vtbl, 0x6d65339b_4d6f_45bc_9c5e_e49b3ff2758d);
+impl windows_core::RuntimeType for IAppMemoryReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppMemoryReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,12 +148,18 @@ pub struct IAppMemoryReport_Vtbl {
     pub TotalCommitLimit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppMemoryReport2, IAppMemoryReport2_Vtbl, 0x5f7f3738_51b7_42dc_b7ed_79ba46d28857);
+impl windows_core::RuntimeType for IAppMemoryReport2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppMemoryReport2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExpectedTotalCommitLimit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppMemoryUsageLimitChangingEventArgs, IAppMemoryUsageLimitChangingEventArgs_Vtbl, 0x79f86664_feca_4da5_9e40_2bc63efdc979);
+impl windows_core::RuntimeType for IAppMemoryUsageLimitChangingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppMemoryUsageLimitChangingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -131,6 +167,9 @@ pub struct IAppMemoryUsageLimitChangingEventArgs_Vtbl {
     pub NewLimit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupBackgroundTaskReport, IAppResourceGroupBackgroundTaskReport_Vtbl, 0x2566e74e_b05d_40c2_9dc1_1a4f039ea120);
+impl windows_core::RuntimeType for IAppResourceGroupBackgroundTaskReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupBackgroundTaskReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +179,9 @@ pub struct IAppResourceGroupBackgroundTaskReport_Vtbl {
     pub EntryPoint: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupInfo, IAppResourceGroupInfo_Vtbl, 0xb913f77a_e807_49f4_845e_7b8bdcfe8ee7);
+impl windows_core::RuntimeType for IAppResourceGroupInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -157,6 +199,9 @@ pub struct IAppResourceGroupInfo_Vtbl {
     pub GetStateReport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupInfo2, IAppResourceGroupInfo2_Vtbl, 0xee9b236d_d305_4d6b_92f7_6afdad72dedc);
+impl windows_core::RuntimeType for IAppResourceGroupInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +210,9 @@ pub struct IAppResourceGroupInfo2_Vtbl {
     pub StartTerminateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupInfoWatcher, IAppResourceGroupInfoWatcher_Vtbl, 0xd9b0a0fd_6e5a_4c72_8b17_09fec4a212bd);
+impl windows_core::RuntimeType for IAppResourceGroupInfoWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupInfoWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +231,9 @@ pub struct IAppResourceGroupInfoWatcher_Vtbl {
     pub Stop: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupInfoWatcherEventArgs, IAppResourceGroupInfoWatcherEventArgs_Vtbl, 0x7a787637_6302_4d2f_bf89_1c12d0b2a6b9);
+impl windows_core::RuntimeType for IAppResourceGroupInfoWatcherEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupInfoWatcherEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -193,6 +244,9 @@ pub struct IAppResourceGroupInfoWatcherEventArgs_Vtbl {
     pub AppResourceGroupInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs, IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs_Vtbl, 0x1bdbedd7_fee6_4fd4_98dd_e92a2cc299f3);
+impl windows_core::RuntimeType for IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,6 +257,9 @@ pub struct IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs_Vtbl {
     pub AppResourceGroupInfo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupMemoryReport, IAppResourceGroupMemoryReport_Vtbl, 0x2c8c06b1_7db1_4c51_a225_7fae2d49e431);
+impl windows_core::RuntimeType for IAppResourceGroupMemoryReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupMemoryReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -212,6 +269,9 @@ pub struct IAppResourceGroupMemoryReport_Vtbl {
     pub TotalCommitUsage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppResourceGroupStateReport, IAppResourceGroupStateReport_Vtbl, 0x52849f18_2f70_4236_ab40_d04db0c7b931);
+impl windows_core::RuntimeType for IAppResourceGroupStateReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppResourceGroupStateReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -219,6 +279,9 @@ pub struct IAppResourceGroupStateReport_Vtbl {
     pub EnergyQuotaState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppResourceGroupEnergyQuotaState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerHost, IAppUriHandlerHost_Vtbl, 0x5d50cac5_92d2_5409_b56f_7f73e10ea4c3);
+impl windows_core::RuntimeType for IAppUriHandlerHost {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerHost_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -226,6 +289,9 @@ pub struct IAppUriHandlerHost_Vtbl {
     pub SetName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerHost2, IAppUriHandlerHost2_Vtbl, 0x3a0bee95_29e4_51bf_8095_a3c068e3c72a);
+impl windows_core::RuntimeType for IAppUriHandlerHost2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerHost2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -233,12 +299,18 @@ pub struct IAppUriHandlerHost2_Vtbl {
     pub SetIsEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerHostFactory, IAppUriHandlerHostFactory_Vtbl, 0x257c3c96_ce04_5f98_96bb_3ebd3e9275bb);
+impl windows_core::RuntimeType for IAppUriHandlerHostFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerHostFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerRegistration, IAppUriHandlerRegistration_Vtbl, 0x6f73aeb1_4569_5c3f_9ba0_99123eea32c3);
+impl windows_core::RuntimeType for IAppUriHandlerRegistration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerRegistration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +326,9 @@ pub struct IAppUriHandlerRegistration_Vtbl {
     SetAppAddedHostsAsync: usize,
 }
 windows_core::imp::define_interface!(IAppUriHandlerRegistration2, IAppUriHandlerRegistration2_Vtbl, 0xd54dac97_cb39_5f1f_883e_01853730bd6d);
+impl windows_core::RuntimeType for IAppUriHandlerRegistration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerRegistration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -268,6 +343,9 @@ pub struct IAppUriHandlerRegistration2_Vtbl {
     pub PackageFamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerRegistrationManager, IAppUriHandlerRegistrationManager_Vtbl, 0xe62c9a52_ac94_5750_ac1b_6cfb6f250263);
+impl windows_core::RuntimeType for IAppUriHandlerRegistrationManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerRegistrationManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -275,12 +353,18 @@ pub struct IAppUriHandlerRegistrationManager_Vtbl {
     pub TryGetRegistration: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerRegistrationManager2, IAppUriHandlerRegistrationManager2_Vtbl, 0xbddfcaf1_b51a_5e69_aefd_7088d9f2b123);
+impl windows_core::RuntimeType for IAppUriHandlerRegistrationManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerRegistrationManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PackageFamilyName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerRegistrationManagerStatics, IAppUriHandlerRegistrationManagerStatics_Vtbl, 0xd5cedd9f_5729_5b76_a1d4_0285f295c124);
+impl windows_core::RuntimeType for IAppUriHandlerRegistrationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerRegistrationManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -288,6 +372,9 @@ pub struct IAppUriHandlerRegistrationManagerStatics_Vtbl {
     pub GetForUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppUriHandlerRegistrationManagerStatics2, IAppUriHandlerRegistrationManagerStatics2_Vtbl, 0x14f78379_6890_5080_90a7_98824a7f079e);
+impl windows_core::RuntimeType for IAppUriHandlerRegistrationManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppUriHandlerRegistrationManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -295,12 +382,18 @@ pub struct IAppUriHandlerRegistrationManagerStatics2_Vtbl {
     pub GetForPackageForUser: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDateTimeSettingsStatics, IDateTimeSettingsStatics_Vtbl, 0x5d2150d1_47ee_48ab_a52b_9f1954278d82);
+impl windows_core::RuntimeType for IDateTimeSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDateTimeSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetSystemDateTime: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDispatcherQueue, IDispatcherQueue_Vtbl, 0x603e88e4_a338_4ffe_a457_a5cfb9ceb899);
+impl windows_core::RuntimeType for IDispatcherQueue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDispatcherQueue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -313,12 +406,18 @@ pub struct IDispatcherQueue_Vtbl {
     pub RemoveShutdownCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDispatcherQueue2, IDispatcherQueue2_Vtbl, 0xc822c647_30ef_506e_bd1e_a647ae6675ff);
+impl windows_core::RuntimeType for IDispatcherQueue2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDispatcherQueue2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub HasThreadAccess: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDispatcherQueueController, IDispatcherQueueController_Vtbl, 0x22f34e66_50db_4e36_a98d_61c01b384d20);
+impl windows_core::RuntimeType for IDispatcherQueueController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDispatcherQueueController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -326,24 +425,36 @@ pub struct IDispatcherQueueController_Vtbl {
     pub ShutdownQueueAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDispatcherQueueControllerStatics, IDispatcherQueueControllerStatics_Vtbl, 0x0a6c98e0_5198_49a2_a313_3f70d1f13c27);
+impl windows_core::RuntimeType for IDispatcherQueueControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDispatcherQueueControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateOnDedicatedThread: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDispatcherQueueShutdownStartingEventArgs, IDispatcherQueueShutdownStartingEventArgs_Vtbl, 0xc4724c4c_ff97_40c0_a226_cc0aaa545e89);
+impl windows_core::RuntimeType for IDispatcherQueueShutdownStartingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDispatcherQueueShutdownStartingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDispatcherQueueStatics, IDispatcherQueueStatics_Vtbl, 0xa96d83d7_9371_4517_9245_d0824ac12c74);
+impl windows_core::RuntimeType for IDispatcherQueueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDispatcherQueueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentThread: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDispatcherQueueTimer, IDispatcherQueueTimer_Vtbl, 0x5feabb1d_a31c_4727_b1ac_37454649d56a);
+impl windows_core::RuntimeType for IDispatcherQueueTimer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDispatcherQueueTimer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -358,6 +469,9 @@ pub struct IDispatcherQueueTimer_Vtbl {
     pub RemoveTick: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFolderLauncherOptions, IFolderLauncherOptions_Vtbl, 0xbb91c27d_6b87_432a_bd04_776c6f5fb2ab);
+impl windows_core::RuntimeType for IFolderLauncherOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFolderLauncherOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -367,6 +481,9 @@ pub struct IFolderLauncherOptions_Vtbl {
     ItemsToSelect: usize,
 }
 windows_core::imp::define_interface!(IKnownUserPropertiesStatics, IKnownUserPropertiesStatics_Vtbl, 0x7755911a_70c5_48e5_b637_5ba3441e4ee4);
+impl windows_core::RuntimeType for IKnownUserPropertiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownUserPropertiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -381,12 +498,18 @@ pub struct IKnownUserPropertiesStatics_Vtbl {
     pub SessionInitiationProtocolUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownUserPropertiesStatics2, IKnownUserPropertiesStatics2_Vtbl, 0x5b450782_f620_577e_b1b3_dd56644d79b1);
+impl windows_core::RuntimeType for IKnownUserPropertiesStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownUserPropertiesStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AgeEnforcementRegion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILaunchUriResult, ILaunchUriResult_Vtbl, 0xec27a8df_f6d5_45ca_913a_70a40c5c8221);
+impl windows_core::RuntimeType for ILaunchUriResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILaunchUriResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -397,6 +520,9 @@ pub struct ILaunchUriResult_Vtbl {
     Result: usize,
 }
 windows_core::imp::define_interface!(ILauncherOptions, ILauncherOptions_Vtbl, 0xbafa21d8_b071_4cd8_853e_341203e557d3);
+impl windows_core::RuntimeType for ILauncherOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -415,6 +541,9 @@ pub struct ILauncherOptions_Vtbl {
     pub SetContentType: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILauncherOptions2, ILauncherOptions2_Vtbl, 0x3ba08eb4_6e40_4dce_a1a3_2f53950afb49);
+impl windows_core::RuntimeType for ILauncherOptions2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherOptions2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -430,6 +559,9 @@ pub struct ILauncherOptions2_Vtbl {
     SetNeighboringFilesQuery: usize,
 }
 windows_core::imp::define_interface!(ILauncherOptions3, ILauncherOptions3_Vtbl, 0xf0770655_4b63_4e3a_9107_4e687841923a);
+impl windows_core::RuntimeType for ILauncherOptions3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherOptions3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -437,6 +569,9 @@ pub struct ILauncherOptions3_Vtbl {
     pub SetIgnoreAppUriHandlers: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILauncherOptions4, ILauncherOptions4_Vtbl, 0xef6fd10e_e6fb_4814_a44e_57e8b9d9a01b);
+impl windows_core::RuntimeType for ILauncherOptions4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherOptions4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -444,6 +579,9 @@ pub struct ILauncherOptions4_Vtbl {
     pub SetLimitPickerToCurrentAppAndAppUriHandlers: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILauncherStatics, ILauncherStatics_Vtbl, 0x277151c3_9e3e_42f6_91a4_5dfdeb232451);
+impl windows_core::RuntimeType for ILauncherStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -459,6 +597,9 @@ pub struct ILauncherStatics_Vtbl {
     pub LaunchUriWithOptionsAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILauncherStatics2, ILauncherStatics2_Vtbl, 0x59ba2fbb_24cb_4c02_a4c4_8294569d54f1);
+impl windows_core::RuntimeType for ILauncherStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -495,6 +636,9 @@ pub struct ILauncherStatics2_Vtbl {
     FindFileHandlersAsync: usize,
 }
 windows_core::imp::define_interface!(ILauncherStatics3, ILauncherStatics3_Vtbl, 0x234261a8_9db3_4683_aa42_dc6f51d33847);
+impl windows_core::RuntimeType for ILauncherStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -508,6 +652,9 @@ pub struct ILauncherStatics3_Vtbl {
     LaunchFolderWithOptionsAsync: usize,
 }
 windows_core::imp::define_interface!(ILauncherStatics4, ILauncherStatics4_Vtbl, 0xb9ec819f_b5a5_41c6_b3b3_dd1b3178bcf2);
+impl windows_core::RuntimeType for ILauncherStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -530,6 +677,9 @@ pub struct ILauncherStatics4_Vtbl {
     LaunchUriForResultsWithDataForUserAsync: usize,
 }
 windows_core::imp::define_interface!(ILauncherStatics5, ILauncherStatics5_Vtbl, 0x5b24ef84_d895_5fea_9153_1ac49aed9ba9);
+impl windows_core::RuntimeType for ILauncherStatics5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherStatics5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -539,6 +689,9 @@ pub struct ILauncherStatics5_Vtbl {
     pub LaunchFolderPathWithOptionsForUserAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILauncherUIOptions, ILauncherUIOptions_Vtbl, 0x1b25da6e_8aa6_41e9_8251_4165f5985f49);
+impl windows_core::RuntimeType for ILauncherUIOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILauncherUIOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -588,6 +741,9 @@ pub struct ILauncherViewOptions_Vtbl {
     SetDesiredRemainingView: usize,
 }
 windows_core::imp::define_interface!(IMemoryManagerStatics, IMemoryManagerStatics_Vtbl, 0x5c6c279c_d7ca_4779_9188_4057219ce64c);
+impl windows_core::RuntimeType for IMemoryManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMemoryManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -602,6 +758,9 @@ pub struct IMemoryManagerStatics_Vtbl {
     pub RemoveAppMemoryUsageLimitChanging: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMemoryManagerStatics2, IMemoryManagerStatics2_Vtbl, 0x6eee351f_6d62_423f_9479_b01f9c9f7669);
+impl windows_core::RuntimeType for IMemoryManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMemoryManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -609,18 +768,27 @@ pub struct IMemoryManagerStatics2_Vtbl {
     pub GetProcessMemoryReport: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMemoryManagerStatics3, IMemoryManagerStatics3_Vtbl, 0x149b59ce_92ad_4e35_89eb_50dfb4c0d91c);
+impl windows_core::RuntimeType for IMemoryManagerStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMemoryManagerStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TrySetAppMemoryUsageLimit: unsafe extern "system" fn(*mut core::ffi::c_void, u64, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMemoryManagerStatics4, IMemoryManagerStatics4_Vtbl, 0xc5a94828_e84e_4886_8a0d_44b3190e3b72);
+impl windows_core::RuntimeType for IMemoryManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMemoryManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExpectedAppMemoryUsageLimit: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessLauncherOptions, IProcessLauncherOptions_Vtbl, 0x3080b9cf_f444_4a83_beaf_a549a0f3229c);
+impl windows_core::RuntimeType for IProcessLauncherOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessLauncherOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -652,12 +820,18 @@ pub struct IProcessLauncherOptions_Vtbl {
     pub SetWorkingDirectory: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessLauncherResult, IProcessLauncherResult_Vtbl, 0x544c8934_86d8_4991_8e75_ece8a43b6b6d);
+impl windows_core::RuntimeType for IProcessLauncherResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessLauncherResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExitCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessLauncherStatics, IProcessLauncherStatics_Vtbl, 0x33ab66e7_2d0e_448b_a6a0_c13c3836d09c);
+impl windows_core::RuntimeType for IProcessLauncherStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessLauncherStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -665,6 +839,9 @@ pub struct IProcessLauncherStatics_Vtbl {
     pub RunToCompletionAsyncWithOptions: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProcessMemoryReport, IProcessMemoryReport_Vtbl, 0x087305a8_9b70_4782_8741_3a982b6ce5e4);
+impl windows_core::RuntimeType for IProcessMemoryReport {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProcessMemoryReport_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -672,6 +849,9 @@ pub struct IProcessMemoryReport_Vtbl {
     pub TotalWorkingSetUsage: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProtocolForResultsOperation, IProtocolForResultsOperation_Vtbl, 0xd581293a_6de9_4d28_9378_f86782e182bb);
+impl windows_core::RuntimeType for IProtocolForResultsOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProtocolForResultsOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -681,6 +861,9 @@ pub struct IProtocolForResultsOperation_Vtbl {
     ReportCompleted: usize,
 }
 windows_core::imp::define_interface!(IRemoteLauncherOptions, IRemoteLauncherOptions_Vtbl, 0x9e3a2788_2891_4cdf_a2d6_9dff7d02e693);
+impl windows_core::RuntimeType for IRemoteLauncherOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteLauncherOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -692,6 +875,9 @@ pub struct IRemoteLauncherOptions_Vtbl {
     PreferredAppIds: usize,
 }
 windows_core::imp::define_interface!(IRemoteLauncherStatics, IRemoteLauncherStatics_Vtbl, 0xd7db7a93_a30c_48b7_9f21_051026a4e517);
+impl windows_core::RuntimeType for IRemoteLauncherStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteLauncherStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -709,6 +895,9 @@ pub struct IRemoteLauncherStatics_Vtbl {
     LaunchUriWithDataAsync: usize,
 }
 windows_core::imp::define_interface!(IShutdownManagerStatics, IShutdownManagerStatics_Vtbl, 0x72e247ed_dd5b_4d6c_b1d0_c57a7bbb5f94);
+impl windows_core::RuntimeType for IShutdownManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShutdownManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -716,6 +905,9 @@ pub struct IShutdownManagerStatics_Vtbl {
     pub CancelShutdown: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShutdownManagerStatics2, IShutdownManagerStatics2_Vtbl, 0x0f69a02f_9c34_43c7_a8c3_70b30a7f7504);
+impl windows_core::RuntimeType for IShutdownManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShutdownManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -724,6 +916,9 @@ pub struct IShutdownManagerStatics2_Vtbl {
     pub EnterPowerStateWithTimeSpan: unsafe extern "system" fn(*mut core::ffi::c_void, PowerState, super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimeZoneSettingsStatics, ITimeZoneSettingsStatics_Vtbl, 0x9b3b2bea_a101_41ae_9fbd_028728bab73d);
+impl windows_core::RuntimeType for ITimeZoneSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimeZoneSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -736,12 +931,18 @@ pub struct ITimeZoneSettingsStatics_Vtbl {
     pub ChangeTimeZoneByDisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITimeZoneSettingsStatics2, ITimeZoneSettingsStatics2_Vtbl, 0x555c0db8_39a8_49fa_b4f6_a2c7fc2842ec);
+impl windows_core::RuntimeType for ITimeZoneSettingsStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimeZoneSettingsStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub AutoUpdateTimeZoneAsync: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::TimeSpan, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUser, IUser_Vtbl, 0xdf9a26c6_e746_4bcd_b5d4_120103c4209b);
+impl windows_core::RuntimeType for IUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -759,18 +960,27 @@ pub struct IUser_Vtbl {
     GetPictureAsync: usize,
 }
 windows_core::imp::define_interface!(IUser2, IUser2_Vtbl, 0x98ba5628_a6e3_518e_89d9_d3b2b1991a10);
+impl windows_core::RuntimeType for IUser2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUser2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CheckUserAgeConsentGroupAsync: unsafe extern "system" fn(*mut core::ffi::c_void, UserAgeConsentGroup, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserAuthenticationStatusChangeDeferral, IUserAuthenticationStatusChangeDeferral_Vtbl, 0x88b59568_bb30_42fb_a270_e9902e40efa7);
+impl windows_core::RuntimeType for IUserAuthenticationStatusChangeDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserAuthenticationStatusChangeDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserAuthenticationStatusChangingEventArgs, IUserAuthenticationStatusChangingEventArgs_Vtbl, 0x8c030f28_a711_4c1e_ab48_04179c15938f);
+impl windows_core::RuntimeType for IUserAuthenticationStatusChangingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserAuthenticationStatusChangingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -780,12 +990,18 @@ pub struct IUserAuthenticationStatusChangingEventArgs_Vtbl {
     pub CurrentStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UserAuthenticationStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserChangedEventArgs, IUserChangedEventArgs_Vtbl, 0x086459dc_18c6_48db_bc99_724fb9203ccc);
+impl windows_core::RuntimeType for IUserChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub User: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserChangedEventArgs2, IUserChangedEventArgs2_Vtbl, 0x6b2ccb44_6f01_560c_97ad_fc7f32ec581f);
+impl windows_core::RuntimeType for IUserChangedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserChangedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -795,6 +1011,9 @@ pub struct IUserChangedEventArgs2_Vtbl {
     ChangedPropertyKinds: usize,
 }
 windows_core::imp::define_interface!(IUserDeviceAssociationChangedEventArgs, IUserDeviceAssociationChangedEventArgs_Vtbl, 0xbd1f6f6c_bb5d_4d7b_a5f0_c8cd11a38d42);
+impl windows_core::RuntimeType for IUserDeviceAssociationChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDeviceAssociationChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -803,6 +1022,9 @@ pub struct IUserDeviceAssociationChangedEventArgs_Vtbl {
     pub OldUser: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserDeviceAssociationStatics, IUserDeviceAssociationStatics_Vtbl, 0x7e491e14_f85a_4c07_8da9_7fe3d0542343);
+impl windows_core::RuntimeType for IUserDeviceAssociationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserDeviceAssociationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -811,6 +1033,9 @@ pub struct IUserDeviceAssociationStatics_Vtbl {
     pub RemoveUserDeviceAssociationChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserPicker, IUserPicker_Vtbl, 0x7d548008_f1e3_4a6c_8ddc_a9bb0f488aed);
+impl windows_core::RuntimeType for IUserPicker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserPicker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -821,12 +1046,18 @@ pub struct IUserPicker_Vtbl {
     pub PickSingleUserAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserPickerStatics, IUserPickerStatics_Vtbl, 0xde3290dc_7e73_4df6_a1ae_4d7eca82b40d);
+impl windows_core::RuntimeType for IUserPickerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserPickerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserStatics, IUserStatics_Vtbl, 0x155eb23b_242a_45e0_a2e9_3171fc6a7fdd);
+impl windows_core::RuntimeType for IUserStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -846,12 +1077,18 @@ pub struct IUserStatics_Vtbl {
     pub GetFromId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserStatics2, IUserStatics2_Vtbl, 0x74a37e11_2eb5_4487_b0d5_2c6790e013e9);
+impl windows_core::RuntimeType for IUserStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserWatcher, IUserWatcher_Vtbl, 0x155eb23b_242a_45e0_a2e9_3171fc6a7fbb);
+impl windows_core::RuntimeType for IUserWatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserWatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -894,7 +1131,7 @@ impl AppActivationResult {
     }
 }
 impl windows_core::RuntimeType for AppActivationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppActivationResult>();
 }
 unsafe impl windows_core::Interface for AppActivationResult {
     type Vtable = IAppActivationResult_Vtbl;
@@ -992,7 +1229,7 @@ impl AppDiagnosticInfo {
     }
 }
 impl windows_core::RuntimeType for AppDiagnosticInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppDiagnosticInfo>();
 }
 unsafe impl windows_core::Interface for AppDiagnosticInfo {
     type Vtable = IAppDiagnosticInfo_Vtbl;
@@ -1081,7 +1318,7 @@ impl AppDiagnosticInfoWatcher {
     }
 }
 impl windows_core::RuntimeType for AppDiagnosticInfoWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppDiagnosticInfoWatcher>();
 }
 unsafe impl windows_core::Interface for AppDiagnosticInfoWatcher {
     type Vtable = IAppDiagnosticInfoWatcher_Vtbl;
@@ -1106,7 +1343,7 @@ impl AppDiagnosticInfoWatcherEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppDiagnosticInfoWatcherEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppDiagnosticInfoWatcherEventArgs>();
 }
 unsafe impl windows_core::Interface for AppDiagnosticInfoWatcherEventArgs {
     type Vtable = IAppDiagnosticInfoWatcherEventArgs_Vtbl;
@@ -1131,7 +1368,7 @@ impl AppExecutionStateChangeResult {
     }
 }
 impl windows_core::RuntimeType for AppExecutionStateChangeResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppExecutionStateChangeResult>();
 }
 unsafe impl windows_core::Interface for AppExecutionStateChangeResult {
     type Vtable = IAppExecutionStateChangeResult_Vtbl;
@@ -1184,7 +1421,7 @@ impl AppMemoryReport {
     }
 }
 impl windows_core::RuntimeType for AppMemoryReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppMemoryReport>();
 }
 unsafe impl windows_core::Interface for AppMemoryReport {
     type Vtable = IAppMemoryReport_Vtbl;
@@ -1216,7 +1453,7 @@ impl AppMemoryUsageLimitChangingEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppMemoryUsageLimitChangingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppMemoryUsageLimitChangingEventArgs>();
 }
 unsafe impl windows_core::Interface for AppMemoryUsageLimitChangingEventArgs {
     type Vtable = IAppMemoryUsageLimitChangingEventArgs_Vtbl;
@@ -1262,7 +1499,7 @@ impl AppResourceGroupBackgroundTaskReport {
     }
 }
 impl windows_core::RuntimeType for AppResourceGroupBackgroundTaskReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppResourceGroupBackgroundTaskReport>();
 }
 unsafe impl windows_core::Interface for AppResourceGroupBackgroundTaskReport {
     type Vtable = IAppResourceGroupBackgroundTaskReport_Vtbl;
@@ -1345,7 +1582,7 @@ impl AppResourceGroupInfo {
     }
 }
 impl windows_core::RuntimeType for AppResourceGroupInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppResourceGroupInfo>();
 }
 unsafe impl windows_core::Interface for AppResourceGroupInfo {
     type Vtable = IAppResourceGroupInfo_Vtbl;
@@ -1448,7 +1685,7 @@ impl AppResourceGroupInfoWatcher {
     }
 }
 impl windows_core::RuntimeType for AppResourceGroupInfoWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppResourceGroupInfoWatcher>();
 }
 unsafe impl windows_core::Interface for AppResourceGroupInfoWatcher {
     type Vtable = IAppResourceGroupInfoWatcher_Vtbl;
@@ -1481,7 +1718,7 @@ impl AppResourceGroupInfoWatcherEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppResourceGroupInfoWatcherEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppResourceGroupInfoWatcherEventArgs>();
 }
 unsafe impl windows_core::Interface for AppResourceGroupInfoWatcherEventArgs {
     type Vtable = IAppResourceGroupInfoWatcherEventArgs_Vtbl;
@@ -1514,7 +1751,7 @@ impl AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {
     type Vtable = IAppResourceGroupInfoWatcherExecutionStateChangedEventArgs_Vtbl;
@@ -1560,7 +1797,7 @@ impl AppResourceGroupMemoryReport {
     }
 }
 impl windows_core::RuntimeType for AppResourceGroupMemoryReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppResourceGroupMemoryReport>();
 }
 unsafe impl windows_core::Interface for AppResourceGroupMemoryReport {
     type Vtable = IAppResourceGroupMemoryReport_Vtbl;
@@ -1592,7 +1829,7 @@ impl AppResourceGroupStateReport {
     }
 }
 impl windows_core::RuntimeType for AppResourceGroupStateReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppResourceGroupStateReport>();
 }
 unsafe impl windows_core::Interface for AppResourceGroupStateReport {
     type Vtable = IAppResourceGroupStateReport_Vtbl;
@@ -1650,7 +1887,7 @@ impl AppUriHandlerHost {
     }
 }
 impl windows_core::RuntimeType for AppUriHandlerHost {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppUriHandlerHost>();
 }
 unsafe impl windows_core::Interface for AppUriHandlerHost {
     type Vtable = IAppUriHandlerHost_Vtbl;
@@ -1724,7 +1961,7 @@ impl AppUriHandlerRegistration {
     }
 }
 impl windows_core::RuntimeType for AppUriHandlerRegistration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppUriHandlerRegistration>();
 }
 unsafe impl windows_core::Interface for AppUriHandlerRegistration {
     type Vtable = IAppUriHandlerRegistration_Vtbl;
@@ -1803,7 +2040,7 @@ impl AppUriHandlerRegistrationManager {
     }
 }
 impl windows_core::RuntimeType for AppUriHandlerRegistrationManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppUriHandlerRegistrationManager>();
 }
 unsafe impl windows_core::Interface for AppUriHandlerRegistrationManager {
     type Vtable = IAppUriHandlerRegistrationManager_Vtbl;
@@ -1908,7 +2145,7 @@ impl DispatcherQueue {
     }
 }
 impl windows_core::RuntimeType for DispatcherQueue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDispatcherQueue>();
 }
 unsafe impl windows_core::Interface for DispatcherQueue {
     type Vtable = IDispatcherQueue_Vtbl;
@@ -1951,7 +2188,7 @@ impl DispatcherQueueController {
     }
 }
 impl windows_core::RuntimeType for DispatcherQueueController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDispatcherQueueController>();
 }
 unsafe impl windows_core::Interface for DispatcherQueueController {
     type Vtable = IDispatcherQueueController_Vtbl;
@@ -1976,7 +2213,7 @@ impl DispatcherQueueShutdownStartingEventArgs {
     }
 }
 impl windows_core::RuntimeType for DispatcherQueueShutdownStartingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDispatcherQueueShutdownStartingEventArgs>();
 }
 unsafe impl windows_core::Interface for DispatcherQueueShutdownStartingEventArgs {
     type Vtable = IDispatcherQueueShutdownStartingEventArgs_Vtbl;
@@ -2045,7 +2282,7 @@ impl DispatcherQueueTimer {
     }
 }
 impl windows_core::RuntimeType for DispatcherQueueTimer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDispatcherQueueTimer>();
 }
 unsafe impl windows_core::Interface for DispatcherQueueTimer {
     type Vtable = IDispatcherQueueTimer_Vtbl;
@@ -2092,7 +2329,7 @@ impl FolderLauncherOptions {
     }
 }
 impl windows_core::RuntimeType for FolderLauncherOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFolderLauncherOptions>();
 }
 unsafe impl windows_core::Interface for FolderLauncherOptions {
     type Vtable = IFolderLauncherOptions_Vtbl;
@@ -2201,7 +2438,7 @@ impl LaunchUriResult {
     }
 }
 impl windows_core::RuntimeType for LaunchUriResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILaunchUriResult>();
 }
 unsafe impl windows_core::Interface for LaunchUriResult {
     type Vtable = ILaunchUriResult_Vtbl;
@@ -2670,7 +2907,7 @@ impl LauncherOptions {
     }
 }
 impl windows_core::RuntimeType for LauncherOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILauncherOptions>();
 }
 unsafe impl windows_core::Interface for LauncherOptions {
     type Vtable = ILauncherOptions_Vtbl;
@@ -2729,7 +2966,7 @@ impl LauncherUIOptions {
     }
 }
 impl windows_core::RuntimeType for LauncherUIOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILauncherUIOptions>();
 }
 unsafe impl windows_core::Interface for LauncherUIOptions {
     type Vtable = ILauncherUIOptions_Vtbl;
@@ -2943,7 +3180,7 @@ impl ProcessLauncherOptions {
     }
 }
 impl windows_core::RuntimeType for ProcessLauncherOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessLauncherOptions>();
 }
 unsafe impl windows_core::Interface for ProcessLauncherOptions {
     type Vtable = IProcessLauncherOptions_Vtbl;
@@ -2968,7 +3205,7 @@ impl ProcessLauncherResult {
     }
 }
 impl windows_core::RuntimeType for ProcessLauncherResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessLauncherResult>();
 }
 unsafe impl windows_core::Interface for ProcessLauncherResult {
     type Vtable = IProcessLauncherResult_Vtbl;
@@ -3000,7 +3237,7 @@ impl ProcessMemoryReport {
     }
 }
 impl windows_core::RuntimeType for ProcessMemoryReport {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProcessMemoryReport>();
 }
 unsafe impl windows_core::Interface for ProcessMemoryReport {
     type Vtable = IProcessMemoryReport_Vtbl;
@@ -3026,7 +3263,7 @@ impl ProtocolForResultsOperation {
     }
 }
 impl windows_core::RuntimeType for ProtocolForResultsOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IProtocolForResultsOperation>();
 }
 unsafe impl windows_core::Interface for ProtocolForResultsOperation {
     type Vtable = IProtocolForResultsOperation_Vtbl;
@@ -3120,7 +3357,7 @@ impl RemoteLauncherOptions {
     }
 }
 impl windows_core::RuntimeType for RemoteLauncherOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteLauncherOptions>();
 }
 unsafe impl windows_core::Interface for RemoteLauncherOptions {
     type Vtable = IRemoteLauncherOptions_Vtbl;
@@ -3319,7 +3556,7 @@ impl User {
     }
 }
 impl windows_core::RuntimeType for User {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUser>();
 }
 unsafe impl windows_core::Interface for User {
     type Vtable = IUser_Vtbl;
@@ -3341,7 +3578,7 @@ impl UserAuthenticationStatusChangeDeferral {
     }
 }
 impl windows_core::RuntimeType for UserAuthenticationStatusChangeDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserAuthenticationStatusChangeDeferral>();
 }
 unsafe impl windows_core::Interface for UserAuthenticationStatusChangeDeferral {
     type Vtable = IUserAuthenticationStatusChangeDeferral_Vtbl;
@@ -3387,7 +3624,7 @@ impl UserAuthenticationStatusChangingEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserAuthenticationStatusChangingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserAuthenticationStatusChangingEventArgs>();
 }
 unsafe impl windows_core::Interface for UserAuthenticationStatusChangingEventArgs {
     type Vtable = IUserAuthenticationStatusChangingEventArgs_Vtbl;
@@ -3420,7 +3657,7 @@ impl UserChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UserChangedEventArgs {
     type Vtable = IUserChangedEventArgs_Vtbl;
@@ -3488,7 +3725,7 @@ impl UserDeviceAssociationChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserDeviceAssociationChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserDeviceAssociationChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UserDeviceAssociationChangedEventArgs {
     type Vtable = IUserDeviceAssociationChangedEventArgs_Vtbl;
@@ -3556,7 +3793,7 @@ impl UserPicker {
     }
 }
 impl windows_core::RuntimeType for UserPicker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserPicker>();
 }
 unsafe impl windows_core::Interface for UserPicker {
     type Vtable = IUserPicker_Vtbl;
@@ -3687,7 +3924,7 @@ impl UserWatcher {
     }
 }
 impl windows_core::RuntimeType for UserWatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserWatcher>();
 }
 unsafe impl windows_core::Interface for UserWatcher {
     type Vtable = IUserWatcher_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Accessibility/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IScreenReaderPositionChangedEventArgs, IScreenReaderPositionChangedEventArgs_Vtbl, 0x557eb5e5_54d0_5ccd_9fc5_ed33357f8a9f);
+impl windows_core::RuntimeType for IScreenReaderPositionChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScreenReaderPositionChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IScreenReaderPositionChangedEventArgs_Vtbl {
     pub IsReadingText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScreenReaderService, IScreenReaderService_Vtbl, 0x19475427_eac0_50d3_bdd9_9b487a226256);
+impl windows_core::RuntimeType for IScreenReaderService {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScreenReaderService_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,7 +40,7 @@ impl ScreenReaderPositionChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ScreenReaderPositionChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScreenReaderPositionChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for ScreenReaderPositionChangedEventArgs {
     type Vtable = IScreenReaderPositionChangedEventArgs_Vtbl;
@@ -80,7 +86,7 @@ impl ScreenReaderService {
     }
 }
 impl windows_core::RuntimeType for ScreenReaderService {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScreenReaderService>();
 }
 unsafe impl windows_core::Interface for ScreenReaderService {
     type Vtable = IScreenReaderService_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAccountsSettingsPane, IAccountsSettingsPane_Vtbl, 0x81ea942c_4f09_4406_a538_838d9b14b7e6);
+impl windows_core::RuntimeType for IAccountsSettingsPane {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccountsSettingsPane_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -6,6 +9,9 @@ pub struct IAccountsSettingsPane_Vtbl {
     pub RemoveAccountCommandsRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccountsSettingsPaneCommandsRequestedEventArgs, IAccountsSettingsPaneCommandsRequestedEventArgs_Vtbl, 0x3b68c099_db19_45d0_9abf_95d3773c9330);
+impl windows_core::RuntimeType for IAccountsSettingsPaneCommandsRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccountsSettingsPaneCommandsRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -30,6 +36,9 @@ pub struct IAccountsSettingsPaneCommandsRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccountsSettingsPaneCommandsRequestedEventArgs2, IAccountsSettingsPaneCommandsRequestedEventArgs2_Vtbl, 0x362f7bad_4e37_4967_8c40_e78ee7a1e5bb);
+impl windows_core::RuntimeType for IAccountsSettingsPaneCommandsRequestedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccountsSettingsPaneCommandsRequestedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,12 +48,18 @@ pub struct IAccountsSettingsPaneCommandsRequestedEventArgs2_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IAccountsSettingsPaneEventDeferral, IAccountsSettingsPaneEventDeferral_Vtbl, 0xcbf25d3f_e5ba_40ef_93da_65e096e5fb04);
+impl windows_core::RuntimeType for IAccountsSettingsPaneEventDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccountsSettingsPaneEventDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccountsSettingsPaneStatics, IAccountsSettingsPaneStatics_Vtbl, 0x561f8b60_b0ec_4150_a8dc_208ee44b068a);
+impl windows_core::RuntimeType for IAccountsSettingsPaneStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccountsSettingsPaneStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -52,6 +67,9 @@ pub struct IAccountsSettingsPaneStatics_Vtbl {
     pub Show: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccountsSettingsPaneStatics2, IAccountsSettingsPaneStatics2_Vtbl, 0xd21df7c2_ce0d_484f_b8e8_e823c215765e);
+impl windows_core::RuntimeType for IAccountsSettingsPaneStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccountsSettingsPaneStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +77,9 @@ pub struct IAccountsSettingsPaneStatics2_Vtbl {
     pub ShowAddAccountAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAccountsSettingsPaneStatics3, IAccountsSettingsPaneStatics3_Vtbl, 0x08410458_a2ba_4c6f_b4ac_48f514331216);
+impl windows_core::RuntimeType for IAccountsSettingsPaneStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccountsSettingsPaneStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,6 +93,9 @@ pub struct IAccountsSettingsPaneStatics3_Vtbl {
     ShowAddAccountForUserAsync: usize,
 }
 windows_core::imp::define_interface!(ICredentialCommand, ICredentialCommand_Vtbl, 0xa5f665e6_6143_4a7a_a971_b017ba978ce2);
+impl windows_core::RuntimeType for ICredentialCommand {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICredentialCommand_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -82,6 +106,9 @@ pub struct ICredentialCommand_Vtbl {
     pub CredentialDeleted: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICredentialCommandFactory, ICredentialCommandFactory_Vtbl, 0x27e88c17_bc3e_4b80_9495_4ed720e48a91);
+impl windows_core::RuntimeType for ICredentialCommandFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICredentialCommandFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -95,6 +122,9 @@ pub struct ICredentialCommandFactory_Vtbl {
     CreateCredentialCommandWithHandler: usize,
 }
 windows_core::imp::define_interface!(ISettingsCommandFactory, ISettingsCommandFactory_Vtbl, 0x68e15b33_1c83_433a_aa5a_ceeea5bd4764);
+impl windows_core::RuntimeType for ISettingsCommandFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISettingsCommandFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -104,6 +134,9 @@ pub struct ISettingsCommandFactory_Vtbl {
     CreateSettingsCommand: usize,
 }
 windows_core::imp::define_interface!(ISettingsCommandStatics, ISettingsCommandStatics_Vtbl, 0x749ae954_2f69_4b17_8aba_d05ce5778e46);
+impl windows_core::RuntimeType for ISettingsCommandStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISettingsCommandStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +147,10 @@ pub struct ISettingsCommandStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISettingsPane, ISettingsPane_Vtbl, 0xb1cd0932_4570_4c69_8d38_89446561ace0);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISettingsPane {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISettingsPane_Vtbl {
@@ -130,6 +167,10 @@ pub struct ISettingsPane_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISettingsPaneCommandsRequest, ISettingsPaneCommandsRequest_Vtbl, 0x44df23ae_5d6e_4068_a168_f47643182114);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISettingsPaneCommandsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISettingsPaneCommandsRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,6 +182,10 @@ pub struct ISettingsPaneCommandsRequest_Vtbl {
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISettingsPaneCommandsRequestedEventArgs, ISettingsPaneCommandsRequestedEventArgs_Vtbl, 0x205f5d24_1b48_4629_a6ca_2fdfedafb75d);
 #[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISettingsPaneCommandsRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
+#[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISettingsPaneCommandsRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,6 +196,10 @@ pub struct ISettingsPaneCommandsRequestedEventArgs_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(ISettingsPaneStatics, ISettingsPaneStatics_Vtbl, 0x1c6a52c5_ff19_471b_ba6b_f8f35694ad9a);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for ISettingsPaneStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct ISettingsPaneStatics_Vtbl {
@@ -169,6 +218,9 @@ pub struct ISettingsPaneStatics_Vtbl {
     Edge: usize,
 }
 windows_core::imp::define_interface!(IWebAccountCommand, IWebAccountCommand_Vtbl, 0xcaa39398_9cfa_4246_b0c4_a913a3896541);
+impl windows_core::RuntimeType for IWebAccountCommand {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountCommand_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -180,6 +232,9 @@ pub struct IWebAccountCommand_Vtbl {
     pub Actions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SupportedWebAccountActions) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountCommandFactory, IWebAccountCommandFactory_Vtbl, 0xbfa6cdff_2f2d_42f5_81de_1d56bafc496d);
+impl windows_core::RuntimeType for IWebAccountCommandFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountCommandFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,12 +244,18 @@ pub struct IWebAccountCommandFactory_Vtbl {
     CreateWebAccountCommand: usize,
 }
 windows_core::imp::define_interface!(IWebAccountInvokedArgs, IWebAccountInvokedArgs_Vtbl, 0xe7abcc40_a1d8_4c5d_9a7f_1d34b2f90ad2);
+impl windows_core::RuntimeType for IWebAccountInvokedArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountInvokedArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Action: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WebAccountAction) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountProviderCommand, IWebAccountProviderCommand_Vtbl, 0xd69bdd9a_a0a6_4e9b_88dc_c71e757a3501);
+impl windows_core::RuntimeType for IWebAccountProviderCommand {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderCommand_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -205,6 +266,9 @@ pub struct IWebAccountProviderCommand_Vtbl {
     pub Invoked: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebAccountProviderCommandFactory, IWebAccountProviderCommandFactory_Vtbl, 0xd5658a1b_b176_4776_8469_a9d3ff0b3f59);
+impl windows_core::RuntimeType for IWebAccountProviderCommandFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebAccountProviderCommandFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -290,7 +354,7 @@ impl AccountsSettingsPane {
     }
 }
 impl windows_core::RuntimeType for AccountsSettingsPane {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccountsSettingsPane>();
 }
 unsafe impl windows_core::Interface for AccountsSettingsPane {
     type Vtable = IAccountsSettingsPane_Vtbl;
@@ -364,7 +428,7 @@ impl AccountsSettingsPaneCommandsRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AccountsSettingsPaneCommandsRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccountsSettingsPaneCommandsRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for AccountsSettingsPaneCommandsRequestedEventArgs {
     type Vtable = IAccountsSettingsPaneCommandsRequestedEventArgs_Vtbl;
@@ -384,7 +448,7 @@ impl AccountsSettingsPaneEventDeferral {
     }
 }
 impl windows_core::RuntimeType for AccountsSettingsPaneEventDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccountsSettingsPaneEventDeferral>();
 }
 unsafe impl windows_core::Interface for AccountsSettingsPaneEventDeferral {
     type Vtable = IAccountsSettingsPaneEventDeferral_Vtbl;
@@ -441,7 +505,7 @@ impl CredentialCommand {
     }
 }
 impl windows_core::RuntimeType for CredentialCommand {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICredentialCommand>();
 }
 unsafe impl windows_core::Interface for CredentialCommand {
     type Vtable = ICredentialCommand_Vtbl;
@@ -536,7 +600,7 @@ impl SettingsCommand {
 }
 #[cfg(feature = "UI_Popups")]
 impl windows_core::RuntimeType for SettingsCommand {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::Popups::IUICommand>();
 }
 #[cfg(feature = "UI_Popups")]
 unsafe impl windows_core::Interface for SettingsCommand {
@@ -598,7 +662,7 @@ impl SettingsPane {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SettingsPane {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISettingsPane>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SettingsPane {
@@ -628,7 +692,7 @@ impl SettingsPaneCommandsRequest {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SettingsPaneCommandsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISettingsPaneCommandsRequest>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SettingsPaneCommandsRequest {
@@ -658,7 +722,7 @@ impl SettingsPaneCommandsRequestedEventArgs {
 }
 #[cfg(feature = "deprecated")]
 impl windows_core::RuntimeType for SettingsPaneCommandsRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISettingsPaneCommandsRequestedEventArgs>();
 }
 #[cfg(feature = "deprecated")]
 unsafe impl windows_core::Interface for SettingsPaneCommandsRequestedEventArgs {
@@ -714,7 +778,7 @@ impl WebAccountCommand {
     }
 }
 impl windows_core::RuntimeType for WebAccountCommand {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountCommand>();
 }
 unsafe impl windows_core::Interface for WebAccountCommand {
     type Vtable = IWebAccountCommand_Vtbl;
@@ -737,7 +801,7 @@ impl WebAccountInvokedArgs {
     }
 }
 impl windows_core::RuntimeType for WebAccountInvokedArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountInvokedArgs>();
 }
 unsafe impl windows_core::Interface for WebAccountInvokedArgs {
     type Vtable = IWebAccountInvokedArgs_Vtbl;
@@ -784,7 +848,7 @@ impl WebAccountProviderCommand {
     }
 }
 impl windows_core::RuntimeType for WebAccountProviderCommand {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebAccountProviderCommand>();
 }
 unsafe impl windows_core::Interface for WebAccountProviderCommand {
     type Vtable = IWebAccountProviderCommand_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Composition/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICompositorController, ICompositorController_Vtbl, 0x2d75f35a_70a7_4395_ba2d_cef0b18399f9);
+impl windows_core::RuntimeType for ICompositorController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositorController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,7 +62,7 @@ impl CompositorController {
     }
 }
 impl windows_core::RuntimeType for CompositorController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositorController>();
 }
 unsafe impl windows_core::Interface for CompositorController {
     type Vtable = ICompositorController_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Composition/Desktop/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Desktop/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IDesktopWindowTarget, IDesktopWindowTarget_Vtbl, 0x6329d6ca_3366_490e_9db3_25312929ac51);
+impl windows_core::RuntimeType for IDesktopWindowTarget {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDesktopWindowTarget_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,7 +142,7 @@ impl DesktopWindowTarget {
     }
 }
 impl windows_core::RuntimeType for DesktopWindowTarget {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDesktopWindowTarget>();
 }
 unsafe impl windows_core::Interface for DesktopWindowTarget {
     type Vtable = IDesktopWindowTarget_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICompositionDebugHeatMaps, ICompositionDebugHeatMaps_Vtbl, 0xe49c90ac_2ff3_5805_718c_b725ee07650f);
+impl windows_core::RuntimeType for ICompositionDebugHeatMaps {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionDebugHeatMaps_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,12 +11,18 @@ pub struct ICompositionDebugHeatMaps_Vtbl {
     pub ShowRedraw: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionDebugSettings, ICompositionDebugSettings_Vtbl, 0x2831987e_1d82_4d38_b7b7_efd11c7bc3d1);
+impl windows_core::RuntimeType for ICompositionDebugSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionDebugSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub HeatMaps: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionDebugSettingsStatics, ICompositionDebugSettingsStatics_Vtbl, 0x64ec1f1e_6af8_4af8_b814_c870fd5a9505);
+impl windows_core::RuntimeType for ICompositionDebugSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionDebugSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,7 +63,7 @@ impl CompositionDebugHeatMaps {
     }
 }
 impl windows_core::RuntimeType for CompositionDebugHeatMaps {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionDebugHeatMaps>();
 }
 unsafe impl windows_core::Interface for CompositionDebugHeatMaps {
     type Vtable = ICompositionDebugHeatMaps_Vtbl;
@@ -93,7 +102,7 @@ impl CompositionDebugSettings {
     }
 }
 impl windows_core::RuntimeType for CompositionDebugSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionDebugSettings>();
 }
 unsafe impl windows_core::Interface for CompositionDebugSettings {
     type Vtable = ICompositionDebugSettings_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISceneLightingEffect, ISceneLightingEffect_Vtbl, 0x91bb5e52_95d1_4f8b_9a5a_6408b24b8c6a);
+impl windows_core::RuntimeType for ISceneLightingEffect {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneLightingEffect_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +23,9 @@ pub struct ISceneLightingEffect_Vtbl {
     pub SetSpecularShine: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneLightingEffect2, ISceneLightingEffect2_Vtbl, 0x9e270e81_72f0_4c5c_95f8_8a6e0024f409);
+impl windows_core::RuntimeType for ISceneLightingEffect2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneLightingEffect2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,7 +132,7 @@ impl SceneLightingEffect {
     }
 }
 impl windows_core::RuntimeType for SceneLightingEffect {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneLightingEffect>();
 }
 unsafe impl windows_core::Interface for SceneLightingEffect {
     type Vtable = ISceneLightingEffect_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICompositionConditionalValue, ICompositionConditionalValue_Vtbl, 0x43250538_eb73_4561_a71d_1a43eaeb7a9b);
+impl windows_core::RuntimeType for ICompositionConditionalValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionConditionalValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct ICompositionConditionalValue_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionConditionalValueStatics, ICompositionConditionalValueStatics_Vtbl, 0x090c4b72_8467_4d0a_9065_ac46b80a5522);
+impl windows_core::RuntimeType for ICompositionConditionalValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionConditionalValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,9 @@ pub struct ICompositionInteractionSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionInteractionSourceCollection, ICompositionInteractionSourceCollection_Vtbl, 0x1b468e4b_a5bf_47d8_a547_3894155a158c);
+impl windows_core::RuntimeType for ICompositionInteractionSourceCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionInteractionSourceCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +42,9 @@ pub struct ICompositionInteractionSourceCollection_Vtbl {
     pub RemoveAll: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionSourceConfiguration, IInteractionSourceConfiguration_Vtbl, 0xa78347e5_a9d1_4d02_985e_b930cd0b9da4);
+impl windows_core::RuntimeType for IInteractionSourceConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionSourceConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +56,9 @@ pub struct IInteractionSourceConfiguration_Vtbl {
     pub SetScaleSourceMode: unsafe extern "system" fn(*mut core::ffi::c_void, InteractionSourceRedirectionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTracker, IInteractionTracker_Vtbl, 0x2a8e8cb1_1000_4416_8363_cc27fb877308);
+impl windows_core::RuntimeType for IInteractionTracker {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTracker_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -136,6 +151,9 @@ pub struct IInteractionTracker_Vtbl {
     TryUpdateScaleWithAdditionalVelocity: usize,
 }
 windows_core::imp::define_interface!(IInteractionTracker2, IInteractionTracker2_Vtbl, 0x25769a3e_ce6d_448c_8386_92620d240756);
+impl windows_core::RuntimeType for IInteractionTracker2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTracker2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -149,6 +167,9 @@ pub struct IInteractionTracker2_Vtbl {
     ConfigureCenterPointYInertiaModifiers: usize,
 }
 windows_core::imp::define_interface!(IInteractionTracker3, IInteractionTracker3_Vtbl, 0xe6c5d7a2_5c4b_42c6_84b7_f69441b18091);
+impl windows_core::RuntimeType for IInteractionTracker3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTracker3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +179,9 @@ pub struct IInteractionTracker3_Vtbl {
     ConfigureVector2PositionInertiaModifiers: usize,
 }
 windows_core::imp::define_interface!(IInteractionTracker4, IInteractionTracker4_Vtbl, 0xebd222bc_04af_4ac7_847d_06ea36e80a16);
+impl windows_core::RuntimeType for IInteractionTracker4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTracker4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,6 +196,9 @@ pub struct IInteractionTracker4_Vtbl {
     pub IsInertiaFromImpulse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTracker5, IInteractionTracker5_Vtbl, 0xd3ef5da2_a254_40e4_88d5_44e4e16b5809);
+impl windows_core::RuntimeType for IInteractionTracker5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTracker5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,40 +208,61 @@ pub struct IInteractionTracker5_Vtbl {
     TryUpdatePositionWithOption: usize,
 }
 windows_core::imp::define_interface!(IInteractionTrackerCustomAnimationStateEnteredArgs, IInteractionTrackerCustomAnimationStateEnteredArgs_Vtbl, 0x8d1c8cf1_d7b0_434c_a5d2_2d7611864834);
+impl windows_core::RuntimeType for IInteractionTrackerCustomAnimationStateEnteredArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerCustomAnimationStateEnteredArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerCustomAnimationStateEnteredArgs2, IInteractionTrackerCustomAnimationStateEnteredArgs2_Vtbl, 0x47d579b7_0985_5e99_b024_2f32c380c1a4);
+impl windows_core::RuntimeType for IInteractionTrackerCustomAnimationStateEnteredArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerCustomAnimationStateEnteredArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsFromBinding: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerIdleStateEnteredArgs, IInteractionTrackerIdleStateEnteredArgs_Vtbl, 0x50012faa_1510_4142_a1a5_019b09f8857b);
+impl windows_core::RuntimeType for IInteractionTrackerIdleStateEnteredArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerIdleStateEnteredArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerIdleStateEnteredArgs2, IInteractionTrackerIdleStateEnteredArgs2_Vtbl, 0xf2e771ed_b803_5137_9435_1c96e48721e9);
+impl windows_core::RuntimeType for IInteractionTrackerIdleStateEnteredArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerIdleStateEnteredArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsFromBinding: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaModifier, IInteractionTrackerInertiaModifier_Vtbl, 0xa0e2c920_26b4_4da2_8b61_5e683979bbe2);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaModifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaModifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaModifierFactory, IInteractionTrackerInertiaModifierFactory_Vtbl, 0x993818fe_c94e_4b86_87f3_922665ba46b9);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaModifierFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaModifierFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaMotion, IInteractionTrackerInertiaMotion_Vtbl, 0x04922fdc_f154_4cb8_bf33_cc1ba611e6db);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaMotion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaMotion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -224,12 +272,18 @@ pub struct IInteractionTrackerInertiaMotion_Vtbl {
     pub SetMotion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaMotionStatics, IInteractionTrackerInertiaMotionStatics_Vtbl, 0x8cc83dd6_ba7b_431a_844b_6eac9130f99a);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaMotionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaMotionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaNaturalMotion, IInteractionTrackerInertiaNaturalMotion_Vtbl, 0x70acdaae_27dc_48ed_a3c3_6d61c9a029d2);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaNaturalMotion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaNaturalMotion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -239,12 +293,18 @@ pub struct IInteractionTrackerInertiaNaturalMotion_Vtbl {
     pub SetNaturalMotion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaNaturalMotionStatics, IInteractionTrackerInertiaNaturalMotionStatics_Vtbl, 0xcfda55b0_5e3e_4289_932d_ee5f50e74283);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaNaturalMotionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaNaturalMotionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaRestingValue, IInteractionTrackerInertiaRestingValue_Vtbl, 0x86f7ec09_5096_4170_9cc8_df2fe101bb93);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaRestingValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaRestingValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,12 +314,18 @@ pub struct IInteractionTrackerInertiaRestingValue_Vtbl {
     pub SetRestingValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaRestingValueStatics, IInteractionTrackerInertiaRestingValueStatics_Vtbl, 0x18ed4699_0745_4096_bcab_3a4e99569bcf);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaRestingValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaRestingValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaStateEnteredArgs, IInteractionTrackerInertiaStateEnteredArgs_Vtbl, 0x87108cf2_e7ff_4f7d_9ffd_d72f1e409b63);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaStateEnteredArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaStateEnteredArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,24 +347,36 @@ pub struct IInteractionTrackerInertiaStateEnteredArgs_Vtbl {
     pub ScaleVelocityInPercentPerSecond: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaStateEnteredArgs2, IInteractionTrackerInertiaStateEnteredArgs2_Vtbl, 0xb1eb32f6_c26c_41f6_a189_fabc22b323cc);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaStateEnteredArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaStateEnteredArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsInertiaFromImpulse: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInertiaStateEnteredArgs3, IInteractionTrackerInertiaStateEnteredArgs3_Vtbl, 0x48ac1c2f_47bd_59af_a58c_79bd2eb9ef71);
+impl windows_core::RuntimeType for IInteractionTrackerInertiaStateEnteredArgs3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInertiaStateEnteredArgs3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsFromBinding: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInteractingStateEnteredArgs, IInteractionTrackerInteractingStateEnteredArgs_Vtbl, 0xa7263939_a17b_4011_99fd_b5c24f143748);
+impl windows_core::RuntimeType for IInteractionTrackerInteractingStateEnteredArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInteractingStateEnteredArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerInteractingStateEnteredArgs2, IInteractionTrackerInteractingStateEnteredArgs2_Vtbl, 0x509652d6_d488_59cd_819f_f52310295b11);
+impl windows_core::RuntimeType for IInteractionTrackerInteractingStateEnteredArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerInteractingStateEnteredArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -370,12 +448,18 @@ pub struct IInteractionTrackerOwner_Vtbl {
     pub ValuesChanged: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerRequestIgnoredArgs, IInteractionTrackerRequestIgnoredArgs_Vtbl, 0x80dd82f1_ce25_488f_91dd_cb6455ccff2e);
+impl windows_core::RuntimeType for IInteractionTrackerRequestIgnoredArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerRequestIgnoredArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RequestId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerStatics, IInteractionTrackerStatics_Vtbl, 0xbba5d7b7_6590_4498_8d6c_eb62b514c92a);
+impl windows_core::RuntimeType for IInteractionTrackerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -383,6 +467,9 @@ pub struct IInteractionTrackerStatics_Vtbl {
     pub CreateWithOwner: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerStatics2, IInteractionTrackerStatics2_Vtbl, 0x35e53720_46b7_5cb0_b505_f3d6884a6163);
+impl windows_core::RuntimeType for IInteractionTrackerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -390,6 +477,9 @@ pub struct IInteractionTrackerStatics2_Vtbl {
     pub GetBindingMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut InteractionBindingAxisModes) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerValuesChangedArgs, IInteractionTrackerValuesChangedArgs_Vtbl, 0xcf1578ef_d3df_4501_b9e6_f02fb22f73d0);
+impl windows_core::RuntimeType for IInteractionTrackerValuesChangedArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerValuesChangedArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -401,16 +491,25 @@ pub struct IInteractionTrackerValuesChangedArgs_Vtbl {
     pub Scale: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerVector2InertiaModifier, IInteractionTrackerVector2InertiaModifier_Vtbl, 0x87e08ab0_3086_4853_a4b7_77882ad5d7e3);
+impl windows_core::RuntimeType for IInteractionTrackerVector2InertiaModifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerVector2InertiaModifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IInteractionTrackerVector2InertiaModifierFactory, IInteractionTrackerVector2InertiaModifierFactory_Vtbl, 0x7401d6c4_6c6d_48df_bc3e_171e227e7d7f);
+impl windows_core::RuntimeType for IInteractionTrackerVector2InertiaModifierFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerVector2InertiaModifierFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IInteractionTrackerVector2InertiaNaturalMotion, IInteractionTrackerVector2InertiaNaturalMotion_Vtbl, 0x5f17695c_162d_4c07_9400_c282b28276ca);
+impl windows_core::RuntimeType for IInteractionTrackerVector2InertiaNaturalMotion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerVector2InertiaNaturalMotion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -420,12 +519,18 @@ pub struct IInteractionTrackerVector2InertiaNaturalMotion_Vtbl {
     pub SetNaturalMotion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInteractionTrackerVector2InertiaNaturalMotionStatics, IInteractionTrackerVector2InertiaNaturalMotionStatics_Vtbl, 0x82001a48_09c0_434f_8189_141c66df362f);
+impl windows_core::RuntimeType for IInteractionTrackerVector2InertiaNaturalMotionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInteractionTrackerVector2InertiaNaturalMotionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualInteractionSource, IVisualInteractionSource_Vtbl, 0xca0e8a86_d8d6_4111_b088_70347bd2b0ed);
+impl windows_core::RuntimeType for IVisualInteractionSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualInteractionSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -454,6 +559,9 @@ pub struct IVisualInteractionSource_Vtbl {
     TryRedirectForManipulation: usize,
 }
 windows_core::imp::define_interface!(IVisualInteractionSource2, IVisualInteractionSource2_Vtbl, 0xaa914893_a73c_414d_80d0_249bad2fbd93);
+impl windows_core::RuntimeType for IVisualInteractionSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualInteractionSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -494,23 +602,35 @@ pub struct IVisualInteractionSource2_Vtbl {
     ConfigureDeltaScaleModifiers: usize,
 }
 windows_core::imp::define_interface!(IVisualInteractionSource3, IVisualInteractionSource3_Vtbl, 0xd941ef2a_0d5c_4057_92d7_c9711533204f);
+impl windows_core::RuntimeType for IVisualInteractionSource3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualInteractionSource3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PointerWheelConfig: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualInteractionSourceObjectFactory, IVisualInteractionSourceObjectFactory_Vtbl, 0xb2ca917c_e98a_41f2_b3c9_891c9266c8f6);
+impl windows_core::RuntimeType for IVisualInteractionSourceObjectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualInteractionSourceObjectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IVisualInteractionSourceStatics, IVisualInteractionSourceStatics_Vtbl, 0x369965e1_8645_4f75_ba00_6479cd10c8e6);
+impl windows_core::RuntimeType for IVisualInteractionSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualInteractionSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualInteractionSourceStatics2, IVisualInteractionSourceStatics2_Vtbl, 0xa979c032_5764_55e0_bc1f_0778786dcfde);
+impl windows_core::RuntimeType for IVisualInteractionSourceStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualInteractionSourceStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -672,7 +792,7 @@ impl CompositionConditionalValue {
     }
 }
 impl windows_core::RuntimeType for CompositionConditionalValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionConditionalValue>();
 }
 unsafe impl windows_core::Interface for CompositionConditionalValue {
     type Vtable = ICompositionConditionalValue_Vtbl;
@@ -831,7 +951,7 @@ impl CompositionInteractionSourceCollection {
     }
 }
 impl windows_core::RuntimeType for CompositionInteractionSourceCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionInteractionSourceCollection>();
 }
 unsafe impl windows_core::Interface for CompositionInteractionSourceCollection {
     type Vtable = ICompositionInteractionSourceCollection_Vtbl;
@@ -1005,7 +1125,7 @@ impl InteractionSourceConfiguration {
     }
 }
 impl windows_core::RuntimeType for InteractionSourceConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionSourceConfiguration>();
 }
 unsafe impl windows_core::Interface for InteractionSourceConfiguration {
     type Vtable = IInteractionSourceConfiguration_Vtbl;
@@ -1468,7 +1588,7 @@ impl InteractionTracker {
     }
 }
 impl windows_core::RuntimeType for InteractionTracker {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTracker>();
 }
 unsafe impl windows_core::Interface for InteractionTracker {
     type Vtable = IInteractionTracker_Vtbl;
@@ -1500,7 +1620,7 @@ impl InteractionTrackerCustomAnimationStateEnteredArgs {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerCustomAnimationStateEnteredArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerCustomAnimationStateEnteredArgs>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerCustomAnimationStateEnteredArgs {
     type Vtable = IInteractionTrackerCustomAnimationStateEnteredArgs_Vtbl;
@@ -1532,7 +1652,7 @@ impl InteractionTrackerIdleStateEnteredArgs {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerIdleStateEnteredArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerIdleStateEnteredArgs>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerIdleStateEnteredArgs {
     type Vtable = IInteractionTrackerIdleStateEnteredArgs_Vtbl;
@@ -1657,7 +1777,7 @@ impl InteractionTrackerInertiaModifier {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerInertiaModifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerInertiaModifier>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerInertiaModifier {
     type Vtable = IInteractionTrackerInertiaModifier_Vtbl;
@@ -1824,7 +1944,7 @@ impl InteractionTrackerInertiaMotion {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerInertiaMotion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerInertiaMotion>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerInertiaMotion {
     type Vtable = IInteractionTrackerInertiaMotion_Vtbl;
@@ -1991,7 +2111,7 @@ impl InteractionTrackerInertiaNaturalMotion {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerInertiaNaturalMotion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerInertiaNaturalMotion>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerInertiaNaturalMotion {
     type Vtable = IInteractionTrackerInertiaNaturalMotion_Vtbl;
@@ -2158,7 +2278,7 @@ impl InteractionTrackerInertiaRestingValue {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerInertiaRestingValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerInertiaRestingValue>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerInertiaRestingValue {
     type Vtable = IInteractionTrackerInertiaRestingValue_Vtbl;
@@ -2242,7 +2362,7 @@ impl InteractionTrackerInertiaStateEnteredArgs {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerInertiaStateEnteredArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerInertiaStateEnteredArgs>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerInertiaStateEnteredArgs {
     type Vtable = IInteractionTrackerInertiaStateEnteredArgs_Vtbl;
@@ -2274,7 +2394,7 @@ impl InteractionTrackerInteractingStateEnteredArgs {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerInteractingStateEnteredArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerInteractingStateEnteredArgs>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerInteractingStateEnteredArgs {
     type Vtable = IInteractionTrackerInteractingStateEnteredArgs_Vtbl;
@@ -2299,7 +2419,7 @@ impl InteractionTrackerRequestIgnoredArgs {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerRequestIgnoredArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerRequestIgnoredArgs>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerRequestIgnoredArgs {
     type Vtable = IInteractionTrackerRequestIgnoredArgs_Vtbl;
@@ -2339,7 +2459,7 @@ impl InteractionTrackerValuesChangedArgs {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerValuesChangedArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerValuesChangedArgs>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerValuesChangedArgs {
     type Vtable = IInteractionTrackerValuesChangedArgs_Vtbl;
@@ -2464,7 +2584,7 @@ impl InteractionTrackerVector2InertiaModifier {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerVector2InertiaModifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerVector2InertiaModifier>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerVector2InertiaModifier {
     type Vtable = IInteractionTrackerVector2InertiaModifier_Vtbl;
@@ -2631,7 +2751,7 @@ impl InteractionTrackerVector2InertiaNaturalMotion {
     }
 }
 impl windows_core::RuntimeType for InteractionTrackerVector2InertiaNaturalMotion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInteractionTrackerVector2InertiaNaturalMotion>();
 }
 unsafe impl windows_core::Interface for InteractionTrackerVector2InertiaNaturalMotion {
     type Vtable = IInteractionTrackerVector2InertiaNaturalMotion_Vtbl;
@@ -2990,7 +3110,7 @@ impl VisualInteractionSource {
     }
 }
 impl windows_core::RuntimeType for VisualInteractionSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisualInteractionSource>();
 }
 unsafe impl windows_core::Interface for VisualInteractionSource {
     type Vtable = IVisualInteractionSource_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISceneBoundingBox, ISceneBoundingBox_Vtbl, 0x5d8ffc70_c618_4083_8251_9962593114aa);
+impl windows_core::RuntimeType for ISceneBoundingBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneBoundingBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,42 +27,66 @@ pub struct ISceneBoundingBox_Vtbl {
     Size: usize,
 }
 windows_core::imp::define_interface!(ISceneComponent, ISceneComponent_Vtbl, 0xae20fc96_226c_44bd_95cb_dd5ed9ebe9a5);
+impl windows_core::RuntimeType for ISceneComponent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneComponent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ComponentType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SceneComponentType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneComponentCollection, ISceneComponentCollection_Vtbl, 0xc483791c_5f46_45e4_b666_a3d2259f9b2e);
+impl windows_core::RuntimeType for ISceneComponentCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneComponentCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneComponentFactory, ISceneComponentFactory_Vtbl, 0x5fbc5574_ddd8_5889_ab5b_d8fa716e7c9e);
+impl windows_core::RuntimeType for ISceneComponentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneComponentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneMaterial, ISceneMaterial_Vtbl, 0x8ca74b7c_30df_4e07_9490_37875af1a123);
+impl windows_core::RuntimeType for ISceneMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneMaterialFactory, ISceneMaterialFactory_Vtbl, 0x67536c19_a707_5254_a495_7fdc799893b9);
+impl windows_core::RuntimeType for ISceneMaterialFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMaterialFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneMaterialInput, ISceneMaterialInput_Vtbl, 0x422a1642_1ef1_485c_97e9_ae6f95ad812f);
+impl windows_core::RuntimeType for ISceneMaterialInput {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMaterialInput_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneMaterialInputFactory, ISceneMaterialInputFactory_Vtbl, 0xa88feb74_7d0a_5e4c_a748_1015af9ca74f);
+impl windows_core::RuntimeType for ISceneMaterialInputFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMaterialInputFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneMesh, ISceneMesh_Vtbl, 0xee9a1530_1155_4c0c_92bd_40020cf78347);
+impl windows_core::RuntimeType for ISceneMesh {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMesh_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,11 +105,17 @@ pub struct ISceneMesh_Vtbl {
     FillMeshAttribute: usize,
 }
 windows_core::imp::define_interface!(ISceneMeshMaterialAttributeMap, ISceneMeshMaterialAttributeMap_Vtbl, 0xce843171_3d43_4855_aa69_31ff988d049d);
+impl windows_core::RuntimeType for ISceneMeshMaterialAttributeMap {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMeshMaterialAttributeMap_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneMeshRendererComponent, ISceneMeshRendererComponent_Vtbl, 0x9929f7e3_6364_477e_98fe_74ed9fd4c2de);
+impl windows_core::RuntimeType for ISceneMeshRendererComponent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMeshRendererComponent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,18 +126,27 @@ pub struct ISceneMeshRendererComponent_Vtbl {
     pub UVMappings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneMeshRendererComponentStatics, ISceneMeshRendererComponentStatics_Vtbl, 0x4954f37a_4459_4521_bd6e_2b38b8d711ea);
+impl windows_core::RuntimeType for ISceneMeshRendererComponentStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMeshRendererComponentStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneMeshStatics, ISceneMeshStatics_Vtbl, 0x8412316c_7b57_473f_966b_81dc277b1751);
+impl windows_core::RuntimeType for ISceneMeshStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMeshStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneMetallicRoughnessMaterial, ISceneMetallicRoughnessMaterial_Vtbl, 0xc1d91446_799c_429e_a4e4_5da645f18e61);
+impl windows_core::RuntimeType for ISceneMetallicRoughnessMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMetallicRoughnessMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,12 +168,18 @@ pub struct ISceneMetallicRoughnessMaterial_Vtbl {
     pub SetRoughnessFactor: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneMetallicRoughnessMaterialStatics, ISceneMetallicRoughnessMaterialStatics_Vtbl, 0x3bddca50_6d9d_4531_8dc4_b27e3e49b7ab);
+impl windows_core::RuntimeType for ISceneMetallicRoughnessMaterialStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneMetallicRoughnessMaterialStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneModelTransform, ISceneModelTransform_Vtbl, 0xc05576c2_32b1_4269_980d_b98537100ae4);
+impl windows_core::RuntimeType for ISceneModelTransform {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneModelTransform_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,6 +221,9 @@ pub struct ISceneModelTransform_Vtbl {
     SetTranslation: usize,
 }
 windows_core::imp::define_interface!(ISceneNode, ISceneNode_Vtbl, 0xacf2c247_f307_4581_9c41_af2e29c3b016);
+impl windows_core::RuntimeType for ISceneNode {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneNode_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,27 +240,42 @@ pub struct ISceneNode_Vtbl {
     pub FindFirstComponentOfType: unsafe extern "system" fn(*mut core::ffi::c_void, SceneComponentType, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneNodeCollection, ISceneNodeCollection_Vtbl, 0x29ada101_2dd9_4332_be63_60d2cf4269f2);
+impl windows_core::RuntimeType for ISceneNodeCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneNodeCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneNodeStatics, ISceneNodeStatics_Vtbl, 0x579a0faa_be9d_4210_908c_93d15feed0b7);
+impl windows_core::RuntimeType for ISceneNodeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneNodeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneObject, ISceneObject_Vtbl, 0x1e94249b_0f1b_49eb_a819_877d8450005b);
+impl windows_core::RuntimeType for ISceneObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneObjectFactory, ISceneObjectFactory_Vtbl, 0x14fe799a_33e4_52ef_956c_44229d21f2c1);
+impl windows_core::RuntimeType for ISceneObjectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneObjectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IScenePbrMaterial, IScenePbrMaterial_Vtbl, 0xaab6ebbe_d680_46df_8294_b6800a9f95e7);
+impl windows_core::RuntimeType for IScenePbrMaterial {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScenePbrMaterial_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -239,21 +305,33 @@ pub struct IScenePbrMaterial_Vtbl {
     pub SetOcclusionStrength: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScenePbrMaterialFactory, IScenePbrMaterialFactory_Vtbl, 0x2e3f3dfe_0b85_5727_b5be_b7d3cbac37fa);
+impl windows_core::RuntimeType for IScenePbrMaterialFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScenePbrMaterialFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneRendererComponent, ISceneRendererComponent_Vtbl, 0xf1acb857_cf4f_4025_9b25_a2d1944cf507);
+impl windows_core::RuntimeType for ISceneRendererComponent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneRendererComponent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneRendererComponentFactory, ISceneRendererComponentFactory_Vtbl, 0x1db6ed6c_aa2c_5967_9035_56352dc69658);
+impl windows_core::RuntimeType for ISceneRendererComponentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneRendererComponentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ISceneSurfaceMaterialInput, ISceneSurfaceMaterialInput_Vtbl, 0x9937da5c_a9ca_4cfc_b3aa_088356518742);
+impl windows_core::RuntimeType for ISceneSurfaceMaterialInput {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneSurfaceMaterialInput_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -267,12 +345,18 @@ pub struct ISceneSurfaceMaterialInput_Vtbl {
     pub SetWrappingVMode: unsafe extern "system" fn(*mut core::ffi::c_void, SceneWrappingMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneSurfaceMaterialInputStatics, ISceneSurfaceMaterialInputStatics_Vtbl, 0x5a2394d3_6429_4589_bbcf_b84f4f3cfbfe);
+impl windows_core::RuntimeType for ISceneSurfaceMaterialInputStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneSurfaceMaterialInputStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneVisual, ISceneVisual_Vtbl, 0x8e672c1e_d734_47b1_be14_3d694ffa4301);
+impl windows_core::RuntimeType for ISceneVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -280,6 +364,9 @@ pub struct ISceneVisual_Vtbl {
     pub SetRoot: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISceneVisualStatics, ISceneVisualStatics_Vtbl, 0xb8347e9a_50aa_4527_8d34_de4cb8ea88b4);
+impl windows_core::RuntimeType for ISceneVisualStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISceneVisualStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -439,7 +526,7 @@ impl SceneBoundingBox {
     }
 }
 impl windows_core::RuntimeType for SceneBoundingBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneBoundingBox>();
 }
 unsafe impl windows_core::Interface for SceneBoundingBox {
     type Vtable = ISceneBoundingBox_Vtbl;
@@ -571,7 +658,7 @@ impl SceneComponent {
     }
 }
 impl windows_core::RuntimeType for SceneComponent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneComponent>();
 }
 unsafe impl windows_core::Interface for SceneComponent {
     type Vtable = ISceneComponent_Vtbl;
@@ -796,7 +883,7 @@ impl SceneComponentCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for SceneComponentCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IVector<SceneComponent>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for SceneComponentCollection {
@@ -941,7 +1028,7 @@ impl SceneMaterial {
     }
 }
 impl windows_core::RuntimeType for SceneMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneMaterial>();
 }
 unsafe impl windows_core::Interface for SceneMaterial {
     type Vtable = ISceneMaterial_Vtbl;
@@ -1066,7 +1153,7 @@ impl SceneMaterialInput {
     }
 }
 impl windows_core::RuntimeType for SceneMaterialInput {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneMaterialInput>();
 }
 unsafe impl windows_core::Interface for SceneMaterialInput {
     type Vtable = ISceneMaterialInput_Vtbl;
@@ -1233,7 +1320,7 @@ impl SceneMesh {
     }
 }
 impl windows_core::RuntimeType for SceneMesh {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneMesh>();
 }
 unsafe impl windows_core::Interface for SceneMesh {
     type Vtable = ISceneMesh_Vtbl;
@@ -1417,7 +1504,7 @@ impl SceneMeshMaterialAttributeMap {
     }
 }
 impl windows_core::RuntimeType for SceneMeshMaterialAttributeMap {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneMeshMaterialAttributeMap>();
 }
 unsafe impl windows_core::Interface for SceneMeshMaterialAttributeMap {
     type Vtable = ISceneMeshMaterialAttributeMap_Vtbl;
@@ -1614,7 +1701,7 @@ impl SceneMeshRendererComponent {
     }
 }
 impl windows_core::RuntimeType for SceneMeshRendererComponent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneMeshRendererComponent>();
 }
 unsafe impl windows_core::Interface for SceneMeshRendererComponent {
     type Vtable = ISceneMeshRendererComponent_Vtbl;
@@ -1926,7 +2013,7 @@ impl SceneMetallicRoughnessMaterial {
     }
 }
 impl windows_core::RuntimeType for SceneMetallicRoughnessMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneMetallicRoughnessMaterial>();
 }
 unsafe impl windows_core::Interface for SceneMetallicRoughnessMaterial {
     type Vtable = ISceneMetallicRoughnessMaterial_Vtbl;
@@ -2125,7 +2212,7 @@ impl SceneModelTransform {
     }
 }
 impl windows_core::RuntimeType for SceneModelTransform {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneModelTransform>();
 }
 unsafe impl windows_core::Interface for SceneModelTransform {
     type Vtable = ISceneModelTransform_Vtbl;
@@ -2301,7 +2388,7 @@ impl SceneNode {
     }
 }
 impl windows_core::RuntimeType for SceneNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneNode>();
 }
 unsafe impl windows_core::Interface for SceneNode {
     type Vtable = ISceneNode_Vtbl;
@@ -2526,7 +2613,7 @@ impl SceneNodeCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for SceneNodeCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::super::Foundation::Collections::IVector<SceneNode>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for SceneNodeCollection {
@@ -2671,7 +2758,7 @@ impl SceneObject {
     }
 }
 impl windows_core::RuntimeType for SceneObject {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneObject>();
 }
 unsafe impl windows_core::Interface for SceneObject {
     type Vtable = ISceneObject_Vtbl;
@@ -2906,7 +2993,7 @@ impl ScenePbrMaterial {
     }
 }
 impl windows_core::RuntimeType for ScenePbrMaterial {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScenePbrMaterial>();
 }
 unsafe impl windows_core::Interface for ScenePbrMaterial {
     type Vtable = IScenePbrMaterial_Vtbl;
@@ -3038,7 +3125,7 @@ impl SceneRendererComponent {
     }
 }
 impl windows_core::RuntimeType for SceneRendererComponent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneRendererComponent>();
 }
 unsafe impl windows_core::Interface for SceneRendererComponent {
     type Vtable = ISceneRendererComponent_Vtbl;
@@ -3224,7 +3311,7 @@ impl SceneSurfaceMaterialInput {
     }
 }
 impl windows_core::RuntimeType for SceneSurfaceMaterialInput {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneSurfaceMaterialInput>();
 }
 unsafe impl windows_core::Interface for SceneSurfaceMaterialInput {
     type Vtable = ISceneSurfaceMaterialInput_Vtbl;
@@ -3648,7 +3735,7 @@ impl SceneVisual {
     }
 }
 impl windows_core::RuntimeType for SceneVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISceneVisual>();
 }
 unsafe impl windows_core::Interface for SceneVisual {
     type Vtable = ISceneVisual_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/mod.rs
@@ -11,6 +11,9 @@ pub mod Interactions;
 #[cfg(feature = "UI_Composition_Scenes")]
 pub mod Scenes;
 windows_core::imp::define_interface!(IAmbientLight, IAmbientLight_Vtbl, 0xa48130a1_b7c4_46f7_b9bf_daf43a44e6ee);
+impl windows_core::RuntimeType for IAmbientLight {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAmbientLight_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +21,9 @@ pub struct IAmbientLight_Vtbl {
     pub SetColor: unsafe extern "system" fn(*mut core::ffi::c_void, super::Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAmbientLight2, IAmbientLight2_Vtbl, 0x3b64a6bf_5f97_4c94_86e5_042dd386b27d);
+impl windows_core::RuntimeType for IAmbientLight2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAmbientLight2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +31,9 @@ pub struct IAmbientLight2_Vtbl {
     pub SetIntensity: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAnimationController, IAnimationController_Vtbl, 0xc934efd2_0722_4f5f_a4e2_9510f3d43bf7);
+impl windows_core::RuntimeType for IAnimationController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnimationController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,6 +47,9 @@ pub struct IAnimationController_Vtbl {
     pub Resume: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAnimationControllerStatics, IAnimationControllerStatics_Vtbl, 0xe71164df_651b_4800_b9e5_6a3bcfed3365);
+impl windows_core::RuntimeType for IAnimationControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnimationControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,6 +76,9 @@ pub struct IAnimationObject_Vtbl {
     pub PopulatePropertyInfo: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAnimationPropertyInfo, IAnimationPropertyInfo_Vtbl, 0xf4716f05_ed77_4e3c_b328_5c3985b3738f);
+impl windows_core::RuntimeType for IAnimationPropertyInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnimationPropertyInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +86,9 @@ pub struct IAnimationPropertyInfo_Vtbl {
     pub SetAccessMode: unsafe extern "system" fn(*mut core::ffi::c_void, AnimationPropertyAccessMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAnimationPropertyInfo2, IAnimationPropertyInfo2_Vtbl, 0x591720b4_7472_5218_8b39_dffe615ae6da);
+impl windows_core::RuntimeType for IAnimationPropertyInfo2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnimationPropertyInfo2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +96,9 @@ pub struct IAnimationPropertyInfo2_Vtbl {
     pub GetResolvedCompositionObjectProperty: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackEasingFunction, IBackEasingFunction_Vtbl, 0xb8560da4_5e3c_545d_b263_7987a2bd27cb);
+impl windows_core::RuntimeType for IBackEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,12 +106,18 @@ pub struct IBackEasingFunction_Vtbl {
     pub Amplitude: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBooleanKeyFrameAnimation, IBooleanKeyFrameAnimation_Vtbl, 0x95e23a08_d1f4_4972_9770_3efe68d82e14);
+impl windows_core::RuntimeType for IBooleanKeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBooleanKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InsertKeyFrame: unsafe extern "system" fn(*mut core::ffi::c_void, f32, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBounceEasingFunction, IBounceEasingFunction_Vtbl, 0xe7fdb44b_aad5_5174_9421_eef8b75a6a43);
+impl windows_core::RuntimeType for IBounceEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBounceEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +126,9 @@ pub struct IBounceEasingFunction_Vtbl {
     pub Bounciness: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBounceScalarNaturalMotionAnimation, IBounceScalarNaturalMotionAnimation_Vtbl, 0xbaa30dcc_a633_4618_9b06_7f7c72c87cff);
+impl windows_core::RuntimeType for IBounceScalarNaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBounceScalarNaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +138,9 @@ pub struct IBounceScalarNaturalMotionAnimation_Vtbl {
     pub SetRestitution: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBounceVector2NaturalMotionAnimation, IBounceVector2NaturalMotionAnimation_Vtbl, 0xda344196_2154_4b3c_88aa_47361204eccd);
+impl windows_core::RuntimeType for IBounceVector2NaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBounceVector2NaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +150,9 @@ pub struct IBounceVector2NaturalMotionAnimation_Vtbl {
     pub SetRestitution: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBounceVector3NaturalMotionAnimation, IBounceVector3NaturalMotionAnimation_Vtbl, 0x47dabc31_10d3_4518_86f1_09caf742d113);
+impl windows_core::RuntimeType for IBounceVector3NaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBounceVector3NaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,12 +162,18 @@ pub struct IBounceVector3NaturalMotionAnimation_Vtbl {
     pub SetRestitution: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICircleEasingFunction, ICircleEasingFunction_Vtbl, 0x1e07222a_6f82_5a28_8748_2e92fc46ee2b);
+impl windows_core::RuntimeType for ICircleEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICircleEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Mode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CompositionEasingFunctionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IColorKeyFrameAnimation, IColorKeyFrameAnimation_Vtbl, 0x93adb5e9_8e05_4593_84a3_dca152781e56);
+impl windows_core::RuntimeType for IColorKeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColorKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,6 +183,9 @@ pub struct IColorKeyFrameAnimation_Vtbl {
     pub InsertKeyFrameWithEasingFunction: unsafe extern "system" fn(*mut core::ffi::c_void, f32, super::Color, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionAnimation, ICompositionAnimation_Vtbl, 0x464c4c2c_1caa_4061_9b40_e13fde1503ca);
+impl windows_core::RuntimeType for ICompositionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -175,6 +220,9 @@ pub struct ICompositionAnimation_Vtbl {
     SetVector4Parameter: usize,
 }
 windows_core::imp::define_interface!(ICompositionAnimation2, ICompositionAnimation2_Vtbl, 0x369b603e_a80f_4948_93e3_ed23fb38c6cb);
+impl windows_core::RuntimeType for ICompositionAnimation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionAnimation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +231,9 @@ pub struct ICompositionAnimation2_Vtbl {
     pub SetTarget: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionAnimation3, ICompositionAnimation3_Vtbl, 0xd51e030d_7da4_4bd7_bc2d_f4517529f43a);
+impl windows_core::RuntimeType for ICompositionAnimation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionAnimation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -192,6 +243,9 @@ pub struct ICompositionAnimation3_Vtbl {
     InitialValueExpressions: usize,
 }
 windows_core::imp::define_interface!(ICompositionAnimation4, ICompositionAnimation4_Vtbl, 0x770137be_76bc_4e23_bfed_fe9cc20f6ec9);
+impl windows_core::RuntimeType for ICompositionAnimation4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionAnimation4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -208,11 +262,17 @@ pub struct ICompositionAnimationBase_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionAnimationFactory, ICompositionAnimationFactory_Vtbl, 0x10f6c4fb_6e51_4c25_bbd3_586a9bec3ef4);
+impl windows_core::RuntimeType for ICompositionAnimationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionAnimationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionAnimationGroup, ICompositionAnimationGroup_Vtbl, 0x5e7cc90c_cd14_4e07_8a55_c72527aabdac);
+impl windows_core::RuntimeType for ICompositionAnimationGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionAnimationGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,26 +282,41 @@ pub struct ICompositionAnimationGroup_Vtbl {
     pub RemoveAll: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionBackdropBrush, ICompositionBackdropBrush_Vtbl, 0xc5acae58_3898_499e_8d7f_224e91286a5d);
+impl windows_core::RuntimeType for ICompositionBackdropBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionBackdropBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionBatchCompletedEventArgs, ICompositionBatchCompletedEventArgs_Vtbl, 0x0d00dad0_9464_450a_a562_2e2698b0a812);
+impl windows_core::RuntimeType for ICompositionBatchCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionBatchCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionBrush, ICompositionBrush_Vtbl, 0xab0d7608_30c0_40e9_b568_b60a6bd1fb46);
+impl windows_core::RuntimeType for ICompositionBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionBrushFactory, ICompositionBrushFactory_Vtbl, 0xda53fb4c_4650_47c4_ad76_765379607ed6);
+impl windows_core::RuntimeType for ICompositionBrushFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionBrushFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionCapabilities, ICompositionCapabilities_Vtbl, 0x8253353e_b517_48bc_b1e8_4b3561a2e181);
+impl windows_core::RuntimeType for ICompositionCapabilities {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionCapabilities_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -251,17 +326,26 @@ pub struct ICompositionCapabilities_Vtbl {
     pub RemoveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionCapabilitiesStatics, ICompositionCapabilitiesStatics_Vtbl, 0xf7b7a86e_6416_49e5_8ddf_afe949e20562);
+impl windows_core::RuntimeType for ICompositionCapabilitiesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionCapabilitiesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionClip, ICompositionClip_Vtbl, 0x1ccd2a52_cfc7_4ace_9983_146bb8eb6a3c);
+impl windows_core::RuntimeType for ICompositionClip {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionClip_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionClip2, ICompositionClip2_Vtbl, 0x5893e069_3516_40e1_89e0_5ba924927235);
+impl windows_core::RuntimeType for ICompositionClip2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionClip2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -311,11 +395,17 @@ pub struct ICompositionClip2_Vtbl {
     SetTransformMatrix: usize,
 }
 windows_core::imp::define_interface!(ICompositionClipFactory, ICompositionClipFactory_Vtbl, 0xb9484caf_20c7_4aed_ac4a_9c78ba1302cf);
+impl windows_core::RuntimeType for ICompositionClipFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionClipFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionColorBrush, ICompositionColorBrush_Vtbl, 0x2b264c5e_bf35_4831_8642_cf70c20fff2f);
+impl windows_core::RuntimeType for ICompositionColorBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionColorBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -323,6 +413,9 @@ pub struct ICompositionColorBrush_Vtbl {
     pub SetColor: unsafe extern "system" fn(*mut core::ffi::c_void, super::Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionColorGradientStop, ICompositionColorGradientStop_Vtbl, 0x6f00ca92_c801_4e41_9a8f_a53e20f57778);
+impl windows_core::RuntimeType for ICompositionColorGradientStop {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionColorGradientStop_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -332,11 +425,17 @@ pub struct ICompositionColorGradientStop_Vtbl {
     pub SetOffset: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionColorGradientStopCollection, ICompositionColorGradientStopCollection_Vtbl, 0x9f1d20ec_7b04_4b1d_90bc_9fa32c0cfd26);
+impl windows_core::RuntimeType for ICompositionColorGradientStopCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionColorGradientStopCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionCommitBatch, ICompositionCommitBatch_Vtbl, 0x0d00dad0_ca07_4400_8c8e_cb5db08559cc);
+impl windows_core::RuntimeType for ICompositionCommitBatch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionCommitBatch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -346,6 +445,9 @@ pub struct ICompositionCommitBatch_Vtbl {
     pub RemoveCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionContainerShape, ICompositionContainerShape_Vtbl, 0x4f5e859b_2e5b_44a8_982c_aa0f69c16059);
+impl windows_core::RuntimeType for ICompositionContainerShape {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionContainerShape_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -355,6 +457,9 @@ pub struct ICompositionContainerShape_Vtbl {
     Shapes: usize,
 }
 windows_core::imp::define_interface!(ICompositionDrawingSurface, ICompositionDrawingSurface_Vtbl, 0xa166c300_fad0_4d11_9e67_e433162ff49e);
+impl windows_core::RuntimeType for ICompositionDrawingSurface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionDrawingSurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -369,6 +474,9 @@ pub struct ICompositionDrawingSurface_Vtbl {
     pub Size: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionDrawingSurface2, ICompositionDrawingSurface2_Vtbl, 0xfad0e88b_e354_44e8_8e3d_c4880d5a213f);
+impl windows_core::RuntimeType for ICompositionDrawingSurface2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionDrawingSurface2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -398,21 +506,33 @@ pub struct ICompositionDrawingSurface2_Vtbl {
     ScrollRectWithClip: usize,
 }
 windows_core::imp::define_interface!(ICompositionDrawingSurfaceFactory, ICompositionDrawingSurfaceFactory_Vtbl, 0x9497b00a_312d_46b9_9db3_412fd79464c8);
+impl windows_core::RuntimeType for ICompositionDrawingSurfaceFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionDrawingSurfaceFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionEasingFunction, ICompositionEasingFunction_Vtbl, 0x5145e356_bf79_4ea8_8cc2_6b5b472e6c9a);
+impl windows_core::RuntimeType for ICompositionEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionEasingFunctionFactory, ICompositionEasingFunctionFactory_Vtbl, 0x60840774_3da0_4949_8200_7206c00190a0);
+impl windows_core::RuntimeType for ICompositionEasingFunctionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEasingFunctionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionEasingFunctionStatics, ICompositionEasingFunctionStatics_Vtbl, 0x17a766b6_2936_53ea_b5af_c642f4a61083);
+impl windows_core::RuntimeType for ICompositionEasingFunctionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEasingFunctionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -432,6 +552,9 @@ pub struct ICompositionEasingFunctionStatics_Vtbl {
     pub CreateSineEasingFunction: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, CompositionEasingFunctionMode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionEffectBrush, ICompositionEffectBrush_Vtbl, 0xbf7f795e_83cc_44bf_a447_3e3c071789ec);
+impl windows_core::RuntimeType for ICompositionEffectBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEffectBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -439,6 +562,9 @@ pub struct ICompositionEffectBrush_Vtbl {
     pub SetSourceParameter: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionEffectFactory, ICompositionEffectFactory_Vtbl, 0xbe5624af_ba7e_4510_9850_41c0b4ff74df);
+impl windows_core::RuntimeType for ICompositionEffectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEffectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -447,18 +573,27 @@ pub struct ICompositionEffectFactory_Vtbl {
     pub LoadStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CompositionEffectFactoryLoadStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionEffectSourceParameter, ICompositionEffectSourceParameter_Vtbl, 0x858ab13a_3292_4e4e_b3bb_2b6c6544a6ee);
+impl windows_core::RuntimeType for ICompositionEffectSourceParameter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEffectSourceParameter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Name: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionEffectSourceParameterFactory, ICompositionEffectSourceParameterFactory_Vtbl, 0xb3d9f276_aba3_4724_acf3_d0397464db1c);
+impl windows_core::RuntimeType for ICompositionEffectSourceParameterFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEffectSourceParameterFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionEllipseGeometry, ICompositionEllipseGeometry_Vtbl, 0x4801f884_f6ad_4b93_afa9_897b64e57b1f);
+impl windows_core::RuntimeType for ICompositionEllipseGeometry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionEllipseGeometry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -480,6 +615,9 @@ pub struct ICompositionEllipseGeometry_Vtbl {
     SetRadius: usize,
 }
 windows_core::imp::define_interface!(ICompositionGeometricClip, ICompositionGeometricClip_Vtbl, 0xc840b581_81c9_4444_a2c1_ccaece3a50e5);
+impl windows_core::RuntimeType for ICompositionGeometricClip {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGeometricClip_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -489,6 +627,9 @@ pub struct ICompositionGeometricClip_Vtbl {
     pub SetViewBox: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionGeometry, ICompositionGeometry_Vtbl, 0xe985217c_6a17_4207_abd8_5fd3dd612a9d);
+impl windows_core::RuntimeType for ICompositionGeometry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGeometry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -500,11 +641,17 @@ pub struct ICompositionGeometry_Vtbl {
     pub SetTrimStart: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionGeometryFactory, ICompositionGeometryFactory_Vtbl, 0xbffebfe1_8c25_480b_9f56_fed6b288055d);
+impl windows_core::RuntimeType for ICompositionGeometryFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGeometryFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionGradientBrush, ICompositionGradientBrush_Vtbl, 0x1d9709e0_ffc6_4c0e_a9ab_34144d4c9098);
+impl windows_core::RuntimeType for ICompositionGradientBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGradientBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -559,6 +706,9 @@ pub struct ICompositionGradientBrush_Vtbl {
     SetTransformMatrix: usize,
 }
 windows_core::imp::define_interface!(ICompositionGradientBrush2, ICompositionGradientBrush2_Vtbl, 0x899dd5a1_b4c7_4b33_a1b6_264addc26d10);
+impl windows_core::RuntimeType for ICompositionGradientBrush2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGradientBrush2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -566,11 +716,17 @@ pub struct ICompositionGradientBrush2_Vtbl {
     pub SetMappingMode: unsafe extern "system" fn(*mut core::ffi::c_void, CompositionMappingMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionGradientBrushFactory, ICompositionGradientBrushFactory_Vtbl, 0x56d765d7_f189_48c9_9c8d_94daf1bec010);
+impl windows_core::RuntimeType for ICompositionGradientBrushFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGradientBrushFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionGraphicsDevice, ICompositionGraphicsDevice_Vtbl, 0xfb22c6e1_80a2_4667_9936_dbeaf6eefe95);
+impl windows_core::RuntimeType for ICompositionGraphicsDevice {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGraphicsDevice_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -582,6 +738,9 @@ pub struct ICompositionGraphicsDevice_Vtbl {
     pub RemoveRenderingDeviceReplaced: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionGraphicsDevice2, ICompositionGraphicsDevice2_Vtbl, 0x0fb8bdf6_c0f0_4bcc_9fb8_084982490d7d);
+impl windows_core::RuntimeType for ICompositionGraphicsDevice2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGraphicsDevice2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -595,6 +754,9 @@ pub struct ICompositionGraphicsDevice2_Vtbl {
     CreateVirtualDrawingSurface: usize,
 }
 windows_core::imp::define_interface!(ICompositionGraphicsDevice3, ICompositionGraphicsDevice3_Vtbl, 0x37f67514_d3ef_49d1_b69d_0d8eabeb3626);
+impl windows_core::RuntimeType for ICompositionGraphicsDevice3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGraphicsDevice3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -605,6 +767,9 @@ pub struct ICompositionGraphicsDevice3_Vtbl {
     pub Trim: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionGraphicsDevice4, ICompositionGraphicsDevice4_Vtbl, 0x5a73bff9_a97f_4cf5_ba46_98ef358e71b1);
+impl windows_core::RuntimeType for ICompositionGraphicsDevice4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionGraphicsDevice4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -614,18 +779,27 @@ pub struct ICompositionGraphicsDevice4_Vtbl {
     CaptureAsync: usize,
 }
 windows_core::imp::define_interface!(ICompositionLight, ICompositionLight_Vtbl, 0x41a6d7c2_2e5d_4bc1_b09e_8f0a03e3d8d3);
+impl windows_core::RuntimeType for ICompositionLight {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionLight_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Targets: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionLight2, ICompositionLight2_Vtbl, 0xa7bcda72_f35d_425d_9b98_23f4205f6669);
+impl windows_core::RuntimeType for ICompositionLight2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionLight2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ExclusionsFromTargets: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionLight3, ICompositionLight3_Vtbl, 0x4b0b00e4_df07_4959_b7a4_4f7e4233f838);
+impl windows_core::RuntimeType for ICompositionLight3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionLight3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -633,11 +807,17 @@ pub struct ICompositionLight3_Vtbl {
     pub SetIsEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionLightFactory, ICompositionLightFactory_Vtbl, 0x069cf306_da3c_4b44_838a_5e03d51ace55);
+impl windows_core::RuntimeType for ICompositionLightFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionLightFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionLineGeometry, ICompositionLineGeometry_Vtbl, 0xdd7615a4_0c9a_4b67_8dce_440a5bf9cdec);
+impl windows_core::RuntimeType for ICompositionLineGeometry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionLineGeometry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -659,6 +839,9 @@ pub struct ICompositionLineGeometry_Vtbl {
     SetEnd: usize,
 }
 windows_core::imp::define_interface!(ICompositionLinearGradientBrush, ICompositionLinearGradientBrush_Vtbl, 0x983bc519_a9db_413c_a2d8_2a9056fc525e);
+impl windows_core::RuntimeType for ICompositionLinearGradientBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionLinearGradientBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -680,6 +863,9 @@ pub struct ICompositionLinearGradientBrush_Vtbl {
     SetStartPoint: usize,
 }
 windows_core::imp::define_interface!(ICompositionMaskBrush, ICompositionMaskBrush_Vtbl, 0x522cf09e_be6b_4f41_be49_f9226d471b4a);
+impl windows_core::RuntimeType for ICompositionMaskBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionMaskBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -689,6 +875,9 @@ pub struct ICompositionMaskBrush_Vtbl {
     pub SetSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionMipmapSurface, ICompositionMipmapSurface_Vtbl, 0x4863675c_cf4a_4b1c_9ece_c5ec0c2b2fe6);
+impl windows_core::RuntimeType for ICompositionMipmapSurface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionMipmapSurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -708,6 +897,9 @@ pub struct ICompositionMipmapSurface_Vtbl {
     pub GetDrawingSurfaceForLevel: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionNineGridBrush, ICompositionNineGridBrush_Vtbl, 0xf25154e4_bc8c_4be7_b80f_8685b83c0186);
+impl windows_core::RuntimeType for ICompositionNineGridBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionNineGridBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -737,6 +929,9 @@ pub struct ICompositionNineGridBrush_Vtbl {
     pub SetInsetScalesWithValues: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, f32, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionObject, ICompositionObject_Vtbl, 0xbcb4ad45_7609_4550_934f_16002a68fded);
+impl windows_core::RuntimeType for ICompositionObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -750,6 +945,9 @@ pub struct ICompositionObject_Vtbl {
     pub StopAnimation: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionObject2, ICompositionObject2_Vtbl, 0xef874ea1_5cff_4b68_9e30_a1519d08ba03);
+impl windows_core::RuntimeType for ICompositionObject2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionObject2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -761,6 +959,9 @@ pub struct ICompositionObject2_Vtbl {
     pub StopAnimationGroup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionObject3, ICompositionObject3_Vtbl, 0x4bc27925_dacd_4cf2_98b1_986b76e7ebe6);
+impl windows_core::RuntimeType for ICompositionObject3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionObject3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -770,23 +971,35 @@ pub struct ICompositionObject3_Vtbl {
     DispatcherQueue: usize,
 }
 windows_core::imp::define_interface!(ICompositionObject4, ICompositionObject4_Vtbl, 0x0bb3784c_346b_4a7c_966b_7310966553d5);
+impl windows_core::RuntimeType for ICompositionObject4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionObject4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryGetAnimationController: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionObject5, ICompositionObject5_Vtbl, 0x1d7f391b_a130_5265_a62b_60b8e668965a);
+impl windows_core::RuntimeType for ICompositionObject5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionObject5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub StartAnimationWithController: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionObjectFactory, ICompositionObjectFactory_Vtbl, 0x51205c5e_558a_4f2a_8d39_37bfe1e20ddd);
+impl windows_core::RuntimeType for ICompositionObjectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionObjectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionObjectStatics, ICompositionObjectStatics_Vtbl, 0xc1ed052f_1ba2_44ba_a904_6a882a0a5adb);
+impl windows_core::RuntimeType for ICompositionObjectStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionObjectStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -794,11 +1007,17 @@ pub struct ICompositionObjectStatics_Vtbl {
     pub StartAnimationGroupWithIAnimationObject: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionPath, ICompositionPath_Vtbl, 0x66da1d5f_2e10_4f22_8a06_0a8151919e60);
+impl windows_core::RuntimeType for ICompositionPath {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionPath_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionPathFactory, ICompositionPathFactory_Vtbl, 0x9c1e8c6a_0f33_4751_9437_eb3fb9d3ab07);
+impl windows_core::RuntimeType for ICompositionPathFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionPathFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -808,6 +1027,9 @@ pub struct ICompositionPathFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ICompositionPathGeometry, ICompositionPathGeometry_Vtbl, 0x0b6a417e_2c77_4c23_af5e_6304c147bb61);
+impl windows_core::RuntimeType for ICompositionPathGeometry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionPathGeometry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -815,6 +1037,9 @@ pub struct ICompositionPathGeometry_Vtbl {
     pub SetPath: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionProjectedShadow, ICompositionProjectedShadow_Vtbl, 0x285b8e72_4328_523f_bcf2_5557c52c3b25);
+impl windows_core::RuntimeType for ICompositionProjectedShadow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionProjectedShadow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -830,6 +1055,9 @@ pub struct ICompositionProjectedShadow_Vtbl {
     pub Receivers: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionProjectedShadowCaster, ICompositionProjectedShadowCaster_Vtbl, 0xb1d7d426_1e36_5a62_be56_a16112fdd148);
+impl windows_core::RuntimeType for ICompositionProjectedShadowCaster {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionProjectedShadowCaster_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -839,6 +1067,9 @@ pub struct ICompositionProjectedShadowCaster_Vtbl {
     pub SetCastingVisual: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionProjectedShadowCasterCollection, ICompositionProjectedShadowCasterCollection_Vtbl, 0xd2525c0c_e07f_58a3_ac91_37f73ee91740);
+impl windows_core::RuntimeType for ICompositionProjectedShadowCasterCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionProjectedShadowCasterCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -851,12 +1082,18 @@ pub struct ICompositionProjectedShadowCasterCollection_Vtbl {
     pub RemoveAll: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionProjectedShadowCasterCollectionStatics, ICompositionProjectedShadowCasterCollectionStatics_Vtbl, 0x56fbb136_e94f_5299_ab5b_6e15e38bd899);
+impl windows_core::RuntimeType for ICompositionProjectedShadowCasterCollectionStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionProjectedShadowCasterCollectionStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MaxRespectedCasters: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionProjectedShadowReceiver, ICompositionProjectedShadowReceiver_Vtbl, 0x1377985a_6a49_536a_9be4_a96a8e5298a9);
+impl windows_core::RuntimeType for ICompositionProjectedShadowReceiver {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionProjectedShadowReceiver_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -864,6 +1101,9 @@ pub struct ICompositionProjectedShadowReceiver_Vtbl {
     pub SetReceivingVisual: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionProjectedShadowReceiverUnorderedCollection, ICompositionProjectedShadowReceiverUnorderedCollection_Vtbl, 0x02b3e3b7_27d2_599f_ac4b_ab787cdde6fd);
+impl windows_core::RuntimeType for ICompositionProjectedShadowReceiverUnorderedCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionProjectedShadowReceiverUnorderedCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -873,6 +1113,9 @@ pub struct ICompositionProjectedShadowReceiverUnorderedCollection_Vtbl {
     pub RemoveAll: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionPropertySet, ICompositionPropertySet_Vtbl, 0xc9d6d202_5f67_4453_9117_9eadd430d3c2);
+impl windows_core::RuntimeType for ICompositionPropertySet {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionPropertySet_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -930,6 +1173,9 @@ pub struct ICompositionPropertySet_Vtbl {
     TryGetVector4: usize,
 }
 windows_core::imp::define_interface!(ICompositionPropertySet2, ICompositionPropertySet2_Vtbl, 0xde80731e_a211_4455_8880_7d0f3f6a44fd);
+impl windows_core::RuntimeType for ICompositionPropertySet2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionPropertySet2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -937,6 +1183,9 @@ pub struct ICompositionPropertySet2_Vtbl {
     pub TryGetBoolean: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool, *mut CompositionGetValueStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionRadialGradientBrush, ICompositionRadialGradientBrush_Vtbl, 0x3d3b50c5_e3fa_4ce2_b9fc_3ee12561788f);
+impl windows_core::RuntimeType for ICompositionRadialGradientBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionRadialGradientBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -966,6 +1215,9 @@ pub struct ICompositionRadialGradientBrush_Vtbl {
     SetGradientOriginOffset: usize,
 }
 windows_core::imp::define_interface!(ICompositionRectangleGeometry, ICompositionRectangleGeometry_Vtbl, 0x0cd51428_5356_4246_aecf_7a0b76975400);
+impl windows_core::RuntimeType for ICompositionRectangleGeometry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionRectangleGeometry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -987,6 +1239,9 @@ pub struct ICompositionRectangleGeometry_Vtbl {
     SetSize: usize,
 }
 windows_core::imp::define_interface!(ICompositionRoundedRectangleGeometry, ICompositionRoundedRectangleGeometry_Vtbl, 0x8770c822_1d50_4b8b_b013_7c9a0e46935f);
+impl windows_core::RuntimeType for ICompositionRoundedRectangleGeometry {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionRoundedRectangleGeometry_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1016,6 +1271,9 @@ pub struct ICompositionRoundedRectangleGeometry_Vtbl {
     SetSize: usize,
 }
 windows_core::imp::define_interface!(ICompositionScopedBatch, ICompositionScopedBatch_Vtbl, 0x0d00dad0_fb07_46fd_8c72_6280d1a3d1dd);
+impl windows_core::RuntimeType for ICompositionScopedBatch {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionScopedBatch_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1028,16 +1286,25 @@ pub struct ICompositionScopedBatch_Vtbl {
     pub RemoveCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionShadow, ICompositionShadow_Vtbl, 0x329e52e2_4335_49cc_b14a_37782d10f0c4);
+impl windows_core::RuntimeType for ICompositionShadow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionShadow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionShadowFactory, ICompositionShadowFactory_Vtbl, 0x221f492f_dcba_4b91_999e_1dc217a01530);
+impl windows_core::RuntimeType for ICompositionShadowFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionShadowFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionShape, ICompositionShape_Vtbl, 0xb47ce2f7_9a88_42c4_9e87_2e500ca8688c);
+impl windows_core::RuntimeType for ICompositionShape {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionShape_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1079,11 +1346,17 @@ pub struct ICompositionShape_Vtbl {
     SetTransformMatrix: usize,
 }
 windows_core::imp::define_interface!(ICompositionShapeFactory, ICompositionShapeFactory_Vtbl, 0x1dfc36d0_b05a_44ef_82b0_12118bcd4cd0);
+impl windows_core::RuntimeType for ICompositionShapeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionShapeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionSpriteShape, ICompositionSpriteShape_Vtbl, 0x401b61bb_0007_4363_b1f3_6bcc003fb83e);
+impl windows_core::RuntimeType for ICompositionSpriteShape {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionSpriteShape_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1152,6 +1425,9 @@ pub struct ICompositionSurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionSurfaceBrush, ICompositionSurfaceBrush_Vtbl, 0xad016d79_1e4c_4c0d_9c29_83338c87c162);
+impl windows_core::RuntimeType for ICompositionSurfaceBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionSurfaceBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1167,6 +1443,9 @@ pub struct ICompositionSurfaceBrush_Vtbl {
     pub SetVerticalAlignmentRatio: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionSurfaceBrush2, ICompositionSurfaceBrush2_Vtbl, 0xd27174d5_64f5_4692_9dc7_71b61d7e5880);
+impl windows_core::RuntimeType for ICompositionSurfaceBrush2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionSurfaceBrush2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1216,6 +1495,9 @@ pub struct ICompositionSurfaceBrush2_Vtbl {
     SetTransformMatrix: usize,
 }
 windows_core::imp::define_interface!(ICompositionSurfaceBrush3, ICompositionSurfaceBrush3_Vtbl, 0x550bb289_1fe0_42e5_8195_1eefa87ff08e);
+impl windows_core::RuntimeType for ICompositionSurfaceBrush3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionSurfaceBrush3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1242,6 +1524,9 @@ pub struct ICompositionSurfaceFacade_Vtbl {
     pub GetRealSurface: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionTarget, ICompositionTarget_Vtbl, 0xa1bea8ba_d726_4663_8129_6b5e7927ffa6);
+impl windows_core::RuntimeType for ICompositionTarget {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionTarget_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1249,11 +1534,17 @@ pub struct ICompositionTarget_Vtbl {
     pub SetRoot: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionTargetFactory, ICompositionTargetFactory_Vtbl, 0x93cd9d2b_8516_4b14_a8ce_f49e2119ec42);
+impl windows_core::RuntimeType for ICompositionTargetFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionTargetFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionTexture, ICompositionTexture_Vtbl, 0x347d03a0_1c0a_4c0b_b232_8570b2b1a4ea);
+impl windows_core::RuntimeType for ICompositionTexture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionTexture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1283,21 +1574,33 @@ pub struct ICompositionTexture_Vtbl {
     SetColorSpace: usize,
 }
 windows_core::imp::define_interface!(ICompositionTextureFactory, ICompositionTextureFactory_Vtbl, 0x09d9523d_471c_5ab5_b053_b568ee46ebfb);
+impl windows_core::RuntimeType for ICompositionTextureFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionTextureFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionTransform, ICompositionTransform_Vtbl, 0x7cd54529_fbed_4112_abc5_185906dd927c);
+impl windows_core::RuntimeType for ICompositionTransform {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionTransform_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionTransformFactory, ICompositionTransformFactory_Vtbl, 0xaaaeca26_c149_517a_8f72_6bff7a65ce08);
+impl windows_core::RuntimeType for ICompositionTransformFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionTransformFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionViewBox, ICompositionViewBox_Vtbl, 0xb440bf07_068f_4537_84c6_4ecbe019e1f4);
+impl windows_core::RuntimeType for ICompositionViewBox {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionViewBox_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1325,6 +1628,9 @@ pub struct ICompositionViewBox_Vtbl {
     pub SetVerticalAlignmentRatio: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositionVirtualDrawingSurface, ICompositionVirtualDrawingSurface_Vtbl, 0xa9c384db_8740_4f94_8b9d_b68521e7863d);
+impl windows_core::RuntimeType for ICompositionVirtualDrawingSurface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionVirtualDrawingSurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1334,11 +1640,17 @@ pub struct ICompositionVirtualDrawingSurface_Vtbl {
     Trim: usize,
 }
 windows_core::imp::define_interface!(ICompositionVirtualDrawingSurfaceFactory, ICompositionVirtualDrawingSurfaceFactory_Vtbl, 0x6766106c_d56b_4a49_b1df_5076a0620768);
+impl windows_core::RuntimeType for ICompositionVirtualDrawingSurfaceFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionVirtualDrawingSurfaceFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICompositionVisualSurface, ICompositionVisualSurface_Vtbl, 0xb224d803_4f6e_4a3f_8cae_3dc1cda74fc6);
+impl windows_core::RuntimeType for ICompositionVisualSurface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositionVisualSurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1362,6 +1674,9 @@ pub struct ICompositionVisualSurface_Vtbl {
     SetSourceSize: usize,
 }
 windows_core::imp::define_interface!(ICompositor, ICompositor_Vtbl, 0xb403ca50_7f8c_4e83_985f_cc45060036d8);
+impl windows_core::RuntimeType for ICompositor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1400,6 +1715,9 @@ pub struct ICompositor_Vtbl {
     pub GetCommitBatch: unsafe extern "system" fn(*mut core::ffi::c_void, CompositionBatchTypes, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositor2, ICompositor2_Vtbl, 0x735081dc_5e24_45da_a38f_e32cc349a9a0);
+impl windows_core::RuntimeType for ICompositor2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1418,12 +1736,18 @@ pub struct ICompositor2_Vtbl {
     pub CreateStepEasingFunctionWithStepCount: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositor3, ICompositor3_Vtbl, 0xc9dd8ef0_6eb1_4e3c_a658_675d9c64d4ab);
+impl windows_core::RuntimeType for ICompositor3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateHostBackdropBrush: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositor4, ICompositor4_Vtbl, 0xae47e78a_7910_4425_a482_a05b758adce9);
+impl windows_core::RuntimeType for ICompositor4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1435,6 +1759,9 @@ pub struct ICompositor4_Vtbl {
     pub CreateSpringVector3Animation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositor5, ICompositor5_Vtbl, 0x48ea31ad_7fcd_4076_a79c_90cc4b852c9b);
+impl windows_core::RuntimeType for ICompositor5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1460,6 +1787,9 @@ pub struct ICompositor5_Vtbl {
     pub RequestCommitAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositor6, ICompositor6_Vtbl, 0x7a38b2bd_cec8_4eeb_830f_d8d07aedebc3);
+impl windows_core::RuntimeType for ICompositor6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1470,6 +1800,9 @@ pub struct ICompositor6_Vtbl {
     pub CreateBooleanKeyFrameAnimation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositor7, ICompositor7_Vtbl, 0xd3483fad_9a12_53ba_bfc8_88b7ff7977c6);
+impl windows_core::RuntimeType for ICompositor7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1486,12 +1819,18 @@ pub struct ICompositor7_Vtbl {
     CreateRectangleClipWithSidesAndRadius: usize,
 }
 windows_core::imp::define_interface!(ICompositor8, ICompositor8_Vtbl, 0x9a0bdee2_fe7b_5f62_a366_9cf8effe2112);
+impl windows_core::RuntimeType for ICompositor8 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositor8_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateAnimationController: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositorStatics, ICompositorStatics_Vtbl, 0x080db93e_121e_4d97_8b74_1dfcf91987ea);
+impl windows_core::RuntimeType for ICompositorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1499,12 +1838,18 @@ pub struct ICompositorStatics_Vtbl {
     pub MinGlobalPlaybackRate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositorWithBlurredWallpaperBackdropBrush, ICompositorWithBlurredWallpaperBackdropBrush_Vtbl, 0x0d8fb190_f122_5b8d_9fdd_543b0d8eb7f3);
+impl windows_core::RuntimeType for ICompositorWithBlurredWallpaperBackdropBrush {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositorWithBlurredWallpaperBackdropBrush_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryCreateBlurredWallpaperBackdropBrush: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositorWithProjectedShadow, ICompositorWithProjectedShadow_Vtbl, 0xa2e6330e_8a60_5a38_bb85_b44ea901677c);
+impl windows_core::RuntimeType for ICompositorWithProjectedShadow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositorWithProjectedShadow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1513,29 +1858,44 @@ pub struct ICompositorWithProjectedShadow_Vtbl {
     pub CreateProjectedShadowReceiver: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositorWithRadialGradient, ICompositorWithRadialGradient_Vtbl, 0x98b9c1a7_8e71_4b53_b4a8_69ba5d19dc5b);
+impl windows_core::RuntimeType for ICompositorWithRadialGradient {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositorWithRadialGradient_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateRadialGradientBrush: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompositorWithVisualSurface, ICompositorWithVisualSurface_Vtbl, 0xcfa1658b_0123_4551_8891_89bdcc40322b);
+impl windows_core::RuntimeType for ICompositorWithVisualSurface {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompositorWithVisualSurface_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateVisualSurface: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContainerVisual, IContainerVisual_Vtbl, 0x02f6bc74_ed20_4773_afe6_d49b4a93db32);
+impl windows_core::RuntimeType for IContainerVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContainerVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Children: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IContainerVisualFactory, IContainerVisualFactory_Vtbl, 0x0363a65b_c7da_4d9a_95f4_69b5c8df670b);
+impl windows_core::RuntimeType for IContainerVisualFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContainerVisualFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICubicBezierEasingFunction, ICubicBezierEasingFunction_Vtbl, 0x32350666_c1e8_44f9_96b8_c98acf0ae698);
+impl windows_core::RuntimeType for ICubicBezierEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICubicBezierEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1549,6 +1909,9 @@ pub struct ICubicBezierEasingFunction_Vtbl {
     ControlPoint2: usize,
 }
 windows_core::imp::define_interface!(IDelegatedInkTrailVisual, IDelegatedInkTrailVisual_Vtbl, 0x856e60b1_e1ab_5b23_8e3d_d513f221c998);
+impl windows_core::RuntimeType for IDelegatedInkTrailVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDelegatedInkTrailVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1558,6 +1921,9 @@ pub struct IDelegatedInkTrailVisual_Vtbl {
     pub StartNewTrail: unsafe extern "system" fn(*mut core::ffi::c_void, super::Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDelegatedInkTrailVisualStatics, IDelegatedInkTrailVisualStatics_Vtbl, 0x0daf6bd5_42c6_555c_9267_e0ac663af836);
+impl windows_core::RuntimeType for IDelegatedInkTrailVisualStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDelegatedInkTrailVisualStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1565,6 +1931,9 @@ pub struct IDelegatedInkTrailVisualStatics_Vtbl {
     pub CreateForSwapChain: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDistantLight, IDistantLight_Vtbl, 0x318cfafc_5ce3_4b55_ab5d_07a00353ac99);
+impl windows_core::RuntimeType for IDistantLight {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDistantLight_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1582,6 +1951,9 @@ pub struct IDistantLight_Vtbl {
     SetDirection: usize,
 }
 windows_core::imp::define_interface!(IDistantLight2, IDistantLight2_Vtbl, 0xdbcdaa1c_294b_48d7_b60e_76df64aa392b);
+impl windows_core::RuntimeType for IDistantLight2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDistantLight2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1589,6 +1961,9 @@ pub struct IDistantLight2_Vtbl {
     pub SetIntensity: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDropShadow, IDropShadow_Vtbl, 0xcb977c07_a154_4851_85e7_a8924c84fad8);
+impl windows_core::RuntimeType for IDropShadow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDropShadow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1610,6 +1985,9 @@ pub struct IDropShadow_Vtbl {
     pub SetOpacity: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDropShadow2, IDropShadow2_Vtbl, 0x6c4218bc_15b9_4c2d_8d4a_0767df11977a);
+impl windows_core::RuntimeType for IDropShadow2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDropShadow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1617,6 +1995,9 @@ pub struct IDropShadow2_Vtbl {
     pub SetSourcePolicy: unsafe extern "system" fn(*mut core::ffi::c_void, CompositionDropShadowSourcePolicy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IElasticEasingFunction, IElasticEasingFunction_Vtbl, 0x66de6285_054e_5594_8475_c22cb51f1bd5);
+impl windows_core::RuntimeType for IElasticEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IElasticEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1625,6 +2006,9 @@ pub struct IElasticEasingFunction_Vtbl {
     pub Springiness: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IExponentialEasingFunction, IExponentialEasingFunction_Vtbl, 0x6f7d1a51_98d2_5638_a34a_00486554c750);
+impl windows_core::RuntimeType for IExponentialEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExponentialEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1632,6 +2016,9 @@ pub struct IExponentialEasingFunction_Vtbl {
     pub Exponent: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IExpressionAnimation, IExpressionAnimation_Vtbl, 0x6acc5431_7d3d_4bf3_abb6_f44bdc4888c1);
+impl windows_core::RuntimeType for IExpressionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IExpressionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1639,11 +2026,17 @@ pub struct IExpressionAnimation_Vtbl {
     pub SetExpression: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IImplicitAnimationCollection, IImplicitAnimationCollection_Vtbl, 0x0598a3ff_0a92_4c9d_a427_b25519250dbf);
+impl windows_core::RuntimeType for IImplicitAnimationCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IImplicitAnimationCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IInsetClip, IInsetClip_Vtbl, 0x1e73e647_84c7_477a_b474_5880e0442e15);
+impl windows_core::RuntimeType for IInsetClip {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInsetClip_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1657,6 +2050,9 @@ pub struct IInsetClip_Vtbl {
     pub SetTopInset: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyFrameAnimation, IKeyFrameAnimation_Vtbl, 0x126e7f22_3ae9_4540_9a8a_deae8a4a4a84);
+impl windows_core::RuntimeType for IKeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1675,6 +2071,9 @@ pub struct IKeyFrameAnimation_Vtbl {
     pub InsertExpressionKeyFrameWithEasingFunction: unsafe extern "system" fn(*mut core::ffi::c_void, f32, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyFrameAnimation2, IKeyFrameAnimation2_Vtbl, 0xf4b488bb_2940_4ec0_a41a_eb6d801a2f18);
+impl windows_core::RuntimeType for IKeyFrameAnimation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyFrameAnimation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1682,6 +2081,9 @@ pub struct IKeyFrameAnimation2_Vtbl {
     pub SetDirection: unsafe extern "system" fn(*mut core::ffi::c_void, AnimationDirection) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyFrameAnimation3, IKeyFrameAnimation3_Vtbl, 0x845bf0b4_d8de_462f_8753_c80d43c6ff5a);
+impl windows_core::RuntimeType for IKeyFrameAnimation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyFrameAnimation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1689,11 +2091,17 @@ pub struct IKeyFrameAnimation3_Vtbl {
     pub SetDelayBehavior: unsafe extern "system" fn(*mut core::ffi::c_void, AnimationDelayBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyFrameAnimationFactory, IKeyFrameAnimationFactory_Vtbl, 0xbf0803f8_712a_4fc1_8c87_970859ed8d2e);
+impl windows_core::RuntimeType for IKeyFrameAnimationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyFrameAnimationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ILayerVisual, ILayerVisual_Vtbl, 0xaf843985_0444_4887_8e83_b40b253f822c);
+impl windows_core::RuntimeType for ILayerVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILayerVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1701,6 +2109,9 @@ pub struct ILayerVisual_Vtbl {
     pub SetEffect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILayerVisual2, ILayerVisual2_Vtbl, 0x98f9aeeb_6f23_49f1_90b1_1f59a14fbce3);
+impl windows_core::RuntimeType for ILayerVisual2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILayerVisual2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1708,11 +2119,17 @@ pub struct ILayerVisual2_Vtbl {
     pub SetShadow: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ILinearEasingFunction, ILinearEasingFunction_Vtbl, 0x9400975a_c7a6_46b3_acf7_1a268a0a117d);
+impl windows_core::RuntimeType for ILinearEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ILinearEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(INaturalMotionAnimation, INaturalMotionAnimation_Vtbl, 0x438de12d_769b_4821_a949_284a6547e873);
+impl windows_core::RuntimeType for INaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1724,11 +2141,17 @@ pub struct INaturalMotionAnimation_Vtbl {
     pub SetStopBehavior: unsafe extern "system" fn(*mut core::ffi::c_void, AnimationStopBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INaturalMotionAnimationFactory, INaturalMotionAnimationFactory_Vtbl, 0xf53acb06_cf6a_4387_a3fe_5221f3e7e0e0);
+impl windows_core::RuntimeType for INaturalMotionAnimationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INaturalMotionAnimationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPathKeyFrameAnimation, IPathKeyFrameAnimation_Vtbl, 0x9d0d18c9_1576_4b3f_be60_1d5031f5e71b);
+impl windows_core::RuntimeType for IPathKeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPathKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1736,6 +2159,9 @@ pub struct IPathKeyFrameAnimation_Vtbl {
     pub InsertKeyFrameWithEasingFunction: unsafe extern "system" fn(*mut core::ffi::c_void, f32, *mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointLight, IPointLight_Vtbl, 0xb18545b3_0c5a_4ab0_bedc_4f3546948272);
+impl windows_core::RuntimeType for IPointLight {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointLight_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1759,6 +2185,9 @@ pub struct IPointLight_Vtbl {
     pub SetQuadraticAttenuation: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointLight2, IPointLight2_Vtbl, 0xefe98f2c_0678_4f69_b164_a810d995bcb7);
+impl windows_core::RuntimeType for IPointLight2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointLight2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1766,6 +2195,9 @@ pub struct IPointLight2_Vtbl {
     pub SetIntensity: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointLight3, IPointLight3_Vtbl, 0x4c0a8367_d4e9_468a_87ae_7ba43ab29485);
+impl windows_core::RuntimeType for IPointLight3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointLight3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1775,6 +2207,9 @@ pub struct IPointLight3_Vtbl {
     pub SetMaxAttenuationCutoff: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPowerEasingFunction, IPowerEasingFunction_Vtbl, 0xc3ff53d6_138b_5815_891a_b7f615ccc563);
+impl windows_core::RuntimeType for IPowerEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPowerEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1782,6 +2217,9 @@ pub struct IPowerEasingFunction_Vtbl {
     pub Power: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IQuaternionKeyFrameAnimation, IQuaternionKeyFrameAnimation_Vtbl, 0x404e5835_ecf6_4240_8520_671279cf36bc);
+impl windows_core::RuntimeType for IQuaternionKeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IQuaternionKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1795,6 +2233,9 @@ pub struct IQuaternionKeyFrameAnimation_Vtbl {
     InsertKeyFrameWithEasingFunction: usize,
 }
 windows_core::imp::define_interface!(IRectangleClip, IRectangleClip_Vtbl, 0xb3e7549e_00b4_5b53_8be8_353f6c433101);
+impl windows_core::RuntimeType for IRectangleClip {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRectangleClip_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1840,6 +2281,9 @@ pub struct IRectangleClip_Vtbl {
     SetTopRightRadius: usize,
 }
 windows_core::imp::define_interface!(IRedirectVisual, IRedirectVisual_Vtbl, 0x8cc6e340_8b75_5422_b06f_09ffe9f8617e);
+impl windows_core::RuntimeType for IRedirectVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRedirectVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1847,12 +2291,18 @@ pub struct IRedirectVisual_Vtbl {
     pub SetSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRenderingDeviceReplacedEventArgs, IRenderingDeviceReplacedEventArgs_Vtbl, 0x3a31ac7d_28bf_4e7a_8524_71679d480f38);
+impl windows_core::RuntimeType for IRenderingDeviceReplacedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRenderingDeviceReplacedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GraphicsDevice: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScalarKeyFrameAnimation, IScalarKeyFrameAnimation_Vtbl, 0xae288fa9_252c_4b95_a725_bf85e38000a1);
+impl windows_core::RuntimeType for IScalarKeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScalarKeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1860,6 +2310,9 @@ pub struct IScalarKeyFrameAnimation_Vtbl {
     pub InsertKeyFrameWithEasingFunction: unsafe extern "system" fn(*mut core::ffi::c_void, f32, f32, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScalarNaturalMotionAnimation, IScalarNaturalMotionAnimation_Vtbl, 0x94a94581_bf92_495b_b5bd_d2c659430737);
+impl windows_core::RuntimeType for IScalarNaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScalarNaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1871,11 +2324,17 @@ pub struct IScalarNaturalMotionAnimation_Vtbl {
     pub SetInitialVelocity: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScalarNaturalMotionAnimationFactory, IScalarNaturalMotionAnimationFactory_Vtbl, 0x835aa4fc_671c_41dd_af48_ae8def8b1529);
+impl windows_core::RuntimeType for IScalarNaturalMotionAnimationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScalarNaturalMotionAnimationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IShapeVisual, IShapeVisual_Vtbl, 0xf2bd13c3_ba7e_4b0f_9126_ffb7536b8176);
+impl windows_core::RuntimeType for IShapeVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShapeVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1887,12 +2346,18 @@ pub struct IShapeVisual_Vtbl {
     pub SetViewBox: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISineEasingFunction, ISineEasingFunction_Vtbl, 0xf1b518bf_9563_5474_bd13_44b2df4b1d58);
+impl windows_core::RuntimeType for ISineEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISineEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Mode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CompositionEasingFunctionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpotLight, ISpotLight_Vtbl, 0x5a9fe273_44a1_4f95_a422_8fa5116bdb44);
+impl windows_core::RuntimeType for ISpotLight {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpotLight_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1934,6 +2399,9 @@ pub struct ISpotLight_Vtbl {
     pub SetQuadraticAttenuation: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpotLight2, ISpotLight2_Vtbl, 0x64ee615e_0686_4dea_a9e8_bc3a8c701459);
+impl windows_core::RuntimeType for ISpotLight2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpotLight2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1943,6 +2411,9 @@ pub struct ISpotLight2_Vtbl {
     pub SetOuterConeIntensity: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpotLight3, ISpotLight3_Vtbl, 0xe4d03eea_131f_480e_859e_b82705b74360);
+impl windows_core::RuntimeType for ISpotLight3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpotLight3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1952,6 +2423,9 @@ pub struct ISpotLight3_Vtbl {
     pub SetMaxAttenuationCutoff: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpringScalarNaturalMotionAnimation, ISpringScalarNaturalMotionAnimation_Vtbl, 0x0572a95f_37f9_4fbe_b87b_5cd03a89501c);
+impl windows_core::RuntimeType for ISpringScalarNaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpringScalarNaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1961,6 +2435,9 @@ pub struct ISpringScalarNaturalMotionAnimation_Vtbl {
     pub SetPeriod: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpringVector2NaturalMotionAnimation, ISpringVector2NaturalMotionAnimation_Vtbl, 0x23f494b5_ee73_4f0f_a423_402b946df4b3);
+impl windows_core::RuntimeType for ISpringVector2NaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpringVector2NaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1970,6 +2447,9 @@ pub struct ISpringVector2NaturalMotionAnimation_Vtbl {
     pub SetPeriod: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpringVector3NaturalMotionAnimation, ISpringVector3NaturalMotionAnimation_Vtbl, 0x6c8749df_d57b_4794_8e2d_cecb11e194e5);
+impl windows_core::RuntimeType for ISpringVector3NaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpringVector3NaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1979,6 +2459,9 @@ pub struct ISpringVector3NaturalMotionAnimation_Vtbl {
     pub SetPeriod: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpriteVisual, ISpriteVisual_Vtbl, 0x08e05581_1ad1_4f97_9757_402d76e4233b);
+impl windows_core::RuntimeType for ISpriteVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpriteVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1986,6 +2469,9 @@ pub struct ISpriteVisual_Vtbl {
     pub SetBrush: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpriteVisual2, ISpriteVisual2_Vtbl, 0x588c9664_997a_4850_91fe_53cb58f81ce9);
+impl windows_core::RuntimeType for ISpriteVisual2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpriteVisual2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1993,6 +2479,9 @@ pub struct ISpriteVisual2_Vtbl {
     pub SetShadow: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStepEasingFunction, IStepEasingFunction_Vtbl, 0xd0caa74b_560c_4a0b_a5f6_206ca8c3ecd6);
+impl windows_core::RuntimeType for IStepEasingFunction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStepEasingFunction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2008,6 +2497,9 @@ pub struct IStepEasingFunction_Vtbl {
     pub SetStepCount: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVector2KeyFrameAnimation, IVector2KeyFrameAnimation_Vtbl, 0xdf414515_4e29_4f11_b55e_bf2a6eb36294);
+impl windows_core::RuntimeType for IVector2KeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVector2KeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2021,6 +2513,9 @@ pub struct IVector2KeyFrameAnimation_Vtbl {
     InsertKeyFrameWithEasingFunction: usize,
 }
 windows_core::imp::define_interface!(IVector2NaturalMotionAnimation, IVector2NaturalMotionAnimation_Vtbl, 0x0f3e0b7d_e512_479d_a00c_77c93a30a395);
+impl windows_core::RuntimeType for IVector2NaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVector2NaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2050,11 +2545,17 @@ pub struct IVector2NaturalMotionAnimation_Vtbl {
     SetInitialVelocity: usize,
 }
 windows_core::imp::define_interface!(IVector2NaturalMotionAnimationFactory, IVector2NaturalMotionAnimationFactory_Vtbl, 0x8c74ff61_0761_48a2_bddb_6afcc52b89d8);
+impl windows_core::RuntimeType for IVector2NaturalMotionAnimationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVector2NaturalMotionAnimationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IVector3KeyFrameAnimation, IVector3KeyFrameAnimation_Vtbl, 0xc8039daa_a281_43c2_a73d_b68e3c533c40);
+impl windows_core::RuntimeType for IVector3KeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVector3KeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2068,6 +2569,9 @@ pub struct IVector3KeyFrameAnimation_Vtbl {
     InsertKeyFrameWithEasingFunction: usize,
 }
 windows_core::imp::define_interface!(IVector3NaturalMotionAnimation, IVector3NaturalMotionAnimation_Vtbl, 0x9c17042c_e2ca_45ad_969e_4e78b7b9ad41);
+impl windows_core::RuntimeType for IVector3NaturalMotionAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVector3NaturalMotionAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2097,11 +2601,17 @@ pub struct IVector3NaturalMotionAnimation_Vtbl {
     SetInitialVelocity: usize,
 }
 windows_core::imp::define_interface!(IVector3NaturalMotionAnimationFactory, IVector3NaturalMotionAnimationFactory_Vtbl, 0x21a81d2f_0880_457b_ac87_b609018c876d);
+impl windows_core::RuntimeType for IVector3NaturalMotionAnimationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVector3NaturalMotionAnimationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IVector4KeyFrameAnimation, IVector4KeyFrameAnimation_Vtbl, 0x2457945b_addd_4385_9606_b6a3d5e4e1b9);
+impl windows_core::RuntimeType for IVector4KeyFrameAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVector4KeyFrameAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2115,6 +2625,9 @@ pub struct IVector4KeyFrameAnimation_Vtbl {
     InsertKeyFrameWithEasingFunction: usize,
 }
 windows_core::imp::define_interface!(IVisual, IVisual_Vtbl, 0x117e202d_a859_4c89_873b_c2aa566788e3);
+impl windows_core::RuntimeType for IVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2201,6 +2714,9 @@ pub struct IVisual_Vtbl {
     SetTransformMatrix: usize,
 }
 windows_core::imp::define_interface!(IVisual2, IVisual2_Vtbl, 0x3052b611_56c3_4c3e_8bf3_f6e1ad473f06);
+impl windows_core::RuntimeType for IVisual2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisual2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2224,6 +2740,9 @@ pub struct IVisual2_Vtbl {
     SetRelativeSizeAdjustment: usize,
 }
 windows_core::imp::define_interface!(IVisual3, IVisual3_Vtbl, 0x30be580d_f4b6_4ab7_80dd_3738cbac9f2c);
+impl windows_core::RuntimeType for IVisual3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisual3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2231,6 +2750,9 @@ pub struct IVisual3_Vtbl {
     pub SetIsHitTestVisible: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisual4, IVisual4_Vtbl, 0x9476bf11_e24b_5bf9_9ebe_6274109b2711);
+impl windows_core::RuntimeType for IVisual4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisual4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2238,6 +2760,9 @@ pub struct IVisual4_Vtbl {
     pub SetIsPixelSnappingEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualCollection, IVisualCollection_Vtbl, 0x8b745505_fd3e_4a98_84a8_e949468c6bcb);
+impl windows_core::RuntimeType for IVisualCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2279,11 +2804,17 @@ pub struct IVisualElement2_Vtbl {
     pub GetVisualInternal: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualFactory, IVisualFactory_Vtbl, 0xad0ff93e_b502_4eb5_87b4_9a38a71d0137);
+impl windows_core::RuntimeType for IVisualFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IVisualUnorderedCollection, IVisualUnorderedCollection_Vtbl, 0x338faa70_54c8_40a7_8029_c9ceeb0aa250);
+impl windows_core::RuntimeType for IVisualUnorderedCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualUnorderedCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -2453,7 +2984,7 @@ impl AmbientLight {
     }
 }
 impl windows_core::RuntimeType for AmbientLight {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAmbientLight>();
 }
 unsafe impl windows_core::Interface for AmbientLight {
     type Vtable = IAmbientLight_Vtbl;
@@ -2636,7 +3167,7 @@ impl AnimationController {
     }
 }
 impl windows_core::RuntimeType for AnimationController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAnimationController>();
 }
 unsafe impl windows_core::Interface for AnimationController {
     type Vtable = IAnimationController_Vtbl;
@@ -2786,7 +3317,7 @@ impl AnimationPropertyInfo {
     }
 }
 impl windows_core::RuntimeType for AnimationPropertyInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAnimationPropertyInfo>();
 }
 unsafe impl windows_core::Interface for AnimationPropertyInfo {
     type Vtable = IAnimationPropertyInfo_Vtbl;
@@ -2925,7 +3456,7 @@ impl BackEasingFunction {
     }
 }
 impl windows_core::RuntimeType for BackEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackEasingFunction>();
 }
 unsafe impl windows_core::Interface for BackEasingFunction {
     type Vtable = IBackEasingFunction_Vtbl;
@@ -3232,7 +3763,7 @@ impl BooleanKeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for BooleanKeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBooleanKeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for BooleanKeyFrameAnimation {
     type Vtable = IBooleanKeyFrameAnimation_Vtbl;
@@ -3378,7 +3909,7 @@ impl BounceEasingFunction {
     }
 }
 impl windows_core::RuntimeType for BounceEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBounceEasingFunction>();
 }
 unsafe impl windows_core::Interface for BounceEasingFunction {
     type Vtable = IBounceEasingFunction_Vtbl;
@@ -3680,7 +4211,7 @@ impl BounceScalarNaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for BounceScalarNaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBounceScalarNaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for BounceScalarNaturalMotionAnimation {
     type Vtable = IBounceScalarNaturalMotionAnimation_Vtbl;
@@ -3988,7 +4519,7 @@ impl BounceVector2NaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for BounceVector2NaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBounceVector2NaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for BounceVector2NaturalMotionAnimation {
     type Vtable = IBounceVector2NaturalMotionAnimation_Vtbl;
@@ -4296,7 +4827,7 @@ impl BounceVector3NaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for BounceVector3NaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBounceVector3NaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for BounceVector3NaturalMotionAnimation {
     type Vtable = IBounceVector3NaturalMotionAnimation_Vtbl;
@@ -4428,7 +4959,7 @@ impl CircleEasingFunction {
     }
 }
 impl windows_core::RuntimeType for CircleEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICircleEasingFunction>();
 }
 unsafe impl windows_core::Interface for CircleEasingFunction {
     type Vtable = ICircleEasingFunction_Vtbl;
@@ -4753,7 +5284,7 @@ impl ColorKeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for ColorKeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IColorKeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for ColorKeyFrameAnimation {
     type Vtable = IColorKeyFrameAnimation_Vtbl;
@@ -4961,7 +5492,7 @@ impl CompositionAnimation {
     }
 }
 impl windows_core::RuntimeType for CompositionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionAnimation>();
 }
 unsafe impl windows_core::Interface for CompositionAnimation {
     type Vtable = ICompositionAnimation_Vtbl;
@@ -5120,7 +5651,7 @@ impl CompositionAnimationGroup {
     }
 }
 impl windows_core::RuntimeType for CompositionAnimationGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionAnimationGroup>();
 }
 unsafe impl windows_core::Interface for CompositionAnimationGroup {
     type Vtable = ICompositionAnimationGroup_Vtbl;
@@ -5261,7 +5792,7 @@ impl CompositionBackdropBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionBackdropBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionBackdropBrush>();
 }
 unsafe impl windows_core::Interface for CompositionBackdropBrush {
     type Vtable = ICompositionBackdropBrush_Vtbl;
@@ -5386,7 +5917,7 @@ impl CompositionBatchCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CompositionBatchCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionBatchCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for CompositionBatchCompletedEventArgs {
     type Vtable = ICompositionBatchCompletedEventArgs_Vtbl;
@@ -5511,7 +6042,7 @@ impl CompositionBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionBrush>();
 }
 unsafe impl windows_core::Interface for CompositionBrush {
     type Vtable = ICompositionBrush_Vtbl;
@@ -5568,7 +6099,7 @@ impl CompositionCapabilities {
     }
 }
 impl windows_core::RuntimeType for CompositionCapabilities {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionCapabilities>();
 }
 unsafe impl windows_core::Interface for CompositionCapabilities {
     type Vtable = ICompositionCapabilities_Vtbl;
@@ -5780,7 +6311,7 @@ impl CompositionClip {
     }
 }
 impl windows_core::RuntimeType for CompositionClip {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionClip>();
 }
 unsafe impl windows_core::Interface for CompositionClip {
     type Vtable = ICompositionClip_Vtbl;
@@ -5916,7 +6447,7 @@ impl CompositionColorBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionColorBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionColorBrush>();
 }
 unsafe impl windows_core::Interface for CompositionColorBrush {
     type Vtable = ICompositionColorBrush_Vtbl;
@@ -6063,7 +6594,7 @@ impl CompositionColorGradientStop {
     }
 }
 impl windows_core::RuntimeType for CompositionColorGradientStop {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionColorGradientStop>();
 }
 unsafe impl windows_core::Interface for CompositionColorGradientStop {
     type Vtable = ICompositionColorGradientStop_Vtbl;
@@ -6178,7 +6709,7 @@ impl CompositionColorGradientStopCollection {
     }
 }
 impl windows_core::RuntimeType for CompositionColorGradientStopCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionColorGradientStopCollection>();
 }
 unsafe impl windows_core::Interface for CompositionColorGradientStopCollection {
     type Vtable = ICompositionColorGradientStopCollection_Vtbl;
@@ -6347,7 +6878,7 @@ impl CompositionCommitBatch {
     }
 }
 impl windows_core::RuntimeType for CompositionCommitBatch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionCommitBatch>();
 }
 unsafe impl windows_core::Interface for CompositionCommitBatch {
     type Vtable = ICompositionCommitBatch_Vtbl;
@@ -6554,7 +7085,7 @@ impl CompositionContainerShape {
     }
 }
 impl windows_core::RuntimeType for CompositionContainerShape {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionContainerShape>();
 }
 unsafe impl windows_core::Interface for CompositionContainerShape {
     type Vtable = ICompositionContainerShape_Vtbl;
@@ -6735,7 +7266,7 @@ impl CompositionDrawingSurface {
     }
 }
 impl windows_core::RuntimeType for CompositionDrawingSurface {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionDrawingSurface>();
 }
 unsafe impl windows_core::Interface for CompositionDrawingSurface {
     type Vtable = ICompositionDrawingSurface_Vtbl;
@@ -6965,7 +7496,7 @@ impl CompositionEasingFunction {
     }
 }
 impl windows_core::RuntimeType for CompositionEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionEasingFunction>();
 }
 unsafe impl windows_core::Interface for CompositionEasingFunction {
     type Vtable = ICompositionEasingFunction_Vtbl;
@@ -7104,7 +7635,7 @@ impl CompositionEffectBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionEffectBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionEffectBrush>();
 }
 unsafe impl windows_core::Interface for CompositionEffectBrush {
     type Vtable = ICompositionEffectBrush_Vtbl;
@@ -7250,7 +7781,7 @@ impl CompositionEffectFactory {
     }
 }
 impl windows_core::RuntimeType for CompositionEffectFactory {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionEffectFactory>();
 }
 unsafe impl windows_core::Interface for CompositionEffectFactory {
     type Vtable = ICompositionEffectFactory_Vtbl;
@@ -7288,7 +7819,7 @@ impl CompositionEffectSourceParameter {
     }
 }
 impl windows_core::RuntimeType for CompositionEffectSourceParameter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionEffectSourceParameter>();
 }
 unsafe impl windows_core::Interface for CompositionEffectSourceParameter {
     type Vtable = ICompositionEffectSourceParameter_Vtbl;
@@ -7472,7 +8003,7 @@ impl CompositionEllipseGeometry {
     }
 }
 impl windows_core::RuntimeType for CompositionEllipseGeometry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionEllipseGeometry>();
 }
 unsafe impl windows_core::Interface for CompositionEllipseGeometry {
     type Vtable = ICompositionEllipseGeometry_Vtbl;
@@ -7712,7 +8243,7 @@ impl CompositionGeometricClip {
     }
 }
 impl windows_core::RuntimeType for CompositionGeometricClip {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionGeometricClip>();
 }
 unsafe impl windows_core::Interface for CompositionGeometricClip {
     type Vtable = ICompositionGeometricClip_Vtbl;
@@ -7870,7 +8401,7 @@ impl CompositionGeometry {
     }
 }
 impl windows_core::RuntimeType for CompositionGeometry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionGeometry>();
 }
 unsafe impl windows_core::Interface for CompositionGeometry {
     type Vtable = ICompositionGeometry_Vtbl;
@@ -8122,7 +8653,7 @@ impl CompositionGradientBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionGradientBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionGradientBrush>();
 }
 unsafe impl windows_core::Interface for CompositionGradientBrush {
     type Vtable = ICompositionGradientBrush_Vtbl;
@@ -8308,7 +8839,7 @@ impl CompositionGraphicsDevice {
     }
 }
 impl windows_core::RuntimeType for CompositionGraphicsDevice {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionGraphicsDevice>();
 }
 unsafe impl windows_core::Interface for CompositionGraphicsDevice {
     type Vtable = ICompositionGraphicsDevice_Vtbl;
@@ -8458,7 +8989,7 @@ impl CompositionLight {
     }
 }
 impl windows_core::RuntimeType for CompositionLight {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionLight>();
 }
 unsafe impl windows_core::Interface for CompositionLight {
     type Vtable = ICompositionLight_Vtbl;
@@ -8642,7 +9173,7 @@ impl CompositionLineGeometry {
     }
 }
 impl windows_core::RuntimeType for CompositionLineGeometry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionLineGeometry>();
 }
 unsafe impl windows_core::Interface for CompositionLineGeometry {
     type Vtable = ICompositionLineGeometry_Vtbl;
@@ -8920,7 +9451,7 @@ impl CompositionLinearGradientBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionLinearGradientBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionLinearGradientBrush>();
 }
 unsafe impl windows_core::Interface for CompositionLinearGradientBrush {
     type Vtable = ICompositionLinearGradientBrush_Vtbl;
@@ -9073,7 +9604,7 @@ impl CompositionMaskBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionMaskBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionMaskBrush>();
 }
 unsafe impl windows_core::Interface for CompositionMaskBrush {
     type Vtable = ICompositionMaskBrush_Vtbl;
@@ -9236,7 +9767,7 @@ impl CompositionMipmapSurface {
     }
 }
 impl windows_core::RuntimeType for CompositionMipmapSurface {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionMipmapSurface>();
 }
 unsafe impl windows_core::Interface for CompositionMipmapSurface {
     type Vtable = ICompositionMipmapSurface_Vtbl;
@@ -9490,7 +10021,7 @@ impl CompositionNineGridBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionNineGridBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionNineGridBrush>();
 }
 unsafe impl windows_core::Interface for CompositionNineGridBrush {
     type Vtable = ICompositionNineGridBrush_Vtbl;
@@ -9634,7 +10165,7 @@ impl CompositionObject {
     }
 }
 impl windows_core::RuntimeType for CompositionObject {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionObject>();
 }
 unsafe impl windows_core::Interface for CompositionObject {
     type Vtable = ICompositionObject_Vtbl;
@@ -9669,7 +10200,7 @@ impl CompositionPath {
     }
 }
 impl windows_core::RuntimeType for CompositionPath {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionPath>();
 }
 unsafe impl windows_core::Interface for CompositionPath {
     type Vtable = ICompositionPath_Vtbl;
@@ -9841,7 +10372,7 @@ impl CompositionPathGeometry {
     }
 }
 impl windows_core::RuntimeType for CompositionPathGeometry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionPathGeometry>();
 }
 unsafe impl windows_core::Interface for CompositionPathGeometry {
     type Vtable = ICompositionPathGeometry_Vtbl;
@@ -10027,7 +10558,7 @@ impl CompositionProjectedShadow {
     }
 }
 impl windows_core::RuntimeType for CompositionProjectedShadow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionProjectedShadow>();
 }
 unsafe impl windows_core::Interface for CompositionProjectedShadow {
     type Vtable = ICompositionProjectedShadow_Vtbl;
@@ -10180,7 +10711,7 @@ impl CompositionProjectedShadowCaster {
     }
 }
 impl windows_core::RuntimeType for CompositionProjectedShadowCaster {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionProjectedShadowCaster>();
 }
 unsafe impl windows_core::Interface for CompositionProjectedShadowCaster {
     type Vtable = ICompositionProjectedShadowCaster_Vtbl;
@@ -10373,7 +10904,7 @@ impl CompositionProjectedShadowCasterCollection {
     }
 }
 impl windows_core::RuntimeType for CompositionProjectedShadowCasterCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionProjectedShadowCasterCollection>();
 }
 unsafe impl windows_core::Interface for CompositionProjectedShadowCasterCollection {
     type Vtable = ICompositionProjectedShadowCasterCollection_Vtbl;
@@ -10528,7 +11059,7 @@ impl CompositionProjectedShadowReceiver {
     }
 }
 impl windows_core::RuntimeType for CompositionProjectedShadowReceiver {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionProjectedShadowReceiver>();
 }
 unsafe impl windows_core::Interface for CompositionProjectedShadowReceiver {
     type Vtable = ICompositionProjectedShadowReceiver_Vtbl;
@@ -10687,7 +11218,7 @@ impl CompositionProjectedShadowReceiverUnorderedCollection {
     }
 }
 impl windows_core::RuntimeType for CompositionProjectedShadowReceiverUnorderedCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionProjectedShadowReceiverUnorderedCollection>();
 }
 unsafe impl windows_core::Interface for CompositionProjectedShadowReceiverUnorderedCollection {
     type Vtable = ICompositionProjectedShadowReceiverUnorderedCollection_Vtbl;
@@ -10939,7 +11470,7 @@ impl CompositionPropertySet {
     }
 }
 impl windows_core::RuntimeType for CompositionPropertySet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionPropertySet>();
 }
 unsafe impl windows_core::Interface for CompositionPropertySet {
     type Vtable = ICompositionPropertySet_Vtbl;
@@ -11230,7 +11761,7 @@ impl CompositionRadialGradientBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionRadialGradientBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionRadialGradientBrush>();
 }
 unsafe impl windows_core::Interface for CompositionRadialGradientBrush {
     type Vtable = ICompositionRadialGradientBrush_Vtbl;
@@ -11414,7 +11945,7 @@ impl CompositionRectangleGeometry {
     }
 }
 impl windows_core::RuntimeType for CompositionRectangleGeometry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionRectangleGeometry>();
 }
 unsafe impl windows_core::Interface for CompositionRectangleGeometry {
     type Vtable = ICompositionRectangleGeometry_Vtbl;
@@ -11611,7 +12142,7 @@ impl CompositionRoundedRectangleGeometry {
     }
 }
 impl windows_core::RuntimeType for CompositionRoundedRectangleGeometry {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionRoundedRectangleGeometry>();
 }
 unsafe impl windows_core::Interface for CompositionRoundedRectangleGeometry {
     type Vtable = ICompositionRoundedRectangleGeometry_Vtbl;
@@ -11776,7 +12307,7 @@ impl CompositionScopedBatch {
     }
 }
 impl windows_core::RuntimeType for CompositionScopedBatch {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionScopedBatch>();
 }
 unsafe impl windows_core::Interface for CompositionScopedBatch {
     type Vtable = ICompositionScopedBatch_Vtbl;
@@ -11901,7 +12432,7 @@ impl CompositionShadow {
     }
 }
 impl windows_core::RuntimeType for CompositionShadow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionShadow>();
 }
 unsafe impl windows_core::Interface for CompositionShadow {
     type Vtable = ICompositionShadow_Vtbl;
@@ -12100,7 +12631,7 @@ impl CompositionShape {
     }
 }
 impl windows_core::RuntimeType for CompositionShape {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionShape>();
 }
 unsafe impl windows_core::Interface for CompositionShape {
     type Vtable = ICompositionShape_Vtbl;
@@ -12325,7 +12856,7 @@ impl CompositionShapeCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for CompositionShapeCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVector<CompositionShape>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for CompositionShapeCollection {
@@ -12682,7 +13213,7 @@ impl CompositionSpriteShape {
     }
 }
 impl windows_core::RuntimeType for CompositionSpriteShape {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionSpriteShape>();
 }
 unsafe impl windows_core::Interface for CompositionSpriteShape {
     type Vtable = ICompositionSpriteShape_Vtbl;
@@ -12895,7 +13426,7 @@ impl CompositionStrokeDashArray {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for CompositionStrokeDashArray {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVector<f32>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for CompositionStrokeDashArray {
@@ -13196,7 +13727,7 @@ impl CompositionSurfaceBrush {
     }
 }
 impl windows_core::RuntimeType for CompositionSurfaceBrush {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionSurfaceBrush>();
 }
 unsafe impl windows_core::Interface for CompositionSurfaceBrush {
     type Vtable = ICompositionSurfaceBrush_Vtbl;
@@ -13335,7 +13866,7 @@ impl CompositionTarget {
     }
 }
 impl windows_core::RuntimeType for CompositionTarget {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionTarget>();
 }
 unsafe impl windows_core::Interface for CompositionTarget {
     type Vtable = ICompositionTarget_Vtbl;
@@ -13499,7 +14030,7 @@ impl CompositionTexture {
     }
 }
 impl windows_core::RuntimeType for CompositionTexture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionTexture>();
 }
 unsafe impl windows_core::Interface for CompositionTexture {
     type Vtable = ICompositionTexture_Vtbl;
@@ -13624,7 +14155,7 @@ impl CompositionTransform {
     }
 }
 impl windows_core::RuntimeType for CompositionTransform {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionTransform>();
 }
 unsafe impl windows_core::Interface for CompositionTransform {
     type Vtable = ICompositionTransform_Vtbl;
@@ -13808,7 +14339,7 @@ impl CompositionViewBox {
     }
 }
 impl windows_core::RuntimeType for CompositionViewBox {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionViewBox>();
 }
 unsafe impl windows_core::Interface for CompositionViewBox {
     type Vtable = ICompositionViewBox_Vtbl;
@@ -13994,7 +14525,7 @@ impl CompositionVirtualDrawingSurface {
     }
 }
 impl windows_core::RuntimeType for CompositionVirtualDrawingSurface {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionVirtualDrawingSurface>();
 }
 unsafe impl windows_core::Interface for CompositionVirtualDrawingSurface {
     type Vtable = ICompositionVirtualDrawingSurface_Vtbl;
@@ -14159,7 +14690,7 @@ impl CompositionVisualSurface {
     }
 }
 impl windows_core::RuntimeType for CompositionVisualSurface {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositionVisualSurface>();
 }
 unsafe impl windows_core::Interface for CompositionVisualSurface {
     type Vtable = ICompositionVisualSurface_Vtbl;
@@ -14794,7 +15325,7 @@ impl Compositor {
     }
 }
 impl windows_core::RuntimeType for Compositor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompositor>();
 }
 unsafe impl windows_core::Interface for Compositor {
     type Vtable = ICompositor_Vtbl;
@@ -15190,7 +15721,7 @@ impl ContainerVisual {
     }
 }
 impl windows_core::RuntimeType for ContainerVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContainerVisual>();
 }
 unsafe impl windows_core::Interface for ContainerVisual {
     type Vtable = IContainerVisual_Vtbl;
@@ -15331,7 +15862,7 @@ impl CubicBezierEasingFunction {
     }
 }
 impl windows_core::RuntimeType for CubicBezierEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICubicBezierEasingFunction>();
 }
 unsafe impl windows_core::Interface for CubicBezierEasingFunction {
     type Vtable = ICubicBezierEasingFunction_Vtbl;
@@ -15766,7 +16297,7 @@ impl DelegatedInkTrailVisual {
     }
 }
 impl windows_core::RuntimeType for DelegatedInkTrailVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDelegatedInkTrailVisual>();
 }
 unsafe impl windows_core::Interface for DelegatedInkTrailVisual {
     type Vtable = IDelegatedInkTrailVisual_Vtbl;
@@ -15965,7 +16496,7 @@ impl DistantLight {
     }
 }
 impl windows_core::RuntimeType for DistantLight {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDistantLight>();
 }
 unsafe impl windows_core::Interface for DistantLight {
     type Vtable = IDistantLight_Vtbl;
@@ -16161,7 +16692,7 @@ impl DropShadow {
     }
 }
 impl windows_core::RuntimeType for DropShadow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDropShadow>();
 }
 unsafe impl windows_core::Interface for DropShadow {
     type Vtable = IDropShadow_Vtbl;
@@ -16307,7 +16838,7 @@ impl ElasticEasingFunction {
     }
 }
 impl windows_core::RuntimeType for ElasticEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IElasticEasingFunction>();
 }
 unsafe impl windows_core::Interface for ElasticEasingFunction {
     type Vtable = IElasticEasingFunction_Vtbl;
@@ -16446,7 +16977,7 @@ impl ExponentialEasingFunction {
     }
 }
 impl windows_core::RuntimeType for ExponentialEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExponentialEasingFunction>();
 }
 unsafe impl windows_core::Interface for ExponentialEasingFunction {
     type Vtable = IExponentialEasingFunction_Vtbl;
@@ -16665,7 +17196,7 @@ impl ExpressionAnimation {
     }
 }
 impl windows_core::RuntimeType for ExpressionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IExpressionAnimation>();
 }
 unsafe impl windows_core::Interface for ExpressionAnimation {
     type Vtable = IExpressionAnimation_Vtbl;
@@ -16852,7 +17383,7 @@ impl ImplicitAnimationCollection {
     }
 }
 impl windows_core::RuntimeType for ImplicitAnimationCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IImplicitAnimationCollection>();
 }
 unsafe impl windows_core::Interface for ImplicitAnimationCollection {
     type Vtable = IImplicitAnimationCollection_Vtbl;
@@ -17056,7 +17587,7 @@ impl InitialValueExpressionCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for InitialValueExpressionCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IMap<windows_core::HSTRING, windows_core::HSTRING>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for InitialValueExpressionCollection {
@@ -17332,7 +17863,7 @@ impl InsetClip {
     }
 }
 impl windows_core::RuntimeType for InsetClip {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInsetClip>();
 }
 unsafe impl windows_core::Interface for InsetClip {
     type Vtable = IInsetClip_Vtbl;
@@ -17635,7 +18166,7 @@ impl KeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for KeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for KeyFrameAnimation {
     type Vtable = IKeyFrameAnimation_Vtbl;
@@ -18059,7 +18590,7 @@ impl LayerVisual {
     }
 }
 impl windows_core::RuntimeType for LayerVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILayerVisual>();
 }
 unsafe impl windows_core::Interface for LayerVisual {
     type Vtable = ILayerVisual_Vtbl;
@@ -18184,7 +18715,7 @@ impl LinearEasingFunction {
     }
 }
 impl windows_core::RuntimeType for LinearEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ILinearEasingFunction>();
 }
 unsafe impl windows_core::Interface for LinearEasingFunction {
     type Vtable = ILinearEasingFunction_Vtbl;
@@ -18425,7 +18956,7 @@ impl NaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for NaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for NaturalMotionAnimation {
     type Vtable = INaturalMotionAnimation_Vtbl;
@@ -18743,7 +19274,7 @@ impl PathKeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for PathKeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPathKeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for PathKeyFrameAnimation {
     type Vtable = IPathKeyFrameAnimation_Vtbl;
@@ -18997,7 +19528,7 @@ impl PointLight {
     }
 }
 impl windows_core::RuntimeType for PointLight {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPointLight>();
 }
 unsafe impl windows_core::Interface for PointLight {
     type Vtable = IPointLight_Vtbl;
@@ -19136,7 +19667,7 @@ impl PowerEasingFunction {
     }
 }
 impl windows_core::RuntimeType for PowerEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPowerEasingFunction>();
 }
 unsafe impl windows_core::Interface for PowerEasingFunction {
     type Vtable = IPowerEasingFunction_Vtbl;
@@ -19452,7 +19983,7 @@ impl QuaternionKeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for QuaternionKeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IQuaternionKeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for QuaternionKeyFrameAnimation {
     type Vtable = IQuaternionKeyFrameAnimation_Vtbl;
@@ -19760,7 +20291,7 @@ impl RectangleClip {
     }
 }
 impl windows_core::RuntimeType for RectangleClip {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRectangleClip>();
 }
 unsafe impl windows_core::Interface for RectangleClip {
     type Vtable = IRectangleClip_Vtbl;
@@ -20170,7 +20701,7 @@ impl RedirectVisual {
     }
 }
 impl windows_core::RuntimeType for RedirectVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRedirectVisual>();
 }
 unsafe impl windows_core::Interface for RedirectVisual {
     type Vtable = IRedirectVisual_Vtbl;
@@ -20302,7 +20833,7 @@ impl RenderingDeviceReplacedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RenderingDeviceReplacedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRenderingDeviceReplacedEventArgs>();
 }
 unsafe impl windows_core::Interface for RenderingDeviceReplacedEventArgs {
     type Vtable = IRenderingDeviceReplacedEventArgs_Vtbl;
@@ -20616,7 +21147,7 @@ impl ScalarKeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for ScalarKeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScalarKeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for ScalarKeyFrameAnimation {
     type Vtable = IScalarKeyFrameAnimation_Vtbl;
@@ -20896,7 +21427,7 @@ impl ScalarNaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for ScalarNaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScalarNaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for ScalarNaturalMotionAnimation {
     type Vtable = IScalarNaturalMotionAnimation_Vtbl;
@@ -21314,7 +21845,7 @@ impl ShapeVisual {
     }
 }
 impl windows_core::RuntimeType for ShapeVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShapeVisual>();
 }
 unsafe impl windows_core::Interface for ShapeVisual {
     type Vtable = IShapeVisual_Vtbl;
@@ -21446,7 +21977,7 @@ impl SineEasingFunction {
     }
 }
 impl windows_core::RuntimeType for SineEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISineEasingFunction>();
 }
 unsafe impl windows_core::Interface for SineEasingFunction {
     type Vtable = ISineEasingFunction_Vtbl;
@@ -21779,7 +22310,7 @@ impl SpotLight {
     }
 }
 impl windows_core::RuntimeType for SpotLight {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpotLight>();
 }
 unsafe impl windows_core::Interface for SpotLight {
     type Vtable = ISpotLight_Vtbl;
@@ -22081,7 +22612,7 @@ impl SpringScalarNaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for SpringScalarNaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpringScalarNaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for SpringScalarNaturalMotionAnimation {
     type Vtable = ISpringScalarNaturalMotionAnimation_Vtbl;
@@ -22389,7 +22920,7 @@ impl SpringVector2NaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for SpringVector2NaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpringVector2NaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for SpringVector2NaturalMotionAnimation {
     type Vtable = ISpringVector2NaturalMotionAnimation_Vtbl;
@@ -22697,7 +23228,7 @@ impl SpringVector3NaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for SpringVector3NaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpringVector3NaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for SpringVector3NaturalMotionAnimation {
     type Vtable = ISpringVector3NaturalMotionAnimation_Vtbl;
@@ -23121,7 +23652,7 @@ impl SpriteVisual {
     }
 }
 impl windows_core::RuntimeType for SpriteVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpriteVisual>();
 }
 unsafe impl windows_core::Interface for SpriteVisual {
     type Vtable = ISpriteVisual_Vtbl;
@@ -23301,7 +23832,7 @@ impl StepEasingFunction {
     }
 }
 impl windows_core::RuntimeType for StepEasingFunction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStepEasingFunction>();
 }
 unsafe impl windows_core::Interface for StepEasingFunction {
     type Vtable = IStepEasingFunction_Vtbl;
@@ -23617,7 +24148,7 @@ impl Vector2KeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for Vector2KeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVector2KeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for Vector2KeyFrameAnimation {
     type Vtable = IVector2KeyFrameAnimation_Vtbl;
@@ -23903,7 +24434,7 @@ impl Vector2NaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for Vector2NaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVector2NaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for Vector2NaturalMotionAnimation {
     type Vtable = IVector2NaturalMotionAnimation_Vtbl;
@@ -24219,7 +24750,7 @@ impl Vector3KeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for Vector3KeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVector3KeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for Vector3KeyFrameAnimation {
     type Vtable = IVector3KeyFrameAnimation_Vtbl;
@@ -24505,7 +25036,7 @@ impl Vector3NaturalMotionAnimation {
     }
 }
 impl windows_core::RuntimeType for Vector3NaturalMotionAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVector3NaturalMotionAnimation>();
 }
 unsafe impl windows_core::Interface for Vector3NaturalMotionAnimation {
     type Vtable = IVector3NaturalMotionAnimation_Vtbl;
@@ -24821,7 +25352,7 @@ impl Vector4KeyFrameAnimation {
     }
 }
 impl windows_core::RuntimeType for Vector4KeyFrameAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVector4KeyFrameAnimation>();
 }
 unsafe impl windows_core::Interface for Vector4KeyFrameAnimation {
     type Vtable = IVector4KeyFrameAnimation_Vtbl;
@@ -25210,7 +25741,7 @@ impl Visual {
     }
 }
 impl windows_core::RuntimeType for Visual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisual>();
 }
 unsafe impl windows_core::Interface for Visual {
     type Vtable = IVisual_Vtbl;
@@ -25392,7 +25923,7 @@ impl VisualCollection {
     }
 }
 impl windows_core::RuntimeType for VisualCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisualCollection>();
 }
 unsafe impl windows_core::Interface for VisualCollection {
     type Vtable = IVisualCollection_Vtbl;
@@ -25567,7 +26098,7 @@ impl VisualUnorderedCollection {
     }
 }
 impl windows_core::RuntimeType for VisualUnorderedCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisualUnorderedCollection>();
 }
 unsafe impl windows_core::Interface for VisualUnorderedCollection {
     type Vtable = IVisualUnorderedCollection_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAnimationDescription, IAnimationDescription_Vtbl, 0x7d11a549_be3d_41de_b081_05c149962f9b);
+impl windows_core::RuntimeType for IAnimationDescription {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnimationDescription_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,12 +15,18 @@ pub struct IAnimationDescription_Vtbl {
     pub ZOrder: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAnimationDescriptionFactory, IAnimationDescriptionFactory_Vtbl, 0xc6e27abe_c1fb_48b5_9271_ecc70ac86ef0);
+impl windows_core::RuntimeType for IAnimationDescriptionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAnimationDescriptionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, AnimationEffect, AnimationEffectTarget, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IOpacityAnimation, IOpacityAnimation_Vtbl, 0x803aabe5_ee7e_455f_84e9_2506afb8d2b4);
+impl windows_core::RuntimeType for IOpacityAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IOpacityAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +85,9 @@ pub struct IPropertyAnimation_Vtbl {
     pub Control2: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScaleAnimation, IScaleAnimation_Vtbl, 0x023552c7_71ab_428c_9c9f_d31780964995);
+impl windows_core::RuntimeType for IScaleAnimation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScaleAnimation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,7 +151,7 @@ impl AnimationDescription {
     }
 }
 impl windows_core::RuntimeType for AnimationDescription {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAnimationDescription>();
 }
 unsafe impl windows_core::Interface for AnimationDescription {
     type Vtable = IAnimationDescription_Vtbl;
@@ -207,7 +219,7 @@ impl OpacityAnimation {
     }
 }
 impl windows_core::RuntimeType for OpacityAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IOpacityAnimation>();
 }
 unsafe impl windows_core::Interface for OpacityAnimation {
     type Vtable = IOpacityAnimation_Vtbl;
@@ -261,7 +273,7 @@ impl PropertyAnimation {
     }
 }
 impl windows_core::RuntimeType for PropertyAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPropertyAnimation>();
 }
 unsafe impl windows_core::Interface for PropertyAnimation {
     type Vtable = IPropertyAnimation_Vtbl;
@@ -350,7 +362,7 @@ impl ScaleAnimation {
     }
 }
 impl windows_core::RuntimeType for ScaleAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScaleAnimation>();
 }
 unsafe impl windows_core::Interface for ScaleAnimation {
     type Vtable = IScaleAnimation_Vtbl;
@@ -404,7 +416,7 @@ impl TranslationAnimation {
     }
 }
 impl windows_core::RuntimeType for TranslationAnimation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPropertyAnimation>();
 }
 unsafe impl windows_core::Interface for TranslationAnimation {
     type Vtable = IPropertyAnimation_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Core/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/Preview/mod.rs
@@ -1,9 +1,15 @@
 windows_core::imp::define_interface!(ICoreAppWindowPreview, ICoreAppWindowPreview_Vtbl, 0xa4f6e665_365e_5fde_87a5_9543c3a15aa8);
+impl windows_core::RuntimeType for ICoreAppWindowPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreAppWindowPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICoreAppWindowPreviewStatics, ICoreAppWindowPreviewStatics_Vtbl, 0x33ac21be_423b_5db6_8a8e_4dc87353b75b);
+impl windows_core::RuntimeType for ICoreAppWindowPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreAppWindowPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -13,6 +19,9 @@ pub struct ICoreAppWindowPreviewStatics_Vtbl {
     GetIdFromWindow: usize,
 }
 windows_core::imp::define_interface!(ISystemNavigationCloseRequestedPreviewEventArgs, ISystemNavigationCloseRequestedPreviewEventArgs_Vtbl, 0x83d00de1_cbe5_4f31_8414_361da046518f);
+impl windows_core::RuntimeType for ISystemNavigationCloseRequestedPreviewEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemNavigationCloseRequestedPreviewEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -21,6 +30,9 @@ pub struct ISystemNavigationCloseRequestedPreviewEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemNavigationManagerPreview, ISystemNavigationManagerPreview_Vtbl, 0xec5f0488_6425_4777_a536_cb5634427f0d);
+impl windows_core::RuntimeType for ISystemNavigationManagerPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemNavigationManagerPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +40,9 @@ pub struct ISystemNavigationManagerPreview_Vtbl {
     pub RemoveCloseRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemNavigationManagerPreviewStatics, ISystemNavigationManagerPreviewStatics_Vtbl, 0x0e971360_df74_4bce_84cb_bd1181ac0a71);
+impl windows_core::RuntimeType for ISystemNavigationManagerPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemNavigationManagerPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,7 +70,7 @@ impl CoreAppWindowPreview {
     }
 }
 impl windows_core::RuntimeType for CoreAppWindowPreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreAppWindowPreview>();
 }
 unsafe impl windows_core::Interface for CoreAppWindowPreview {
     type Vtable = ICoreAppWindowPreview_Vtbl;
@@ -91,7 +106,7 @@ impl SystemNavigationCloseRequestedPreviewEventArgs {
     }
 }
 impl windows_core::RuntimeType for SystemNavigationCloseRequestedPreviewEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemNavigationCloseRequestedPreviewEventArgs>();
 }
 unsafe impl windows_core::Interface for SystemNavigationCloseRequestedPreviewEventArgs {
     type Vtable = ISystemNavigationCloseRequestedPreviewEventArgs_Vtbl;
@@ -134,7 +149,7 @@ impl SystemNavigationManagerPreview {
     }
 }
 impl windows_core::RuntimeType for SystemNavigationManagerPreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemNavigationManagerPreview>();
 }
 unsafe impl windows_core::Interface for SystemNavigationManagerPreview {
     type Vtable = ISystemNavigationManagerPreview_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -3,6 +3,9 @@ pub mod AnimationMetrics;
 #[cfg(feature = "UI_Core_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(IAcceleratorKeyEventArgs, IAcceleratorKeyEventArgs_Vtbl, 0xff1c4c4a_9287_470b_836e_9086e3126ade);
+impl windows_core::RuntimeType for IAcceleratorKeyEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAcceleratorKeyEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,12 +17,18 @@ pub struct IAcceleratorKeyEventArgs_Vtbl {
     pub KeyStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CorePhysicalKeyStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAcceleratorKeyEventArgs2, IAcceleratorKeyEventArgs2_Vtbl, 0xd300a9f6_2f7e_4873_a555_166e596ee1c5);
+impl windows_core::RuntimeType for IAcceleratorKeyEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAcceleratorKeyEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAutomationProviderRequestedEventArgs, IAutomationProviderRequestedEventArgs_Vtbl, 0x961ff258_21bf_4b42_a298_fa479d4c52e2);
+impl windows_core::RuntimeType for IAutomationProviderRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutomationProviderRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +36,9 @@ pub struct IAutomationProviderRequestedEventArgs_Vtbl {
     pub SetAutomationProvider: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBackRequestedEventArgs, IBackRequestedEventArgs_Vtbl, 0xd603d28a_e411_4a4e_ba41_6a327a8675bc);
+impl windows_core::RuntimeType for IBackRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBackRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +46,9 @@ pub struct IBackRequestedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICharacterReceivedEventArgs, ICharacterReceivedEventArgs_Vtbl, 0xc584659f_99b2_4bcc_bd33_04e63f42902e);
+impl windows_core::RuntimeType for ICharacterReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICharacterReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +56,9 @@ pub struct ICharacterReceivedEventArgs_Vtbl {
     pub KeyStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CorePhysicalKeyStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IClosestInteractiveBoundsRequestedEventArgs, IClosestInteractiveBoundsRequestedEventArgs_Vtbl, 0x347c11d7_f6f8_40e3_b29f_ae50d3e86486);
+impl windows_core::RuntimeType for IClosestInteractiveBoundsRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClosestInteractiveBoundsRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +95,9 @@ pub struct ICoreAcceleratorKeys_Vtbl {
     pub RemoveAcceleratorKeyActivated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreClosestInteractiveBoundsRequested, ICoreClosestInteractiveBoundsRequested_Vtbl, 0xf303043a_e8bf_4e8e_ae69_c9dadd57a114);
+impl windows_core::RuntimeType for ICoreClosestInteractiveBoundsRequested {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreClosestInteractiveBoundsRequested_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +105,9 @@ pub struct ICoreClosestInteractiveBoundsRequested_Vtbl {
     pub RemoveClosestInteractiveBoundsRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreComponentFocusable, ICoreComponentFocusable_Vtbl, 0x52f96fa3_8742_4411_ae69_79a85f29ac8b);
+impl windows_core::RuntimeType for ICoreComponentFocusable {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreComponentFocusable_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +118,9 @@ pub struct ICoreComponentFocusable_Vtbl {
     pub RemoveLostFocus: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreCursor, ICoreCursor_Vtbl, 0x96893acf_111d_442c_8a77_b87992f8e2d6);
+impl windows_core::RuntimeType for ICoreCursor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreCursor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -101,12 +128,18 @@ pub struct ICoreCursor_Vtbl {
     pub Type: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CoreCursorType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreCursorFactory, ICoreCursorFactory_Vtbl, 0xf6359621_a79d_4ed3_8c32_a9ef9d6b76a4);
+impl windows_core::RuntimeType for ICoreCursorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreCursorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateCursor: unsafe extern "system" fn(*mut core::ffi::c_void, CoreCursorType, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDispatcher, ICoreDispatcher_Vtbl, 0x60db2fa8_b705_4fde_a7d6_ebbb1891d39e);
+impl windows_core::RuntimeType for ICoreDispatcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDispatcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +149,9 @@ pub struct ICoreDispatcher_Vtbl {
     pub RunIdleAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDispatcher2, ICoreDispatcher2_Vtbl, 0x6f5e63c7_e3aa_4eae_b0e0_dcf321ca4b2f);
+impl windows_core::RuntimeType for ICoreDispatcher2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDispatcher2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -123,6 +159,9 @@ pub struct ICoreDispatcher2_Vtbl {
     pub TryRunIdleAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreDispatcherWithTaskPriority, ICoreDispatcherWithTaskPriority_Vtbl, 0xbafaecad_484d_41be_ba80_1d58c65263ea);
+impl windows_core::RuntimeType for ICoreDispatcherWithTaskPriority {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreDispatcherWithTaskPriority_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -133,6 +172,9 @@ pub struct ICoreDispatcherWithTaskPriority_Vtbl {
     pub StopProcessEvents: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreIndependentInputSourceController, ICoreIndependentInputSourceController_Vtbl, 0x0963261c_84fe_578a_83ca_6425309ccde4);
+impl windows_core::RuntimeType for ICoreIndependentInputSourceController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreIndependentInputSourceController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +187,9 @@ pub struct ICoreIndependentInputSourceController_Vtbl {
     pub SetControlledInputWithFilters: unsafe extern "system" fn(*mut core::ffi::c_void, CoreInputDeviceTypes, CoreIndependentInputFilters, CoreIndependentInputFilters) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreIndependentInputSourceControllerStatics, ICoreIndependentInputSourceControllerStatics_Vtbl, 0x3edc4e20_9a8a_5691_8586_fca4cb57526d);
+impl windows_core::RuntimeType for ICoreIndependentInputSourceControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreIndependentInputSourceControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -206,6 +251,9 @@ pub struct ICoreInputSourceBase_Vtbl {
     pub RemoveInputEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreKeyboardInputSource, ICoreKeyboardInputSource_Vtbl, 0x231c9088_e469_4df1_b208_6e490d71cb90);
+impl windows_core::RuntimeType for ICoreKeyboardInputSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreKeyboardInputSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +269,9 @@ pub struct ICoreKeyboardInputSource_Vtbl {
     pub RemoveKeyUp: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreKeyboardInputSource2, ICoreKeyboardInputSource2_Vtbl, 0xfa24cb94_f963_47a5_8778_207c482b0afd);
+impl windows_core::RuntimeType for ICoreKeyboardInputSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreKeyboardInputSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -609,6 +660,9 @@ pub struct ICorePointerRedirector_Vtbl {
     pub RemovePointerRoutedReleased: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTouchHitTesting, ICoreTouchHitTesting_Vtbl, 0xb1d8a289_3acf_4124_9fa3_ea8aba353c21);
+impl windows_core::RuntimeType for ICoreTouchHitTesting {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTouchHitTesting_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1037,12 +1091,18 @@ pub struct ICoreWindow_Vtbl {
     pub RemoveVisibilityChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindow2, ICoreWindow2_Vtbl, 0x7c2b1b85_6917_4361_9c02_0d9e3a420b95);
+impl windows_core::RuntimeType for ICoreWindow2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindow2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetPointerPosition: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindow3, ICoreWindow3_Vtbl, 0x32c20dd8_faef_4375_a2ab_32640e4815c7);
+impl windows_core::RuntimeType for ICoreWindow3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindow3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1051,6 +1111,9 @@ pub struct ICoreWindow3_Vtbl {
     pub GetCurrentKeyEventDeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindow4, ICoreWindow4_Vtbl, 0x35caf0d0_47f0_436c_af97_0dd88f6f5f02);
+impl windows_core::RuntimeType for ICoreWindow4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindow4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1060,6 +1123,9 @@ pub struct ICoreWindow4_Vtbl {
     pub RemoveResizeCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindow5, ICoreWindow5_Vtbl, 0x4b4ae1e1_2e6d_4eaa_bda1_1c5cc1bee141);
+impl windows_core::RuntimeType for ICoreWindow5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindow5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1070,6 +1136,9 @@ pub struct ICoreWindow5_Vtbl {
     pub ActivationMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CoreWindowActivationMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowDialog, ICoreWindowDialog_Vtbl, 0xe7392ce0_c78d_427e_8b2c_01ff420c69d5);
+impl windows_core::RuntimeType for ICoreWindowDialog {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowDialog_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1103,6 +1172,9 @@ pub struct ICoreWindowDialog_Vtbl {
     ShowAsync: usize,
 }
 windows_core::imp::define_interface!(ICoreWindowDialogFactory, ICoreWindowDialogFactory_Vtbl, 0xcfb2a855_1c59_4b13_b1e5_16e29805f7c4);
+impl windows_core::RuntimeType for ICoreWindowDialogFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowDialogFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1133,6 +1205,9 @@ pub struct ICoreWindowEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowFlyout, ICoreWindowFlyout_Vtbl, 0xe89d854d_2050_40bb_b344_f6f355eeb314);
+impl windows_core::RuntimeType for ICoreWindowFlyout {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowFlyout_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1164,6 +1239,9 @@ pub struct ICoreWindowFlyout_Vtbl {
     ShowAsync: usize,
 }
 windows_core::imp::define_interface!(ICoreWindowFlyoutFactory, ICoreWindowFlyoutFactory_Vtbl, 0xdec4c6c4_93e8_4f7c_be27_cefaa1af68a7);
+impl windows_core::RuntimeType for ICoreWindowFlyoutFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowFlyoutFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1171,18 +1249,27 @@ pub struct ICoreWindowFlyoutFactory_Vtbl {
     pub CreateWithTitle: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Point, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowPopupShowingEventArgs, ICoreWindowPopupShowingEventArgs_Vtbl, 0x26155fa2_5ba5_4ea4_a3b4_2dc7d63c8e26);
+impl windows_core::RuntimeType for ICoreWindowPopupShowingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowPopupShowingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetDesiredSize: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowResizeManager, ICoreWindowResizeManager_Vtbl, 0xb8f0b925_b350_48b3_a198_5c1a84700243);
+impl windows_core::RuntimeType for ICoreWindowResizeManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowResizeManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub NotifyLayoutCompleted: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowResizeManagerLayoutCapability, ICoreWindowResizeManagerLayoutCapability_Vtbl, 0xbb74f27b_a544_4301_80e6_0ae033ef4536);
+impl windows_core::RuntimeType for ICoreWindowResizeManagerLayoutCapability {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowResizeManagerLayoutCapability_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1190,24 +1277,36 @@ pub struct ICoreWindowResizeManagerLayoutCapability_Vtbl {
     pub ShouldWaitForLayoutCompletion: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowResizeManagerStatics, ICoreWindowResizeManagerStatics_Vtbl, 0xae4a9045_6d70_49db_8e68_46ffbd17d38d);
+impl windows_core::RuntimeType for ICoreWindowResizeManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowResizeManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowStatic, ICoreWindowStatic_Vtbl, 0x4d239005_3c2a_41b1_9022_536bb9cf93b1);
+impl windows_core::RuntimeType for ICoreWindowStatic {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowStatic_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentThread: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWindowWithContext, ICoreWindowWithContext_Vtbl, 0x9ac40241_3575_4c3b_af66_e8c529d4d06c);
+impl windows_core::RuntimeType for ICoreWindowWithContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWindowWithContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub UIContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IIdleDispatchedHandlerArgs, IIdleDispatchedHandlerArgs_Vtbl, 0x98bb6a24_dc1c_43cb_b4ed_d1c0eb2391f3);
+impl windows_core::RuntimeType for IIdleDispatchedHandlerArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IIdleDispatchedHandlerArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1233,12 +1332,18 @@ pub struct IInitializeWithCoreWindow_Vtbl {
     pub Initialize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputEnabledEventArgs, IInputEnabledEventArgs_Vtbl, 0x80371d4f_2fd8_4c24_aa86_3163a87b4e5a);
+impl windows_core::RuntimeType for IInputEnabledEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputEnabledEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InputEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyEventArgs, IKeyEventArgs_Vtbl, 0x5ff5e930_2544_4a17_bd78_1f2fdebb106b);
+impl windows_core::RuntimeType for IKeyEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1249,12 +1354,18 @@ pub struct IKeyEventArgs_Vtbl {
     pub KeyStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CorePhysicalKeyStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyEventArgs2, IKeyEventArgs2_Vtbl, 0x583add98_0790_4571_9b12_645ef9d79e42);
+impl windows_core::RuntimeType for IKeyEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DeviceId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerEventArgs, IPointerEventArgs_Vtbl, 0x920d9cb1_a5fc_4a21_8c09_49dfe6ffe25f);
+impl windows_core::RuntimeType for IPointerEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1272,6 +1383,9 @@ pub struct IPointerEventArgs_Vtbl {
     GetIntermediatePoints: usize,
 }
 windows_core::imp::define_interface!(ISystemNavigationManager, ISystemNavigationManager_Vtbl, 0x93023118_cf50_42a6_9706_69107fa122e1);
+impl windows_core::RuntimeType for ISystemNavigationManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemNavigationManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1279,6 +1393,9 @@ pub struct ISystemNavigationManager_Vtbl {
     pub RemoveBackRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemNavigationManager2, ISystemNavigationManager2_Vtbl, 0x8c510401_67be_49ae_9509_671c1e54a389);
+impl windows_core::RuntimeType for ISystemNavigationManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemNavigationManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1286,12 +1403,18 @@ pub struct ISystemNavigationManager2_Vtbl {
     pub SetAppViewBackButtonVisibility: unsafe extern "system" fn(*mut core::ffi::c_void, AppViewBackButtonVisibility) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemNavigationManagerStatics, ISystemNavigationManagerStatics_Vtbl, 0xdc52b5ce_bee0_4305_8c54_68228ed683b5);
+impl windows_core::RuntimeType for ISystemNavigationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemNavigationManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITouchHitTestingEventArgs, ITouchHitTestingEventArgs_Vtbl, 0x22f3b823_0b7c_424e_9df7_33d4f962931b);
+impl windows_core::RuntimeType for ITouchHitTestingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITouchHitTestingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1303,18 +1426,27 @@ pub struct ITouchHitTestingEventArgs_Vtbl {
     pub EvaluateProximityToPolygon: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const super::super::Foundation::Point, *mut CoreProximityEvaluation) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisibilityChangedEventArgs, IVisibilityChangedEventArgs_Vtbl, 0xbf9918ea_d801_4564_a495_b1e84f8ad085);
+impl windows_core::RuntimeType for IVisibilityChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisibilityChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Visible: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowActivatedEventArgs, IWindowActivatedEventArgs_Vtbl, 0x179d65e7_4658_4cb6_aa13_41d094ea255e);
+impl windows_core::RuntimeType for IWindowActivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowActivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub WindowActivationState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CoreWindowActivationState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowSizeChangedEventArgs, IWindowSizeChangedEventArgs_Vtbl, 0x5a200ec7_0426_47dc_b86c_6f475915e451);
+impl windows_core::RuntimeType for IWindowSizeChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowSizeChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1368,7 +1500,7 @@ impl AcceleratorKeyEventArgs {
     }
 }
 impl windows_core::RuntimeType for AcceleratorKeyEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAcceleratorKeyEventArgs>();
 }
 unsafe impl windows_core::Interface for AcceleratorKeyEventArgs {
     type Vtable = IAcceleratorKeyEventArgs_Vtbl;
@@ -1412,7 +1544,7 @@ impl AutomationProviderRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AutomationProviderRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutomationProviderRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for AutomationProviderRequestedEventArgs {
     type Vtable = IAutomationProviderRequestedEventArgs_Vtbl;
@@ -1439,7 +1571,7 @@ impl BackRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for BackRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBackRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for BackRequestedEventArgs {
     type Vtable = IBackRequestedEventArgs_Vtbl;
@@ -1483,7 +1615,7 @@ impl CharacterReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CharacterReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICharacterReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for CharacterReceivedEventArgs {
     type Vtable = ICharacterReceivedEventArgs_Vtbl;
@@ -1524,7 +1656,7 @@ impl ClosestInteractiveBoundsRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ClosestInteractiveBoundsRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IClosestInteractiveBoundsRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for ClosestInteractiveBoundsRequestedEventArgs {
     type Vtable = IClosestInteractiveBoundsRequestedEventArgs_Vtbl;
@@ -1555,7 +1687,7 @@ impl CoreAcceleratorKeys {
     }
 }
 impl windows_core::RuntimeType for CoreAcceleratorKeys {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreAcceleratorKeys>();
 }
 unsafe impl windows_core::Interface for CoreAcceleratorKeys {
     type Vtable = ICoreAcceleratorKeys_Vtbl;
@@ -1868,7 +2000,7 @@ impl CoreComponentInputSource {
     }
 }
 impl windows_core::RuntimeType for CoreComponentInputSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputSourceBase>();
 }
 unsafe impl windows_core::Interface for CoreComponentInputSource {
     type Vtable = ICoreInputSourceBase_Vtbl;
@@ -1911,7 +2043,7 @@ impl CoreCursor {
     }
 }
 impl windows_core::RuntimeType for CoreCursor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreCursor>();
 }
 unsafe impl windows_core::Interface for CoreCursor {
     type Vtable = ICoreCursor_Vtbl;
@@ -2024,7 +2156,7 @@ impl CoreDispatcher {
     }
 }
 impl windows_core::RuntimeType for CoreDispatcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreDispatcher>();
 }
 unsafe impl windows_core::Interface for CoreDispatcher {
     type Vtable = ICoreDispatcher_Vtbl;
@@ -2259,7 +2391,7 @@ impl CoreIndependentInputSource {
     }
 }
 impl windows_core::RuntimeType for CoreIndependentInputSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputSourceBase>();
 }
 unsafe impl windows_core::Interface for CoreIndependentInputSource {
     type Vtable = ICoreInputSourceBase_Vtbl;
@@ -2344,7 +2476,7 @@ impl CoreIndependentInputSourceController {
     }
 }
 impl windows_core::RuntimeType for CoreIndependentInputSourceController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreIndependentInputSourceController>();
 }
 unsafe impl windows_core::Interface for CoreIndependentInputSourceController {
     type Vtable = ICoreIndependentInputSourceController_Vtbl;
@@ -2840,7 +2972,7 @@ impl CoreWindow {
     }
 }
 impl windows_core::RuntimeType for CoreWindow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWindow>();
 }
 unsafe impl windows_core::Interface for CoreWindow {
     type Vtable = ICoreWindow_Vtbl;
@@ -2978,7 +3110,7 @@ impl CoreWindowDialog {
     }
 }
 impl windows_core::RuntimeType for CoreWindowDialog {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWindowDialog>();
 }
 unsafe impl windows_core::Interface for CoreWindowDialog {
     type Vtable = ICoreWindowDialog_Vtbl;
@@ -3006,7 +3138,7 @@ impl CoreWindowEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreWindowEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWindowEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreWindowEventArgs {
     type Vtable = ICoreWindowEventArgs_Vtbl;
@@ -3132,7 +3264,7 @@ impl CoreWindowFlyout {
     }
 }
 impl windows_core::RuntimeType for CoreWindowFlyout {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWindowFlyout>();
 }
 unsafe impl windows_core::Interface for CoreWindowFlyout {
     type Vtable = ICoreWindowFlyout_Vtbl;
@@ -3152,7 +3284,7 @@ impl CoreWindowPopupShowingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreWindowPopupShowingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWindowPopupShowingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreWindowPopupShowingEventArgs {
     type Vtable = ICoreWindowPopupShowingEventArgs_Vtbl;
@@ -3194,7 +3326,7 @@ impl CoreWindowResizeManager {
     }
 }
 impl windows_core::RuntimeType for CoreWindowResizeManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWindowResizeManager>();
 }
 unsafe impl windows_core::Interface for CoreWindowResizeManager {
     type Vtable = ICoreWindowResizeManager_Vtbl;
@@ -3219,7 +3351,7 @@ impl IdleDispatchedHandlerArgs {
     }
 }
 impl windows_core::RuntimeType for IdleDispatchedHandlerArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IIdleDispatchedHandlerArgs>();
 }
 unsafe impl windows_core::Interface for IdleDispatchedHandlerArgs {
     type Vtable = IIdleDispatchedHandlerArgs_Vtbl;
@@ -3254,7 +3386,7 @@ impl InputEnabledEventArgs {
     }
 }
 impl windows_core::RuntimeType for InputEnabledEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputEnabledEventArgs>();
 }
 unsafe impl windows_core::Interface for InputEnabledEventArgs {
     type Vtable = IInputEnabledEventArgs_Vtbl;
@@ -3304,7 +3436,7 @@ impl KeyEventArgs {
     }
 }
 impl windows_core::RuntimeType for KeyEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyEventArgs>();
 }
 unsafe impl windows_core::Interface for KeyEventArgs {
     type Vtable = IKeyEventArgs_Vtbl;
@@ -3356,7 +3488,7 @@ impl PointerEventArgs {
     }
 }
 impl windows_core::RuntimeType for PointerEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPointerEventArgs>();
 }
 unsafe impl windows_core::Interface for PointerEventArgs {
     type Vtable = IPointerEventArgs_Vtbl;
@@ -3408,7 +3540,7 @@ impl SystemNavigationManager {
     }
 }
 impl windows_core::RuntimeType for SystemNavigationManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemNavigationManager>();
 }
 unsafe impl windows_core::Interface for SystemNavigationManager {
     type Vtable = ISystemNavigationManager_Vtbl;
@@ -3477,7 +3609,7 @@ impl TouchHitTestingEventArgs {
     }
 }
 impl windows_core::RuntimeType for TouchHitTestingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITouchHitTestingEventArgs>();
 }
 unsafe impl windows_core::Interface for TouchHitTestingEventArgs {
     type Vtable = ITouchHitTestingEventArgs_Vtbl;
@@ -3512,7 +3644,7 @@ impl VisibilityChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VisibilityChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisibilityChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for VisibilityChangedEventArgs {
     type Vtable = IVisibilityChangedEventArgs_Vtbl;
@@ -3547,7 +3679,7 @@ impl WindowActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowActivatedEventArgs {
     type Vtable = IWindowActivatedEventArgs_Vtbl;
@@ -3582,7 +3714,7 @@ impl WindowSizeChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowSizeChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowSizeChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowSizeChangedEventArgs {
     type Vtable = IWindowSizeChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IRadialControllerIndependentInputSource, IRadialControllerIndependentInputSource_Vtbl, 0x3d577ef6_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerIndependentInputSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerIndependentInputSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,6 +12,9 @@ pub struct IRadialControllerIndependentInputSource_Vtbl {
     Dispatcher: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerIndependentInputSource2, IRadialControllerIndependentInputSource2_Vtbl, 0x7073aad8_35f3_4eeb_8751_be4d0a66faf4);
+impl windows_core::RuntimeType for IRadialControllerIndependentInputSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerIndependentInputSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +24,9 @@ pub struct IRadialControllerIndependentInputSource2_Vtbl {
     DispatcherQueue: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerIndependentInputSourceStatics, IRadialControllerIndependentInputSourceStatics_Vtbl, 0x3d577ef5_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerIndependentInputSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerIndependentInputSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,7 +80,7 @@ impl RadialControllerIndependentInputSource {
     }
 }
 impl windows_core::RuntimeType for RadialControllerIndependentInputSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerIndependentInputSource>();
 }
 unsafe impl windows_core::Interface for RadialControllerIndependentInputSource {
     type Vtable = IRadialControllerIndependentInputSource_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
@@ -1,10 +1,16 @@
 windows_core::imp::define_interface!(IInkAnalysisInkBullet, IInkAnalysisInkBullet_Vtbl, 0xee049368_6110_4136_95f9_ee809fc20030);
+impl windows_core::RuntimeType for IInkAnalysisInkBullet {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisInkBullet_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RecognizedText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkAnalysisInkDrawing, IInkAnalysisInkDrawing_Vtbl, 0x6a85ed1f_1fe4_4e15_898c_8e112377e021);
+impl windows_core::RuntimeType for IInkAnalysisInkDrawing {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisInkDrawing_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,6 +22,9 @@ pub struct IInkAnalysisInkDrawing_Vtbl {
     Points: usize,
 }
 windows_core::imp::define_interface!(IInkAnalysisInkWord, IInkAnalysisInkWord_Vtbl, 0x4bd228ad_83af_4034_8f3b_f8687dfff436);
+impl windows_core::RuntimeType for IInkAnalysisInkWord {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisInkWord_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +35,9 @@ pub struct IInkAnalysisInkWord_Vtbl {
     TextAlternates: usize,
 }
 windows_core::imp::define_interface!(IInkAnalysisLine, IInkAnalysisLine_Vtbl, 0xa06d048d_2b8d_4754_ad5a_d0871193a956);
+impl windows_core::RuntimeType for IInkAnalysisLine {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisLine_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +45,9 @@ pub struct IInkAnalysisLine_Vtbl {
     pub IndentLevel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkAnalysisListItem, IInkAnalysisListItem_Vtbl, 0xb4e3c23f_c4c3_4c3a_a1a6_9d85547ee586);
+impl windows_core::RuntimeType for IInkAnalysisListItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisListItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -118,18 +133,27 @@ pub struct IInkAnalysisNode_Vtbl {
     GetStrokeIds: usize,
 }
 windows_core::imp::define_interface!(IInkAnalysisParagraph, IInkAnalysisParagraph_Vtbl, 0xd9ad045c_0cd1_4dd4_a68b_eb1f12b3d727);
+impl windows_core::RuntimeType for IInkAnalysisParagraph {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisParagraph_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RecognizedText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkAnalysisResult, IInkAnalysisResult_Vtbl, 0x8948ba79_a243_4aa3_a294_1f98bd0ff580);
+impl windows_core::RuntimeType for IInkAnalysisResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Status: unsafe extern "system" fn(*mut core::ffi::c_void, *mut InkAnalysisStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkAnalysisRoot, IInkAnalysisRoot_Vtbl, 0x3fb6a3c4_2fde_4061_8502_a90f32545b84);
+impl windows_core::RuntimeType for IInkAnalysisRoot {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisRoot_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,12 +164,18 @@ pub struct IInkAnalysisRoot_Vtbl {
     FindNodes: usize,
 }
 windows_core::imp::define_interface!(IInkAnalysisWritingRegion, IInkAnalysisWritingRegion_Vtbl, 0xdd6d6231_bd16_4663_b5ae_941d3043ef5b);
+impl windows_core::RuntimeType for IInkAnalysisWritingRegion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalysisWritingRegion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub RecognizedText: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkAnalyzer, IInkAnalyzer_Vtbl, 0xf12b8f95_0866_4dc5_8c77_f88614dfe38c);
+impl windows_core::RuntimeType for IInkAnalyzer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkAnalyzer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -252,7 +282,7 @@ impl InkAnalysisInkBullet {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisInkBullet {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisInkBullet>();
 }
 unsafe impl windows_core::Interface for InkAnalysisInkBullet {
     type Vtable = IInkAnalysisInkBullet_Vtbl;
@@ -345,7 +375,7 @@ impl InkAnalysisInkDrawing {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisInkDrawing {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisInkDrawing>();
 }
 unsafe impl windows_core::Interface for InkAnalysisInkDrawing {
     type Vtable = IInkAnalysisInkDrawing_Vtbl;
@@ -431,7 +461,7 @@ impl InkAnalysisInkWord {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisInkWord {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisInkWord>();
 }
 unsafe impl windows_core::Interface for InkAnalysisInkWord {
     type Vtable = IInkAnalysisInkWord_Vtbl;
@@ -516,7 +546,7 @@ impl InkAnalysisLine {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisLine {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisLine>();
 }
 unsafe impl windows_core::Interface for InkAnalysisLine {
     type Vtable = IInkAnalysisLine_Vtbl;
@@ -594,7 +624,7 @@ impl InkAnalysisListItem {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisListItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisListItem>();
 }
 unsafe impl windows_core::Interface for InkAnalysisListItem {
     type Vtable = IInkAnalysisListItem_Vtbl;
@@ -665,7 +695,7 @@ impl InkAnalysisNode {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisNode>();
 }
 unsafe impl windows_core::Interface for InkAnalysisNode {
     type Vtable = IInkAnalysisNode_Vtbl;
@@ -743,7 +773,7 @@ impl InkAnalysisParagraph {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisParagraph {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisParagraph>();
 }
 unsafe impl windows_core::Interface for InkAnalysisParagraph {
     type Vtable = IInkAnalysisParagraph_Vtbl;
@@ -768,7 +798,7 @@ impl InkAnalysisResult {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisResult>();
 }
 unsafe impl windows_core::Interface for InkAnalysisResult {
     type Vtable = IInkAnalysisResult_Vtbl;
@@ -854,7 +884,7 @@ impl InkAnalysisRoot {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisRoot {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisRoot>();
 }
 unsafe impl windows_core::Interface for InkAnalysisRoot {
     type Vtable = IInkAnalysisRoot_Vtbl;
@@ -932,7 +962,7 @@ impl InkAnalysisWritingRegion {
     }
 }
 impl windows_core::RuntimeType for InkAnalysisWritingRegion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalysisWritingRegion>();
 }
 unsafe impl windows_core::Interface for InkAnalysisWritingRegion {
     type Vtable = IInkAnalysisWritingRegion_Vtbl;
@@ -1020,7 +1050,7 @@ impl InkAnalyzer {
     }
 }
 impl windows_core::RuntimeType for InkAnalyzer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkAnalyzer>();
 }
 unsafe impl windows_core::Interface for InkAnalyzer {
     type Vtable = IInkAnalyzer_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICoreIncrementalInkStroke, ICoreIncrementalInkStroke_Vtbl, 0xfda015d3_9d66_4f7d_a57f_cc70b9cfaa76);
+impl windows_core::RuntimeType for ICoreIncrementalInkStroke {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreIncrementalInkStroke_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +18,9 @@ pub struct ICoreIncrementalInkStroke_Vtbl {
     pub BoundingRect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreIncrementalInkStrokeFactory, ICoreIncrementalInkStrokeFactory_Vtbl, 0xd7c59f46_8da8_4f70_9751_e53bb6df4596);
+impl windows_core::RuntimeType for ICoreIncrementalInkStrokeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreIncrementalInkStrokeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +30,9 @@ pub struct ICoreIncrementalInkStrokeFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(ICoreInkIndependentInputSource, ICoreInkIndependentInputSource_Vtbl, 0x39b38da9_7639_4499_a5b5_191d00e35b16);
+impl windows_core::RuntimeType for ICoreInkIndependentInputSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInkIndependentInputSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -65,6 +74,9 @@ pub struct ICoreInkIndependentInputSource_Vtbl {
     pub InkPresenter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInkIndependentInputSource2, ICoreInkIndependentInputSource2_Vtbl, 0x2846b012_0b59_5bb9_a3c5_becb7cf03a33);
+impl windows_core::RuntimeType for ICoreInkIndependentInputSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInkIndependentInputSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,12 +90,18 @@ pub struct ICoreInkIndependentInputSource2_Vtbl {
     SetPointerCursor: usize,
 }
 windows_core::imp::define_interface!(ICoreInkIndependentInputSourceStatics, ICoreInkIndependentInputSourceStatics_Vtbl, 0x73e6011b_80c0_4dfb_9b66_10ba7f3f9c84);
+impl windows_core::RuntimeType for ICoreInkIndependentInputSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInkIndependentInputSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInkPresenterHost, ICoreInkPresenterHost_Vtbl, 0x396e89e6_7d55_4617_9e58_68c70c9169b9);
+impl windows_core::RuntimeType for ICoreInkPresenterHost {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInkPresenterHost_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,6 +116,9 @@ pub struct ICoreInkPresenterHost_Vtbl {
     SetRootVisual: usize,
 }
 windows_core::imp::define_interface!(ICoreWetStrokeUpdateEventArgs, ICoreWetStrokeUpdateEventArgs_Vtbl, 0xfb07d14c_3380_457a_a987_991357896c1b);
+impl windows_core::RuntimeType for ICoreWetStrokeUpdateEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWetStrokeUpdateEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -110,6 +131,9 @@ pub struct ICoreWetStrokeUpdateEventArgs_Vtbl {
     pub SetDisposition: unsafe extern "system" fn(*mut core::ffi::c_void, CoreWetStrokeDisposition) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWetStrokeUpdateSource, ICoreWetStrokeUpdateSource_Vtbl, 0x1f718e22_ee52_4e00_8209_4c3e5b21a3cc);
+impl windows_core::RuntimeType for ICoreWetStrokeUpdateSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWetStrokeUpdateSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,6 +150,9 @@ pub struct ICoreWetStrokeUpdateSource_Vtbl {
     pub InkPresenter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreWetStrokeUpdateSourceStatics, ICoreWetStrokeUpdateSourceStatics_Vtbl, 0x3dad9cba_1d3d_46ae_ab9d_8647486c6f90);
+impl windows_core::RuntimeType for ICoreWetStrokeUpdateSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreWetStrokeUpdateSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -193,7 +220,7 @@ impl CoreIncrementalInkStroke {
     }
 }
 impl windows_core::RuntimeType for CoreIncrementalInkStroke {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreIncrementalInkStroke>();
 }
 unsafe impl windows_core::Interface for CoreIncrementalInkStroke {
     type Vtable = ICoreIncrementalInkStroke_Vtbl;
@@ -353,7 +380,7 @@ impl CoreInkIndependentInputSource {
     }
 }
 impl windows_core::RuntimeType for CoreInkIndependentInputSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInkIndependentInputSource>();
 }
 unsafe impl windows_core::Interface for CoreInkIndependentInputSource {
     type Vtable = ICoreInkIndependentInputSource_Vtbl;
@@ -401,7 +428,7 @@ impl CoreInkPresenterHost {
     }
 }
 impl windows_core::RuntimeType for CoreInkPresenterHost {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInkPresenterHost>();
 }
 unsafe impl windows_core::Interface for CoreInkPresenterHost {
     type Vtable = ICoreInkPresenterHost_Vtbl;
@@ -445,7 +472,7 @@ impl CoreWetStrokeUpdateEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreWetStrokeUpdateEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWetStrokeUpdateEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreWetStrokeUpdateEventArgs {
     type Vtable = ICoreWetStrokeUpdateEventArgs_Vtbl;
@@ -554,7 +581,7 @@ impl CoreWetStrokeUpdateSource {
     }
 }
 impl windows_core::RuntimeType for CoreWetStrokeUpdateSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreWetStrokeUpdateSource>();
 }
 unsafe impl windows_core::Interface for CoreWetStrokeUpdateSource {
     type Vtable = ICoreWetStrokeUpdateSource_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Preview/mod.rs
@@ -1,9 +1,15 @@
 windows_core::imp::define_interface!(IPalmRejectionDelayZonePreview, IPalmRejectionDelayZonePreview_Vtbl, 0x62b496cb_539d_5343_a65f_41f5300ec70c);
+impl windows_core::RuntimeType for IPalmRejectionDelayZonePreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPalmRejectionDelayZonePreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IPalmRejectionDelayZonePreviewStatics, IPalmRejectionDelayZonePreviewStatics_Vtbl, 0xcdef5ee0_93d0_53a9_8f0e_9a379f8f7530);
+impl windows_core::RuntimeType for IPalmRejectionDelayZonePreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPalmRejectionDelayZonePreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,7 +60,7 @@ impl PalmRejectionDelayZonePreview {
     }
 }
 impl windows_core::RuntimeType for PalmRejectionDelayZonePreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPalmRejectionDelayZonePreview>();
 }
 unsafe impl windows_core::Interface for PalmRejectionDelayZonePreview {
     type Vtable = IPalmRejectionDelayZonePreview_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
@@ -5,6 +5,9 @@ pub mod Core;
 #[cfg(feature = "UI_Input_Inking_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(IInkDrawingAttributes, IInkDrawingAttributes_Vtbl, 0x97a2176c_6774_48ad_84f0_48f5a9be74f9);
+impl windows_core::RuntimeType for IInkDrawingAttributes {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkDrawingAttributes_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -20,6 +23,9 @@ pub struct IInkDrawingAttributes_Vtbl {
     pub SetFitToCurve: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkDrawingAttributes2, IInkDrawingAttributes2_Vtbl, 0x7cab6508_8ec4_42fd_a5a5_e4b7d1d5316d);
+impl windows_core::RuntimeType for IInkDrawingAttributes2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkDrawingAttributes2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,6 +41,9 @@ pub struct IInkDrawingAttributes2_Vtbl {
     pub SetDrawAsHighlighter: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkDrawingAttributes3, IInkDrawingAttributes3_Vtbl, 0x72020002_7d5b_4690_8af4_e664cbe2b74f);
+impl windows_core::RuntimeType for IInkDrawingAttributes3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkDrawingAttributes3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -42,6 +51,9 @@ pub struct IInkDrawingAttributes3_Vtbl {
     pub PencilProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkDrawingAttributes4, IInkDrawingAttributes4_Vtbl, 0xef65dc25_9f19_456d_91a3_bc3a3d91c5fb);
+impl windows_core::RuntimeType for IInkDrawingAttributes4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkDrawingAttributes4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,12 +61,18 @@ pub struct IInkDrawingAttributes4_Vtbl {
     pub SetIgnoreTilt: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkDrawingAttributes5, IInkDrawingAttributes5_Vtbl, 0xd11aa0bb_0775_4852_ae64_41143a7ae6c9);
+impl windows_core::RuntimeType for IInkDrawingAttributes5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkDrawingAttributes5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ModelerAttributes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkDrawingAttributesPencilProperties, IInkDrawingAttributesPencilProperties_Vtbl, 0x4f2534cb_2d86_41bb_b0e8_e4c2a0253c52);
+impl windows_core::RuntimeType for IInkDrawingAttributesPencilProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkDrawingAttributesPencilProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,12 +80,18 @@ pub struct IInkDrawingAttributesPencilProperties_Vtbl {
     pub SetOpacity: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkDrawingAttributesStatics, IInkDrawingAttributesStatics_Vtbl, 0xf731e03f_1a65_4862_96cb_6e1665e17f6d);
+impl windows_core::RuntimeType for IInkDrawingAttributesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkDrawingAttributesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateForPencil: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkInputConfiguration, IInkInputConfiguration_Vtbl, 0x93a68dc4_0b7b_49d7_b34f_9901e524dcf2);
+impl windows_core::RuntimeType for IInkInputConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkInputConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +101,9 @@ pub struct IInkInputConfiguration_Vtbl {
     pub SetIsEraserInputEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkInputConfiguration2, IInkInputConfiguration2_Vtbl, 0x6ac2272e_81b4_5cc4_a36d_d057c387dfda);
+impl windows_core::RuntimeType for IInkInputConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkInputConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +111,9 @@ pub struct IInkInputConfiguration2_Vtbl {
     pub SetIsPenHapticFeedbackEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkInputProcessingConfiguration, IInkInputProcessingConfiguration_Vtbl, 0x2778d85e_33ca_4b06_a6d3_ac3945116d37);
+impl windows_core::RuntimeType for IInkInputProcessingConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkInputProcessingConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,6 +123,9 @@ pub struct IInkInputProcessingConfiguration_Vtbl {
     pub SetRightDragAction: unsafe extern "system" fn(*mut core::ffi::c_void, InkInputRightDragAction) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkManager, IInkManager_Vtbl, 0x4744737d_671b_4163_9c95_4e8d7a035fe1);
+impl windows_core::RuntimeType for IInkManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -108,6 +141,9 @@ pub struct IInkManager_Vtbl {
     RecognizeAsync2: usize,
 }
 windows_core::imp::define_interface!(IInkModelerAttributes, IInkModelerAttributes_Vtbl, 0xbad31f27_0cd9_4bfd_b6f3_9e03ba8d7454);
+impl windows_core::RuntimeType for IInkModelerAttributes {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkModelerAttributes_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +153,9 @@ pub struct IInkModelerAttributes_Vtbl {
     pub SetScalingFactor: unsafe extern "system" fn(*mut core::ffi::c_void, f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkModelerAttributes2, IInkModelerAttributes2_Vtbl, 0x86d1d09a_4ef8_5e25_b7bc_b65424f16bb3);
+impl windows_core::RuntimeType for IInkModelerAttributes2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkModelerAttributes2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,6 +163,9 @@ pub struct IInkModelerAttributes2_Vtbl {
     pub SetUseVelocityBasedPressure: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPoint, IInkPoint_Vtbl, 0x9f87272b_858c_46a5_9b41_d195970459fd);
+impl windows_core::RuntimeType for IInkPoint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPoint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -131,6 +173,9 @@ pub struct IInkPoint_Vtbl {
     pub Pressure: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPoint2, IInkPoint2_Vtbl, 0xfba9c3f7_ae56_4d5c_bd2f_0ac45f5e4af9);
+impl windows_core::RuntimeType for IInkPoint2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPoint2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,12 +203,18 @@ pub struct IInkPointFactory_Vtbl {
     pub CreateInkPoint: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::Point, f32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPointFactory2, IInkPointFactory2_Vtbl, 0xe0145e85_daff_45f2_ad69_050d8256a209);
+impl windows_core::RuntimeType for IInkPointFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPointFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInkPointWithTiltAndTimestamp: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::Point, f32, f32, f32, u64, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPresenter, IInkPresenter_Vtbl, 0xa69b70e2_887b_458f_b173_4fe4438930a3);
+impl windows_core::RuntimeType for IInkPresenter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPresenter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -192,6 +243,9 @@ pub struct IInkPresenter_Vtbl {
     pub RemoveStrokesErased: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPresenter2, IInkPresenter2_Vtbl, 0xcf53e612_9a34_11e6_9f33_a24fc0d9649c);
+impl windows_core::RuntimeType for IInkPresenter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPresenter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,12 +253,18 @@ pub struct IInkPresenter2_Vtbl {
     pub SetHighContrastAdjustment: unsafe extern "system" fn(*mut core::ffi::c_void, InkHighContrastAdjustment) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPresenter3, IInkPresenter3_Vtbl, 0x51e1ce89_d37d_4a90_83fc_7f5e9dfbf217);
+impl windows_core::RuntimeType for IInkPresenter3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPresenter3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InputConfiguration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPresenterProtractor, IInkPresenterProtractor_Vtbl, 0x7de3f2aa_ef6c_4e91_a73b_5b70d56fbd17);
+impl windows_core::RuntimeType for IInkPresenterProtractor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPresenterProtractor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -224,12 +284,18 @@ pub struct IInkPresenterProtractor_Vtbl {
     pub SetAccentColor: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPresenterProtractorFactory, IInkPresenterProtractorFactory_Vtbl, 0x320103c9_68fa_47e9_8127_8370711fc46c);
+impl windows_core::RuntimeType for IInkPresenterProtractorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPresenterProtractorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPresenterRuler, IInkPresenterRuler_Vtbl, 0x6cda7d5a_dec7_4dd7_877a_2133f183d48a);
+impl windows_core::RuntimeType for IInkPresenterRuler {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPresenterRuler_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -239,6 +305,9 @@ pub struct IInkPresenterRuler_Vtbl {
     pub SetWidth: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkPresenterRuler2, IInkPresenterRuler2_Vtbl, 0x45130dc1_bc61_44d4_a423_54712ae671c4);
+impl windows_core::RuntimeType for IInkPresenterRuler2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkPresenterRuler2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -349,6 +418,9 @@ pub struct IInkPresenterStencil_Vtbl {
     SetTransform: usize,
 }
 windows_core::imp::define_interface!(IInkRecognitionResult, IInkRecognitionResult_Vtbl, 0x36461a94_5068_40ef_8a05_2c2fb60908a2);
+impl windows_core::RuntimeType for IInkRecognitionResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkRecognitionResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -363,6 +435,9 @@ pub struct IInkRecognitionResult_Vtbl {
     GetStrokes: usize,
 }
 windows_core::imp::define_interface!(IInkRecognizer, IInkRecognizer_Vtbl, 0x077ccea3_904d_442a_b151_aaca3631c43b);
+impl windows_core::RuntimeType for IInkRecognizer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkRecognizer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -415,6 +490,9 @@ pub struct IInkRecognizerContainer_Vtbl {
     GetRecognizers: usize,
 }
 windows_core::imp::define_interface!(IInkStroke, IInkStroke_Vtbl, 0x15144d60_cce3_4fcf_9d52_11518ab6afd4);
+impl windows_core::RuntimeType for IInkStroke {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStroke_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -431,6 +509,9 @@ pub struct IInkStroke_Vtbl {
     pub Clone: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStroke2, IInkStroke2_Vtbl, 0x5db9e4f4_bafa_4de1_89d3_201b1ed7d89b);
+impl windows_core::RuntimeType for IInkStroke2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStroke2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -448,6 +529,9 @@ pub struct IInkStroke2_Vtbl {
     GetInkPoints: usize,
 }
 windows_core::imp::define_interface!(IInkStroke3, IInkStroke3_Vtbl, 0x4a807374_9499_411d_a1c4_68855d03d65f);
+impl windows_core::RuntimeType for IInkStroke3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStroke3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -458,12 +542,18 @@ pub struct IInkStroke3_Vtbl {
     pub SetStrokeDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStroke4, IInkStroke4_Vtbl, 0xcd5b62e5_b6e9_5b91_a577_1921d2348690);
+impl windows_core::RuntimeType for IInkStroke4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStroke4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PointerId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStrokeBuilder, IInkStrokeBuilder_Vtbl, 0x82bbd1dc_1c63_41dc_9e07_4b4a70ced801);
+impl windows_core::RuntimeType for IInkStrokeBuilder {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokeBuilder_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -477,6 +567,9 @@ pub struct IInkStrokeBuilder_Vtbl {
     pub SetDefaultDrawingAttributes: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStrokeBuilder2, IInkStrokeBuilder2_Vtbl, 0xbd82bc27_731f_4cbc_bbbf_6d468044f1e5);
+impl windows_core::RuntimeType for IInkStrokeBuilder2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokeBuilder2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -486,6 +579,9 @@ pub struct IInkStrokeBuilder2_Vtbl {
     CreateStrokeFromInkPoints: usize,
 }
 windows_core::imp::define_interface!(IInkStrokeBuilder3, IInkStrokeBuilder3_Vtbl, 0xb2c71fcd_5472_46b1_a81d_c37a3d169441);
+impl windows_core::RuntimeType for IInkStrokeBuilder3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokeBuilder3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -648,6 +744,9 @@ pub struct IInkStrokeContainer_Vtbl {
     GetRecognitionResults: usize,
 }
 windows_core::imp::define_interface!(IInkStrokeContainer2, IInkStrokeContainer2_Vtbl, 0x8901d364_da36_4bcf_9e5c_d195825995b4);
+impl windows_core::RuntimeType for IInkStrokeContainer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokeContainer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -658,6 +757,9 @@ pub struct IInkStrokeContainer2_Vtbl {
     pub Clear: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStrokeContainer3, IInkStrokeContainer3_Vtbl, 0x3d07bea5_baea_4c82_a719_7b83da1067d2);
+impl windows_core::RuntimeType for IInkStrokeContainer3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokeContainer3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -668,6 +770,9 @@ pub struct IInkStrokeContainer3_Vtbl {
     pub GetStrokeById: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStrokeInput, IInkStrokeInput_Vtbl, 0xcf2ffe7b_5e10_43c6_a080_88f26e1dc67d);
+impl windows_core::RuntimeType for IInkStrokeInput {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokeInput_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -694,6 +799,9 @@ pub struct IInkStrokeInput_Vtbl {
     pub InkPresenter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStrokeRenderingSegment, IInkStrokeRenderingSegment_Vtbl, 0x68510f1f_88e3_477a_a2fa_569f5f1f9bd5);
+impl windows_core::RuntimeType for IInkStrokeRenderingSegment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokeRenderingSegment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -706,6 +814,9 @@ pub struct IInkStrokeRenderingSegment_Vtbl {
     pub Twist: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkStrokesCollectedEventArgs, IInkStrokesCollectedEventArgs_Vtbl, 0xc4f3f229_1938_495c_b4d9_6de4b08d4811);
+impl windows_core::RuntimeType for IInkStrokesCollectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokesCollectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -715,6 +826,9 @@ pub struct IInkStrokesCollectedEventArgs_Vtbl {
     Strokes: usize,
 }
 windows_core::imp::define_interface!(IInkStrokesErasedEventArgs, IInkStrokesErasedEventArgs_Vtbl, 0xa4216a22_1503_4ebf_8ff5_2de84584a8aa);
+impl windows_core::RuntimeType for IInkStrokesErasedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkStrokesErasedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -724,6 +838,9 @@ pub struct IInkStrokesErasedEventArgs_Vtbl {
     Strokes: usize,
 }
 windows_core::imp::define_interface!(IInkSynchronizer, IInkSynchronizer_Vtbl, 0x9b9ea160_ae9b_45f9_8407_4b493b163661);
+impl windows_core::RuntimeType for IInkSynchronizer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkSynchronizer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -734,6 +851,9 @@ pub struct IInkSynchronizer_Vtbl {
     pub EndDry: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInkUnprocessedInput, IInkUnprocessedInput_Vtbl, 0xdb4445e0_8398_4921_ac3b_ab978c5ba256);
+impl windows_core::RuntimeType for IInkUnprocessedInput {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInkUnprocessedInput_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -775,6 +895,9 @@ pub struct IInkUnprocessedInput_Vtbl {
     pub InkPresenter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenAndInkSettings, IPenAndInkSettings_Vtbl, 0xbc2ceb8f_0066_44a8_bb7a_b839b3deb8f5);
+impl windows_core::RuntimeType for IPenAndInkSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenAndInkSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -786,12 +909,18 @@ pub struct IPenAndInkSettings_Vtbl {
     pub IsTouchHandwritingEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenAndInkSettings2, IPenAndInkSettings2_Vtbl, 0x3262da53_1f44_55e2_9929_ebf77e5481b8);
+impl windows_core::RuntimeType for IPenAndInkSettings2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenAndInkSettings2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SetPenHandedness: unsafe extern "system" fn(*mut core::ffi::c_void, PenHandedness) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPenAndInkSettingsStatics, IPenAndInkSettingsStatics_Vtbl, 0xed6dd036_5708_5c3c_96db_f2f552eab641);
+impl windows_core::RuntimeType for IPenAndInkSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPenAndInkSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -933,7 +1062,7 @@ impl InkDrawingAttributes {
     }
 }
 impl windows_core::RuntimeType for InkDrawingAttributes {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkDrawingAttributes>();
 }
 unsafe impl windows_core::Interface for InkDrawingAttributes {
     type Vtable = IInkDrawingAttributes_Vtbl;
@@ -962,7 +1091,7 @@ impl InkDrawingAttributesPencilProperties {
     }
 }
 impl windows_core::RuntimeType for InkDrawingAttributesPencilProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkDrawingAttributesPencilProperties>();
 }
 unsafe impl windows_core::Interface for InkDrawingAttributesPencilProperties {
     type Vtable = IInkDrawingAttributesPencilProperties_Vtbl;
@@ -1013,7 +1142,7 @@ impl InkInputConfiguration {
     }
 }
 impl windows_core::RuntimeType for InkInputConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkInputConfiguration>();
 }
 unsafe impl windows_core::Interface for InkInputConfiguration {
     type Vtable = IInkInputConfiguration_Vtbl;
@@ -1053,7 +1182,7 @@ impl InkInputProcessingConfiguration {
     }
 }
 impl windows_core::RuntimeType for InkInputProcessingConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkInputProcessingConfiguration>();
 }
 unsafe impl windows_core::Interface for InkInputProcessingConfiguration {
     type Vtable = IInkInputProcessingConfiguration_Vtbl;
@@ -1268,7 +1397,7 @@ impl InkManager {
     }
 }
 impl windows_core::RuntimeType for InkManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkManager>();
 }
 unsafe impl windows_core::Interface for InkManager {
     type Vtable = IInkManager_Vtbl;
@@ -1317,7 +1446,7 @@ impl InkModelerAttributes {
     }
 }
 impl windows_core::RuntimeType for InkModelerAttributes {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkModelerAttributes>();
 }
 unsafe impl windows_core::Interface for InkModelerAttributes {
     type Vtable = IInkModelerAttributes_Vtbl;
@@ -1392,7 +1521,7 @@ impl InkPoint {
     }
 }
 impl windows_core::RuntimeType for InkPoint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkPoint>();
 }
 unsafe impl windows_core::Interface for InkPoint {
     type Vtable = IInkPoint_Vtbl;
@@ -1540,7 +1669,7 @@ impl InkPresenter {
     }
 }
 impl windows_core::RuntimeType for InkPresenter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkPresenter>();
 }
 unsafe impl windows_core::Interface for InkPresenter {
     type Vtable = IInkPresenter_Vtbl;
@@ -1703,7 +1832,7 @@ impl InkPresenterProtractor {
     }
 }
 impl windows_core::RuntimeType for InkPresenterProtractor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkPresenterProtractor>();
 }
 unsafe impl windows_core::Interface for InkPresenterProtractor {
     type Vtable = IInkPresenterProtractor_Vtbl;
@@ -1833,7 +1962,7 @@ impl InkPresenterRuler {
     }
 }
 impl windows_core::RuntimeType for InkPresenterRuler {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkPresenterRuler>();
 }
 unsafe impl windows_core::Interface for InkPresenterRuler {
     type Vtable = IInkPresenterRuler_Vtbl;
@@ -1874,7 +2003,7 @@ impl InkRecognitionResult {
     }
 }
 impl windows_core::RuntimeType for InkRecognitionResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkRecognitionResult>();
 }
 unsafe impl windows_core::Interface for InkRecognitionResult {
     type Vtable = IInkRecognitionResult_Vtbl;
@@ -1899,7 +2028,7 @@ impl InkRecognizer {
     }
 }
 impl windows_core::RuntimeType for InkRecognizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkRecognizer>();
 }
 unsafe impl windows_core::Interface for InkRecognizer {
     type Vtable = IInkRecognizer_Vtbl;
@@ -1949,7 +2078,7 @@ impl InkRecognizerContainer {
     }
 }
 impl windows_core::RuntimeType for InkRecognizerContainer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkRecognizerContainer>();
 }
 unsafe impl windows_core::Interface for InkRecognizerContainer {
     type Vtable = IInkRecognizerContainer_Vtbl;
@@ -2082,7 +2211,7 @@ impl InkStroke {
     }
 }
 impl windows_core::RuntimeType for InkStroke {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkStroke>();
 }
 unsafe impl windows_core::Interface for InkStroke {
     type Vtable = IInkStroke_Vtbl;
@@ -2176,7 +2305,7 @@ impl InkStrokeBuilder {
     }
 }
 impl windows_core::RuntimeType for InkStrokeBuilder {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkStrokeBuilder>();
 }
 unsafe impl windows_core::Interface for InkStrokeBuilder {
     type Vtable = IInkStrokeBuilder_Vtbl;
@@ -2340,7 +2469,7 @@ impl InkStrokeContainer {
     }
 }
 impl windows_core::RuntimeType for InkStrokeContainer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkStrokeContainer>();
 }
 unsafe impl windows_core::Interface for InkStrokeContainer {
     type Vtable = IInkStrokeContainer_Vtbl;
@@ -2423,7 +2552,7 @@ impl InkStrokeInput {
     }
 }
 impl windows_core::RuntimeType for InkStrokeInput {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkStrokeInput>();
 }
 unsafe impl windows_core::Interface for InkStrokeInput {
     type Vtable = IInkStrokeInput_Vtbl;
@@ -2490,7 +2619,7 @@ impl InkStrokeRenderingSegment {
     }
 }
 impl windows_core::RuntimeType for InkStrokeRenderingSegment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkStrokeRenderingSegment>();
 }
 unsafe impl windows_core::Interface for InkStrokeRenderingSegment {
     type Vtable = IInkStrokeRenderingSegment_Vtbl;
@@ -2516,7 +2645,7 @@ impl InkStrokesCollectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for InkStrokesCollectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkStrokesCollectedEventArgs>();
 }
 unsafe impl windows_core::Interface for InkStrokesCollectedEventArgs {
     type Vtable = IInkStrokesCollectedEventArgs_Vtbl;
@@ -2540,7 +2669,7 @@ impl InkStrokesErasedEventArgs {
     }
 }
 impl windows_core::RuntimeType for InkStrokesErasedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkStrokesErasedEventArgs>();
 }
 unsafe impl windows_core::Interface for InkStrokesErasedEventArgs {
     type Vtable = IInkStrokesErasedEventArgs_Vtbl;
@@ -2568,7 +2697,7 @@ impl InkSynchronizer {
     }
 }
 impl windows_core::RuntimeType for InkSynchronizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkSynchronizer>();
 }
 unsafe impl windows_core::Interface for InkSynchronizer {
     type Vtable = IInkSynchronizer_Vtbl;
@@ -2696,7 +2825,7 @@ impl InkUnprocessedInput {
     }
 }
 impl windows_core::RuntimeType for InkUnprocessedInput {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInkUnprocessedInput>();
 }
 unsafe impl windows_core::Interface for InkUnprocessedInput {
     type Vtable = IInkUnprocessedInput_Vtbl;
@@ -2771,7 +2900,7 @@ impl PenAndInkSettings {
     }
 }
 impl windows_core::RuntimeType for PenAndInkSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPenAndInkSettings>();
 }
 unsafe impl windows_core::Interface for PenAndInkSettings {
     type Vtable = IPenAndInkSettings_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IInjectedInputGamepadInfo, IInjectedInputGamepadInfo_Vtbl, 0x20ae9a3f_df11_4572_a9ab_d75b8a5e48ad);
+impl windows_core::RuntimeType for IInjectedInputGamepadInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInjectedInputGamepadInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +27,9 @@ pub struct IInjectedInputGamepadInfo_Vtbl {
     pub SetRightTrigger: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInjectedInputGamepadInfoFactory, IInjectedInputGamepadInfoFactory_Vtbl, 0x59596876_6c39_4ec4_8b2a_29ef7de18aca);
+impl windows_core::RuntimeType for IInjectedInputGamepadInfoFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInjectedInputGamepadInfoFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -33,6 +39,9 @@ pub struct IInjectedInputGamepadInfoFactory_Vtbl {
     CreateInstanceFromGamepadReading: usize,
 }
 windows_core::imp::define_interface!(IInjectedInputKeyboardInfo, IInjectedInputKeyboardInfo_Vtbl, 0x4b46d140_2b6a_5ffa_7eae_bd077b052acd);
+impl windows_core::RuntimeType for IInjectedInputKeyboardInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInjectedInputKeyboardInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +53,9 @@ pub struct IInjectedInputKeyboardInfo_Vtbl {
     pub SetVirtualKey: unsafe extern "system" fn(*mut core::ffi::c_void, u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInjectedInputMouseInfo, IInjectedInputMouseInfo_Vtbl, 0x96f56e6b_e47a_5cf4_418d_8a5fb9670c7d);
+impl windows_core::RuntimeType for IInjectedInputMouseInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInjectedInputMouseInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +71,9 @@ pub struct IInjectedInputMouseInfo_Vtbl {
     pub SetTimeOffsetInMilliseconds: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInjectedInputPenInfo, IInjectedInputPenInfo_Vtbl, 0x6b40ad03_ca1e_5527_7e02_2828540bb1d4);
+impl windows_core::RuntimeType for IInjectedInputPenInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInjectedInputPenInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -78,6 +93,9 @@ pub struct IInjectedInputPenInfo_Vtbl {
     pub SetTiltY: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInjectedInputTouchInfo, IInjectedInputTouchInfo_Vtbl, 0x224fd1df_43e8_5ef5_510a_69ca8c9b4c28);
+impl windows_core::RuntimeType for IInjectedInputTouchInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInjectedInputTouchInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,6 +111,9 @@ pub struct IInjectedInputTouchInfo_Vtbl {
     pub SetTouchParameters: unsafe extern "system" fn(*mut core::ffi::c_void, InjectedInputTouchParameters) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputInjector, IInputInjector_Vtbl, 0x8ec26f84_0b02_4bd2_ad7a_3d4658be3e18);
+impl windows_core::RuntimeType for IInputInjector {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputInjector_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -116,6 +137,9 @@ pub struct IInputInjector_Vtbl {
     pub InjectShortcut: unsafe extern "system" fn(*mut core::ffi::c_void, InjectedInputShortcut) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputInjector2, IInputInjector2_Vtbl, 0x8e7a905d_1453_43a7_9bcb_06d6d7b305f7);
+impl windows_core::RuntimeType for IInputInjector2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputInjector2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -124,12 +148,18 @@ pub struct IInputInjector2_Vtbl {
     pub UninitializeGamepadInjection: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputInjectorStatics, IInputInjectorStatics_Vtbl, 0xdeae6943_7402_4141_a5c6_0c01aa57b16a);
+impl windows_core::RuntimeType for IInputInjectorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputInjectorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryCreate: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputInjectorStatics2, IInputInjectorStatics2_Vtbl, 0xa4db38fb_dd8c_414f_95ea_f87ef4c0ae6c);
+impl windows_core::RuntimeType for IInputInjectorStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputInjectorStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -240,7 +270,7 @@ impl InjectedInputGamepadInfo {
     }
 }
 impl windows_core::RuntimeType for InjectedInputGamepadInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInjectedInputGamepadInfo>();
 }
 unsafe impl windows_core::Interface for InjectedInputGamepadInfo {
     type Vtable = IInjectedInputGamepadInfo_Vtbl;
@@ -296,7 +326,7 @@ impl InjectedInputKeyboardInfo {
     }
 }
 impl windows_core::RuntimeType for InjectedInputKeyboardInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInjectedInputKeyboardInfo>();
 }
 unsafe impl windows_core::Interface for InjectedInputKeyboardInfo {
     type Vtable = IInjectedInputKeyboardInfo_Vtbl;
@@ -374,7 +404,7 @@ impl InjectedInputMouseInfo {
     }
 }
 impl windows_core::RuntimeType for InjectedInputMouseInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInjectedInputMouseInfo>();
 }
 unsafe impl windows_core::Interface for InjectedInputMouseInfo {
     type Vtable = IInjectedInputMouseInfo_Vtbl;
@@ -474,7 +504,7 @@ impl InjectedInputPenInfo {
     }
 }
 impl windows_core::RuntimeType for InjectedInputPenInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInjectedInputPenInfo>();
 }
 unsafe impl windows_core::Interface for InjectedInputPenInfo {
     type Vtable = IInjectedInputPenInfo_Vtbl;
@@ -552,7 +582,7 @@ impl InjectedInputTouchInfo {
     }
 }
 impl windows_core::RuntimeType for InjectedInputTouchInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInjectedInputTouchInfo>();
 }
 unsafe impl windows_core::Interface for InjectedInputTouchInfo {
     type Vtable = IInjectedInputTouchInfo_Vtbl;
@@ -656,7 +686,7 @@ impl InputInjector {
     }
 }
 impl windows_core::RuntimeType for InputInjector {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputInjector>();
 }
 unsafe impl windows_core::Interface for InputInjector {
     type Vtable = IInputInjector_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "UI_Input_Preview_Injection")]
 pub mod Injection;
 windows_core::imp::define_interface!(IInputActivationListenerPreviewStatics, IInputActivationListenerPreviewStatics_Vtbl, 0xf0551ce5_0de6_5be0_a589_f737201a4582);
+impl windows_core::RuntimeType for IInputActivationListenerPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputActivationListenerPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISpatialGestureRecognizer, ISpatialGestureRecognizer_Vtbl, 0x71605bcc_0c35_4673_adbd_cc04caa6ef45);
+impl windows_core::RuntimeType for ISpatialGestureRecognizer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialGestureRecognizer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,24 +39,36 @@ pub struct ISpatialGestureRecognizer_Vtbl {
     pub GestureSettings: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialGestureSettings) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialGestureRecognizerFactory, ISpatialGestureRecognizerFactory_Vtbl, 0x77214186_57b9_3150_8382_698b24e264d0);
+impl windows_core::RuntimeType for ISpatialGestureRecognizerFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialGestureRecognizerFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, SpatialGestureSettings, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialHoldCanceledEventArgs, ISpatialHoldCanceledEventArgs_Vtbl, 0x5dfcb667_4caa_4093_8c35_b601a839f31b);
+impl windows_core::RuntimeType for ISpatialHoldCanceledEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialHoldCanceledEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InteractionSourceKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourceKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialHoldCompletedEventArgs, ISpatialHoldCompletedEventArgs_Vtbl, 0x3f64470b_4cfd_43da_8dc4_e64552173971);
+impl windows_core::RuntimeType for ISpatialHoldCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialHoldCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InteractionSourceKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourceKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialHoldStartedEventArgs, ISpatialHoldStartedEventArgs_Vtbl, 0x8e343d79_acb6_4144_8615_2cfba8a3cb3f);
+impl windows_core::RuntimeType for ISpatialHoldStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialHoldStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,12 +79,18 @@ pub struct ISpatialHoldStartedEventArgs_Vtbl {
     TryGetPointerPose: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteraction, ISpatialInteraction_Vtbl, 0xfc967639_88e6_4646_9112_4344aaec9dfa);
+impl windows_core::RuntimeType for ISpatialInteraction {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteraction_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub SourceState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionController, ISpatialInteractionController_Vtbl, 0x5f0e5ba3_0954_4e97_86c5_e7f30b114dfd);
+impl windows_core::RuntimeType for ISpatialInteractionController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +105,9 @@ pub struct ISpatialInteractionController_Vtbl {
     pub Version: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionController2, ISpatialInteractionController2_Vtbl, 0x35b6d924_c7a2_49b7_b72e_5436b2fb8f9c);
+impl windows_core::RuntimeType for ISpatialInteractionController2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionController2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -93,6 +117,9 @@ pub struct ISpatialInteractionController2_Vtbl {
     TryGetRenderableModelAsync: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionController3, ISpatialInteractionController3_Vtbl, 0x628466a0_9d91_4a0b_888d_165e670a8cd5);
+impl windows_core::RuntimeType for ISpatialInteractionController3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionController3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,6 +129,9 @@ pub struct ISpatialInteractionController3_Vtbl {
     TryGetBatteryReport: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionControllerProperties, ISpatialInteractionControllerProperties_Vtbl, 0x61056fb1_7ba9_4e35_b93f_9272cba9b28b);
+impl windows_core::RuntimeType for ISpatialInteractionControllerProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionControllerProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +144,9 @@ pub struct ISpatialInteractionControllerProperties_Vtbl {
     pub TouchpadY: unsafe extern "system" fn(*mut core::ffi::c_void, *mut f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionDetectedEventArgs, ISpatialInteractionDetectedEventArgs_Vtbl, 0x075878e4_5961_3b41_9dfb_cea5d89cc38a);
+impl windows_core::RuntimeType for ISpatialInteractionDetectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionDetectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -125,12 +158,18 @@ pub struct ISpatialInteractionDetectedEventArgs_Vtbl {
     pub Interaction: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionDetectedEventArgs2, ISpatialInteractionDetectedEventArgs2_Vtbl, 0x7b263e93_5f13_419c_97d5_834678266aa6);
+impl windows_core::RuntimeType for ISpatialInteractionDetectedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionDetectedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InteractionSource: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionManager, ISpatialInteractionManager_Vtbl, 0x32a64ea8_a15a_3995_b8bd_80513cb5adef);
+impl windows_core::RuntimeType for ISpatialInteractionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,18 +191,27 @@ pub struct ISpatialInteractionManager_Vtbl {
     GetDetectedSourcesAtTimestamp: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionManagerStatics, ISpatialInteractionManagerStatics_Vtbl, 0x00e31fa6_8ca2_30bf_91fe_d9cb4a008990);
+impl windows_core::RuntimeType for ISpatialInteractionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionManagerStatics2, ISpatialInteractionManagerStatics2_Vtbl, 0x93f16c52_b88a_5929_8d7c_48cb948b081c);
+impl windows_core::RuntimeType for ISpatialInteractionManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsSourceKindSupported: unsafe extern "system" fn(*mut core::ffi::c_void, SpatialInteractionSourceKind, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSource, ISpatialInteractionSource_Vtbl, 0xfb5433ba_b0b3_3148_9f3b_e9f5de568f5d);
+impl windows_core::RuntimeType for ISpatialInteractionSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -171,6 +219,9 @@ pub struct ISpatialInteractionSource_Vtbl {
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourceKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSource2, ISpatialInteractionSource2_Vtbl, 0xe4c5b70c_0470_4028_88c0_a0eb44d34efe);
+impl windows_core::RuntimeType for ISpatialInteractionSource2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSource2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -184,12 +235,18 @@ pub struct ISpatialInteractionSource2_Vtbl {
     TryGetStateAtTimestamp: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSource3, ISpatialInteractionSource3_Vtbl, 0x0406d9f9_9afd_44f9_85dc_700023a962e3);
+impl windows_core::RuntimeType for ISpatialInteractionSource3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSource3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Handedness: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourceHandedness) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSource4, ISpatialInteractionSource4_Vtbl, 0x0073bc4d_df66_5a91_a2ba_cea3e5c58a19);
+impl windows_core::RuntimeType for ISpatialInteractionSource4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSource4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,18 +260,27 @@ pub struct ISpatialInteractionSource4_Vtbl {
     TryCreateHandMeshObserverAsync: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceEventArgs, ISpatialInteractionSourceEventArgs_Vtbl, 0x23b786cf_ec23_3979_b27c_eb0e12feb7c7);
+impl windows_core::RuntimeType for ISpatialInteractionSourceEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceEventArgs2, ISpatialInteractionSourceEventArgs2_Vtbl, 0xd8b4b467_e648_4d52_ab49_e0d227199f63);
+impl windows_core::RuntimeType for ISpatialInteractionSourceEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PressKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionPressKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceLocation, ISpatialInteractionSourceLocation_Vtbl, 0xea4696c4_7e8b_30ca_bcc5_c77189cea30a);
+impl windows_core::RuntimeType for ISpatialInteractionSourceLocation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceLocation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -228,6 +294,9 @@ pub struct ISpatialInteractionSourceLocation_Vtbl {
     Velocity: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceLocation2, ISpatialInteractionSourceLocation2_Vtbl, 0x4c671045_3917_40fc_a9ac_31c9cf5ff91b);
+impl windows_core::RuntimeType for ISpatialInteractionSourceLocation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceLocation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -237,6 +306,9 @@ pub struct ISpatialInteractionSourceLocation2_Vtbl {
     Orientation: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceLocation3, ISpatialInteractionSourceLocation3_Vtbl, 0x6702e65e_e915_4cfb_9c1b_0538efc86687);
+impl windows_core::RuntimeType for ISpatialInteractionSourceLocation3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceLocation3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +320,9 @@ pub struct ISpatialInteractionSourceLocation3_Vtbl {
     pub SourcePointerPose: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceProperties, ISpatialInteractionSourceProperties_Vtbl, 0x05604542_3ef7_3222_9f53_63c9cb7e3bc7);
+impl windows_core::RuntimeType for ISpatialInteractionSourceProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -262,6 +337,9 @@ pub struct ISpatialInteractionSourceProperties_Vtbl {
     TryGetLocation: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceState, ISpatialInteractionSourceState_Vtbl, 0xd5c475ef_4b63_37ec_98b9_9fc652b9d2f2);
+impl windows_core::RuntimeType for ISpatialInteractionSourceState {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceState_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -278,6 +356,9 @@ pub struct ISpatialInteractionSourceState_Vtbl {
     TryGetPointerPose: usize,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceState2, ISpatialInteractionSourceState2_Vtbl, 0x45f6d0bd_1773_492e_9ba3_8ac1cbe77c08);
+impl windows_core::RuntimeType for ISpatialInteractionSourceState2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceState2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -288,6 +369,9 @@ pub struct ISpatialInteractionSourceState2_Vtbl {
     pub ControllerProperties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialInteractionSourceState3, ISpatialInteractionSourceState3_Vtbl, 0xf2f00bc2_bd2b_4a01_a8fb_323e0158527c);
+impl windows_core::RuntimeType for ISpatialInteractionSourceState3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialInteractionSourceState3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -297,12 +381,18 @@ pub struct ISpatialInteractionSourceState3_Vtbl {
     TryGetHandPose: usize,
 }
 windows_core::imp::define_interface!(ISpatialManipulationCanceledEventArgs, ISpatialManipulationCanceledEventArgs_Vtbl, 0x2d40d1cb_e7da_4220_b0bf_819301674780);
+impl windows_core::RuntimeType for ISpatialManipulationCanceledEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialManipulationCanceledEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InteractionSourceKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourceKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialManipulationCompletedEventArgs, ISpatialManipulationCompletedEventArgs_Vtbl, 0x05086802_f301_4343_9250_2fbaa5f87a37);
+impl windows_core::RuntimeType for ISpatialManipulationCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialManipulationCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -313,6 +403,9 @@ pub struct ISpatialManipulationCompletedEventArgs_Vtbl {
     TryGetCumulativeDelta: usize,
 }
 windows_core::imp::define_interface!(ISpatialManipulationDelta, ISpatialManipulationDelta_Vtbl, 0xa7ec967a_d123_3a81_a15b_992923dcbe91);
+impl windows_core::RuntimeType for ISpatialManipulationDelta {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialManipulationDelta_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -322,6 +415,9 @@ pub struct ISpatialManipulationDelta_Vtbl {
     Translation: usize,
 }
 windows_core::imp::define_interface!(ISpatialManipulationStartedEventArgs, ISpatialManipulationStartedEventArgs_Vtbl, 0xa1d6bbce_42a5_377b_ada6_d28e3d384737);
+impl windows_core::RuntimeType for ISpatialManipulationStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialManipulationStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -332,6 +428,9 @@ pub struct ISpatialManipulationStartedEventArgs_Vtbl {
     TryGetPointerPose: usize,
 }
 windows_core::imp::define_interface!(ISpatialManipulationUpdatedEventArgs, ISpatialManipulationUpdatedEventArgs_Vtbl, 0x5f230b9b_60c6_4dc6_bdc9_9f4a6f15fe49);
+impl windows_core::RuntimeType for ISpatialManipulationUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialManipulationUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -342,12 +441,18 @@ pub struct ISpatialManipulationUpdatedEventArgs_Vtbl {
     TryGetCumulativeDelta: usize,
 }
 windows_core::imp::define_interface!(ISpatialNavigationCanceledEventArgs, ISpatialNavigationCanceledEventArgs_Vtbl, 0xce503edc_e8a5_46f0_92d4_3c122b35112a);
+impl windows_core::RuntimeType for ISpatialNavigationCanceledEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialNavigationCanceledEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InteractionSourceKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourceKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialNavigationCompletedEventArgs, ISpatialNavigationCompletedEventArgs_Vtbl, 0x012e80b7_af3b_42c2_9e41_baaa0e721f3a);
+impl windows_core::RuntimeType for ISpatialNavigationCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialNavigationCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -358,6 +463,9 @@ pub struct ISpatialNavigationCompletedEventArgs_Vtbl {
     NormalizedOffset: usize,
 }
 windows_core::imp::define_interface!(ISpatialNavigationStartedEventArgs, ISpatialNavigationStartedEventArgs_Vtbl, 0x754a348a_fb64_4656_8ebd_9deecaafe475);
+impl windows_core::RuntimeType for ISpatialNavigationStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialNavigationStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -371,6 +479,9 @@ pub struct ISpatialNavigationStartedEventArgs_Vtbl {
     pub IsNavigatingZ: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialNavigationUpdatedEventArgs, ISpatialNavigationUpdatedEventArgs_Vtbl, 0x9b713fd7_839d_4a74_8732_45466fc044b5);
+impl windows_core::RuntimeType for ISpatialNavigationUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialNavigationUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -381,6 +492,9 @@ pub struct ISpatialNavigationUpdatedEventArgs_Vtbl {
     NormalizedOffset: usize,
 }
 windows_core::imp::define_interface!(ISpatialPointerInteractionSourcePose, ISpatialPointerInteractionSourcePose_Vtbl, 0xa7104307_2c2b_4d3a_92a7_80ced7c4a0d0);
+impl windows_core::RuntimeType for ISpatialPointerInteractionSourcePose {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialPointerInteractionSourcePose_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -398,6 +512,9 @@ pub struct ISpatialPointerInteractionSourcePose_Vtbl {
     UpDirection: usize,
 }
 windows_core::imp::define_interface!(ISpatialPointerInteractionSourcePose2, ISpatialPointerInteractionSourcePose2_Vtbl, 0xeccd86b8_52db_469f_9e3f_80c47f74bce9);
+impl windows_core::RuntimeType for ISpatialPointerInteractionSourcePose2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialPointerInteractionSourcePose2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -408,6 +525,9 @@ pub struct ISpatialPointerInteractionSourcePose2_Vtbl {
     pub PositionAccuracy: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourcePositionAccuracy) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialPointerPose, ISpatialPointerPose_Vtbl, 0x6953a42e_c17e_357d_97a1_7269d0ed2d10);
+impl windows_core::RuntimeType for ISpatialPointerPose {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialPointerPose_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -421,12 +541,18 @@ pub struct ISpatialPointerPose_Vtbl {
     Head: usize,
 }
 windows_core::imp::define_interface!(ISpatialPointerPose2, ISpatialPointerPose2_Vtbl, 0x9d202b17_954e_4e0c_96d1_b6790b6fc2fd);
+impl windows_core::RuntimeType for ISpatialPointerPose2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialPointerPose2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryGetInteractionSourcePose: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialPointerPose3, ISpatialPointerPose3_Vtbl, 0x6342f3f0_ec49_5b4b_b8d1_d16cbb16be84);
+impl windows_core::RuntimeType for ISpatialPointerPose3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialPointerPose3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -437,6 +563,9 @@ pub struct ISpatialPointerPose3_Vtbl {
     pub IsHeadCapturedBySystem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialPointerPoseStatics, ISpatialPointerPoseStatics_Vtbl, 0xa25591a9_aca1_3ee0_9816_785cfb2e3fb8);
+impl windows_core::RuntimeType for ISpatialPointerPoseStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialPointerPoseStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -446,12 +575,18 @@ pub struct ISpatialPointerPoseStatics_Vtbl {
     TryGetAtTimestamp: usize,
 }
 windows_core::imp::define_interface!(ISpatialRecognitionEndedEventArgs, ISpatialRecognitionEndedEventArgs_Vtbl, 0x0e35f5cb_3f75_43f3_ac81_d1dc2df9b1fb);
+impl windows_core::RuntimeType for ISpatialRecognitionEndedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialRecognitionEndedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub InteractionSourceKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut SpatialInteractionSourceKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialRecognitionStartedEventArgs, ISpatialRecognitionStartedEventArgs_Vtbl, 0x24da128f_0008_4a6d_aa50_2a76f9cfb264);
+impl windows_core::RuntimeType for ISpatialRecognitionStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialRecognitionStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -463,6 +598,9 @@ pub struct ISpatialRecognitionStartedEventArgs_Vtbl {
     pub IsGesturePossible: unsafe extern "system" fn(*mut core::ffi::c_void, SpatialGestureSettings, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISpatialTappedEventArgs, ISpatialTappedEventArgs_Vtbl, 0x296d83de_f444_4aa1_b2bf_9dc88d567da6);
+impl windows_core::RuntimeType for ISpatialTappedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISpatialTappedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -712,7 +850,7 @@ impl SpatialGestureRecognizer {
     }
 }
 impl windows_core::RuntimeType for SpatialGestureRecognizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialGestureRecognizer>();
 }
 unsafe impl windows_core::Interface for SpatialGestureRecognizer {
     type Vtable = ISpatialGestureRecognizer_Vtbl;
@@ -737,7 +875,7 @@ impl SpatialHoldCanceledEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialHoldCanceledEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialHoldCanceledEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialHoldCanceledEventArgs {
     type Vtable = ISpatialHoldCanceledEventArgs_Vtbl;
@@ -762,7 +900,7 @@ impl SpatialHoldCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialHoldCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialHoldCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialHoldCompletedEventArgs {
     type Vtable = ISpatialHoldCompletedEventArgs_Vtbl;
@@ -798,7 +936,7 @@ impl SpatialHoldStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialHoldStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialHoldStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialHoldStartedEventArgs {
     type Vtable = ISpatialHoldStartedEventArgs_Vtbl;
@@ -823,7 +961,7 @@ impl SpatialInteraction {
     }
 }
 impl windows_core::RuntimeType for SpatialInteraction {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteraction>();
 }
 unsafe impl windows_core::Interface for SpatialInteraction {
     type Vtable = ISpatialInteraction_Vtbl;
@@ -900,7 +1038,7 @@ impl SpatialInteractionController {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionController>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionController {
     type Vtable = ISpatialInteractionController_Vtbl;
@@ -967,7 +1105,7 @@ impl SpatialInteractionControllerProperties {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionControllerProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionControllerProperties>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionControllerProperties {
     type Vtable = ISpatialInteractionControllerProperties_Vtbl;
@@ -1017,7 +1155,7 @@ impl SpatialInteractionDetectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionDetectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionDetectedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionDetectedEventArgs {
     type Vtable = ISpatialInteractionDetectedEventArgs_Vtbl;
@@ -1152,7 +1290,7 @@ impl SpatialInteractionManager {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionManager>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionManager {
     type Vtable = ISpatialInteractionManager_Vtbl;
@@ -1246,7 +1384,7 @@ impl SpatialInteractionSource {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionSource>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionSource {
     type Vtable = ISpatialInteractionSource_Vtbl;
@@ -1278,7 +1416,7 @@ impl SpatialInteractionSourceEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionSourceEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionSourceEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionSourceEventArgs {
     type Vtable = ISpatialInteractionSourceEventArgs_Vtbl;
@@ -1342,7 +1480,7 @@ impl SpatialInteractionSourceLocation {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionSourceLocation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionSourceLocation>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionSourceLocation {
     type Vtable = ISpatialInteractionSourceLocation_Vtbl;
@@ -1389,7 +1527,7 @@ impl SpatialInteractionSourceProperties {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionSourceProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionSourceProperties>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionSourceProperties {
     type Vtable = ISpatialInteractionSourceProperties_Vtbl;
@@ -1490,7 +1628,7 @@ impl SpatialInteractionSourceState {
     }
 }
 impl windows_core::RuntimeType for SpatialInteractionSourceState {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialInteractionSourceState>();
 }
 unsafe impl windows_core::Interface for SpatialInteractionSourceState {
     type Vtable = ISpatialInteractionSourceState_Vtbl;
@@ -1515,7 +1653,7 @@ impl SpatialManipulationCanceledEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialManipulationCanceledEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialManipulationCanceledEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialManipulationCanceledEventArgs {
     type Vtable = ISpatialManipulationCanceledEventArgs_Vtbl;
@@ -1551,7 +1689,7 @@ impl SpatialManipulationCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialManipulationCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialManipulationCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialManipulationCompletedEventArgs {
     type Vtable = ISpatialManipulationCompletedEventArgs_Vtbl;
@@ -1577,7 +1715,7 @@ impl SpatialManipulationDelta {
     }
 }
 impl windows_core::RuntimeType for SpatialManipulationDelta {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialManipulationDelta>();
 }
 unsafe impl windows_core::Interface for SpatialManipulationDelta {
     type Vtable = ISpatialManipulationDelta_Vtbl;
@@ -1613,7 +1751,7 @@ impl SpatialManipulationStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialManipulationStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialManipulationStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialManipulationStartedEventArgs {
     type Vtable = ISpatialManipulationStartedEventArgs_Vtbl;
@@ -1649,7 +1787,7 @@ impl SpatialManipulationUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialManipulationUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialManipulationUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialManipulationUpdatedEventArgs {
     type Vtable = ISpatialManipulationUpdatedEventArgs_Vtbl;
@@ -1674,7 +1812,7 @@ impl SpatialNavigationCanceledEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialNavigationCanceledEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialNavigationCanceledEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialNavigationCanceledEventArgs {
     type Vtable = ISpatialNavigationCanceledEventArgs_Vtbl;
@@ -1707,7 +1845,7 @@ impl SpatialNavigationCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialNavigationCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialNavigationCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialNavigationCompletedEventArgs {
     type Vtable = ISpatialNavigationCompletedEventArgs_Vtbl;
@@ -1764,7 +1902,7 @@ impl SpatialNavigationStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialNavigationStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialNavigationStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialNavigationStartedEventArgs {
     type Vtable = ISpatialNavigationStartedEventArgs_Vtbl;
@@ -1797,7 +1935,7 @@ impl SpatialNavigationUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialNavigationUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialNavigationUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialNavigationUpdatedEventArgs {
     type Vtable = ISpatialNavigationUpdatedEventArgs_Vtbl;
@@ -1854,7 +1992,7 @@ impl SpatialPointerInteractionSourcePose {
     }
 }
 impl windows_core::RuntimeType for SpatialPointerInteractionSourcePose {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialPointerInteractionSourcePose>();
 }
 unsafe impl windows_core::Interface for SpatialPointerInteractionSourcePose {
     type Vtable = ISpatialPointerInteractionSourcePose_Vtbl;
@@ -1929,7 +2067,7 @@ impl SpatialPointerPose {
     }
 }
 impl windows_core::RuntimeType for SpatialPointerPose {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialPointerPose>();
 }
 unsafe impl windows_core::Interface for SpatialPointerPose {
     type Vtable = ISpatialPointerPose_Vtbl;
@@ -1954,7 +2092,7 @@ impl SpatialRecognitionEndedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialRecognitionEndedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialRecognitionEndedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialRecognitionEndedEventArgs {
     type Vtable = ISpatialRecognitionEndedEventArgs_Vtbl;
@@ -1997,7 +2135,7 @@ impl SpatialRecognitionStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialRecognitionStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialRecognitionStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialRecognitionStartedEventArgs {
     type Vtable = ISpatialRecognitionStartedEventArgs_Vtbl;
@@ -2040,7 +2178,7 @@ impl SpatialTappedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SpatialTappedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISpatialTappedEventArgs>();
 }
 unsafe impl windows_core::Interface for SpatialTappedEventArgs {
     type Vtable = ISpatialTappedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/mod.rs
@@ -7,16 +7,25 @@ pub mod Preview;
 #[cfg(feature = "UI_Input_Spatial")]
 pub mod Spatial;
 windows_core::imp::define_interface!(IAttachableInputObject, IAttachableInputObject_Vtbl, 0x9b822734_a3c1_542a_b2f4_0e32b773fb07);
+impl windows_core::RuntimeType for IAttachableInputObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAttachableInputObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IAttachableInputObjectFactory, IAttachableInputObjectFactory_Vtbl, 0xa4c54c4e_42bc_58fa_a640_ea1516f4c06b);
+impl windows_core::RuntimeType for IAttachableInputObjectFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAttachableInputObjectFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ICrossSlidingEventArgs, ICrossSlidingEventArgs_Vtbl, 0xe9374738_6f88_41d9_8720_78e08e398349);
+impl windows_core::RuntimeType for ICrossSlidingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICrossSlidingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,12 +37,18 @@ pub struct ICrossSlidingEventArgs_Vtbl {
     pub CrossSlidingState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CrossSlidingState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICrossSlidingEventArgs2, ICrossSlidingEventArgs2_Vtbl, 0xeefb7d48_c070_59f3_8dab_bcaf621d8687);
+impl windows_core::RuntimeType for ICrossSlidingEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICrossSlidingEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDraggingEventArgs, IDraggingEventArgs_Vtbl, 0x1c905384_083c_4bd3_b559_179cddeb33ec);
+impl windows_core::RuntimeType for IDraggingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDraggingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,12 +60,18 @@ pub struct IDraggingEventArgs_Vtbl {
     pub DraggingState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut DraggingState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IDraggingEventArgs2, IDraggingEventArgs2_Vtbl, 0x71efdbf9_382a_55ca_b4b9_008123c1bf1a);
+impl windows_core::RuntimeType for IDraggingEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDraggingEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEdgeGesture, IEdgeGesture_Vtbl, 0x580d5292_2ab1_49aa_a7f0_33bd3f8df9f1);
+impl windows_core::RuntimeType for IEdgeGesture {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEdgeGesture_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,18 +83,27 @@ pub struct IEdgeGesture_Vtbl {
     pub RemoveCanceled: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEdgeGestureEventArgs, IEdgeGestureEventArgs_Vtbl, 0x44fa4a24_2d09_42e1_8b5e_368208796a4c);
+impl windows_core::RuntimeType for IEdgeGestureEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEdgeGestureEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut EdgeGestureKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IEdgeGestureStatics, IEdgeGestureStatics_Vtbl, 0xbc6a8519_18ee_4043_9839_4fc584d60a14);
+impl windows_core::RuntimeType for IEdgeGestureStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IEdgeGestureStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGestureRecognizer, IGestureRecognizer_Vtbl, 0xb47a37bf_3d6b_4f88_83e8_6dcb4012ffb0);
+impl windows_core::RuntimeType for IGestureRecognizer {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGestureRecognizer_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -140,6 +170,9 @@ pub struct IGestureRecognizer_Vtbl {
     pub RemoveCrossSliding: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IGestureRecognizer2, IGestureRecognizer2_Vtbl, 0xd646097f_6ef7_5746_8ba8_8ff2206e6f3b);
+impl windows_core::RuntimeType for IGestureRecognizer2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IGestureRecognizer2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +194,9 @@ pub struct IGestureRecognizer2_Vtbl {
     pub SetTranslationMaxContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHoldingEventArgs, IHoldingEventArgs_Vtbl, 0x2bf755c5_e799_41b4_bb40_242f40959b71);
+impl windows_core::RuntimeType for IHoldingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHoldingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -172,6 +208,9 @@ pub struct IHoldingEventArgs_Vtbl {
     pub HoldingState: unsafe extern "system" fn(*mut core::ffi::c_void, *mut HoldingState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHoldingEventArgs2, IHoldingEventArgs2_Vtbl, 0x141da9ea_4c79_5674_afea_493fdeb91f19);
+impl windows_core::RuntimeType for IHoldingEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHoldingEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -179,6 +218,9 @@ pub struct IHoldingEventArgs2_Vtbl {
     pub CurrentContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputActivationListener, IInputActivationListener_Vtbl, 0x5d6d4ed2_28c7_5ae3_aa74_c918a9f243ca);
+impl windows_core::RuntimeType for IInputActivationListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputActivationListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -187,12 +229,18 @@ pub struct IInputActivationListener_Vtbl {
     pub RemoveInputActivationChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputActivationListenerActivationChangedEventArgs, IInputActivationListenerActivationChangedEventArgs_Vtbl, 0x7699b465_1dcf_5791_b4b9_6cafbeed2056);
+impl windows_core::RuntimeType for IInputActivationListenerActivationChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputActivationListenerActivationChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub State: unsafe extern "system" fn(*mut core::ffi::c_void, *mut InputActivationState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyboardDeliveryInterceptor, IKeyboardDeliveryInterceptor_Vtbl, 0xb4baf068_8f49_446c_8db5_8c0ffe85cc9e);
+impl windows_core::RuntimeType for IKeyboardDeliveryInterceptor {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyboardDeliveryInterceptor_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -210,12 +258,18 @@ pub struct IKeyboardDeliveryInterceptor_Vtbl {
     pub RemoveKeyUp: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKeyboardDeliveryInterceptorStatics, IKeyboardDeliveryInterceptorStatics_Vtbl, 0xf9f63ba2_ceba_4755_8a7e_14c0ffecd239);
+impl windows_core::RuntimeType for IKeyboardDeliveryInterceptorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKeyboardDeliveryInterceptorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationCompletedEventArgs, IManipulationCompletedEventArgs_Vtbl, 0xb34ab22b_d19b_46ff_9f38_dec7754bb9e7);
+impl windows_core::RuntimeType for IManipulationCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -228,6 +282,9 @@ pub struct IManipulationCompletedEventArgs_Vtbl {
     pub Velocities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ManipulationVelocities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationCompletedEventArgs2, IManipulationCompletedEventArgs2_Vtbl, 0xf0c0dce7_30a9_5b96_886f_6560a85e4757);
+impl windows_core::RuntimeType for IManipulationCompletedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationCompletedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -235,6 +292,9 @@ pub struct IManipulationCompletedEventArgs2_Vtbl {
     pub CurrentContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationInertiaStartingEventArgs, IManipulationInertiaStartingEventArgs_Vtbl, 0xdd37a898_26bf_467a_9ce5_ccf3fb11371e);
+impl windows_core::RuntimeType for IManipulationInertiaStartingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationInertiaStartingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,12 +308,18 @@ pub struct IManipulationInertiaStartingEventArgs_Vtbl {
     pub Velocities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ManipulationVelocities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationInertiaStartingEventArgs2, IManipulationInertiaStartingEventArgs2_Vtbl, 0xc25409b8_f9fa_5a45_bd97_dcbbb2201860);
+impl windows_core::RuntimeType for IManipulationInertiaStartingEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationInertiaStartingEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationStartedEventArgs, IManipulationStartedEventArgs_Vtbl, 0xddec873e_cfce_4932_8c1d_3c3d011a34c0);
+impl windows_core::RuntimeType for IManipulationStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -265,12 +331,18 @@ pub struct IManipulationStartedEventArgs_Vtbl {
     pub Cumulative: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ManipulationDelta) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationStartedEventArgs2, IManipulationStartedEventArgs2_Vtbl, 0x2da3db4e_e583_5055_afaa_16fd986531a6);
+impl windows_core::RuntimeType for IManipulationStartedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationStartedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationUpdatedEventArgs, IManipulationUpdatedEventArgs_Vtbl, 0xcb354ce5_abb8_4f9f_b3ce_8181aa61ad82);
+impl windows_core::RuntimeType for IManipulationUpdatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationUpdatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -284,6 +356,9 @@ pub struct IManipulationUpdatedEventArgs_Vtbl {
     pub Velocities: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ManipulationVelocities) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IManipulationUpdatedEventArgs2, IManipulationUpdatedEventArgs2_Vtbl, 0xf3dfb96a_3306_5903_a1c5_ff9757a8689e);
+impl windows_core::RuntimeType for IManipulationUpdatedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IManipulationUpdatedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -291,6 +366,9 @@ pub struct IManipulationUpdatedEventArgs2_Vtbl {
     pub CurrentContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMouseWheelParameters, IMouseWheelParameters_Vtbl, 0xead0ca44_9ded_4037_8149_5e4cc2564468);
+impl windows_core::RuntimeType for IMouseWheelParameters {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMouseWheelParameters_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -304,6 +382,9 @@ pub struct IMouseWheelParameters_Vtbl {
     pub SetPageTranslation: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerPoint, IPointerPoint_Vtbl, 0xe995317d_7296_42d9_8233_c5be73b74a4a);
+impl windows_core::RuntimeType for IPointerPoint {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerPoint_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -320,6 +401,9 @@ pub struct IPointerPoint_Vtbl {
     pub Properties: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerPointProperties, IPointerPointProperties_Vtbl, 0xc79d8a4b_c163_4ee7_803f_67ce79f9972d);
+impl windows_core::RuntimeType for IPointerPointProperties {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerPointProperties_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -349,12 +433,18 @@ pub struct IPointerPointProperties_Vtbl {
     pub GetUsageValue: unsafe extern "system" fn(*mut core::ffi::c_void, u32, u32, *mut i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerPointProperties2, IPointerPointProperties2_Vtbl, 0x22c3433a_c83b_41c0_a296_5e232d64d6af);
+impl windows_core::RuntimeType for IPointerPointProperties2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerPointProperties2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ZDistance: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerPointStatics, IPointerPointStatics_Vtbl, 0xa506638d_2a1a_413e_bc75_9f38381cc069);
+impl windows_core::RuntimeType for IPointerPointStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerPointStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -405,6 +495,9 @@ pub struct IPointerPointTransform_Vtbl {
     pub TransformBounds: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Rect, *mut super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerVisualizationSettings, IPointerVisualizationSettings_Vtbl, 0x4d1e6461_84f7_499d_bd91_2a36e2b7aaa2);
+impl windows_core::RuntimeType for IPointerVisualizationSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerVisualizationSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -414,12 +507,18 @@ pub struct IPointerVisualizationSettings_Vtbl {
     pub IsBarrelButtonFeedbackEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPointerVisualizationSettingsStatics, IPointerVisualizationSettingsStatics_Vtbl, 0x68870edb_165b_4214_b4f3_584eca8c8a69);
+impl windows_core::RuntimeType for IPointerVisualizationSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPointerVisualizationSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialController, IRadialController_Vtbl, 0x3055d1c8_df51_43d4_b23b_0e1037467a09);
+impl windows_core::RuntimeType for IRadialController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -444,6 +543,9 @@ pub struct IRadialController_Vtbl {
     pub RemoveControlAcquired: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialController2, IRadialController2_Vtbl, 0x3d577eff_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialController2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialController2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -455,12 +557,18 @@ pub struct IRadialController2_Vtbl {
     pub RemoveButtonReleased: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerButtonClickedEventArgs, IRadialControllerButtonClickedEventArgs_Vtbl, 0x206aa438_e651_11e5_bf62_2c27d7404e85);
+impl windows_core::RuntimeType for IRadialControllerButtonClickedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerButtonClickedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Contact: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerButtonClickedEventArgs2, IRadialControllerButtonClickedEventArgs2_Vtbl, 0x3d577ef3_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerButtonClickedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerButtonClickedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -470,6 +578,9 @@ pub struct IRadialControllerButtonClickedEventArgs2_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerButtonHoldingEventArgs, IRadialControllerButtonHoldingEventArgs_Vtbl, 0x3d577eee_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerButtonHoldingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerButtonHoldingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -480,6 +591,9 @@ pub struct IRadialControllerButtonHoldingEventArgs_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerButtonPressedEventArgs, IRadialControllerButtonPressedEventArgs_Vtbl, 0x3d577eed_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerButtonPressedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerButtonPressedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -490,6 +604,9 @@ pub struct IRadialControllerButtonPressedEventArgs_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerButtonReleasedEventArgs, IRadialControllerButtonReleasedEventArgs_Vtbl, 0x3d577eef_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerButtonReleasedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerButtonReleasedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -500,6 +617,9 @@ pub struct IRadialControllerButtonReleasedEventArgs_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerConfiguration, IRadialControllerConfiguration_Vtbl, 0xa6b79ecb_6a52_4430_910c_56370a9d6b42);
+impl windows_core::RuntimeType for IRadialControllerConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -511,6 +631,9 @@ pub struct IRadialControllerConfiguration_Vtbl {
     pub TrySelectDefaultMenuItem: unsafe extern "system" fn(*mut core::ffi::c_void, RadialControllerSystemMenuItemKind, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerConfiguration2, IRadialControllerConfiguration2_Vtbl, 0x3d577ef7_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerConfiguration2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerConfiguration2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -520,12 +643,18 @@ pub struct IRadialControllerConfiguration2_Vtbl {
     pub IsMenuSuppressed: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerConfigurationStatics, IRadialControllerConfigurationStatics_Vtbl, 0x79b6b0e5_069a_4486_a99d_8db772b9642f);
+impl windows_core::RuntimeType for IRadialControllerConfigurationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerConfigurationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerConfigurationStatics2, IRadialControllerConfigurationStatics2_Vtbl, 0x53e08b17_e205_48d3_9caf_80ff47c4d7c7);
+impl windows_core::RuntimeType for IRadialControllerConfigurationStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerConfigurationStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -535,12 +664,18 @@ pub struct IRadialControllerConfigurationStatics2_Vtbl {
     pub IsAppControllerEnabled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerControlAcquiredEventArgs, IRadialControllerControlAcquiredEventArgs_Vtbl, 0x206aa439_e651_11e5_bf62_2c27d7404e85);
+impl windows_core::RuntimeType for IRadialControllerControlAcquiredEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerControlAcquiredEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Contact: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerControlAcquiredEventArgs2, IRadialControllerControlAcquiredEventArgs2_Vtbl, 0x3d577ef4_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerControlAcquiredEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerControlAcquiredEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -551,6 +686,9 @@ pub struct IRadialControllerControlAcquiredEventArgs2_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerMenu, IRadialControllerMenu_Vtbl, 0x8506b35d_f640_4412_aba0_bad077e5ea8a);
+impl windows_core::RuntimeType for IRadialControllerMenu {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerMenu_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -565,6 +703,9 @@ pub struct IRadialControllerMenu_Vtbl {
     pub TrySelectPreviouslySelectedMenuItem: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerMenuItem, IRadialControllerMenuItem_Vtbl, 0xc80fc98d_ad0b_4c9c_8f2f_136a2373a6ba);
+impl windows_core::RuntimeType for IRadialControllerMenuItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerMenuItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -575,6 +716,9 @@ pub struct IRadialControllerMenuItem_Vtbl {
     pub RemoveInvoked: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerMenuItemStatics, IRadialControllerMenuItemStatics_Vtbl, 0x249e0887_d842_4524_9df8_e0d647edc887);
+impl windows_core::RuntimeType for IRadialControllerMenuItemStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerMenuItemStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -585,6 +729,9 @@ pub struct IRadialControllerMenuItemStatics_Vtbl {
     pub CreateFromKnownIcon: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, RadialControllerMenuKnownIcon, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerMenuItemStatics2, IRadialControllerMenuItemStatics2_Vtbl, 0x0cbb70be_7e3e_48bd_be04_2c7fcaa9c1ff);
+impl windows_core::RuntimeType for IRadialControllerMenuItemStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerMenuItemStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -592,6 +739,9 @@ pub struct IRadialControllerMenuItemStatics2_Vtbl {
     pub CreateFromFontGlyphWithUri: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerRotationChangedEventArgs, IRadialControllerRotationChangedEventArgs_Vtbl, 0x206aa435_e651_11e5_bf62_2c27d7404e85);
+impl windows_core::RuntimeType for IRadialControllerRotationChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerRotationChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -599,6 +749,9 @@ pub struct IRadialControllerRotationChangedEventArgs_Vtbl {
     pub Contact: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerRotationChangedEventArgs2, IRadialControllerRotationChangedEventArgs2_Vtbl, 0x3d577eec_4cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerRotationChangedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerRotationChangedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -609,6 +762,9 @@ pub struct IRadialControllerRotationChangedEventArgs2_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerScreenContact, IRadialControllerScreenContact_Vtbl, 0x206aa434_e651_11e5_bf62_2c27d7404e85);
+impl windows_core::RuntimeType for IRadialControllerScreenContact {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerScreenContact_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -616,12 +772,18 @@ pub struct IRadialControllerScreenContact_Vtbl {
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerScreenContactContinuedEventArgs, IRadialControllerScreenContactContinuedEventArgs_Vtbl, 0x206aa437_e651_11e5_bf62_2c27d7404e85);
+impl windows_core::RuntimeType for IRadialControllerScreenContactContinuedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerScreenContactContinuedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Contact: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerScreenContactContinuedEventArgs2, IRadialControllerScreenContactContinuedEventArgs2_Vtbl, 0x3d577ef1_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerScreenContactContinuedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerScreenContactContinuedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -632,6 +794,9 @@ pub struct IRadialControllerScreenContactContinuedEventArgs2_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerScreenContactEndedEventArgs, IRadialControllerScreenContactEndedEventArgs_Vtbl, 0x3d577ef2_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerScreenContactEndedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerScreenContactEndedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -642,12 +807,18 @@ pub struct IRadialControllerScreenContactEndedEventArgs_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerScreenContactStartedEventArgs, IRadialControllerScreenContactStartedEventArgs_Vtbl, 0x206aa436_e651_11e5_bf62_2c27d7404e85);
+impl windows_core::RuntimeType for IRadialControllerScreenContactStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerScreenContactStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Contact: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRadialControllerScreenContactStartedEventArgs2, IRadialControllerScreenContactStartedEventArgs2_Vtbl, 0x3d577ef0_3cee_11e6_b535_001bdc06ab3b);
+impl windows_core::RuntimeType for IRadialControllerScreenContactStartedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerScreenContactStartedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -658,6 +829,9 @@ pub struct IRadialControllerScreenContactStartedEventArgs2_Vtbl {
     SimpleHapticsController: usize,
 }
 windows_core::imp::define_interface!(IRadialControllerStatics, IRadialControllerStatics_Vtbl, 0xfaded0b7_b84c_4894_87aa_8f25aa5f288b);
+impl windows_core::RuntimeType for IRadialControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRadialControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -665,6 +839,9 @@ pub struct IRadialControllerStatics_Vtbl {
     pub CreateForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRightTappedEventArgs, IRightTappedEventArgs_Vtbl, 0x4cbf40bd_af7a_4a36_9476_b1dce141709a);
+impl windows_core::RuntimeType for IRightTappedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRightTappedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -675,12 +852,18 @@ pub struct IRightTappedEventArgs_Vtbl {
     pub Position: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Point) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRightTappedEventArgs2, IRightTappedEventArgs2_Vtbl, 0x61c7b7bb_9f57_5857_a33c_c58c3dfa959e);
+impl windows_core::RuntimeType for IRightTappedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRightTappedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ContactCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemButtonEventController, ISystemButtonEventController_Vtbl, 0x59b893a9_73bc_52b5_ba41_82511b2cb46c);
+impl windows_core::RuntimeType for ISystemButtonEventController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemButtonEventController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -694,6 +877,9 @@ pub struct ISystemButtonEventController_Vtbl {
     pub RemoveSystemFunctionLockIndicatorChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemButtonEventControllerStatics, ISystemButtonEventControllerStatics_Vtbl, 0x632fb07b_20bd_5e15_af4a_00dbf2064ffa);
+impl windows_core::RuntimeType for ISystemButtonEventControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemButtonEventControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -703,6 +889,9 @@ pub struct ISystemButtonEventControllerStatics_Vtbl {
     CreateForDispatcherQueue: usize,
 }
 windows_core::imp::define_interface!(ISystemFunctionButtonEventArgs, ISystemFunctionButtonEventArgs_Vtbl, 0x4833896f_80d1_5dd6_92a7_62a508ffef5a);
+impl windows_core::RuntimeType for ISystemFunctionButtonEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemFunctionButtonEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -711,6 +900,9 @@ pub struct ISystemFunctionButtonEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemFunctionLockChangedEventArgs, ISystemFunctionLockChangedEventArgs_Vtbl, 0xcd040608_fcf9_585c_beab_f1d2eaf364ab);
+impl windows_core::RuntimeType for ISystemFunctionLockChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemFunctionLockChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -720,6 +912,9 @@ pub struct ISystemFunctionLockChangedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISystemFunctionLockIndicatorChangedEventArgs, ISystemFunctionLockIndicatorChangedEventArgs_Vtbl, 0xb212b94e_7a6f_58ae_b304_bae61d0371b9);
+impl windows_core::RuntimeType for ISystemFunctionLockIndicatorChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISystemFunctionLockIndicatorChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -729,6 +924,9 @@ pub struct ISystemFunctionLockIndicatorChangedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITappedEventArgs, ITappedEventArgs_Vtbl, 0xcfa126e4_253a_4c3c_953b_395c37aed309);
+impl windows_core::RuntimeType for ITappedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITappedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -740,6 +938,9 @@ pub struct ITappedEventArgs_Vtbl {
     pub TapCount: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITappedEventArgs2, ITappedEventArgs2_Vtbl, 0x294388f2_177e_51d5_be56_ee0866fa968c);
+impl windows_core::RuntimeType for ITappedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITappedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -757,7 +958,7 @@ impl AttachableInputObject {
     }
 }
 impl windows_core::RuntimeType for AttachableInputObject {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAttachableInputObject>();
 }
 unsafe impl windows_core::Interface for AttachableInputObject {
     type Vtable = IAttachableInputObject_Vtbl;
@@ -804,7 +1005,7 @@ impl CrossSlidingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CrossSlidingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICrossSlidingEventArgs>();
 }
 unsafe impl windows_core::Interface for CrossSlidingEventArgs {
     type Vtable = ICrossSlidingEventArgs_Vtbl;
@@ -849,7 +1050,7 @@ impl DraggingEventArgs {
     }
 }
 impl windows_core::RuntimeType for DraggingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDraggingEventArgs>();
 }
 unsafe impl windows_core::Interface for DraggingEventArgs {
     type Vtable = IDraggingEventArgs_Vtbl;
@@ -918,7 +1119,7 @@ impl EdgeGesture {
     }
 }
 impl windows_core::RuntimeType for EdgeGesture {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEdgeGesture>();
 }
 unsafe impl windows_core::Interface for EdgeGesture {
     type Vtable = IEdgeGesture_Vtbl;
@@ -941,7 +1142,7 @@ impl EdgeGestureEventArgs {
     }
 }
 impl windows_core::RuntimeType for EdgeGestureEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IEdgeGestureEventArgs>();
 }
 unsafe impl windows_core::Interface for EdgeGestureEventArgs {
     type Vtable = IEdgeGestureEventArgs_Vtbl;
@@ -1411,7 +1612,7 @@ impl GestureRecognizer {
     }
 }
 impl windows_core::RuntimeType for GestureRecognizer {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IGestureRecognizer>();
 }
 unsafe impl windows_core::Interface for GestureRecognizer {
     type Vtable = IGestureRecognizer_Vtbl;
@@ -1463,7 +1664,7 @@ impl HoldingEventArgs {
     }
 }
 impl windows_core::RuntimeType for HoldingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHoldingEventArgs>();
 }
 unsafe impl windows_core::Interface for HoldingEventArgs {
     type Vtable = IHoldingEventArgs_Vtbl;
@@ -1505,7 +1706,7 @@ impl InputActivationListener {
     }
 }
 impl windows_core::RuntimeType for InputActivationListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputActivationListener>();
 }
 unsafe impl windows_core::Interface for InputActivationListener {
     type Vtable = IInputActivationListener_Vtbl;
@@ -1530,7 +1731,7 @@ impl InputActivationListenerActivationChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for InputActivationListenerActivationChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputActivationListenerActivationChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for InputActivationListenerActivationChangedEventArgs {
     type Vtable = IInputActivationListenerActivationChangedEventArgs_Vtbl;
@@ -1600,7 +1801,7 @@ impl KeyboardDeliveryInterceptor {
     }
 }
 impl windows_core::RuntimeType for KeyboardDeliveryInterceptor {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IKeyboardDeliveryInterceptor>();
 }
 unsafe impl windows_core::Interface for KeyboardDeliveryInterceptor {
     type Vtable = IKeyboardDeliveryInterceptor_Vtbl;
@@ -1661,7 +1862,7 @@ impl ManipulationCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ManipulationCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IManipulationCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for ManipulationCompletedEventArgs {
     type Vtable = IManipulationCompletedEventArgs_Vtbl;
@@ -1720,7 +1921,7 @@ impl ManipulationInertiaStartingEventArgs {
     }
 }
 impl windows_core::RuntimeType for ManipulationInertiaStartingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IManipulationInertiaStartingEventArgs>();
 }
 unsafe impl windows_core::Interface for ManipulationInertiaStartingEventArgs {
     type Vtable = IManipulationInertiaStartingEventArgs_Vtbl;
@@ -1765,7 +1966,7 @@ impl ManipulationStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ManipulationStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IManipulationStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for ManipulationStartedEventArgs {
     type Vtable = IManipulationStartedEventArgs_Vtbl;
@@ -1831,7 +2032,7 @@ impl ManipulationUpdatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ManipulationUpdatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IManipulationUpdatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ManipulationUpdatedEventArgs {
     type Vtable = IManipulationUpdatedEventArgs_Vtbl;
@@ -1891,7 +2092,7 @@ impl MouseWheelParameters {
     }
 }
 impl windows_core::RuntimeType for MouseWheelParameters {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMouseWheelParameters>();
 }
 unsafe impl windows_core::Interface for MouseWheelParameters {
     type Vtable = IMouseWheelParameters_Vtbl;
@@ -2001,7 +2202,7 @@ impl PointerPoint {
     }
 }
 impl windows_core::RuntimeType for PointerPoint {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPointerPoint>();
 }
 unsafe impl windows_core::Interface for PointerPoint {
     type Vtable = IPointerPoint_Vtbl;
@@ -2192,7 +2393,7 @@ impl PointerPointProperties {
     }
 }
 impl windows_core::RuntimeType for PointerPointProperties {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPointerPointProperties>();
 }
 unsafe impl windows_core::Interface for PointerPointProperties {
     type Vtable = IPointerPointProperties_Vtbl;
@@ -2241,7 +2442,7 @@ impl PointerVisualizationSettings {
     }
 }
 impl windows_core::RuntimeType for PointerVisualizationSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPointerVisualizationSettings>();
 }
 unsafe impl windows_core::Interface for PointerVisualizationSettings {
     type Vtable = IPointerVisualizationSettings_Vtbl;
@@ -2445,7 +2646,7 @@ impl RadialController {
     }
 }
 impl windows_core::RuntimeType for RadialController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialController>();
 }
 unsafe impl windows_core::Interface for RadialController {
     type Vtable = IRadialController_Vtbl;
@@ -2478,7 +2679,7 @@ impl RadialControllerButtonClickedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerButtonClickedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerButtonClickedEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerButtonClickedEventArgs {
     type Vtable = IRadialControllerButtonClickedEventArgs_Vtbl;
@@ -2511,7 +2712,7 @@ impl RadialControllerButtonHoldingEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerButtonHoldingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerButtonHoldingEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerButtonHoldingEventArgs {
     type Vtable = IRadialControllerButtonHoldingEventArgs_Vtbl;
@@ -2544,7 +2745,7 @@ impl RadialControllerButtonPressedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerButtonPressedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerButtonPressedEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerButtonPressedEventArgs {
     type Vtable = IRadialControllerButtonPressedEventArgs_Vtbl;
@@ -2577,7 +2778,7 @@ impl RadialControllerButtonReleasedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerButtonReleasedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerButtonReleasedEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerButtonReleasedEventArgs {
     type Vtable = IRadialControllerButtonReleasedEventArgs_Vtbl;
@@ -2676,7 +2877,7 @@ impl RadialControllerConfiguration {
     }
 }
 impl windows_core::RuntimeType for RadialControllerConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerConfiguration>();
 }
 unsafe impl windows_core::Interface for RadialControllerConfiguration {
     type Vtable = IRadialControllerConfiguration_Vtbl;
@@ -2716,7 +2917,7 @@ impl RadialControllerControlAcquiredEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerControlAcquiredEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerControlAcquiredEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerControlAcquiredEventArgs {
     type Vtable = IRadialControllerControlAcquiredEventArgs_Vtbl;
@@ -2774,7 +2975,7 @@ impl RadialControllerMenu {
     }
 }
 impl windows_core::RuntimeType for RadialControllerMenu {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerMenu>();
 }
 unsafe impl windows_core::Interface for RadialControllerMenu {
     type Vtable = IRadialControllerMenu_Vtbl;
@@ -2868,7 +3069,7 @@ impl RadialControllerMenuItem {
     }
 }
 impl windows_core::RuntimeType for RadialControllerMenuItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerMenuItem>();
 }
 unsafe impl windows_core::Interface for RadialControllerMenuItem {
     type Vtable = IRadialControllerMenuItem_Vtbl;
@@ -2915,7 +3116,7 @@ impl RadialControllerRotationChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerRotationChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerRotationChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerRotationChangedEventArgs {
     type Vtable = IRadialControllerRotationChangedEventArgs_Vtbl;
@@ -2947,7 +3148,7 @@ impl RadialControllerScreenContact {
     }
 }
 impl windows_core::RuntimeType for RadialControllerScreenContact {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerScreenContact>();
 }
 unsafe impl windows_core::Interface for RadialControllerScreenContact {
     type Vtable = IRadialControllerScreenContact_Vtbl;
@@ -2987,7 +3188,7 @@ impl RadialControllerScreenContactContinuedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerScreenContactContinuedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerScreenContactContinuedEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerScreenContactContinuedEventArgs {
     type Vtable = IRadialControllerScreenContactContinuedEventArgs_Vtbl;
@@ -3020,7 +3221,7 @@ impl RadialControllerScreenContactEndedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerScreenContactEndedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerScreenContactEndedEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerScreenContactEndedEventArgs {
     type Vtable = IRadialControllerScreenContactEndedEventArgs_Vtbl;
@@ -3060,7 +3261,7 @@ impl RadialControllerScreenContactStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RadialControllerScreenContactStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRadialControllerScreenContactStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for RadialControllerScreenContactStartedEventArgs {
     type Vtable = IRadialControllerScreenContactStartedEventArgs_Vtbl;
@@ -3100,7 +3301,7 @@ impl RightTappedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RightTappedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRightTappedEventArgs>();
 }
 unsafe impl windows_core::Interface for RightTappedEventArgs {
     type Vtable = IRightTappedEventArgs_Vtbl;
@@ -3192,7 +3393,7 @@ impl SystemButtonEventController {
     }
 }
 impl windows_core::RuntimeType for SystemButtonEventController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemButtonEventController>();
 }
 unsafe impl windows_core::Interface for SystemButtonEventController {
     type Vtable = ISystemButtonEventController_Vtbl;
@@ -3228,7 +3429,7 @@ impl SystemFunctionButtonEventArgs {
     }
 }
 impl windows_core::RuntimeType for SystemFunctionButtonEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemFunctionButtonEventArgs>();
 }
 unsafe impl windows_core::Interface for SystemFunctionButtonEventArgs {
     type Vtable = ISystemFunctionButtonEventArgs_Vtbl;
@@ -3271,7 +3472,7 @@ impl SystemFunctionLockChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SystemFunctionLockChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemFunctionLockChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for SystemFunctionLockChangedEventArgs {
     type Vtable = ISystemFunctionLockChangedEventArgs_Vtbl;
@@ -3314,7 +3515,7 @@ impl SystemFunctionLockIndicatorChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for SystemFunctionLockIndicatorChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISystemFunctionLockIndicatorChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for SystemFunctionLockIndicatorChangedEventArgs {
     type Vtable = ISystemFunctionLockIndicatorChangedEventArgs_Vtbl;
@@ -3361,7 +3562,7 @@ impl TappedEventArgs {
     }
 }
 impl windows_core::RuntimeType for TappedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITappedEventArgs>();
 }
 unsafe impl windows_core::Interface for TappedEventArgs {
     type Vtable = ITappedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IUserNotificationListener, IUserNotificationListener_Vtbl, 0x62553e41_8a06_4cef_8215_6033a5be4b03);
+impl windows_core::RuntimeType for IUserNotificationListener {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserNotificationListener_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -15,6 +18,9 @@ pub struct IUserNotificationListener_Vtbl {
     pub RemoveNotification: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserNotificationListenerStatics, IUserNotificationListenerStatics_Vtbl, 0xff6123cf_4386_4aa3_b73d_b804e5b63b23);
+impl windows_core::RuntimeType for IUserNotificationListenerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserNotificationListenerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -89,7 +95,7 @@ impl UserNotificationListener {
     }
 }
 impl windows_core::RuntimeType for UserNotificationListener {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserNotificationListener>();
 }
 unsafe impl windows_core::Interface for UserNotificationListener {
     type Vtable = IUserNotificationListener_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Notifications/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/Preview/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IToastOcclusionManagerPreviewStatics, IToastOcclusionManagerPreviewStatics_Vtbl, 0x507e5c83_50f9_5412_8953_b65c18cfab12);
+impl windows_core::RuntimeType for IToastOcclusionManagerPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastOcclusionManagerPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
@@ -34,6 +34,9 @@ pub struct IAdaptiveNotificationContent_Vtbl {
     Hints: usize,
 }
 windows_core::imp::define_interface!(IAdaptiveNotificationText, IAdaptiveNotificationText_Vtbl, 0x46d4a3be_609a_4326_a40b_bfde872034a3);
+impl windows_core::RuntimeType for IAdaptiveNotificationText {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAdaptiveNotificationText_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,6 +46,9 @@ pub struct IAdaptiveNotificationText_Vtbl {
     pub SetLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBadgeNotification, IBadgeNotification_Vtbl, 0x075cb4ca_d08a_4e2f_9233_7e289c1f7722);
+impl windows_core::RuntimeType for IBadgeNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBadgeNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +60,9 @@ pub struct IBadgeNotification_Vtbl {
     pub ExpirationTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IBadgeNotificationFactory, IBadgeNotificationFactory_Vtbl, 0xedf255ce_0618_4d59_948a_5a61040c52f9);
+impl windows_core::RuntimeType for IBadgeNotificationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBadgeNotificationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +72,9 @@ pub struct IBadgeNotificationFactory_Vtbl {
     CreateBadgeNotification: usize,
 }
 windows_core::imp::define_interface!(IBadgeUpdateManagerForUser, IBadgeUpdateManagerForUser_Vtbl, 0x996b21bc_0386_44e5_ba8d_0c1077a62e92);
+impl windows_core::RuntimeType for IBadgeUpdateManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBadgeUpdateManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +87,9 @@ pub struct IBadgeUpdateManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IBadgeUpdateManagerStatics, IBadgeUpdateManagerStatics_Vtbl, 0x33400faa_6dd5_4105_aebc_9b50fca492da);
+impl windows_core::RuntimeType for IBadgeUpdateManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBadgeUpdateManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -87,6 +102,9 @@ pub struct IBadgeUpdateManagerStatics_Vtbl {
     GetTemplateContent: usize,
 }
 windows_core::imp::define_interface!(IBadgeUpdateManagerStatics2, IBadgeUpdateManagerStatics2_Vtbl, 0x979a35ce_f940_48bf_94e8_ca244d400b41);
+impl windows_core::RuntimeType for IBadgeUpdateManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBadgeUpdateManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -96,6 +114,9 @@ pub struct IBadgeUpdateManagerStatics2_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(IBadgeUpdater, IBadgeUpdater_Vtbl, 0xb5fa1fd4_7562_4f6c_bfa3_1b6ed2e57f2f);
+impl windows_core::RuntimeType for IBadgeUpdater {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IBadgeUpdater_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,6 +127,9 @@ pub struct IBadgeUpdater_Vtbl {
     pub StopPeriodicUpdate: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownAdaptiveNotificationHintsStatics, IKnownAdaptiveNotificationHintsStatics_Vtbl, 0x06206598_d496_497d_8692_4f7d7c2770df);
+impl windows_core::RuntimeType for IKnownAdaptiveNotificationHintsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownAdaptiveNotificationHintsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -117,6 +141,9 @@ pub struct IKnownAdaptiveNotificationHintsStatics_Vtbl {
     pub Align: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownAdaptiveNotificationTextStylesStatics, IKnownAdaptiveNotificationTextStylesStatics_Vtbl, 0x202192d7_8996_45aa_8ba1_d461d72c2a1b);
+impl windows_core::RuntimeType for IKnownAdaptiveNotificationTextStylesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownAdaptiveNotificationTextStylesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -141,12 +168,18 @@ pub struct IKnownAdaptiveNotificationTextStylesStatics_Vtbl {
     pub HeaderNumeralSubtle: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IKnownNotificationBindingsStatics, IKnownNotificationBindingsStatics_Vtbl, 0x79427bae_a8b7_4d58_89ea_76a7b7bccded);
+impl windows_core::RuntimeType for IKnownNotificationBindingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IKnownNotificationBindingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ToastGeneric: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INotification, INotification_Vtbl, 0x108037fe_eb76_4f82_97bc_da07530a2e20);
+impl windows_core::RuntimeType for INotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,6 +189,9 @@ pub struct INotification_Vtbl {
     pub SetVisual: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INotificationBinding, INotificationBinding_Vtbl, 0xf29e4b85_0370_4ad3_b4ea_da9e35e7eabf);
+impl windows_core::RuntimeType for INotificationBinding {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotificationBinding_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,6 +209,9 @@ pub struct INotificationBinding_Vtbl {
     GetTextElements: usize,
 }
 windows_core::imp::define_interface!(INotificationData, INotificationData_Vtbl, 0x9ffd2312_9d6a_4aaf_b6ac_ff17f0c1f280);
+impl windows_core::RuntimeType for INotificationData {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotificationData_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -184,6 +223,9 @@ pub struct INotificationData_Vtbl {
     pub SetSequenceNumber: unsafe extern "system" fn(*mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INotificationDataFactory, INotificationDataFactory_Vtbl, 0x23c1e33a_1c10_46fb_8040_dec384621cf8);
+impl windows_core::RuntimeType for INotificationDataFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotificationDataFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,6 +239,9 @@ pub struct INotificationDataFactory_Vtbl {
     CreateNotificationDataWithValues: usize,
 }
 windows_core::imp::define_interface!(INotificationVisual, INotificationVisual_Vtbl, 0x68835b8e_aa56_4e11_86d3_5f9a6957bc5b);
+impl windows_core::RuntimeType for INotificationVisual {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INotificationVisual_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -209,6 +254,9 @@ pub struct INotificationVisual_Vtbl {
     pub GetBinding: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScheduledTileNotification, IScheduledTileNotification_Vtbl, 0x0abca6d5_99dc_4c78_a11c_c9e7f86d7ef7);
+impl windows_core::RuntimeType for IScheduledTileNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledTileNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -225,6 +273,9 @@ pub struct IScheduledTileNotification_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScheduledTileNotificationFactory, IScheduledTileNotificationFactory_Vtbl, 0x3383138a_98c0_4c3b_bbd6_4a633c7cfc29);
+impl windows_core::RuntimeType for IScheduledTileNotificationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledTileNotificationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -234,6 +285,9 @@ pub struct IScheduledTileNotificationFactory_Vtbl {
     CreateScheduledTileNotification: usize,
 }
 windows_core::imp::define_interface!(IScheduledToastNotification, IScheduledToastNotification_Vtbl, 0x79f577f8_0de7_48cd_9740_9b370490c838);
+impl windows_core::RuntimeType for IScheduledToastNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledToastNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -248,6 +302,9 @@ pub struct IScheduledToastNotification_Vtbl {
     pub Id: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScheduledToastNotification2, IScheduledToastNotification2_Vtbl, 0xa66ea09c_31b4_43b0_b5dd_7a40e85363b1);
+impl windows_core::RuntimeType for IScheduledToastNotification2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledToastNotification2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -259,6 +316,9 @@ pub struct IScheduledToastNotification2_Vtbl {
     pub SuppressPopup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScheduledToastNotification3, IScheduledToastNotification3_Vtbl, 0x98429e8b_bd32_4a3b_9d15_22aea49462a1);
+impl windows_core::RuntimeType for IScheduledToastNotification3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledToastNotification3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -268,6 +328,9 @@ pub struct IScheduledToastNotification3_Vtbl {
     pub SetRemoteId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScheduledToastNotification4, IScheduledToastNotification4_Vtbl, 0x1d4761fd_bdef_4e4a_96be_0101369b58d2);
+impl windows_core::RuntimeType for IScheduledToastNotification4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledToastNotification4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -275,6 +338,9 @@ pub struct IScheduledToastNotification4_Vtbl {
     pub SetExpirationTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IScheduledToastNotificationFactory, IScheduledToastNotificationFactory_Vtbl, 0xe7bed191_0bb9_4189_8394_31761b476fd7);
+impl windows_core::RuntimeType for IScheduledToastNotificationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledToastNotificationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -288,6 +354,9 @@ pub struct IScheduledToastNotificationFactory_Vtbl {
     CreateScheduledToastNotificationRecurring: usize,
 }
 windows_core::imp::define_interface!(IScheduledToastNotificationShowingEventArgs, IScheduledToastNotificationShowingEventArgs_Vtbl, 0x6173f6b4_412a_5e2c_a6ed_a0209aef9a09);
+impl windows_core::RuntimeType for IScheduledToastNotificationShowingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IScheduledToastNotificationShowingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -297,12 +366,18 @@ pub struct IScheduledToastNotificationShowingEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShownTileNotification, IShownTileNotification_Vtbl, 0x342d8988_5af2_481a_a6a3_f2fdc78de88e);
+impl windows_core::RuntimeType for IShownTileNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShownTileNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Arguments: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITileFlyoutNotification, ITileFlyoutNotification_Vtbl, 0x9a53b261_c70c_42be_b2f3_f42aa97d34e5);
+impl windows_core::RuntimeType for ITileFlyoutNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileFlyoutNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -314,6 +389,9 @@ pub struct ITileFlyoutNotification_Vtbl {
     pub ExpirationTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITileFlyoutNotificationFactory, ITileFlyoutNotificationFactory_Vtbl, 0xef556ff5_5226_4f2b_b278_88a35dfe569f);
+impl windows_core::RuntimeType for ITileFlyoutNotificationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileFlyoutNotificationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -323,6 +401,9 @@ pub struct ITileFlyoutNotificationFactory_Vtbl {
     CreateTileFlyoutNotification: usize,
 }
 windows_core::imp::define_interface!(ITileFlyoutUpdateManagerStatics, ITileFlyoutUpdateManagerStatics_Vtbl, 0x04363b0b_1ac0_4b99_88e7_ada83e953d48);
+impl windows_core::RuntimeType for ITileFlyoutUpdateManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileFlyoutUpdateManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -335,6 +416,9 @@ pub struct ITileFlyoutUpdateManagerStatics_Vtbl {
     GetTemplateContent: usize,
 }
 windows_core::imp::define_interface!(ITileFlyoutUpdater, ITileFlyoutUpdater_Vtbl, 0x8d40c76a_c465_4052_a740_5c2654c1a089);
+impl windows_core::RuntimeType for ITileFlyoutUpdater {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileFlyoutUpdater_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -346,6 +430,9 @@ pub struct ITileFlyoutUpdater_Vtbl {
     pub Setting: unsafe extern "system" fn(*mut core::ffi::c_void, *mut NotificationSetting) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITileNotification, ITileNotification_Vtbl, 0xebaec8fa_50ec_4c18_b4d0_3af02e5540ab);
+impl windows_core::RuntimeType for ITileNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -359,6 +446,9 @@ pub struct ITileNotification_Vtbl {
     pub Tag: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITileNotificationFactory, ITileNotificationFactory_Vtbl, 0xc6abdd6e_4928_46c8_bdbf_81a047dea0d4);
+impl windows_core::RuntimeType for ITileNotificationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileNotificationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -368,6 +458,9 @@ pub struct ITileNotificationFactory_Vtbl {
     CreateTileNotification: usize,
 }
 windows_core::imp::define_interface!(ITileUpdateManagerForUser, ITileUpdateManagerForUser_Vtbl, 0x55141348_2ee2_4e2d_9cc1_216a20decc9f);
+impl windows_core::RuntimeType for ITileUpdateManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileUpdateManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -380,6 +473,9 @@ pub struct ITileUpdateManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(ITileUpdateManagerStatics, ITileUpdateManagerStatics_Vtbl, 0xda159e5d_3ea9_4986_8d84_b09d5e12276d);
+impl windows_core::RuntimeType for ITileUpdateManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileUpdateManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -392,6 +488,9 @@ pub struct ITileUpdateManagerStatics_Vtbl {
     GetTemplateContent: usize,
 }
 windows_core::imp::define_interface!(ITileUpdateManagerStatics2, ITileUpdateManagerStatics2_Vtbl, 0x731c1ddc_8e14_4b7c_a34b_9d22de76c84d);
+impl windows_core::RuntimeType for ITileUpdateManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileUpdateManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -401,6 +500,9 @@ pub struct ITileUpdateManagerStatics2_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(ITileUpdater, ITileUpdater_Vtbl, 0x0942a48b_1d91_44ec_9243_c1e821c29a20);
+impl windows_core::RuntimeType for ITileUpdater {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileUpdater_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -427,6 +529,9 @@ pub struct ITileUpdater_Vtbl {
     StartPeriodicUpdateBatchAtTime: usize,
 }
 windows_core::imp::define_interface!(ITileUpdater2, ITileUpdater2_Vtbl, 0xa2266e12_15ee_43ed_83f5_65b352bb1a84);
+impl windows_core::RuntimeType for ITileUpdater2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileUpdater2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -435,12 +540,18 @@ pub struct ITileUpdater2_Vtbl {
     pub EnableNotificationQueueForSquare310x310: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastActivatedEventArgs, IToastActivatedEventArgs_Vtbl, 0xe3bf92f3_c197_436f_8265_0625824f8dac);
+impl windows_core::RuntimeType for IToastActivatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastActivatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Arguments: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastActivatedEventArgs2, IToastActivatedEventArgs2_Vtbl, 0xab7da512_cc61_568e_81be_304ac31038fa);
+impl windows_core::RuntimeType for IToastActivatedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastActivatedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -450,6 +561,9 @@ pub struct IToastActivatedEventArgs2_Vtbl {
     UserInput: usize,
 }
 windows_core::imp::define_interface!(IToastCollection, IToastCollection_Vtbl, 0x0a8bc3b0_e0be_4858_bc2a_89dfe0b32863);
+impl windows_core::RuntimeType for IToastCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -462,12 +576,18 @@ pub struct IToastCollection_Vtbl {
     pub SetIcon: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastCollectionFactory, IToastCollectionFactory_Vtbl, 0x164dd3d7_73c4_44f7_b4ff_fb6d4bf1f4c6);
+impl windows_core::RuntimeType for IToastCollectionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastCollectionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateInstance: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastCollectionManager, IToastCollectionManager_Vtbl, 0x2a1821fe_179d_49bc_b79d_a527920d3665);
+impl windows_core::RuntimeType for IToastCollectionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastCollectionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -486,18 +606,27 @@ pub struct IToastCollectionManager_Vtbl {
     pub AppId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastDismissedEventArgs, IToastDismissedEventArgs_Vtbl, 0x3f89d935_d9cb_4538_a0f0_ffe7659938f8);
+impl windows_core::RuntimeType for IToastDismissedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastDismissedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ToastDismissalReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastFailedEventArgs, IToastFailedEventArgs_Vtbl, 0x35176862_cfd4_44f8_ad64_f500fd896c3b);
+impl windows_core::RuntimeType for IToastFailedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastFailedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ErrorCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut windows_core::HRESULT) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotification, IToastNotification_Vtbl, 0x997e2675_059e_4e60_8b06_1760917c8b80);
+impl windows_core::RuntimeType for IToastNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -515,6 +644,9 @@ pub struct IToastNotification_Vtbl {
     pub RemoveFailed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotification2, IToastNotification2_Vtbl, 0x9dfb9fd1_143a_490e_90bf_b9fba7132de7);
+impl windows_core::RuntimeType for IToastNotification2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotification2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -526,6 +658,9 @@ pub struct IToastNotification2_Vtbl {
     pub SuppressPopup: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotification3, IToastNotification3_Vtbl, 0x31e8aed8_8141_4f99_bc0a_c4ed21297d77);
+impl windows_core::RuntimeType for IToastNotification3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotification3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -535,6 +670,9 @@ pub struct IToastNotification3_Vtbl {
     pub SetRemoteId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotification4, IToastNotification4_Vtbl, 0x15154935_28ea_4727_88e9_c58680e2d118);
+impl windows_core::RuntimeType for IToastNotification4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotification4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -544,6 +682,9 @@ pub struct IToastNotification4_Vtbl {
     pub SetPriority: unsafe extern "system" fn(*mut core::ffi::c_void, ToastNotificationPriority) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotification6, IToastNotification6_Vtbl, 0x43ebfe53_89ae_5c1e_a279_3aecfe9b6f54);
+impl windows_core::RuntimeType for IToastNotification6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotification6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -551,6 +692,9 @@ pub struct IToastNotification6_Vtbl {
     pub SetExpiresOnReboot: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationActionTriggerDetail, IToastNotificationActionTriggerDetail_Vtbl, 0x9445135a_38f3_42f6_96aa_7955b0f03da2);
+impl windows_core::RuntimeType for IToastNotificationActionTriggerDetail {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationActionTriggerDetail_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -561,6 +705,9 @@ pub struct IToastNotificationActionTriggerDetail_Vtbl {
     UserInput: usize,
 }
 windows_core::imp::define_interface!(IToastNotificationFactory, IToastNotificationFactory_Vtbl, 0x04124b20_82c6_4229_b109_fd9ed4662b53);
+impl windows_core::RuntimeType for IToastNotificationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -570,6 +717,9 @@ pub struct IToastNotificationFactory_Vtbl {
     CreateToastNotification: usize,
 }
 windows_core::imp::define_interface!(IToastNotificationHistory, IToastNotificationHistory_Vtbl, 0x5caddc63_01d3_4c97_986f_0533483fee14);
+impl windows_core::RuntimeType for IToastNotificationHistory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationHistory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -582,6 +732,9 @@ pub struct IToastNotificationHistory_Vtbl {
     pub ClearWithId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationHistory2, IToastNotificationHistory2_Vtbl, 0x3bc3d253_2f31_4092_9129_8ad5abf067da);
+impl windows_core::RuntimeType for IToastNotificationHistory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationHistory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -595,18 +748,27 @@ pub struct IToastNotificationHistory2_Vtbl {
     GetHistoryWithId: usize,
 }
 windows_core::imp::define_interface!(IToastNotificationHistoryChangedTriggerDetail, IToastNotificationHistoryChangedTriggerDetail_Vtbl, 0xdb037ffa_0068_412c_9c83_267c37f65670);
+impl windows_core::RuntimeType for IToastNotificationHistoryChangedTriggerDetail {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationHistoryChangedTriggerDetail_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ChangeType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ToastHistoryChangedType) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationHistoryChangedTriggerDetail2, IToastNotificationHistoryChangedTriggerDetail2_Vtbl, 0x0b36e982_c871_49fb_babb_25bdbc4cc45b);
+impl windows_core::RuntimeType for IToastNotificationHistoryChangedTriggerDetail2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationHistoryChangedTriggerDetail2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CollectionId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationManagerForUser, IToastNotificationManagerForUser_Vtbl, 0x79ab57f6_43fe_487b_8a7f_99567200ae94);
+impl windows_core::RuntimeType for IToastNotificationManagerForUser {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationManagerForUser_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -619,6 +781,9 @@ pub struct IToastNotificationManagerForUser_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IToastNotificationManagerForUser2, IToastNotificationManagerForUser2_Vtbl, 0x679c64b7_81ab_42c2_8819_c958767753f4);
+impl windows_core::RuntimeType for IToastNotificationManagerForUser2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationManagerForUser2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -628,6 +793,9 @@ pub struct IToastNotificationManagerForUser2_Vtbl {
     pub GetToastCollectionManagerWithAppId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationManagerForUser3, IToastNotificationManagerForUser3_Vtbl, 0x3efcb176_6cc1_56dc_973b_251f7aacb1c5);
+impl windows_core::RuntimeType for IToastNotificationManagerForUser3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationManagerForUser3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -636,6 +804,9 @@ pub struct IToastNotificationManagerForUser3_Vtbl {
     pub RemoveNotificationModeChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationManagerStatics, IToastNotificationManagerStatics_Vtbl, 0x50ac103f_d235_4598_bbef_98fe4d1a3ad4);
+impl windows_core::RuntimeType for IToastNotificationManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -647,12 +818,18 @@ pub struct IToastNotificationManagerStatics_Vtbl {
     GetTemplateContent: usize,
 }
 windows_core::imp::define_interface!(IToastNotificationManagerStatics2, IToastNotificationManagerStatics2_Vtbl, 0x7ab93c52_0e48_4750_ba9d_1a4113981847);
+impl windows_core::RuntimeType for IToastNotificationManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub History: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationManagerStatics4, IToastNotificationManagerStatics4_Vtbl, 0x8f993fd3_e516_45fb_8130_398e93fa52c3);
+impl windows_core::RuntimeType for IToastNotificationManagerStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationManagerStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -663,12 +840,18 @@ pub struct IToastNotificationManagerStatics4_Vtbl {
     pub ConfigureNotificationMirroring: unsafe extern "system" fn(*mut core::ffi::c_void, NotificationMirroring) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotificationManagerStatics5, IToastNotificationManagerStatics5_Vtbl, 0xd6f5f569_d40d_407c_8989_88cab42cfd14);
+impl windows_core::RuntimeType for IToastNotificationManagerStatics5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotificationManagerStatics5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotifier, IToastNotifier_Vtbl, 0x75927b93_03f3_41ec_91d3_6e5bac1b38e7);
+impl windows_core::RuntimeType for IToastNotifier {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotifier_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -683,6 +866,9 @@ pub struct IToastNotifier_Vtbl {
     GetScheduledToastNotifications: usize,
 }
 windows_core::imp::define_interface!(IToastNotifier2, IToastNotifier2_Vtbl, 0x354389c6_7c01_4bd5_9c20_604340cd2b74);
+impl windows_core::RuntimeType for IToastNotifier2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotifier2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -690,6 +876,9 @@ pub struct IToastNotifier2_Vtbl {
     pub UpdateWithTag: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut NotificationUpdateResult) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IToastNotifier3, IToastNotifier3_Vtbl, 0xae75a04a_3b0c_51ad_b7e8_b08ab6052549);
+impl windows_core::RuntimeType for IToastNotifier3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IToastNotifier3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -697,6 +886,9 @@ pub struct IToastNotifier3_Vtbl {
     pub RemoveScheduledToastNotificationShowing: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserNotification, IUserNotification_Vtbl, 0xadf7e52f_4e53_42d5_9c33_eb5ea515b23e);
+impl windows_core::RuntimeType for IUserNotification {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserNotification_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -709,6 +901,9 @@ pub struct IUserNotification_Vtbl {
     pub CreationTime: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::DateTime) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUserNotificationChangedEventArgs, IUserNotificationChangedEventArgs_Vtbl, 0xb6bd6839_79cf_4b25_82c0_0ce1eef81f8c);
+impl windows_core::RuntimeType for IUserNotificationChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUserNotificationChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -767,7 +962,7 @@ impl AdaptiveNotificationText {
     }
 }
 impl windows_core::RuntimeType for AdaptiveNotificationText {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAdaptiveNotificationText>();
 }
 unsafe impl windows_core::Interface for AdaptiveNotificationText {
     type Vtable = IAdaptiveNotificationText_Vtbl;
@@ -822,7 +1017,7 @@ impl BadgeNotification {
     }
 }
 impl windows_core::RuntimeType for BadgeNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBadgeNotification>();
 }
 unsafe impl windows_core::Interface for BadgeNotification {
     type Vtable = IBadgeNotification_Vtbl;
@@ -920,7 +1115,7 @@ impl BadgeUpdateManagerForUser {
     }
 }
 impl windows_core::RuntimeType for BadgeUpdateManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBadgeUpdateManagerForUser>();
 }
 unsafe impl windows_core::Interface for BadgeUpdateManagerForUser {
     type Vtable = IBadgeUpdateManagerForUser_Vtbl;
@@ -967,7 +1162,7 @@ impl BadgeUpdater {
     }
 }
 impl windows_core::RuntimeType for BadgeUpdater {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IBadgeUpdater>();
 }
 unsafe impl windows_core::Interface for BadgeUpdater {
     type Vtable = IBadgeUpdater_Vtbl;
@@ -1209,7 +1404,7 @@ impl Notification {
     }
 }
 impl windows_core::RuntimeType for Notification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INotification>();
 }
 unsafe impl windows_core::Interface for Notification {
     type Vtable = INotification_Vtbl;
@@ -1265,7 +1460,7 @@ impl NotificationBinding {
     }
 }
 impl windows_core::RuntimeType for NotificationBinding {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INotificationBinding>();
 }
 unsafe impl windows_core::Interface for NotificationBinding {
     type Vtable = INotificationBinding_Vtbl;
@@ -1334,7 +1529,7 @@ impl NotificationData {
     }
 }
 impl windows_core::RuntimeType for NotificationData {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INotificationData>();
 }
 unsafe impl windows_core::Interface for NotificationData {
     type Vtable = INotificationData_Vtbl;
@@ -1378,7 +1573,7 @@ impl NotificationVisual {
     }
 }
 impl windows_core::RuntimeType for NotificationVisual {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INotificationVisual>();
 }
 unsafe impl windows_core::Interface for NotificationVisual {
     type Vtable = INotificationVisual_Vtbl;
@@ -1462,7 +1657,7 @@ impl ScheduledTileNotification {
     }
 }
 impl windows_core::RuntimeType for ScheduledTileNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScheduledTileNotification>();
 }
 unsafe impl windows_core::Interface for ScheduledTileNotification {
     type Vtable = IScheduledTileNotification_Vtbl;
@@ -1614,7 +1809,7 @@ impl ScheduledToastNotification {
     }
 }
 impl windows_core::RuntimeType for ScheduledToastNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScheduledToastNotification>();
 }
 unsafe impl windows_core::Interface for ScheduledToastNotification {
     type Vtable = IScheduledToastNotification_Vtbl;
@@ -1657,7 +1852,7 @@ impl ScheduledToastNotificationShowingEventArgs {
     }
 }
 impl windows_core::RuntimeType for ScheduledToastNotificationShowingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IScheduledToastNotificationShowingEventArgs>();
 }
 unsafe impl windows_core::Interface for ScheduledToastNotificationShowingEventArgs {
     type Vtable = IScheduledToastNotificationShowingEventArgs_Vtbl;
@@ -1682,7 +1877,7 @@ impl ShownTileNotification {
     }
 }
 impl windows_core::RuntimeType for ShownTileNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShownTileNotification>();
 }
 unsafe impl windows_core::Interface for ShownTileNotification {
     type Vtable = IShownTileNotification_Vtbl;
@@ -1737,7 +1932,7 @@ impl TileFlyoutNotification {
     }
 }
 impl windows_core::RuntimeType for TileFlyoutNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITileFlyoutNotification>();
 }
 unsafe impl windows_core::Interface for TileFlyoutNotification {
     type Vtable = ITileFlyoutNotification_Vtbl;
@@ -1827,7 +2022,7 @@ impl TileFlyoutUpdater {
     }
 }
 impl windows_core::RuntimeType for TileFlyoutUpdater {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITileFlyoutUpdater>();
 }
 unsafe impl windows_core::Interface for TileFlyoutUpdater {
     type Vtable = ITileFlyoutUpdater_Vtbl;
@@ -1891,7 +2086,7 @@ impl TileNotification {
     }
 }
 impl windows_core::RuntimeType for TileNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITileNotification>();
 }
 unsafe impl windows_core::Interface for TileNotification {
     type Vtable = ITileNotification_Vtbl;
@@ -1989,7 +2184,7 @@ impl TileUpdateManagerForUser {
     }
 }
 impl windows_core::RuntimeType for TileUpdateManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITileUpdateManagerForUser>();
 }
 unsafe impl windows_core::Interface for TileUpdateManagerForUser {
     type Vtable = ITileUpdateManagerForUser_Vtbl;
@@ -2097,7 +2292,7 @@ impl TileUpdater {
     }
 }
 impl windows_core::RuntimeType for TileUpdater {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITileUpdater>();
 }
 unsafe impl windows_core::Interface for TileUpdater {
     type Vtable = ITileUpdater_Vtbl;
@@ -2130,7 +2325,7 @@ impl ToastActivatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ToastActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastActivatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ToastActivatedEventArgs {
     type Vtable = IToastActivatedEventArgs_Vtbl;
@@ -2203,7 +2398,7 @@ impl ToastCollection {
     }
 }
 impl windows_core::RuntimeType for ToastCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastCollection>();
 }
 unsafe impl windows_core::Interface for ToastCollection {
     type Vtable = IToastCollection_Vtbl;
@@ -2275,7 +2470,7 @@ impl ToastCollectionManager {
     }
 }
 impl windows_core::RuntimeType for ToastCollectionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastCollectionManager>();
 }
 unsafe impl windows_core::Interface for ToastCollectionManager {
     type Vtable = IToastCollectionManager_Vtbl;
@@ -2300,7 +2495,7 @@ impl ToastDismissedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ToastDismissedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastDismissedEventArgs>();
 }
 unsafe impl windows_core::Interface for ToastDismissedEventArgs {
     type Vtable = IToastDismissedEventArgs_Vtbl;
@@ -2325,7 +2520,7 @@ impl ToastFailedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ToastFailedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastFailedEventArgs>();
 }
 unsafe impl windows_core::Interface for ToastFailedEventArgs {
     type Vtable = IToastFailedEventArgs_Vtbl;
@@ -2513,7 +2708,7 @@ impl ToastNotification {
     }
 }
 impl windows_core::RuntimeType for ToastNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotification>();
 }
 unsafe impl windows_core::Interface for ToastNotification {
     type Vtable = IToastNotification_Vtbl;
@@ -2546,7 +2741,7 @@ impl ToastNotificationActionTriggerDetail {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationActionTriggerDetail {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotificationActionTriggerDetail>();
 }
 unsafe impl windows_core::Interface for ToastNotificationActionTriggerDetail {
     type Vtable = IToastNotificationActionTriggerDetail_Vtbl;
@@ -2606,7 +2801,7 @@ impl ToastNotificationHistory {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationHistory {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotificationHistory>();
 }
 unsafe impl windows_core::Interface for ToastNotificationHistory {
     type Vtable = IToastNotificationHistory_Vtbl;
@@ -2636,7 +2831,7 @@ impl ToastNotificationHistoryChangedTriggerDetail {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationHistoryChangedTriggerDetail {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotificationHistoryChangedTriggerDetail>();
 }
 unsafe impl windows_core::Interface for ToastNotificationHistoryChangedTriggerDetail {
     type Vtable = IToastNotificationHistoryChangedTriggerDetail_Vtbl;
@@ -2800,7 +2995,7 @@ impl ToastNotificationManagerForUser {
     }
 }
 impl windows_core::RuntimeType for ToastNotificationManagerForUser {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotificationManagerForUser>();
 }
 unsafe impl windows_core::Interface for ToastNotificationManagerForUser {
     type Vtable = IToastNotificationManagerForUser_Vtbl;
@@ -2895,7 +3090,7 @@ impl ToastNotifier {
     }
 }
 impl windows_core::RuntimeType for ToastNotifier {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IToastNotifier>();
 }
 unsafe impl windows_core::Interface for ToastNotifier {
     type Vtable = IToastNotifier_Vtbl;
@@ -2942,7 +3137,7 @@ impl UserNotification {
     }
 }
 impl windows_core::RuntimeType for UserNotification {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserNotification>();
 }
 unsafe impl windows_core::Interface for UserNotification {
     type Vtable = IUserNotification_Vtbl;
@@ -2974,7 +3169,7 @@ impl UserNotificationChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for UserNotificationChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUserNotificationChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UserNotificationChangedEventArgs {
     type Vtable = IUserNotificationChangedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IMessageDialog, IMessageDialog_Vtbl, 0x33f59b01_5325_43ab_9ab3_bdae440e4121);
+impl windows_core::RuntimeType for IMessageDialog {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageDialog_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +22,9 @@ pub struct IMessageDialog_Vtbl {
     pub SetOptions: unsafe extern "system" fn(*mut core::ffi::c_void, MessageDialogOptions) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IMessageDialogFactory, IMessageDialogFactory_Vtbl, 0x2d161777_a66f_4ea5_bb87_793ffa4941f2);
+impl windows_core::RuntimeType for IMessageDialogFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IMessageDialogFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +32,9 @@ pub struct IMessageDialogFactory_Vtbl {
     pub CreateWithTitle: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IPopupMenu, IPopupMenu_Vtbl, 0x4e9bc6dc_880d_47fc_a0a1_72b639e62559);
+impl windows_core::RuntimeType for IPopupMenu {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IPopupMenu_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -94,6 +103,9 @@ pub struct IUICommand_Vtbl {
     pub SetId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUICommandFactory, IUICommandFactory_Vtbl, 0xa21a8189_26b0_4676_ae94_54041bc125e8);
+impl windows_core::RuntimeType for IUICommandFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUICommandFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -195,7 +207,7 @@ impl MessageDialog {
     }
 }
 impl windows_core::RuntimeType for MessageDialog {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IMessageDialog>();
 }
 unsafe impl windows_core::Interface for MessageDialog {
     type Vtable = IMessageDialog_Vtbl;
@@ -247,7 +259,7 @@ impl PopupMenu {
     }
 }
 impl windows_core::RuntimeType for PopupMenu {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IPopupMenu>();
 }
 unsafe impl windows_core::Interface for PopupMenu {
     type Vtable = IPopupMenu_Vtbl;
@@ -340,7 +352,7 @@ impl UICommand {
     }
 }
 impl windows_core::RuntimeType for UICommand {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUICommand>();
 }
 unsafe impl windows_core::Interface for UICommand {
     type Vtable = IUICommand_Vtbl;
@@ -405,7 +417,7 @@ impl UICommandSeparator {
     }
 }
 impl windows_core::RuntimeType for UICommandSeparator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUICommand>();
 }
 unsafe impl windows_core::Interface for UICommandSeparator {
     type Vtable = IUICommand_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Shell/mod.rs
@@ -37,6 +37,9 @@ pub struct IAdaptiveCardBuilderStatics_Vtbl {
     pub CreateAdaptiveCardFromJson: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFocusSession, IFocusSession_Vtbl, 0x069fbab8_0e84_5f2f_8614_9b6544326277);
+impl windows_core::RuntimeType for IFocusSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFocusSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +47,9 @@ pub struct IFocusSession_Vtbl {
     pub End: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFocusSessionManager, IFocusSessionManager_Vtbl, 0xe7ffbaa9_d8be_5dbf_bac6_49364842e37e);
+impl windows_core::RuntimeType for IFocusSessionManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFocusSessionManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +62,9 @@ pub struct IFocusSessionManager_Vtbl {
     pub RemoveIsFocusActiveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFocusSessionManagerStatics, IFocusSessionManagerStatics_Vtbl, 0x834df764_cb9a_5d0a_aa9f_73df4f249395);
+impl windows_core::RuntimeType for IFocusSessionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFocusSessionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -63,6 +72,9 @@ pub struct IFocusSessionManagerStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecurityAppManager, ISecurityAppManager_Vtbl, 0x96ac500c_aed4_561d_bde8_953520343a2d);
+impl windows_core::RuntimeType for ISecurityAppManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecurityAppManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -71,6 +83,9 @@ pub struct ISecurityAppManager_Vtbl {
     pub UpdateState: unsafe extern "system" fn(*mut core::ffi::c_void, SecurityAppKind, windows_core::GUID, SecurityAppState, SecurityAppSubstatus, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareWindowCommandEventArgs, IShareWindowCommandEventArgs_Vtbl, 0x4578dc09_a523_5756_a995_e4feb991fff0);
+impl windows_core::RuntimeType for IShareWindowCommandEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareWindowCommandEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -79,6 +94,9 @@ pub struct IShareWindowCommandEventArgs_Vtbl {
     pub SetCommand: unsafe extern "system" fn(*mut core::ffi::c_void, ShareWindowCommand) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareWindowCommandSource, IShareWindowCommandSource_Vtbl, 0xcb3b7ae3_6b9c_561e_bccc_61e68e0abfef);
+impl windows_core::RuntimeType for IShareWindowCommandSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareWindowCommandSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,12 +109,18 @@ pub struct IShareWindowCommandSource_Vtbl {
     pub RemoveCommandInvoked: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IShareWindowCommandSourceStatics, IShareWindowCommandSourceStatics_Vtbl, 0xb0eb6656_9cac_517c_b6c7_8ef715084295);
+impl windows_core::RuntimeType for IShareWindowCommandSourceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IShareWindowCommandSourceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITaskbarManager, ITaskbarManager_Vtbl, 0x87490a19_1ad9_49f4_b2e8_86738dc5ac40);
+impl windows_core::RuntimeType for ITaskbarManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITaskbarManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -114,6 +138,9 @@ pub struct ITaskbarManager_Vtbl {
     RequestPinAppListEntryAsync: usize,
 }
 windows_core::imp::define_interface!(ITaskbarManager2, ITaskbarManager2_Vtbl, 0x79f0a06e_7b02_4911_918c_dee0bbd20ba4);
+impl windows_core::RuntimeType for ITaskbarManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITaskbarManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -125,17 +152,26 @@ pub struct ITaskbarManager2_Vtbl {
     pub TryUnpinSecondaryTileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITaskbarManagerDesktopAppSupportStatics, ITaskbarManagerDesktopAppSupportStatics_Vtbl, 0xcdfefd63_e879_4134_b9a7_8283f05f9480);
+impl windows_core::RuntimeType for ITaskbarManagerDesktopAppSupportStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITaskbarManagerDesktopAppSupportStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(ITaskbarManagerStatics, ITaskbarManagerStatics_Vtbl, 0xdb32ab74_de52_4fe6_b7b6_95ff9f8395df);
+impl windows_core::RuntimeType for ITaskbarManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITaskbarManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDefault: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTab, IWindowTab_Vtbl, 0x551e776a_7928_4d60_bdd9_672b5a5758eb);
+impl windows_core::RuntimeType for IWindowTab {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTab_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,18 +188,27 @@ pub struct IWindowTab_Vtbl {
     pub ReportThumbnailAvailable: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabCloseRequestedEventArgs, IWindowTabCloseRequestedEventArgs_Vtbl, 0x477282e9_eec4_5882_9889_2dd64d0f9fb6);
+impl windows_core::RuntimeType for IWindowTabCloseRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabCloseRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Tab: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabCollection, IWindowTabCollection_Vtbl, 0xaccd0d6c_ed07_519a_8c33_17e02e7e9b0f);
+impl windows_core::RuntimeType for IWindowTabCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MoveTab: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabGroup, IWindowTabGroup_Vtbl, 0xa9c2c4fe_6cfe_449c_8b57_5756771abe56);
+impl windows_core::RuntimeType for IWindowTabGroup {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabGroup_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,11 +218,17 @@ pub struct IWindowTabGroup_Vtbl {
     pub SetIcon: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabIcon, IWindowTabIcon_Vtbl, 0xf92f398f_3669_4d0c_a183_14ddae6f6538);
+impl windows_core::RuntimeType for IWindowTabIcon {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabIcon_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IWindowTabIconStatics, IWindowTabIconStatics_Vtbl, 0x2e18d95e_2cbb_4084_af0c_36ee1c2d54b1);
+impl windows_core::RuntimeType for IWindowTabIconStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabIconStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +240,9 @@ pub struct IWindowTabIconStatics_Vtbl {
     CreateFromImage: usize,
 }
 windows_core::imp::define_interface!(IWindowTabManager, IWindowTabManager_Vtbl, 0x97b3c697_f43a_43e7_b3a2_e889a9835599);
+impl windows_core::RuntimeType for IWindowTabManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -204,6 +258,9 @@ pub struct IWindowTabManager_Vtbl {
     pub RemoveTabThumbnailRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabManagerStatics, IWindowTabManagerStatics_Vtbl, 0x76755668_45f0_4e0b_8172_4e6d9d0f87bd);
+impl windows_core::RuntimeType for IWindowTabManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -212,12 +269,18 @@ pub struct IWindowTabManagerStatics_Vtbl {
     pub IsTabTearOutSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabSwitchRequestedEventArgs, IWindowTabSwitchRequestedEventArgs_Vtbl, 0x7cbc421a_58a4_568b_a351_f8a947a5aad8);
+impl windows_core::RuntimeType for IWindowTabSwitchRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabSwitchRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Tab: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabTearOutRequestedEventArgs, IWindowTabTearOutRequestedEventArgs_Vtbl, 0x17d66659_5005_5ece_99af_566306e73642);
+impl windows_core::RuntimeType for IWindowTabTearOutRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabTearOutRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -227,6 +290,9 @@ pub struct IWindowTabTearOutRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowTabThumbnailRequestedEventArgs, IWindowTabThumbnailRequestedEventArgs_Vtbl, 0x2d558e54_9c4e_5abc_ab72_3350fb4937a0);
+impl windows_core::RuntimeType for IWindowTabThumbnailRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowTabThumbnailRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,7 +347,7 @@ impl FocusSession {
     }
 }
 impl windows_core::RuntimeType for FocusSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFocusSession>();
 }
 unsafe impl windows_core::Interface for FocusSession {
     type Vtable = IFocusSession_Vtbl;
@@ -362,7 +428,7 @@ impl FocusSessionManager {
     }
 }
 impl windows_core::RuntimeType for FocusSessionManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFocusSessionManager>();
 }
 unsafe impl windows_core::Interface for FocusSessionManager {
     type Vtable = IFocusSessionManager_Vtbl;
@@ -408,7 +474,7 @@ impl SecurityAppManager {
     }
 }
 impl windows_core::RuntimeType for SecurityAppManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISecurityAppManager>();
 }
 unsafe impl windows_core::Interface for SecurityAppManager {
     type Vtable = ISecurityAppManager_Vtbl;
@@ -444,7 +510,7 @@ impl ShareWindowCommandEventArgs {
     }
 }
 impl windows_core::RuntimeType for ShareWindowCommandEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareWindowCommandEventArgs>();
 }
 unsafe impl windows_core::Interface for ShareWindowCommandEventArgs {
     type Vtable = IShareWindowCommandEventArgs_Vtbl;
@@ -513,7 +579,7 @@ impl ShareWindowCommandSource {
     }
 }
 impl windows_core::RuntimeType for ShareWindowCommandSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IShareWindowCommandSource>();
 }
 unsafe impl windows_core::Interface for ShareWindowCommandSource {
     type Vtable = IShareWindowCommandSource_Vtbl;
@@ -617,7 +683,7 @@ impl TaskbarManager {
     }
 }
 impl windows_core::RuntimeType for TaskbarManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITaskbarManager>();
 }
 unsafe impl windows_core::Interface for TaskbarManager {
     type Vtable = ITaskbarManager_Vtbl;
@@ -710,7 +776,7 @@ impl WindowTab {
     }
 }
 impl windows_core::RuntimeType for WindowTab {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTab>();
 }
 unsafe impl windows_core::Interface for WindowTab {
     type Vtable = IWindowTab_Vtbl;
@@ -735,7 +801,7 @@ impl WindowTabCloseRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowTabCloseRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabCloseRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowTabCloseRequestedEventArgs {
     type Vtable = IWindowTabCloseRequestedEventArgs_Vtbl;
@@ -857,7 +923,7 @@ impl WindowTabCollection {
     }
 }
 impl windows_core::RuntimeType for WindowTabCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabCollection>();
 }
 unsafe impl windows_core::Interface for WindowTabCollection {
     type Vtable = IWindowTabCollection_Vtbl;
@@ -923,7 +989,7 @@ impl WindowTabGroup {
     }
 }
 impl windows_core::RuntimeType for WindowTabGroup {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabGroup>();
 }
 unsafe impl windows_core::Interface for WindowTabGroup {
     type Vtable = IWindowTabGroup_Vtbl;
@@ -971,7 +1037,7 @@ impl WindowTabIcon {
     }
 }
 impl windows_core::RuntimeType for WindowTabIcon {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabIcon>();
 }
 unsafe impl windows_core::Interface for WindowTabIcon {
     type Vtable = IWindowTabIcon_Vtbl;
@@ -1082,7 +1148,7 @@ impl WindowTabManager {
     }
 }
 impl windows_core::RuntimeType for WindowTabManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabManager>();
 }
 unsafe impl windows_core::Interface for WindowTabManager {
     type Vtable = IWindowTabManager_Vtbl;
@@ -1107,7 +1173,7 @@ impl WindowTabSwitchRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowTabSwitchRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabSwitchRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowTabSwitchRequestedEventArgs {
     type Vtable = IWindowTabSwitchRequestedEventArgs_Vtbl;
@@ -1150,7 +1216,7 @@ impl WindowTabTearOutRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowTabTearOutRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabTearOutRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowTabTearOutRequestedEventArgs {
     type Vtable = IWindowTabTearOutRequestedEventArgs_Vtbl;
@@ -1213,7 +1279,7 @@ impl WindowTabThumbnailRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowTabThumbnailRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowTabThumbnailRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowTabThumbnailRequestedEventArgs {
     type Vtable = IWindowTabThumbnailRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IJumpList, IJumpList_Vtbl, 0xb0234c3e_cd6f_4cb6_a611_61fd505f3ed1);
+impl windows_core::RuntimeType for IJumpList {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJumpList_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -11,6 +14,9 @@ pub struct IJumpList_Vtbl {
     pub SaveAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJumpListItem, IJumpListItem_Vtbl, 0x7adb6717_8b5d_4820_995b_9b418dbe48b0);
+impl windows_core::RuntimeType for IJumpListItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJumpListItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +33,9 @@ pub struct IJumpListItem_Vtbl {
     pub SetLogo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJumpListItemStatics, IJumpListItemStatics_Vtbl, 0xf1bfc4e8_c7aa_49cb_8dde_ecfccd7ad7e4);
+impl windows_core::RuntimeType for IJumpListItemStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJumpListItemStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -34,6 +43,9 @@ pub struct IJumpListItemStatics_Vtbl {
     pub CreateSeparator: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IJumpListStatics, IJumpListStatics_Vtbl, 0xa7e0c681_e67e_4b74_8250_3f322c4d92c3);
+impl windows_core::RuntimeType for IJumpListStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJumpListStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +53,9 @@ pub struct IJumpListStatics_Vtbl {
     pub IsSupported: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTile, ISecondaryTile_Vtbl, 0x9e9e51e0_2bb5_4bc0_bb8d_42b23abcc88d);
+impl windows_core::RuntimeType for ISecondaryTile {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTile_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -127,6 +142,9 @@ pub struct ISecondaryTile_Vtbl {
     pub UpdateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTile2, ISecondaryTile2_Vtbl, 0xb2f6cc35_3250_4990_923c_294ab4b694dd);
+impl windows_core::RuntimeType for ISecondaryTile2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTile2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -139,6 +157,9 @@ pub struct ISecondaryTile2_Vtbl {
     pub RemoveVisualElementsRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTileFactory, ISecondaryTileFactory_Vtbl, 0x57f52ca0_51bc_4abf_8ebf_627a0398b05a);
+impl windows_core::RuntimeType for ISecondaryTileFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTileFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -153,12 +174,18 @@ pub struct ISecondaryTileFactory_Vtbl {
     pub CreateWithId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTileFactory2, ISecondaryTileFactory2_Vtbl, 0x274b8a3b_522d_448e_9eb2_d0672ab345c8);
+impl windows_core::RuntimeType for ISecondaryTileFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTileFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateMinimalTile: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, TileSize, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTileStatics, ISecondaryTileStatics_Vtbl, 0x99908dae_d051_4676_87fe_9ec242d83c74);
+impl windows_core::RuntimeType for ISecondaryTileStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTileStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -177,6 +204,9 @@ pub struct ISecondaryTileStatics_Vtbl {
     FindAllForPackageAsync: usize,
 }
 windows_core::imp::define_interface!(ISecondaryTileVisualElements, ISecondaryTileVisualElements_Vtbl, 0x1d8df333_815e_413f_9f50_a81da70a96b2);
+impl windows_core::RuntimeType for ISecondaryTileVisualElements {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTileVisualElements_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,6 +244,9 @@ pub struct ISecondaryTileVisualElements_Vtbl {
     pub ShowNameOnSquare310x310Logo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTileVisualElements2, ISecondaryTileVisualElements2_Vtbl, 0xfd2e31d0_57dc_4794_8ecf_5682f5f3e6ef);
+impl windows_core::RuntimeType for ISecondaryTileVisualElements2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTileVisualElements2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +254,9 @@ pub struct ISecondaryTileVisualElements2_Vtbl {
     pub Square71x71Logo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTileVisualElements3, ISecondaryTileVisualElements3_Vtbl, 0x56b55ad6_d15c_40f4_81e7_57ffd8f8a4e9);
+impl windows_core::RuntimeType for ISecondaryTileVisualElements3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTileVisualElements3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -228,12 +264,18 @@ pub struct ISecondaryTileVisualElements3_Vtbl {
     pub Square44x44Logo: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISecondaryTileVisualElements4, ISecondaryTileVisualElements4_Vtbl, 0x66566117_b544_40d2_8d12_74d4ec24d04c);
+impl windows_core::RuntimeType for ISecondaryTileVisualElements4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISecondaryTileVisualElements4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub MixedRealityModel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStartScreenManager, IStartScreenManager_Vtbl, 0x4a1dcbcb_26e9_4eb4_8933_859eb6ecdb29);
+impl windows_core::RuntimeType for IStartScreenManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStartScreenManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -255,6 +297,9 @@ pub struct IStartScreenManager_Vtbl {
     RequestAddAppListEntryAsync: usize,
 }
 windows_core::imp::define_interface!(IStartScreenManager2, IStartScreenManager2_Vtbl, 0x08a716b6_316b_4ad9_acb8_fe9cf00bd608);
+impl windows_core::RuntimeType for IStartScreenManager2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStartScreenManager2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -262,6 +307,9 @@ pub struct IStartScreenManager2_Vtbl {
     pub TryRemoveSecondaryTileAsync: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStartScreenManagerStatics, IStartScreenManagerStatics_Vtbl, 0x7865ef0f_b585_464e_8993_34e8f8738d48);
+impl windows_core::RuntimeType for IStartScreenManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStartScreenManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -272,6 +320,9 @@ pub struct IStartScreenManagerStatics_Vtbl {
     GetForUser: usize,
 }
 windows_core::imp::define_interface!(ITileMixedRealityModel, ITileMixedRealityModel_Vtbl, 0xb0764e5b_887d_4242_9a19_3d0a4ea78031);
+impl windows_core::RuntimeType for ITileMixedRealityModel {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileMixedRealityModel_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -287,6 +338,9 @@ pub struct ITileMixedRealityModel_Vtbl {
     BoundingBox: usize,
 }
 windows_core::imp::define_interface!(ITileMixedRealityModel2, ITileMixedRealityModel2_Vtbl, 0x439470b2_d7c5_410b_8319_9486a27b6c67);
+impl windows_core::RuntimeType for ITileMixedRealityModel2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITileMixedRealityModel2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,6 +348,9 @@ pub struct ITileMixedRealityModel2_Vtbl {
     pub ActivationBehavior: unsafe extern "system" fn(*mut core::ffi::c_void, *mut TileMixedRealityModelActivationBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualElementsRequest, IVisualElementsRequest_Vtbl, 0xc138333a_9308_4072_88cc_d068db347c68);
+impl windows_core::RuntimeType for IVisualElementsRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualElementsRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -306,12 +363,18 @@ pub struct IVisualElementsRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualElementsRequestDeferral, IVisualElementsRequestDeferral_Vtbl, 0xa1656eb0_0126_4357_8204_bd82bb2a046d);
+impl windows_core::RuntimeType for IVisualElementsRequestDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualElementsRequestDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Complete: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IVisualElementsRequestedEventArgs, IVisualElementsRequestedEventArgs_Vtbl, 0x7b6fc982_3a0d_4ece_af96_cd17e1b00b2d);
+impl windows_core::RuntimeType for IVisualElementsRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IVisualElementsRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -367,7 +430,7 @@ impl JumpList {
     }
 }
 impl windows_core::RuntimeType for JumpList {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IJumpList>();
 }
 unsafe impl windows_core::Interface for JumpList {
     type Vtable = IJumpList_Vtbl;
@@ -470,7 +533,7 @@ impl JumpListItem {
     }
 }
 impl windows_core::RuntimeType for JumpListItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IJumpListItem>();
 }
 unsafe impl windows_core::Interface for JumpListItem {
     type Vtable = IJumpListItem_Vtbl;
@@ -839,7 +902,7 @@ impl SecondaryTile {
     }
 }
 impl windows_core::RuntimeType for SecondaryTile {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISecondaryTile>();
 }
 unsafe impl windows_core::Interface for SecondaryTile {
     type Vtable = ISecondaryTile_Vtbl;
@@ -1021,7 +1084,7 @@ impl SecondaryTileVisualElements {
     }
 }
 impl windows_core::RuntimeType for SecondaryTileVisualElements {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISecondaryTileVisualElements>();
 }
 unsafe impl windows_core::Interface for SecondaryTileVisualElements {
     type Vtable = ISecondaryTileVisualElements_Vtbl;
@@ -1115,7 +1178,7 @@ impl StartScreenManager {
     }
 }
 impl windows_core::RuntimeType for StartScreenManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStartScreenManager>();
 }
 unsafe impl windows_core::Interface for StartScreenManager {
     type Vtable = IStartScreenManager_Vtbl;
@@ -1174,7 +1237,7 @@ impl TileMixedRealityModel {
     }
 }
 impl windows_core::RuntimeType for TileMixedRealityModel {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITileMixedRealityModel>();
 }
 unsafe impl windows_core::Interface for TileMixedRealityModel {
     type Vtable = ITileMixedRealityModel_Vtbl;
@@ -1221,7 +1284,7 @@ impl VisualElementsRequest {
     }
 }
 impl windows_core::RuntimeType for VisualElementsRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisualElementsRequest>();
 }
 unsafe impl windows_core::Interface for VisualElementsRequest {
     type Vtable = IVisualElementsRequest_Vtbl;
@@ -1243,7 +1306,7 @@ impl VisualElementsRequestDeferral {
     }
 }
 impl windows_core::RuntimeType for VisualElementsRequestDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisualElementsRequestDeferral>();
 }
 unsafe impl windows_core::Interface for VisualElementsRequestDeferral {
     type Vtable = IVisualElementsRequestDeferral_Vtbl;
@@ -1268,7 +1331,7 @@ impl VisualElementsRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for VisualElementsRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IVisualElementsRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for VisualElementsRequestedEventArgs {
     type Vtable = IVisualElementsRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICoreTextCompositionCompletedEventArgs, ICoreTextCompositionCompletedEventArgs_Vtbl, 0x1f34ebb6_b79f_4121_a5e7_fda9b8616e30);
+impl windows_core::RuntimeType for ICoreTextCompositionCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextCompositionCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct ICoreTextCompositionCompletedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextCompositionSegment, ICoreTextCompositionSegment_Vtbl, 0x776c6bd9_4ead_4da7_8f47_3a88b523cc34);
+impl windows_core::RuntimeType for ICoreTextCompositionSegment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextCompositionSegment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -17,6 +23,9 @@ pub struct ICoreTextCompositionSegment_Vtbl {
     pub Range: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CoreTextRange) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextCompositionStartedEventArgs, ICoreTextCompositionStartedEventArgs_Vtbl, 0x276b16a9_64e7_4ab0_bc4b_a02d73835bfb);
+impl windows_core::RuntimeType for ICoreTextCompositionStartedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextCompositionStartedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -24,6 +33,9 @@ pub struct ICoreTextCompositionStartedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextEditContext, ICoreTextEditContext_Vtbl, 0xbf6608af_4041_47c3_b263_a918eb5eaef2);
+impl windows_core::RuntimeType for ICoreTextEditContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextEditContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -60,6 +72,9 @@ pub struct ICoreTextEditContext_Vtbl {
     pub NotifyLayoutChanged: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextEditContext2, ICoreTextEditContext2_Vtbl, 0xb1867dbb_083b_49e1_b281_2b35d62bf466);
+impl windows_core::RuntimeType for ICoreTextEditContext2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextEditContext2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +82,9 @@ pub struct ICoreTextEditContext2_Vtbl {
     pub RemoveNotifyFocusLeaveCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextFormatUpdatingEventArgs, ICoreTextFormatUpdatingEventArgs_Vtbl, 0x7310bd33_b4a8_43b1_b37b_0724d4aca7ab);
+impl windows_core::RuntimeType for ICoreTextFormatUpdatingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextFormatUpdatingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -91,6 +109,9 @@ pub struct ICoreTextFormatUpdatingEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextLayoutBounds, ICoreTextLayoutBounds_Vtbl, 0xe972c974_4436_4917_80d0_a525e4ca6780);
+impl windows_core::RuntimeType for ICoreTextLayoutBounds {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextLayoutBounds_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,6 +121,9 @@ pub struct ICoreTextLayoutBounds_Vtbl {
     pub SetControlBounds: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextLayoutRequest, ICoreTextLayoutRequest_Vtbl, 0x2555a8cc_51fd_4f03_98bf_ac78174d68e0);
+impl windows_core::RuntimeType for ICoreTextLayoutRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextLayoutRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -109,18 +133,27 @@ pub struct ICoreTextLayoutRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextLayoutRequest2, ICoreTextLayoutRequest2_Vtbl, 0x676de624_cd3d_4bcd_bf01_7f7110954511);
+impl windows_core::RuntimeType for ICoreTextLayoutRequest2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextLayoutRequest2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LayoutBoundsVisualPixels: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextLayoutRequestedEventArgs, ICoreTextLayoutRequestedEventArgs_Vtbl, 0xb1dc6ae0_9a7b_4e9e_a566_4a6b5f8ad676);
+impl windows_core::RuntimeType for ICoreTextLayoutRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextLayoutRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextSelectionRequest, ICoreTextSelectionRequest_Vtbl, 0xf0a70403_208b_4301_883c_74ca7485fd8d);
+impl windows_core::RuntimeType for ICoreTextSelectionRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextSelectionRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -130,12 +163,18 @@ pub struct ICoreTextSelectionRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextSelectionRequestedEventArgs, ICoreTextSelectionRequestedEventArgs_Vtbl, 0x13c6682b_f614_421a_8f4b_9ec8a5a37fcd);
+impl windows_core::RuntimeType for ICoreTextSelectionRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextSelectionRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextSelectionUpdatingEventArgs, ICoreTextSelectionUpdatingEventArgs_Vtbl, 0xd445839f_fe7f_4bd5_8a26_0922c1b3e639);
+impl windows_core::RuntimeType for ICoreTextSelectionUpdatingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextSelectionUpdatingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -146,6 +185,9 @@ pub struct ICoreTextSelectionUpdatingEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextServicesManager, ICoreTextServicesManager_Vtbl, 0xc2507d83_6e0a_4a8a_bdf8_1948874854ba);
+impl windows_core::RuntimeType for ICoreTextServicesManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextServicesManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,18 +200,27 @@ pub struct ICoreTextServicesManager_Vtbl {
     pub CreateEditContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextServicesManagerStatics, ICoreTextServicesManagerStatics_Vtbl, 0x1520a388_e2cf_4d65_aeb9_b32d86fe39b9);
+impl windows_core::RuntimeType for ICoreTextServicesManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextServicesManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextServicesStatics, ICoreTextServicesStatics_Vtbl, 0x91859a46_eccf_47a4_8ae7_098a9c6fbb15);
+impl windows_core::RuntimeType for ICoreTextServicesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextServicesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub HiddenCharacter: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u16) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextTextRequest, ICoreTextTextRequest_Vtbl, 0x50d950a9_f51e_4cc1_8ca1_e6346d1a61be);
+impl windows_core::RuntimeType for ICoreTextTextRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextTextRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -180,12 +231,18 @@ pub struct ICoreTextTextRequest_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextTextRequestedEventArgs, ICoreTextTextRequestedEventArgs_Vtbl, 0xf096a2d0_41c6_4c02_8b1a_d953b00cabb3);
+impl windows_core::RuntimeType for ICoreTextTextRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextTextRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Request: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreTextTextUpdatingEventArgs, ICoreTextTextUpdatingEventArgs_Vtbl, 0xeea7918d_cc2b_4f03_8ff6_02fd217db450);
+impl windows_core::RuntimeType for ICoreTextTextUpdatingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreTextTextUpdatingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -230,7 +287,7 @@ impl CoreTextCompositionCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextCompositionCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextCompositionCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextCompositionCompletedEventArgs {
     type Vtable = ICoreTextCompositionCompletedEventArgs_Vtbl;
@@ -262,7 +319,7 @@ impl CoreTextCompositionSegment {
     }
 }
 impl windows_core::RuntimeType for CoreTextCompositionSegment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextCompositionSegment>();
 }
 unsafe impl windows_core::Interface for CoreTextCompositionSegment {
     type Vtable = ICoreTextCompositionSegment_Vtbl;
@@ -294,7 +351,7 @@ impl CoreTextCompositionStartedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextCompositionStartedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextCompositionStartedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextCompositionStartedEventArgs {
     type Vtable = ICoreTextCompositionStartedEventArgs_Vtbl;
@@ -516,7 +573,7 @@ impl CoreTextEditContext {
     }
 }
 impl windows_core::RuntimeType for CoreTextEditContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextEditContext>();
 }
 unsafe impl windows_core::Interface for CoreTextEditContext {
     type Vtable = ICoreTextEditContext_Vtbl;
@@ -604,7 +661,7 @@ impl CoreTextFormatUpdatingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextFormatUpdatingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextFormatUpdatingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextFormatUpdatingEventArgs {
     type Vtable = ICoreTextFormatUpdatingEventArgs_Vtbl;
@@ -644,7 +701,7 @@ impl CoreTextLayoutBounds {
     }
 }
 impl windows_core::RuntimeType for CoreTextLayoutBounds {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextLayoutBounds>();
 }
 unsafe impl windows_core::Interface for CoreTextLayoutBounds {
     type Vtable = ICoreTextLayoutBounds_Vtbl;
@@ -697,7 +754,7 @@ impl CoreTextLayoutRequest {
     }
 }
 impl windows_core::RuntimeType for CoreTextLayoutRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextLayoutRequest>();
 }
 unsafe impl windows_core::Interface for CoreTextLayoutRequest {
     type Vtable = ICoreTextLayoutRequest_Vtbl;
@@ -722,7 +779,7 @@ impl CoreTextLayoutRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextLayoutRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextLayoutRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextLayoutRequestedEventArgs {
     type Vtable = ICoreTextLayoutRequestedEventArgs_Vtbl;
@@ -765,7 +822,7 @@ impl CoreTextSelectionRequest {
     }
 }
 impl windows_core::RuntimeType for CoreTextSelectionRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextSelectionRequest>();
 }
 unsafe impl windows_core::Interface for CoreTextSelectionRequest {
     type Vtable = ICoreTextSelectionRequest_Vtbl;
@@ -790,7 +847,7 @@ impl CoreTextSelectionRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextSelectionRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextSelectionRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextSelectionRequestedEventArgs {
     type Vtable = ICoreTextSelectionRequestedEventArgs_Vtbl;
@@ -840,7 +897,7 @@ impl CoreTextSelectionUpdatingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextSelectionUpdatingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextSelectionUpdatingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextSelectionUpdatingEventArgs {
     type Vtable = ICoreTextSelectionUpdatingEventArgs_Vtbl;
@@ -915,7 +972,7 @@ impl CoreTextServicesManager {
     }
 }
 impl windows_core::RuntimeType for CoreTextServicesManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextServicesManager>();
 }
 unsafe impl windows_core::Interface for CoreTextServicesManager {
     type Vtable = ICoreTextServicesManager_Vtbl;
@@ -965,7 +1022,7 @@ impl CoreTextTextRequest {
     }
 }
 impl windows_core::RuntimeType for CoreTextTextRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextTextRequest>();
 }
 unsafe impl windows_core::Interface for CoreTextTextRequest {
     type Vtable = ICoreTextTextRequest_Vtbl;
@@ -990,7 +1047,7 @@ impl CoreTextTextRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextTextRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextTextRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextTextRequestedEventArgs {
     type Vtable = ICoreTextTextRequestedEventArgs_Vtbl;
@@ -1062,7 +1119,7 @@ impl CoreTextTextUpdatingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreTextTextUpdatingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreTextTextUpdatingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreTextTextUpdatingEventArgs {
     type Vtable = ICoreTextTextUpdatingEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "UI_Text_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IContentLinkInfo, IContentLinkInfo_Vtbl, 0x1ed52525_1c5f_48cb_b335_78b50a2ee642);
+impl windows_core::RuntimeType for IContentLinkInfo {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IContentLinkInfo_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -16,11 +19,17 @@ pub struct IContentLinkInfo_Vtbl {
     pub SetLinkContentKind: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFontWeights, IFontWeights_Vtbl, 0x7880a444_01ab_4997_8517_df822a0c45f1);
+impl windows_core::RuntimeType for IFontWeights {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFontWeights_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IFontWeightsStatics, IFontWeightsStatics_Vtbl, 0xb3b579d5_1ba9_48eb_9dad_c095e8c23ba3);
+impl windows_core::RuntimeType for IFontWeightsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFontWeightsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -37,6 +46,9 @@ pub struct IFontWeightsStatics_Vtbl {
     pub Thin: unsafe extern "system" fn(*mut core::ffi::c_void, *mut FontWeight) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRichEditTextRange, IRichEditTextRange_Vtbl, 0x374e3515_ba8a_4a6e_8c59_0dde3d0cf5cd);
+impl windows_core::RuntimeType for IRichEditTextRange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRichEditTextRange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -389,6 +401,9 @@ pub struct ITextCharacterFormat_Vtbl {
     pub IsEqual: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextConstantsStatics, ITextConstantsStatics_Vtbl, 0x779e7c33_189d_4bfa_97c8_10db135d976e);
+impl windows_core::RuntimeType for ITextConstantsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextConstantsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -610,6 +625,9 @@ pub struct ITextDocument_Vtbl {
     pub Undo: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextDocument2, ITextDocument2_Vtbl, 0xf2311112_8c89_49c9_9118_f057cbb814ee);
+impl windows_core::RuntimeType for ITextDocument2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextDocument2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -619,12 +637,18 @@ pub struct ITextDocument2_Vtbl {
     pub SetIgnoreTrailingCharacterSpacing: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextDocument3, ITextDocument3_Vtbl, 0x75ab03a1_a6f8_441d_aa18_0a851d6e5e3c);
+impl windows_core::RuntimeType for ITextDocument3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextDocument3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ClearUndoRedoHistory: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ITextDocument4, ITextDocument4_Vtbl, 0x619c20f2_cb3b_4521_981f_2865b1b93f04);
+impl windows_core::RuntimeType for ITextDocument4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITextDocument4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1817,7 +1841,7 @@ impl ContentLinkInfo {
     }
 }
 impl windows_core::RuntimeType for ContentLinkInfo {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IContentLinkInfo>();
 }
 unsafe impl windows_core::Interface for ContentLinkInfo {
     type Vtable = IContentLinkInfo_Vtbl;
@@ -1906,7 +1930,7 @@ impl FontWeights {
     }
 }
 impl windows_core::RuntimeType for FontWeights {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFontWeights>();
 }
 unsafe impl windows_core::Interface for FontWeights {
     type Vtable = IFontWeights_Vtbl;
@@ -2127,7 +2151,7 @@ impl RichEditTextDocument {
     }
 }
 impl windows_core::RuntimeType for RichEditTextDocument {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITextDocument>();
 }
 unsafe impl windows_core::Interface for RichEditTextDocument {
     type Vtable = ITextDocument_Vtbl;
@@ -2473,7 +2497,7 @@ impl RichEditTextRange {
     }
 }
 impl windows_core::RuntimeType for RichEditTextRange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ITextRange>();
 }
 unsafe impl windows_core::Interface for RichEditTextRange {
     type Vtable = ITextRange_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAutomationRemoteOperationResult, IAutomationRemoteOperationResult_Vtbl, 0xe0f80c42_4a67_5534_bf5a_09e8a99b36b1);
+impl windows_core::RuntimeType for IAutomationRemoteOperationResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutomationRemoteOperationResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -28,6 +31,9 @@ pub struct ICoreAutomationConnectionBoundObjectProvider_Vtbl {
     pub IsComThreadingRequired: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreAutomationRegistrarStatics, ICoreAutomationRegistrarStatics_Vtbl, 0x3e50129b_d6dc_5680_b580_ffff78300304);
+impl windows_core::RuntimeType for ICoreAutomationRegistrarStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreAutomationRegistrarStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -35,6 +41,9 @@ pub struct ICoreAutomationRegistrarStatics_Vtbl {
     pub UnregisterAnnotationType: unsafe extern "system" fn(*mut core::ffi::c_void, AutomationAnnotationTypeRegistration) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreAutomationRemoteOperation, ICoreAutomationRemoteOperation_Vtbl, 0x3ac656f4_e2bc_5c6e_b8e7_b224fb74b060);
+impl windows_core::RuntimeType for ICoreAutomationRemoteOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreAutomationRemoteOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,12 +54,18 @@ pub struct ICoreAutomationRemoteOperation_Vtbl {
     pub Execute: unsafe extern "system" fn(*mut core::ffi::c_void, u32, *const u8, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreAutomationRemoteOperation2, ICoreAutomationRemoteOperation2_Vtbl, 0xeefaf86f_e953_5099_8ce9_dca813482ba0);
+impl windows_core::RuntimeType for ICoreAutomationRemoteOperation2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreAutomationRemoteOperation2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ImportConnectionBoundObject: unsafe extern "system" fn(*mut core::ffi::c_void, AutomationRemoteOperationOperandId, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreAutomationRemoteOperationContext, ICoreAutomationRemoteOperationContext_Vtbl, 0xb9af9cbb_3d3e_5918_a16b_7861626a3aeb);
+impl windows_core::RuntimeType for ICoreAutomationRemoteOperationContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreAutomationRemoteOperationContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +101,9 @@ pub struct ICoreAutomationRemoteOperationExtensionProvider_Vtbl {
     pub IsExtensionSupported: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteAutomationClientSession, IRemoteAutomationClientSession_Vtbl, 0x5c8a091d_94cc_5b33_afdb_678cded2bd54);
+impl windows_core::RuntimeType for IRemoteAutomationClientSession {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteAutomationClientSession_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -99,6 +117,9 @@ pub struct IRemoteAutomationClientSession_Vtbl {
     pub RemoveDisconnected: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteAutomationClientSessionFactory, IRemoteAutomationClientSessionFactory_Vtbl, 0xf250263d_6057_5373_a5a5_ed7265fe0376);
+impl windows_core::RuntimeType for IRemoteAutomationClientSessionFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteAutomationClientSessionFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -106,6 +127,9 @@ pub struct IRemoteAutomationClientSessionFactory_Vtbl {
     pub CreateInstance2: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, windows_core::GUID, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteAutomationConnectionRequestedEventArgs, IRemoteAutomationConnectionRequestedEventArgs_Vtbl, 0xea3319a8_e3a8_5dc6_adf8_044e46b14af5);
+impl windows_core::RuntimeType for IRemoteAutomationConnectionRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteAutomationConnectionRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -113,18 +137,27 @@ pub struct IRemoteAutomationConnectionRequestedEventArgs_Vtbl {
     pub RemoteProcessId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut u32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteAutomationDisconnectedEventArgs, IRemoteAutomationDisconnectedEventArgs_Vtbl, 0xbbb33a3d_5d90_5c38_9eb2_dd9dcc1b2e3f);
+impl windows_core::RuntimeType for IRemoteAutomationDisconnectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteAutomationDisconnectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub LocalPipeName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteAutomationServerStatics, IRemoteAutomationServerStatics_Vtbl, 0xe6e8945e_0c11_5028_9ae3_c2771288b6b7);
+impl windows_core::RuntimeType for IRemoteAutomationServerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteAutomationServerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ReportSession: unsafe extern "system" fn(*mut core::ffi::c_void, windows_core::GUID) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IRemoteAutomationWindow, IRemoteAutomationWindow_Vtbl, 0x7c607689_496d_512a_9bd5_c050cfaf1428);
+impl windows_core::RuntimeType for IRemoteAutomationWindow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IRemoteAutomationWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -173,7 +206,7 @@ impl AutomationRemoteOperationResult {
     }
 }
 impl windows_core::RuntimeType for AutomationRemoteOperationResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutomationRemoteOperationResult>();
 }
 unsafe impl windows_core::Interface for AutomationRemoteOperationResult {
     type Vtable = IAutomationRemoteOperationResult_Vtbl;
@@ -257,7 +290,7 @@ impl CoreAutomationRemoteOperation {
     }
 }
 impl windows_core::RuntimeType for CoreAutomationRemoteOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreAutomationRemoteOperation>();
 }
 unsafe impl windows_core::Interface for CoreAutomationRemoteOperation {
     type Vtable = ICoreAutomationRemoteOperation_Vtbl;
@@ -296,7 +329,7 @@ impl CoreAutomationRemoteOperationContext {
     }
 }
 impl windows_core::RuntimeType for CoreAutomationRemoteOperationContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreAutomationRemoteOperationContext>();
 }
 unsafe impl windows_core::Interface for CoreAutomationRemoteOperationContext {
     type Vtable = ICoreAutomationRemoteOperationContext_Vtbl;
@@ -384,7 +417,7 @@ impl RemoteAutomationClientSession {
     }
 }
 impl windows_core::RuntimeType for RemoteAutomationClientSession {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteAutomationClientSession>();
 }
 unsafe impl windows_core::Interface for RemoteAutomationClientSession {
     type Vtable = IRemoteAutomationClientSession_Vtbl;
@@ -416,7 +449,7 @@ impl RemoteAutomationConnectionRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteAutomationConnectionRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteAutomationConnectionRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteAutomationConnectionRequestedEventArgs {
     type Vtable = IRemoteAutomationConnectionRequestedEventArgs_Vtbl;
@@ -441,7 +474,7 @@ impl RemoteAutomationDisconnectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for RemoteAutomationDisconnectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteAutomationDisconnectedEventArgs>();
 }
 unsafe impl windows_core::Interface for RemoteAutomationDisconnectedEventArgs {
     type Vtable = IRemoteAutomationDisconnectedEventArgs_Vtbl;
@@ -487,7 +520,7 @@ impl RemoteAutomationWindow {
     }
 }
 impl windows_core::RuntimeType for RemoteAutomationWindow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IRemoteAutomationWindow>();
 }
 unsafe impl windows_core::Interface for RemoteAutomationWindow {
     type Vtable = IRemoteAutomationWindow_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "UI_UIAutomation_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IAutomationConnection, IAutomationConnection_Vtbl, 0xaad262ed_0ef4_5d43_97be_a834e27b65b9);
+impl windows_core::RuntimeType for IAutomationConnection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutomationConnection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -9,12 +12,18 @@ pub struct IAutomationConnection_Vtbl {
     pub ExecutableFileName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAutomationConnectionBoundObject, IAutomationConnectionBoundObject_Vtbl, 0x5e8558fb_ca52_5b65_9830_dd2905816093);
+impl windows_core::RuntimeType for IAutomationConnectionBoundObject {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutomationConnectionBoundObject_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Connection: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAutomationElement, IAutomationElement_Vtbl, 0xa1898370_2c07_56fd_993f_61a72a08058c);
+impl windows_core::RuntimeType for IAutomationElement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutomationElement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -23,6 +32,9 @@ pub struct IAutomationElement_Vtbl {
     pub ExecutableFileName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAutomationTextRange, IAutomationTextRange_Vtbl, 0x7e101b65_40d3_5994_85a9_0a0cb9a4ec98);
+impl windows_core::RuntimeType for IAutomationTextRange {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAutomationTextRange_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,7 +67,7 @@ impl AutomationConnection {
     }
 }
 impl windows_core::RuntimeType for AutomationConnection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutomationConnection>();
 }
 unsafe impl windows_core::Interface for AutomationConnection {
     type Vtable = IAutomationConnection_Vtbl;
@@ -80,7 +92,7 @@ impl AutomationConnectionBoundObject {
     }
 }
 impl windows_core::RuntimeType for AutomationConnectionBoundObject {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutomationConnectionBoundObject>();
 }
 unsafe impl windows_core::Interface for AutomationConnectionBoundObject {
     type Vtable = IAutomationConnectionBoundObject_Vtbl;
@@ -119,7 +131,7 @@ impl AutomationElement {
     }
 }
 impl windows_core::RuntimeType for AutomationElement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutomationElement>();
 }
 unsafe impl windows_core::Interface for AutomationElement {
     type Vtable = IAutomationElement_Vtbl;
@@ -136,7 +148,7 @@ pub struct AutomationTextRange(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(AutomationTextRange, windows_core::IUnknown, windows_core::IInspectable);
 impl AutomationTextRange {}
 impl windows_core::RuntimeType for AutomationTextRange {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAutomationTextRange>();
 }
 unsafe impl windows_core::Interface for AutomationTextRange {
     type Vtable = IAutomationTextRange_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ICoreFrameworkInputView, ICoreFrameworkInputView_Vtbl, 0xd77c94ae_46b8_5d4a_9489_8ddec3d639a6);
+impl windows_core::RuntimeType for ICoreFrameworkInputView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreFrameworkInputView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -8,6 +11,9 @@ pub struct ICoreFrameworkInputView_Vtbl {
     pub RemoveOcclusionsChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreFrameworkInputViewAnimationStartingEventArgs, ICoreFrameworkInputViewAnimationStartingEventArgs_Vtbl, 0xc0ec901c_bba4_501b_ae8b_65c9e756a719);
+impl windows_core::RuntimeType for ICoreFrameworkInputViewAnimationStartingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreFrameworkInputViewAnimationStartingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,6 +25,9 @@ pub struct ICoreFrameworkInputViewAnimationStartingEventArgs_Vtbl {
     pub AnimationDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreFrameworkInputViewOcclusionsChangedEventArgs, ICoreFrameworkInputViewOcclusionsChangedEventArgs_Vtbl, 0xf36f4949_c82c_53d1_a75d_2b2baf0d9b0d);
+impl windows_core::RuntimeType for ICoreFrameworkInputViewOcclusionsChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreFrameworkInputViewOcclusionsChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -29,6 +38,9 @@ pub struct ICoreFrameworkInputViewOcclusionsChangedEventArgs_Vtbl {
     pub Handled: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreFrameworkInputViewStatics, ICoreFrameworkInputViewStatics_Vtbl, 0x6eebd9b6_eac2_5f8b_975f_772ee3e42eeb);
+impl windows_core::RuntimeType for ICoreFrameworkInputViewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreFrameworkInputViewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -36,6 +48,9 @@ pub struct ICoreFrameworkInputViewStatics_Vtbl {
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputView, ICoreInputView_Vtbl, 0xc770cd7a_7001_4c32_bf94_25c1f554cbf1);
+impl windows_core::RuntimeType for ICoreInputView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -49,6 +64,9 @@ pub struct ICoreInputView_Vtbl {
     pub TryHidePrimaryView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputView2, ICoreInputView2_Vtbl, 0x0ed726c1_e09a_4ae8_aedf_dfa4857d1a01);
+impl windows_core::RuntimeType for ICoreInputView2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputView2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,6 +77,9 @@ pub struct ICoreInputView2_Vtbl {
     pub TryTransferXYFocusToPrimaryView: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::Rect, CoreInputViewXYFocusTransferDirection, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputView3, ICoreInputView3_Vtbl, 0xbc941653_3ab9_4849_8f58_46e7f0353cfc);
+impl windows_core::RuntimeType for ICoreInputView3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputView3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +88,9 @@ pub struct ICoreInputView3_Vtbl {
     pub TryHide: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputView4, ICoreInputView4_Vtbl, 0x002863d6_d9ef_57eb_8cef_77f6ce1b7ee7);
+impl windows_core::RuntimeType for ICoreInputView4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputView4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -76,6 +100,9 @@ pub struct ICoreInputView4_Vtbl {
     pub RemovePrimaryViewHiding: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputView5, ICoreInputView5_Vtbl, 0x136316e0_c6d5_5c57_811e_1ad8a99ba6ab);
+impl windows_core::RuntimeType for ICoreInputView5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputView5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +113,9 @@ pub struct ICoreInputView5_Vtbl {
     pub RemovePrimaryViewAnimationStarting: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewAnimationStartingEventArgs, ICoreInputViewAnimationStartingEventArgs_Vtbl, 0xa9144af2_b55c_5ea1_b8ab_5340f3e94897);
+impl windows_core::RuntimeType for ICoreInputViewAnimationStartingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewAnimationStartingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,12 +128,18 @@ pub struct ICoreInputViewAnimationStartingEventArgs_Vtbl {
     pub AnimationDuration: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::TimeSpan) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewHidingEventArgs, ICoreInputViewHidingEventArgs_Vtbl, 0xeada47bd_bac5_5336_848d_41083584daad);
+impl windows_core::RuntimeType for ICoreInputViewHidingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewHidingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryCancel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewOcclusion, ICoreInputViewOcclusion_Vtbl, 0xcc36ce06_3865_4177_b5f5_8b65e0b9ce84);
+impl windows_core::RuntimeType for ICoreInputViewOcclusion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewOcclusion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -111,6 +147,9 @@ pub struct ICoreInputViewOcclusion_Vtbl {
     pub OcclusionKind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut CoreInputViewOcclusionKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewOcclusionsChangedEventArgs, ICoreInputViewOcclusionsChangedEventArgs_Vtbl, 0xbe1027e8_b3ee_4df7_9554_89cdc66082c2);
+impl windows_core::RuntimeType for ICoreInputViewOcclusionsChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewOcclusionsChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -122,24 +161,36 @@ pub struct ICoreInputViewOcclusionsChangedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewShowingEventArgs, ICoreInputViewShowingEventArgs_Vtbl, 0xca52261b_fb9e_5daf_a98c_262b8b76af50);
+impl windows_core::RuntimeType for ICoreInputViewShowingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewShowingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub TryCancel: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewStatics, ICoreInputViewStatics_Vtbl, 0x7d9b97cd_edbe_49cf_a54f_337de052907f);
+impl windows_core::RuntimeType for ICoreInputViewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewStatics2, ICoreInputViewStatics2_Vtbl, 0x7ebc0862_d049_4e52_87b0_1e90e98c49ed);
+impl windows_core::RuntimeType for ICoreInputViewStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForUIContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICoreInputViewTransferringXYFocusEventArgs, ICoreInputViewTransferringXYFocusEventArgs_Vtbl, 0x04de169f_ba02_4850_8b55_d82d03ba6d7f);
+impl windows_core::RuntimeType for ICoreInputViewTransferringXYFocusEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICoreInputViewTransferringXYFocusEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,6 +202,9 @@ pub struct ICoreInputViewTransferringXYFocusEventArgs_Vtbl {
     pub KeepPrimaryViewVisible: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettingsController, IUISettingsController_Vtbl, 0x78a51ac4_15c0_5a1b_a75b_acbf9cb8bb9e);
+impl windows_core::RuntimeType for IUISettingsController {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettingsController_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -161,6 +215,9 @@ pub struct IUISettingsController_Vtbl {
     pub SetTextScaleFactor: unsafe extern "system" fn(*mut core::ffi::c_void, f64) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettingsControllerStatics, IUISettingsControllerStatics_Vtbl, 0xeb3c68cc_c220_578c_8119_7db324ed26a6);
+impl windows_core::RuntimeType for IUISettingsControllerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettingsControllerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,7 +278,7 @@ impl CoreFrameworkInputView {
     }
 }
 impl windows_core::RuntimeType for CoreFrameworkInputView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreFrameworkInputView>();
 }
 unsafe impl windows_core::Interface for CoreFrameworkInputView {
     type Vtable = ICoreFrameworkInputView_Vtbl;
@@ -261,7 +318,7 @@ impl CoreFrameworkInputViewAnimationStartingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreFrameworkInputViewAnimationStartingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreFrameworkInputViewAnimationStartingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreFrameworkInputViewAnimationStartingEventArgs {
     type Vtable = ICoreFrameworkInputViewAnimationStartingEventArgs_Vtbl;
@@ -294,7 +351,7 @@ impl CoreFrameworkInputViewOcclusionsChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreFrameworkInputViewOcclusionsChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreFrameworkInputViewOcclusionsChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreFrameworkInputViewOcclusionsChangedEventArgs {
     type Vtable = ICoreFrameworkInputViewOcclusionsChangedEventArgs_Vtbl;
@@ -492,7 +549,7 @@ impl CoreInputView {
     }
 }
 impl windows_core::RuntimeType for CoreInputView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputView>();
 }
 unsafe impl windows_core::Interface for CoreInputView {
     type Vtable = ICoreInputView_Vtbl;
@@ -536,7 +593,7 @@ impl CoreInputViewAnimationStartingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreInputViewAnimationStartingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputViewAnimationStartingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreInputViewAnimationStartingEventArgs {
     type Vtable = ICoreInputViewAnimationStartingEventArgs_Vtbl;
@@ -561,7 +618,7 @@ impl CoreInputViewHidingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreInputViewHidingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputViewHidingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreInputViewHidingEventArgs {
     type Vtable = ICoreInputViewHidingEventArgs_Vtbl;
@@ -593,7 +650,7 @@ impl CoreInputViewOcclusion {
     }
 }
 impl windows_core::RuntimeType for CoreInputViewOcclusion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputViewOcclusion>();
 }
 unsafe impl windows_core::Interface for CoreInputViewOcclusion {
     type Vtable = ICoreInputViewOcclusion_Vtbl;
@@ -630,7 +687,7 @@ impl CoreInputViewOcclusionsChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreInputViewOcclusionsChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputViewOcclusionsChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreInputViewOcclusionsChangedEventArgs {
     type Vtable = ICoreInputViewOcclusionsChangedEventArgs_Vtbl;
@@ -655,7 +712,7 @@ impl CoreInputViewShowingEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreInputViewShowingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputViewShowingEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreInputViewShowingEventArgs {
     type Vtable = ICoreInputViewShowingEventArgs_Vtbl;
@@ -709,7 +766,7 @@ impl CoreInputViewTransferringXYFocusEventArgs {
     }
 }
 impl windows_core::RuntimeType for CoreInputViewTransferringXYFocusEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICoreInputViewTransferringXYFocusEventArgs>();
 }
 unsafe impl windows_core::Interface for CoreInputViewTransferringXYFocusEventArgs {
     type Vtable = ICoreInputViewTransferringXYFocusEventArgs_Vtbl;
@@ -758,7 +815,7 @@ impl UISettingsController {
     }
 }
 impl windows_core::RuntimeType for UISettingsController {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUISettingsController>();
 }
 unsafe impl windows_core::Interface for UISettingsController {
     type Vtable = IUISettingsController_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "UI_ViewManagement_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IAccessibilitySettings, IAccessibilitySettings_Vtbl, 0xfe0e8147_c4c0_4562_b962_1327b52ad5b9);
+impl windows_core::RuntimeType for IAccessibilitySettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAccessibilitySettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,6 +13,9 @@ pub struct IAccessibilitySettings_Vtbl {
     pub RemoveHighContrastChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivationViewSwitcher, IActivationViewSwitcher_Vtbl, 0xdca71bb6_7350_492b_aac7_c8a13d7224ad);
+impl windows_core::RuntimeType for IActivationViewSwitcher {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivationViewSwitcher_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +24,9 @@ pub struct IActivationViewSwitcher_Vtbl {
     pub IsViewPresentedOnActivationVirtualDesktop: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationView, IApplicationView_Vtbl, 0xd222d519_4361_451e_96c4_60f4f9742db0);
+impl windows_core::RuntimeType for IApplicationView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,6 +47,9 @@ pub struct IApplicationView_Vtbl {
     pub RemoveConsolidated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationView2, IApplicationView2_Vtbl, 0xe876b196_a545_40dc_b594_450cba68cc00);
+impl windows_core::RuntimeType for IApplicationView2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationView2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +68,9 @@ pub struct IApplicationView2_Vtbl {
     pub DesiredBoundsMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut ApplicationViewBoundsMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationView3, IApplicationView3_Vtbl, 0x903c9ce5_793a_4fdf_a2b2_af1ac21e3108);
+impl windows_core::RuntimeType for IApplicationView3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationView3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -70,6 +85,9 @@ pub struct IApplicationView3_Vtbl {
     pub SetPreferredMinSize: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationView4, IApplicationView4_Vtbl, 0x15e5cbec_9e0f_46b5_bc3f_9bf653e74b5e);
+impl windows_core::RuntimeType for IApplicationView4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationView4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -80,6 +98,9 @@ pub struct IApplicationView4_Vtbl {
     pub TryConsolidateAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationView7, IApplicationView7_Vtbl, 0xa0369647_5faf_5aa6_9c38_befbb12a071e);
+impl windows_core::RuntimeType for IApplicationView7 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationView7_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -87,6 +108,9 @@ pub struct IApplicationView7_Vtbl {
     pub SetPersistedStateId: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationView9, IApplicationView9_Vtbl, 0x9c6516f9_021a_5f01_93e5_9bdad2647574);
+impl windows_core::RuntimeType for IApplicationView9 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationView9_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -100,12 +124,18 @@ pub struct IApplicationView9_Vtbl {
     GetDisplayRegions: usize,
 }
 windows_core::imp::define_interface!(IApplicationViewConsolidatedEventArgs, IApplicationViewConsolidatedEventArgs_Vtbl, 0x514449ec_7ea2_4de7_a6a6_7dfbaaebb6fb);
+impl windows_core::RuntimeType for IApplicationViewConsolidatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewConsolidatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsUserInitiated: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewConsolidatedEventArgs2, IApplicationViewConsolidatedEventArgs2_Vtbl, 0x1c199ecc_6dc1_40f4_afee_07d9ea296430);
+impl windows_core::RuntimeType for IApplicationViewConsolidatedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewConsolidatedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -113,6 +143,10 @@ pub struct IApplicationViewConsolidatedEventArgs2_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IApplicationViewFullscreenStatics, IApplicationViewFullscreenStatics_Vtbl, 0xbc792ebd_64fe_4b65_a0c0_901ce2b68636);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IApplicationViewFullscreenStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IApplicationViewFullscreenStatics_Vtbl {
@@ -123,6 +157,9 @@ pub struct IApplicationViewFullscreenStatics_Vtbl {
     TryUnsnapToFullscreen: usize,
 }
 windows_core::imp::define_interface!(IApplicationViewInteropStatics, IApplicationViewInteropStatics_Vtbl, 0xc446fb5d_4793_4896_a8e2_be57a8bb0f50);
+impl windows_core::RuntimeType for IApplicationViewInteropStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewInteropStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -132,11 +169,17 @@ pub struct IApplicationViewInteropStatics_Vtbl {
     GetApplicationViewIdForWindow: usize,
 }
 windows_core::imp::define_interface!(IApplicationViewScaling, IApplicationViewScaling_Vtbl, 0x1d0ddc23_23f3_4b2d_84fe_74bf37b48b66);
+impl windows_core::RuntimeType for IApplicationViewScaling {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewScaling_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IApplicationViewScalingStatics, IApplicationViewScalingStatics_Vtbl, 0xb08fecf0_b946_45c8_a5e3_71f5aa78f861);
+impl windows_core::RuntimeType for IApplicationViewScalingStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewScalingStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,6 +188,10 @@ pub struct IApplicationViewScalingStatics_Vtbl {
 }
 #[cfg(feature = "deprecated")]
 windows_core::imp::define_interface!(IApplicationViewStatics, IApplicationViewStatics_Vtbl, 0x010a6306_c433_44e5_a9f2_bd84d4030a95);
+#[cfg(feature = "deprecated")]
+impl windows_core::RuntimeType for IApplicationViewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[cfg(feature = "deprecated")]
 #[repr(C)]
 pub struct IApplicationViewStatics_Vtbl {
@@ -159,6 +206,9 @@ pub struct IApplicationViewStatics_Vtbl {
     TryUnsnap: usize,
 }
 windows_core::imp::define_interface!(IApplicationViewStatics2, IApplicationViewStatics2_Vtbl, 0xaf338ae5_cf64_423c_85e5_f3e72448fb23);
+impl windows_core::RuntimeType for IApplicationViewStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -167,6 +217,9 @@ pub struct IApplicationViewStatics2_Vtbl {
     pub SetTerminateAppOnFinalViewClose: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewStatics3, IApplicationViewStatics3_Vtbl, 0xa28d7594_8c41_4e13_9719_5164796fe4c7);
+impl windows_core::RuntimeType for IApplicationViewStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -176,6 +229,9 @@ pub struct IApplicationViewStatics3_Vtbl {
     pub SetPreferredLaunchViewSize: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewStatics4, IApplicationViewStatics4_Vtbl, 0x08fd8d33_2611_5336_a315_d98e6366c9db);
+impl windows_core::RuntimeType for IApplicationViewStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -183,6 +239,9 @@ pub struct IApplicationViewStatics4_Vtbl {
     pub ClearPersistedState: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewSwitcherStatics, IApplicationViewSwitcherStatics_Vtbl, 0x975f2f1e_e656_4c5e_a0a1_717c6ffa7d64);
+impl windows_core::RuntimeType for IApplicationViewSwitcherStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewSwitcherStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -196,12 +255,18 @@ pub struct IApplicationViewSwitcherStatics_Vtbl {
     pub PrepareForCustomAnimatedSwitchAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, i32, ApplicationViewSwitchingOptions, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewSwitcherStatics2, IApplicationViewSwitcherStatics2_Vtbl, 0x60e995cd_4fc2_48c4_b8e3_395f2b9f0fc1);
+impl windows_core::RuntimeType for IApplicationViewSwitcherStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewSwitcherStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DisableSystemViewActivationPolicy: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewSwitcherStatics3, IApplicationViewSwitcherStatics3_Vtbl, 0x92059420_80a7_486d_b21f_c7a4a242a383);
+impl windows_core::RuntimeType for IApplicationViewSwitcherStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewSwitcherStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -209,6 +274,9 @@ pub struct IApplicationViewSwitcherStatics3_Vtbl {
     pub TryShowAsViewModeWithPreferencesAsync: unsafe extern "system" fn(*mut core::ffi::c_void, i32, ApplicationViewMode, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewTitleBar, IApplicationViewTitleBar_Vtbl, 0x00924ac0_932b_4a6b_9c4b_dc38c82478ce);
+impl windows_core::RuntimeType for IApplicationViewTitleBar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewTitleBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -238,6 +306,9 @@ pub struct IApplicationViewTitleBar_Vtbl {
     pub ButtonInactiveBackgroundColor: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewTransferContext, IApplicationViewTransferContext_Vtbl, 0x8574bc63_3c17_408e_9408_8a1a9ea81bfa);
+impl windows_core::RuntimeType for IApplicationViewTransferContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewTransferContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -245,18 +316,27 @@ pub struct IApplicationViewTransferContext_Vtbl {
     pub SetViewId: unsafe extern "system" fn(*mut core::ffi::c_void, i32) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewTransferContextStatics, IApplicationViewTransferContextStatics_Vtbl, 0x15a89d92_dd79_4b0b_bc47_d5f195f14661);
+impl windows_core::RuntimeType for IApplicationViewTransferContextStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewTransferContextStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub DataPackageFormatId: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IApplicationViewWithContext, IApplicationViewWithContext_Vtbl, 0xbd55d512_9dc1_44fc_8501_666625df60dc);
+impl windows_core::RuntimeType for IApplicationViewWithContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IApplicationViewWithContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub UIContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputPane, IInputPane_Vtbl, 0x640ada70_06f3_4c87_a678_9829c9127c28);
+impl windows_core::RuntimeType for IInputPane {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputPane_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -267,6 +347,9 @@ pub struct IInputPane_Vtbl {
     pub OccludedRect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputPane2, IInputPane2_Vtbl, 0x8a6b3f26_7090_4793_944c_c3f2cde26276);
+impl windows_core::RuntimeType for IInputPane2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputPane2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -274,6 +357,9 @@ pub struct IInputPane2_Vtbl {
     pub TryHide: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputPaneControl, IInputPaneControl_Vtbl, 0x088bb24f_962f_489d_aa6e_c6be1a0a6e52);
+impl windows_core::RuntimeType for IInputPaneControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputPaneControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,18 +367,27 @@ pub struct IInputPaneControl_Vtbl {
     pub SetVisible: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputPaneStatics, IInputPaneStatics_Vtbl, 0x95f4af3a_ef47_424a_9741_fd2815eba2bd);
+impl windows_core::RuntimeType for IInputPaneStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputPaneStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputPaneStatics2, IInputPaneStatics2_Vtbl, 0x1b63529b_d9ec_4531_8445_71bab9fb828e);
+impl windows_core::RuntimeType for IInputPaneStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputPaneStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForUIContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IInputPaneVisibilityEventArgs, IInputPaneVisibilityEventArgs_Vtbl, 0xd243e016_d907_4fcc_bb8d_f77baa5028f1);
+impl windows_core::RuntimeType for IInputPaneVisibilityEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IInputPaneVisibilityEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -301,6 +396,9 @@ pub struct IInputPaneVisibilityEventArgs_Vtbl {
     pub EnsuredFocusedElementInView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProjectionManagerStatics, IProjectionManagerStatics_Vtbl, 0xb65f913d_e2f0_4ffd_ba95_34241647e45c);
+impl windows_core::RuntimeType for IProjectionManagerStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProjectionManagerStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -312,6 +410,9 @@ pub struct IProjectionManagerStatics_Vtbl {
     pub RemoveProjectionDisplayAvailableChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IProjectionManagerStatics2, IProjectionManagerStatics2_Vtbl, 0xf33d2f43_2749_4cde_b977_c0c41e7415d1);
+impl windows_core::RuntimeType for IProjectionManagerStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IProjectionManagerStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -327,6 +428,9 @@ pub struct IProjectionManagerStatics2_Vtbl {
     pub GetDeviceSelector: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStatusBar, IStatusBar_Vtbl, 0x0ffcc5bf_98d0_4864_b1e8_b3f4020be8b4);
+impl windows_core::RuntimeType for IStatusBar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStatusBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -346,6 +450,9 @@ pub struct IStatusBar_Vtbl {
     pub RemoveHiding: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStatusBarProgressIndicator, IStatusBarProgressIndicator_Vtbl, 0x76cb2670_a3d7_49cf_8200_4f3eedca27bb);
+impl windows_core::RuntimeType for IStatusBarProgressIndicator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStatusBarProgressIndicator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -357,12 +464,18 @@ pub struct IStatusBarProgressIndicator_Vtbl {
     pub SetProgressValue: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IStatusBarStatics, IStatusBarStatics_Vtbl, 0x8b463fdf_422f_4561_8806_fb1289cadfb7);
+impl windows_core::RuntimeType for IStatusBarStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IStatusBarStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettings, IUISettings_Vtbl, 0x85361600_1c63_4627_bcb1_3a89e0bc9c55);
+impl windows_core::RuntimeType for IUISettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -381,6 +494,9 @@ pub struct IUISettings_Vtbl {
     pub UIElementColor: unsafe extern "system" fn(*mut core::ffi::c_void, UIElementType, *mut super::Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettings2, IUISettings2_Vtbl, 0xbad82401_2721_44f9_bb91_2bb228be442f);
+impl windows_core::RuntimeType for IUISettings2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettings2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -389,6 +505,9 @@ pub struct IUISettings2_Vtbl {
     pub RemoveTextScaleFactorChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettings3, IUISettings3_Vtbl, 0x03021be4_5254_4781_8194_5168f7d06d7b);
+impl windows_core::RuntimeType for IUISettings3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettings3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -397,6 +516,9 @@ pub struct IUISettings3_Vtbl {
     pub RemoveColorValuesChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettings4, IUISettings4_Vtbl, 0x52bb3002_919b_4d6b_9b78_8dd66ff4b93b);
+impl windows_core::RuntimeType for IUISettings4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettings4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -405,6 +527,9 @@ pub struct IUISettings4_Vtbl {
     pub RemoveAdvancedEffectsEnabledChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettings5, IUISettings5_Vtbl, 0x5349d588_0cb5_5f05_bd34_706b3231f0bd);
+impl windows_core::RuntimeType for IUISettings5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettings5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -413,6 +538,9 @@ pub struct IUISettings5_Vtbl {
     pub RemoveAutoHideScrollBarsChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettings6, IUISettings6_Vtbl, 0xaef19bd7_fe31_5a04_ada4_469aaec6dfa9);
+impl windows_core::RuntimeType for IUISettings6 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettings6_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -422,33 +550,51 @@ pub struct IUISettings6_Vtbl {
     pub RemoveMessageDurationChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUISettingsAnimationsEnabledChangedEventArgs, IUISettingsAnimationsEnabledChangedEventArgs_Vtbl, 0x0c7b4b3d_2ea1_533e_894d_415bc5243c29);
+impl windows_core::RuntimeType for IUISettingsAnimationsEnabledChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettingsAnimationsEnabledChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IUISettingsAutoHideScrollBarsChangedEventArgs, IUISettingsAutoHideScrollBarsChangedEventArgs_Vtbl, 0x87afd4b2_9146_5f02_8f6b_06d454174c0f);
+impl windows_core::RuntimeType for IUISettingsAutoHideScrollBarsChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettingsAutoHideScrollBarsChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IUISettingsMessageDurationChangedEventArgs, IUISettingsMessageDurationChangedEventArgs_Vtbl, 0x338aad52_4a5d_5b59_8002_d930f608fd6e);
+impl windows_core::RuntimeType for IUISettingsMessageDurationChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUISettingsMessageDurationChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IUIViewSettings, IUIViewSettings_Vtbl, 0xc63657f6_8850_470d_88f8_455e16ea2c26);
+impl windows_core::RuntimeType for IUIViewSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUIViewSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub UserInteractionMode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut UserInteractionMode) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUIViewSettingsStatics, IUIViewSettingsStatics_Vtbl, 0x595c97a5_f8f6_41cf_b0fb_aacdb81fd5f6);
+impl windows_core::RuntimeType for IUIViewSettingsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUIViewSettingsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IViewModePreferences, IViewModePreferences_Vtbl, 0x878fcd3a_0b99_42c9_84d0_d3f1d403554b);
+impl windows_core::RuntimeType for IViewModePreferences {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IViewModePreferences_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -458,6 +604,9 @@ pub struct IViewModePreferences_Vtbl {
     pub SetCustomSize: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IViewModePreferencesStatics, IViewModePreferencesStatics_Vtbl, 0x69b60a65_5de5_40d8_8306_3833df7a2274);
+impl windows_core::RuntimeType for IViewModePreferencesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IViewModePreferencesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -505,7 +654,7 @@ impl AccessibilitySettings {
     }
 }
 impl windows_core::RuntimeType for AccessibilitySettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAccessibilitySettings>();
 }
 unsafe impl windows_core::Interface for AccessibilitySettings {
     type Vtable = IAccessibilitySettings_Vtbl;
@@ -544,7 +693,7 @@ impl ActivationViewSwitcher {
     }
 }
 impl windows_core::RuntimeType for ActivationViewSwitcher {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivationViewSwitcher>();
 }
 unsafe impl windows_core::Interface for ActivationViewSwitcher {
     type Vtable = IActivationViewSwitcher_Vtbl;
@@ -914,7 +1063,7 @@ impl ApplicationView {
     }
 }
 impl windows_core::RuntimeType for ApplicationView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationView>();
 }
 unsafe impl windows_core::Interface for ApplicationView {
     type Vtable = IApplicationView_Vtbl;
@@ -946,7 +1095,7 @@ impl ApplicationViewConsolidatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for ApplicationViewConsolidatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationViewConsolidatedEventArgs>();
 }
 unsafe impl windows_core::Interface for ApplicationViewConsolidatedEventArgs {
     type Vtable = IApplicationViewConsolidatedEventArgs_Vtbl;
@@ -981,7 +1130,7 @@ impl ApplicationViewScaling {
     }
 }
 impl windows_core::RuntimeType for ApplicationViewScaling {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationViewScaling>();
 }
 unsafe impl windows_core::Interface for ApplicationViewScaling {
     type Vtable = IApplicationViewScaling_Vtbl;
@@ -1249,7 +1398,7 @@ impl ApplicationViewTitleBar {
     }
 }
 impl windows_core::RuntimeType for ApplicationViewTitleBar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationViewTitleBar>();
 }
 unsafe impl windows_core::Interface for ApplicationViewTitleBar {
     type Vtable = IApplicationViewTitleBar_Vtbl;
@@ -1296,7 +1445,7 @@ impl ApplicationViewTransferContext {
     }
 }
 impl windows_core::RuntimeType for ApplicationViewTransferContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IApplicationViewTransferContext>();
 }
 unsafe impl windows_core::Interface for ApplicationViewTransferContext {
     type Vtable = IApplicationViewTransferContext_Vtbl;
@@ -1397,7 +1546,7 @@ impl InputPane {
     }
 }
 impl windows_core::RuntimeType for InputPane {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputPane>();
 }
 unsafe impl windows_core::Interface for InputPane {
     type Vtable = IInputPane_Vtbl;
@@ -1431,7 +1580,7 @@ impl InputPaneVisibilityEventArgs {
     }
 }
 impl windows_core::RuntimeType for InputPaneVisibilityEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IInputPaneVisibilityEventArgs>();
 }
 unsafe impl windows_core::Interface for InputPaneVisibilityEventArgs {
     type Vtable = IInputPaneVisibilityEventArgs_Vtbl;
@@ -1634,7 +1783,7 @@ impl StatusBar {
     }
 }
 impl windows_core::RuntimeType for StatusBar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStatusBar>();
 }
 unsafe impl windows_core::Interface for StatusBar {
     type Vtable = IStatusBar_Vtbl;
@@ -1691,7 +1840,7 @@ impl StatusBarProgressIndicator {
     }
 }
 impl windows_core::RuntimeType for StatusBarProgressIndicator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IStatusBarProgressIndicator>();
 }
 unsafe impl windows_core::Interface for StatusBarProgressIndicator {
     type Vtable = IStatusBarProgressIndicator_Vtbl;
@@ -1919,7 +2068,7 @@ impl UISettings {
     }
 }
 impl windows_core::RuntimeType for UISettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUISettings>();
 }
 unsafe impl windows_core::Interface for UISettings {
     type Vtable = IUISettings_Vtbl;
@@ -1936,7 +2085,7 @@ pub struct UISettingsAnimationsEnabledChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettingsAnimationsEnabledChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettingsAnimationsEnabledChangedEventArgs {}
 impl windows_core::RuntimeType for UISettingsAnimationsEnabledChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUISettingsAnimationsEnabledChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UISettingsAnimationsEnabledChangedEventArgs {
     type Vtable = IUISettingsAnimationsEnabledChangedEventArgs_Vtbl;
@@ -1953,7 +2102,7 @@ pub struct UISettingsAutoHideScrollBarsChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettingsAutoHideScrollBarsChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettingsAutoHideScrollBarsChangedEventArgs {}
 impl windows_core::RuntimeType for UISettingsAutoHideScrollBarsChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUISettingsAutoHideScrollBarsChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UISettingsAutoHideScrollBarsChangedEventArgs {
     type Vtable = IUISettingsAutoHideScrollBarsChangedEventArgs_Vtbl;
@@ -1970,7 +2119,7 @@ pub struct UISettingsMessageDurationChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UISettingsMessageDurationChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl UISettingsMessageDurationChangedEventArgs {}
 impl windows_core::RuntimeType for UISettingsMessageDurationChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUISettingsMessageDurationChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for UISettingsMessageDurationChangedEventArgs {
     type Vtable = IUISettingsMessageDurationChangedEventArgs_Vtbl;
@@ -2006,7 +2155,7 @@ impl UIViewSettings {
     }
 }
 impl windows_core::RuntimeType for UIViewSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUIViewSettings>();
 }
 unsafe impl windows_core::Interface for UIViewSettings {
     type Vtable = IUIViewSettings_Vtbl;
@@ -2057,7 +2206,7 @@ impl ViewModePreferences {
     }
 }
 impl windows_core::RuntimeType for ViewModePreferences {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IViewModePreferences>();
 }
 unsafe impl windows_core::Interface for ViewModePreferences {
     type Vtable = IViewModePreferences_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IWebUICommandBar, IWebUICommandBar_Vtbl, 0xa4fc0016_dbe5_41ad_8d7b_14698bd6911d);
+impl windows_core::RuntimeType for IWebUICommandBar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -31,6 +34,9 @@ pub struct IWebUICommandBar_Vtbl {
     pub RemoveSizeChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarBitmapIcon, IWebUICommandBarBitmapIcon_Vtbl, 0x858f4f45_08d8_4a46_81ec_00015b0b1c6c);
+impl windows_core::RuntimeType for IWebUICommandBarBitmapIcon {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarBitmapIcon_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -38,12 +44,18 @@ pub struct IWebUICommandBarBitmapIcon_Vtbl {
     pub SetUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarBitmapIconFactory, IWebUICommandBarBitmapIconFactory_Vtbl, 0xf3f7d78a_7673_444a_be62_ac12d31c2231);
+impl windows_core::RuntimeType for IWebUICommandBarBitmapIconFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarBitmapIconFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarConfirmationButton, IWebUICommandBarConfirmationButton_Vtbl, 0x86e7824a_e3d5_4eb6_b2ff_8f018a172105);
+impl windows_core::RuntimeType for IWebUICommandBarConfirmationButton {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarConfirmationButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +85,9 @@ pub struct IWebUICommandBarIcon_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IWebUICommandBarIconButton, IWebUICommandBarIconButton_Vtbl, 0x8f1bc93a_3a7c_4842_a0cf_aff6ea308586);
+impl windows_core::RuntimeType for IWebUICommandBarIconButton {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarIconButton_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -90,24 +105,36 @@ pub struct IWebUICommandBarIconButton_Vtbl {
     pub RemoveItemInvoked: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarItemInvokedEventArgs, IWebUICommandBarItemInvokedEventArgs_Vtbl, 0x304edbdd_e741_41ef_bdc4_a45cea2a4f70);
+impl windows_core::RuntimeType for IWebUICommandBarItemInvokedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarItemInvokedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub IsPrimaryCommand: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarSizeChangedEventArgs, IWebUICommandBarSizeChangedEventArgs_Vtbl, 0xfbf1e2f6_3029_4719_8378_92f82b87af1e);
+impl windows_core::RuntimeType for IWebUICommandBarSizeChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarSizeChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Size: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarStatics, IWebUICommandBarStatics_Vtbl, 0x1449cdb9_a506_45be_8f42_b2837e2fe0c9);
+impl windows_core::RuntimeType for IWebUICommandBarStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetForCurrentView: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarSymbolIcon, IWebUICommandBarSymbolIcon_Vtbl, 0xd4935477_fd26_46ed_8658_1a3f4400e7b3);
+impl windows_core::RuntimeType for IWebUICommandBarSymbolIcon {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarSymbolIcon_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,6 +142,9 @@ pub struct IWebUICommandBarSymbolIcon_Vtbl {
     pub SetSymbol: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUICommandBarSymbolIconFactory, IWebUICommandBarSymbolIconFactory_Vtbl, 0x51be1a1f_3730_429e_b622_14e2b7bf6a07);
+impl windows_core::RuntimeType for IWebUICommandBarSymbolIconFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUICommandBarSymbolIconFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -269,7 +299,7 @@ impl WebUICommandBar {
     }
 }
 impl windows_core::RuntimeType for WebUICommandBar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUICommandBar>();
 }
 unsafe impl windows_core::Interface for WebUICommandBar {
     type Vtable = IWebUICommandBar_Vtbl;
@@ -323,7 +353,7 @@ impl WebUICommandBarBitmapIcon {
     }
 }
 impl windows_core::RuntimeType for WebUICommandBarBitmapIcon {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUICommandBarBitmapIcon>();
 }
 unsafe impl windows_core::Interface for WebUICommandBarBitmapIcon {
     type Vtable = IWebUICommandBarBitmapIcon_Vtbl;
@@ -374,7 +404,7 @@ impl WebUICommandBarConfirmationButton {
     }
 }
 impl windows_core::RuntimeType for WebUICommandBarConfirmationButton {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUICommandBarConfirmationButton>();
 }
 unsafe impl windows_core::Interface for WebUICommandBarConfirmationButton {
     type Vtable = IWebUICommandBarConfirmationButton_Vtbl;
@@ -472,7 +502,7 @@ impl WebUICommandBarIconButton {
     }
 }
 impl windows_core::RuntimeType for WebUICommandBarIconButton {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUICommandBarIconButton>();
 }
 unsafe impl windows_core::Interface for WebUICommandBarIconButton {
     type Vtable = IWebUICommandBarIconButton_Vtbl;
@@ -497,7 +527,7 @@ impl WebUICommandBarItemInvokedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebUICommandBarItemInvokedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUICommandBarItemInvokedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebUICommandBarItemInvokedEventArgs {
     type Vtable = IWebUICommandBarItemInvokedEventArgs_Vtbl;
@@ -522,7 +552,7 @@ impl WebUICommandBarSizeChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebUICommandBarSizeChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUICommandBarSizeChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebUICommandBarSizeChangedEventArgs {
     type Vtable = IWebUICommandBarSizeChangedEventArgs_Vtbl;
@@ -570,7 +600,7 @@ impl WebUICommandBarSymbolIcon {
     }
 }
 impl windows_core::RuntimeType for WebUICommandBarSymbolIcon {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUICommandBarSymbolIcon>();
 }
 unsafe impl windows_core::Interface for WebUICommandBarSymbolIcon {
     type Vtable = IWebUICommandBarSymbolIcon_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "UI_WebUI_Core")]
 pub mod Core;
 windows_core::imp::define_interface!(IActivatedDeferral, IActivatedDeferral_Vtbl, 0xc3bd1978_a431_49d8_a76a_395a4e03dcf3);
+impl windows_core::RuntimeType for IActivatedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivatedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,12 +29,18 @@ pub struct IActivatedEventArgsDeferral_Vtbl {
     pub ActivatedOperation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IActivatedOperation, IActivatedOperation_Vtbl, 0xb6a0b4bc_c6ca_42fd_9818_71904e45fed7);
+impl windows_core::RuntimeType for IActivatedOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IActivatedOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHtmlPrintDocumentSource, IHtmlPrintDocumentSource_Vtbl, 0xcea6469a_0e05_467a_abc9_36ec1d4cdcb6);
+impl windows_core::RuntimeType for IHtmlPrintDocumentSource {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHtmlPrintDocumentSource_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -55,6 +64,9 @@ pub struct IHtmlPrintDocumentSource_Vtbl {
     pub TrySetPageRange: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(INewWebUIViewCreatedEventArgs, INewWebUIViewCreatedEventArgs_Vtbl, 0xe8e1b216_be2b_4c9e_85e7_083143ec4be7);
+impl windows_core::RuntimeType for INewWebUIViewCreatedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct INewWebUIViewCreatedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -67,6 +79,9 @@ pub struct INewWebUIViewCreatedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUIActivationStatics, IWebUIActivationStatics_Vtbl, 0x351b86bd_43b3_482b_85db_35d87b517ad9);
+impl windows_core::RuntimeType for IWebUIActivationStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUIActivationStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -86,6 +101,9 @@ pub struct IWebUIActivationStatics_Vtbl {
     pub RemoveNavigated: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUIActivationStatics2, IWebUIActivationStatics2_Vtbl, 0xc8e88696_4d78_4aa4_8f06_2a9eadc6c40a);
+impl windows_core::RuntimeType for IWebUIActivationStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUIActivationStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -102,6 +120,9 @@ pub struct IWebUIActivationStatics2_Vtbl {
     pub EnablePrelaunch: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUIActivationStatics3, IWebUIActivationStatics3_Vtbl, 0x91abb686_1af5_4445_b49f_9459f40fc8de);
+impl windows_core::RuntimeType for IWebUIActivationStatics3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUIActivationStatics3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -115,6 +136,9 @@ pub struct IWebUIActivationStatics3_Vtbl {
     RequestRestartForUserAsync: usize,
 }
 windows_core::imp::define_interface!(IWebUIActivationStatics4, IWebUIActivationStatics4_Vtbl, 0x5e391429_183f_478d_8a25_67f80d03935b);
+impl windows_core::RuntimeType for IWebUIActivationStatics4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUIActivationStatics4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -151,12 +175,18 @@ pub struct IWebUIBackgroundTaskInstance_Vtbl {
     pub SetSucceeded: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUIBackgroundTaskInstanceStatics, IWebUIBackgroundTaskInstanceStatics_Vtbl, 0x9c7a5291_19ae_4ca3_b94b_fe4ec744a740);
+impl windows_core::RuntimeType for IWebUIBackgroundTaskInstanceStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUIBackgroundTaskInstanceStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Current: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUINavigatedDeferral, IWebUINavigatedDeferral_Vtbl, 0xd804204d_831f_46e2_b432_3afce211f962);
+impl windows_core::RuntimeType for IWebUINavigatedDeferral {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUINavigatedDeferral_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -182,12 +212,18 @@ pub struct IWebUINavigatedEventArgs_Vtbl {
     pub NavigatedOperation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUINavigatedOperation, IWebUINavigatedOperation_Vtbl, 0x7a965f08_8182_4a89_ab67_8492e8750d4b);
+impl windows_core::RuntimeType for IWebUINavigatedOperation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUINavigatedOperation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUIView, IWebUIView_Vtbl, 0x6783f64f_52da_4fd7_be69_8ef6284b423c);
+impl windows_core::RuntimeType for IWebUIView {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUIView_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -203,6 +239,9 @@ pub struct IWebUIView_Vtbl {
     pub SetIgnoreApplicationContentUriRulesNavigationRestrictions: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebUIViewStatics, IWebUIViewStatics_Vtbl, 0xb591e668_8e59_44f9_8803_1b24c9149d30);
+impl windows_core::RuntimeType for IWebUIViewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebUIViewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -220,7 +259,7 @@ impl ActivatedDeferral {
     }
 }
 impl windows_core::RuntimeType for ActivatedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivatedDeferral>();
 }
 unsafe impl windows_core::Interface for ActivatedDeferral {
     type Vtable = IActivatedDeferral_Vtbl;
@@ -243,7 +282,7 @@ impl ActivatedOperation {
     }
 }
 impl windows_core::RuntimeType for ActivatedOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IActivatedOperation>();
 }
 unsafe impl windows_core::Interface for ActivatedOperation {
     type Vtable = IActivatedOperation_Vtbl;
@@ -273,7 +312,7 @@ impl BackgroundActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for BackgroundActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IBackgroundActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for BackgroundActivatedEventArgs {
@@ -309,7 +348,7 @@ impl EnteredBackgroundEventArgs {
 }
 #[cfg(feature = "ApplicationModel")]
 impl windows_core::RuntimeType for EnteredBackgroundEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::IEnteredBackgroundEventArgs>();
 }
 #[cfg(feature = "ApplicationModel")]
 unsafe impl windows_core::Interface for EnteredBackgroundEventArgs {
@@ -439,7 +478,7 @@ impl HtmlPrintDocumentSource {
     }
 }
 impl windows_core::RuntimeType for HtmlPrintDocumentSource {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHtmlPrintDocumentSource>();
 }
 unsafe impl windows_core::Interface for HtmlPrintDocumentSource {
     type Vtable = IHtmlPrintDocumentSource_Vtbl;
@@ -471,7 +510,7 @@ impl LeavingBackgroundEventArgs {
 }
 #[cfg(feature = "ApplicationModel")]
 impl windows_core::RuntimeType for LeavingBackgroundEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::ILeavingBackgroundEventArgs>();
 }
 #[cfg(feature = "ApplicationModel")]
 unsafe impl windows_core::Interface for LeavingBackgroundEventArgs {
@@ -522,7 +561,7 @@ impl NewWebUIViewCreatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for NewWebUIViewCreatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, INewWebUIViewCreatedEventArgs>();
 }
 unsafe impl windows_core::Interface for NewWebUIViewCreatedEventArgs {
     type Vtable = INewWebUIViewCreatedEventArgs_Vtbl;
@@ -549,7 +588,7 @@ impl SuspendingDeferral {
 }
 #[cfg(feature = "ApplicationModel")]
 impl windows_core::RuntimeType for SuspendingDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::ISuspendingDeferral>();
 }
 #[cfg(feature = "ApplicationModel")]
 unsafe impl windows_core::Interface for SuspendingDeferral {
@@ -581,7 +620,7 @@ impl SuspendingEventArgs {
 }
 #[cfg(feature = "ApplicationModel")]
 impl windows_core::RuntimeType for SuspendingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::ISuspendingEventArgs>();
 }
 #[cfg(feature = "ApplicationModel")]
 unsafe impl windows_core::Interface for SuspendingEventArgs {
@@ -621,7 +660,7 @@ impl SuspendingOperation {
 }
 #[cfg(feature = "ApplicationModel")]
 impl windows_core::RuntimeType for SuspendingOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::ISuspendingOperation>();
 }
 #[cfg(feature = "ApplicationModel")]
 unsafe impl windows_core::Interface for SuspendingOperation {
@@ -847,7 +886,7 @@ impl WebUIAppointmentsProviderAddAppointmentActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIAppointmentsProviderAddAppointmentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IAppointmentsProviderAddAppointmentActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIAppointmentsProviderAddAppointmentActivatedEventArgs {
@@ -926,7 +965,7 @@ impl WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IAppointmentsProviderRemoveAppointmentActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIAppointmentsProviderRemoveAppointmentActivatedEventArgs {
@@ -1005,7 +1044,7 @@ impl WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IAppointmentsProviderReplaceAppointmentActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIAppointmentsProviderReplaceAppointmentActivatedEventArgs {
@@ -1100,7 +1139,7 @@ impl WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IAppointmentsProviderShowAppointmentDetailsActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIAppointmentsProviderShowAppointmentDetailsActivatedEventArgs {
@@ -1187,7 +1226,7 @@ impl WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IAppointmentsProviderShowTimeFrameActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIAppointmentsProviderShowTimeFrameActivatedEventArgs {
@@ -1304,7 +1343,7 @@ impl WebUIBackgroundTaskInstanceRuntimeClass {
     }
 }
 impl windows_core::RuntimeType for WebUIBackgroundTaskInstanceRuntimeClass {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUIBackgroundTaskInstance>();
 }
 unsafe impl windows_core::Interface for WebUIBackgroundTaskInstanceRuntimeClass {
     type Vtable = IWebUIBackgroundTaskInstance_Vtbl;
@@ -1373,7 +1412,7 @@ impl WebUIBarcodeScannerPreviewActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIBarcodeScannerPreviewActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IBarcodeScannerPreviewActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIBarcodeScannerPreviewActivatedEventArgs {
@@ -1448,7 +1487,7 @@ impl WebUICachedFileUpdaterActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUICachedFileUpdaterActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::ICachedFileUpdaterActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUICachedFileUpdaterActivatedEventArgs {
@@ -1519,7 +1558,7 @@ impl WebUICameraSettingsActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUICameraSettingsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::ICameraSettingsActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUICameraSettingsActivatedEventArgs {
@@ -1590,7 +1629,7 @@ impl WebUICommandLineActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUICommandLineActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::ICommandLineActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUICommandLineActivatedEventArgs {
@@ -1681,7 +1720,7 @@ impl WebUIContactCallActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIContactCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IContactCallActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIContactCallActivatedEventArgs {
@@ -1760,7 +1799,7 @@ impl WebUIContactMapActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIContactMapActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IContactMapActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIContactMapActivatedEventArgs {
@@ -1847,7 +1886,7 @@ impl WebUIContactMessageActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIContactMessageActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IContactMessageActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIContactMessageActivatedEventArgs {
@@ -1926,7 +1965,7 @@ impl WebUIContactPanelActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIContactPanelActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IContactPanelActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIContactPanelActivatedEventArgs {
@@ -1993,7 +2032,7 @@ impl WebUIContactPickerActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIContactPickerActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IContactPickerActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIContactPickerActivatedEventArgs {
@@ -2080,7 +2119,7 @@ impl WebUIContactPostActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIContactPostActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IContactPostActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIContactPostActivatedEventArgs {
@@ -2167,7 +2206,7 @@ impl WebUIContactVideoCallActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIContactVideoCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IContactVideoCallActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIContactVideoCallActivatedEventArgs {
@@ -2254,7 +2293,7 @@ impl WebUIDeviceActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIDeviceActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IDeviceActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIDeviceActivatedEventArgs {
@@ -2325,7 +2364,7 @@ impl WebUIDevicePairingActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIDevicePairingActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IDevicePairingActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIDevicePairingActivatedEventArgs {
@@ -2420,7 +2459,7 @@ impl WebUIDialReceiverActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIDialReceiverActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IDialReceiverActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIDialReceiverActivatedEventArgs {
@@ -2515,7 +2554,7 @@ impl WebUIFileActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIFileActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IFileActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIFileActivatedEventArgs {
@@ -2594,7 +2633,7 @@ impl WebUIFileOpenPickerActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIFileOpenPickerActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IFileOpenPickerActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIFileOpenPickerActivatedEventArgs {
@@ -2673,7 +2712,7 @@ impl WebUIFileOpenPickerContinuationEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 impl windows_core::RuntimeType for WebUIFileOpenPickerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IFileOpenPickerContinuationEventArgs>();
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 unsafe impl windows_core::Interface for WebUIFileOpenPickerContinuationEventArgs {
@@ -2760,7 +2799,7 @@ impl WebUIFileSavePickerActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIFileSavePickerActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IFileSavePickerActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIFileSavePickerActivatedEventArgs {
@@ -2839,7 +2878,7 @@ impl WebUIFileSavePickerContinuationEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 impl windows_core::RuntimeType for WebUIFileSavePickerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IFileSavePickerContinuationEventArgs>();
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 unsafe impl windows_core::Interface for WebUIFileSavePickerContinuationEventArgs {
@@ -2918,7 +2957,7 @@ impl WebUIFolderPickerContinuationEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 impl windows_core::RuntimeType for WebUIFolderPickerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IFolderPickerContinuationEventArgs>();
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 unsafe impl windows_core::Interface for WebUIFolderPickerContinuationEventArgs {
@@ -3030,7 +3069,7 @@ impl WebUILaunchActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUILaunchActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::ILaunchActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUILaunchActivatedEventArgs {
@@ -3109,7 +3148,7 @@ impl WebUILockScreenActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUILockScreenActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::ILockScreenActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUILockScreenActivatedEventArgs {
@@ -3196,7 +3235,7 @@ impl WebUILockScreenCallActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUILockScreenCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::ILockScreenCallActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUILockScreenCallActivatedEventArgs {
@@ -3251,7 +3290,7 @@ impl WebUILockScreenComponentActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUILockScreenComponentActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUILockScreenComponentActivatedEventArgs {
@@ -3273,7 +3312,7 @@ impl WebUINavigatedDeferral {
     }
 }
 impl windows_core::RuntimeType for WebUINavigatedDeferral {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUINavigatedDeferral>();
 }
 unsafe impl windows_core::Interface for WebUINavigatedDeferral {
     type Vtable = IWebUINavigatedDeferral_Vtbl;
@@ -3297,7 +3336,7 @@ impl WebUINavigatedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebUINavigatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUINavigatedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebUINavigatedEventArgs {
     type Vtable = IWebUINavigatedEventArgs_Vtbl;
@@ -3320,7 +3359,7 @@ impl WebUINavigatedOperation {
     }
 }
 impl windows_core::RuntimeType for WebUINavigatedOperation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUINavigatedOperation>();
 }
 unsafe impl windows_core::Interface for WebUINavigatedOperation {
     type Vtable = IWebUINavigatedOperation_Vtbl;
@@ -3389,7 +3428,7 @@ impl WebUIPhoneCallActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIPhoneCallActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IPhoneCallActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIPhoneCallActivatedEventArgs {
@@ -3456,7 +3495,7 @@ impl WebUIPrint3DWorkflowActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIPrint3DWorkflowActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IPrint3DWorkflowActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIPrint3DWorkflowActivatedEventArgs {
@@ -3519,7 +3558,7 @@ impl WebUIPrintTaskSettingsActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIPrintTaskSettingsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IPrintTaskSettingsActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIPrintTaskSettingsActivatedEventArgs {
@@ -3574,7 +3613,7 @@ impl WebUIPrintWorkflowForegroundTaskActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIPrintWorkflowForegroundTaskActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIPrintWorkflowForegroundTaskActivatedEventArgs {
@@ -3669,7 +3708,7 @@ impl WebUIProtocolActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIProtocolActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IProtocolActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIProtocolActivatedEventArgs {
@@ -3781,7 +3820,7 @@ impl WebUIProtocolForResultsActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIProtocolForResultsActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IProtocolForResultsActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIProtocolForResultsActivatedEventArgs {
@@ -3852,7 +3891,7 @@ impl WebUIRestrictedLaunchActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIRestrictedLaunchActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IRestrictedLaunchActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIRestrictedLaunchActivatedEventArgs {
@@ -3939,7 +3978,7 @@ impl WebUISearchActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUISearchActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::ISearchActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUISearchActivatedEventArgs {
@@ -4010,7 +4049,7 @@ impl WebUIShareTargetActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIShareTargetActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IShareTargetActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIShareTargetActivatedEventArgs {
@@ -4081,7 +4120,7 @@ impl WebUIStartupTaskActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIStartupTaskActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IStartupTaskActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIStartupTaskActivatedEventArgs {
@@ -4164,7 +4203,7 @@ impl WebUIToastNotificationActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIToastNotificationActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IToastNotificationActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIToastNotificationActivatedEventArgs {
@@ -4227,7 +4266,7 @@ impl WebUIUserDataAccountProviderActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIUserDataAccountProviderActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IUserDataAccountProviderActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIUserDataAccountProviderActivatedEventArgs {
@@ -4761,7 +4800,7 @@ impl WebUIView {
     }
 }
 impl windows_core::RuntimeType for WebUIView {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebUIView>();
 }
 unsafe impl windows_core::Interface for WebUIView {
     type Vtable = IWebUIView_Vtbl;
@@ -4830,7 +4869,7 @@ impl WebUIVoiceCommandActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIVoiceCommandActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IVoiceCommandActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIVoiceCommandActivatedEventArgs {
@@ -4909,7 +4948,7 @@ impl WebUIWalletActionActivatedEventArgs {
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 impl windows_core::RuntimeType for WebUIWalletActionActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IWalletActionActivatedEventArgs>();
 }
 #[cfg(all(feature = "ApplicationModel_Activation", feature = "deprecated"))]
 unsafe impl windows_core::Interface for WebUIWalletActionActivatedEventArgs {
@@ -4980,7 +5019,7 @@ impl WebUIWebAccountProviderActivatedEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIWebAccountProviderActivatedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IWebAccountProviderActivatedEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIWebAccountProviderActivatedEventArgs {
@@ -5051,7 +5090,7 @@ impl WebUIWebAuthenticationBrokerContinuationEventArgs {
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 impl windows_core::RuntimeType for WebUIWebAuthenticationBrokerContinuationEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::ApplicationModel::Activation::IWebAuthenticationBrokerContinuationEventArgs>();
 }
 #[cfg(feature = "ApplicationModel_Activation")]
 unsafe impl windows_core::Interface for WebUIWebAuthenticationBrokerContinuationEventArgs {

--- a/crates/libs/windows/src/Windows/UI/WindowManagement/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WindowManagement/Preview/mod.rs
@@ -1,9 +1,15 @@
 windows_core::imp::define_interface!(IWindowManagementPreview, IWindowManagementPreview_Vtbl, 0x4ef55b0d_561d_513c_a67c_2c02b69cef41);
+impl windows_core::RuntimeType for IWindowManagementPreview {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowManagementPreview_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IWindowManagementPreviewStatics, IWindowManagementPreviewStatics_Vtbl, 0x0f9725c6_c004_5a23_8fd2_8d092ce2704a);
+impl windows_core::RuntimeType for IWindowManagementPreviewStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowManagementPreviewStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,7 +33,7 @@ impl WindowManagementPreview {
     }
 }
 impl windows_core::RuntimeType for WindowManagementPreview {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowManagementPreview>();
 }
 unsafe impl windows_core::Interface for WindowManagementPreview {
     type Vtable = IWindowManagementPreview_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
@@ -1,6 +1,9 @@
 #[cfg(feature = "UI_WindowManagement_Preview")]
 pub mod Preview;
 windows_core::imp::define_interface!(IAppWindow, IAppWindow_Vtbl, 0x663014a6_b75e_5dbd_995c_f0117fa3fb61);
+impl windows_core::RuntimeType for IAppWindow {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindow_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +44,9 @@ pub struct IAppWindow_Vtbl {
     pub RemoveCloseRequested: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowChangedEventArgs, IAppWindowChangedEventArgs_Vtbl, 0x1de1f3be_a655_55ad_b2b6_eb240f880356);
+impl windows_core::RuntimeType for IAppWindowChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +60,9 @@ pub struct IAppWindowChangedEventArgs_Vtbl {
     pub DidWindowPresentationChange: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowCloseRequestedEventArgs, IAppWindowCloseRequestedEventArgs_Vtbl, 0xe9ff01da_e7a2_57a8_8b5e_39c4003afdbb);
+impl windows_core::RuntimeType for IAppWindowCloseRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowCloseRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -62,12 +71,18 @@ pub struct IAppWindowCloseRequestedEventArgs_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowClosedEventArgs, IAppWindowClosedEventArgs_Vtbl, 0xcc7df816_9520_5a06_821e_456ad8b358aa);
+impl windows_core::RuntimeType for IAppWindowClosedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowClosedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppWindowClosedReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowFrame, IAppWindowFrame_Vtbl, 0x9ee22601_7e5d_52af_846b_01dc6c296567);
+impl windows_core::RuntimeType for IAppWindowFrame {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowFrame_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -77,6 +92,9 @@ pub struct IAppWindowFrame_Vtbl {
     DragRegionVisuals: usize,
 }
 windows_core::imp::define_interface!(IAppWindowFrameStyle, IAppWindowFrameStyle_Vtbl, 0xac412946_e1ac_5230_944a_c60873dcf4a9);
+impl windows_core::RuntimeType for IAppWindowFrameStyle {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowFrameStyle_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +102,9 @@ pub struct IAppWindowFrameStyle_Vtbl {
     pub SetFrameStyle: unsafe extern "system" fn(*mut core::ffi::c_void, AppWindowFrameStyle) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowPlacement, IAppWindowPlacement_Vtbl, 0x03dc815e_e7a9_5857_9c03_7d670594410e);
+impl windows_core::RuntimeType for IAppWindowPlacement {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowPlacement_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -92,17 +113,26 @@ pub struct IAppWindowPlacement_Vtbl {
     pub Size: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Size) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowPresentationConfiguration, IAppWindowPresentationConfiguration_Vtbl, 0xb5a43ee3_df33_5e67_bd31_1072457300df);
+impl windows_core::RuntimeType for IAppWindowPresentationConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowPresentationConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Kind: unsafe extern "system" fn(*mut core::ffi::c_void, *mut AppWindowPresentationKind) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowPresentationConfigurationFactory, IAppWindowPresentationConfigurationFactory_Vtbl, 0xfd3606a6_7875_5de8_84ff_6351ee13dd0d);
+impl windows_core::RuntimeType for IAppWindowPresentationConfigurationFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowPresentationConfigurationFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IAppWindowPresenter, IAppWindowPresenter_Vtbl, 0x5ae9ed73_e1fd_5317_ad78_5a3ed271bbde);
+impl windows_core::RuntimeType for IAppWindowPresenter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowPresenter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -112,6 +142,9 @@ pub struct IAppWindowPresenter_Vtbl {
     pub RequestPresentationByKind: unsafe extern "system" fn(*mut core::ffi::c_void, AppWindowPresentationKind, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowStatics, IAppWindowStatics_Vtbl, 0xff1f3ea3_b769_50ef_9873_108cd0e89746);
+impl windows_core::RuntimeType for IAppWindowStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,6 +153,9 @@ pub struct IAppWindowStatics_Vtbl {
     pub ClearPersistedState: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowTitleBar, IAppWindowTitleBar_Vtbl, 0x6e932c84_f644_541d_a2d7_0c262437842d);
+impl windows_core::RuntimeType for IAppWindowTitleBar {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowTitleBar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -156,12 +192,18 @@ pub struct IAppWindowTitleBar_Vtbl {
     GetTitleBarOcclusions: usize,
 }
 windows_core::imp::define_interface!(IAppWindowTitleBarOcclusion, IAppWindowTitleBarOcclusion_Vtbl, 0xfea3cffd_2ccf_5fc3_aeae_f843876bf37e);
+impl windows_core::RuntimeType for IAppWindowTitleBarOcclusion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowTitleBarOcclusion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub OccludingRect: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::super::Foundation::Rect) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAppWindowTitleBarVisibility, IAppWindowTitleBarVisibility_Vtbl, 0xa215a4e3_6e7e_5651_8c3b_624819528154);
+impl windows_core::RuntimeType for IAppWindowTitleBarVisibility {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAppWindowTitleBarVisibility_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -169,16 +211,25 @@ pub struct IAppWindowTitleBarVisibility_Vtbl {
     pub SetPreferredVisibility: unsafe extern "system" fn(*mut core::ffi::c_void, AppWindowTitleBarVisibility) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ICompactOverlayPresentationConfiguration, ICompactOverlayPresentationConfiguration_Vtbl, 0xa7e5750f_5730_56c6_8e1f_d63ff4d7980d);
+impl windows_core::RuntimeType for ICompactOverlayPresentationConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICompactOverlayPresentationConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IDefaultPresentationConfiguration, IDefaultPresentationConfiguration_Vtbl, 0xd8c2b53b_2168_5703_a853_d525589fe2b9);
+impl windows_core::RuntimeType for IDefaultPresentationConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDefaultPresentationConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IDisplayRegion, IDisplayRegion_Vtbl, 0xdb50c3a2_4094_5f47_8cb1_ea01ddafaa94);
+impl windows_core::RuntimeType for IDisplayRegion {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IDisplayRegion_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -191,6 +242,9 @@ pub struct IDisplayRegion_Vtbl {
     pub RemoveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IFullScreenPresentationConfiguration, IFullScreenPresentationConfiguration_Vtbl, 0x43d3dcd8_d2a8_503d_a626_15533d6d5f62);
+impl windows_core::RuntimeType for IFullScreenPresentationConfiguration {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IFullScreenPresentationConfiguration_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -198,6 +252,9 @@ pub struct IFullScreenPresentationConfiguration_Vtbl {
     pub SetIsExclusive: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowServicesStatics, IWindowServicesStatics_Vtbl, 0xcff4d519_50a6_5c64_97f6_c2d96add7f42);
+impl windows_core::RuntimeType for IWindowServicesStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowServicesStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,6 +264,9 @@ pub struct IWindowServicesStatics_Vtbl {
     FindAllTopLevelWindowIds: usize,
 }
 windows_core::imp::define_interface!(IWindowingEnvironment, IWindowingEnvironment_Vtbl, 0x264363c0_2a49_5417_b3ae_48a71c63a3bd);
+impl windows_core::RuntimeType for IWindowingEnvironment {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowingEnvironment_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -220,23 +280,35 @@ pub struct IWindowingEnvironment_Vtbl {
     pub RemoveChanged: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowingEnvironmentAddedEventArgs, IWindowingEnvironmentAddedEventArgs_Vtbl, 0xff2a5b7f_f183_5c66_99b2_429082069299);
+impl windows_core::RuntimeType for IWindowingEnvironmentAddedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowingEnvironmentAddedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub WindowingEnvironment: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowingEnvironmentChangedEventArgs, IWindowingEnvironmentChangedEventArgs_Vtbl, 0x4160cfc6_023d_5e9a_b431_350e67dc978a);
+impl windows_core::RuntimeType for IWindowingEnvironmentChangedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowingEnvironmentChangedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IWindowingEnvironmentRemovedEventArgs, IWindowingEnvironmentRemovedEventArgs_Vtbl, 0x2e5b5473_beff_5e53_9316_7e775fe568b3);
+impl windows_core::RuntimeType for IWindowingEnvironmentRemovedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowingEnvironmentRemovedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub WindowingEnvironment: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWindowingEnvironmentStatics, IWindowingEnvironmentStatics_Vtbl, 0x874e9fb7_c642_55ab_8aa2_162f734a9a72);
+impl windows_core::RuntimeType for IWindowingEnvironmentStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWindowingEnvironmentStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -463,7 +535,7 @@ impl AppWindow {
     }
 }
 impl windows_core::RuntimeType for AppWindow {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindow>();
 }
 unsafe impl windows_core::Interface for AppWindow {
     type Vtable = IAppWindow_Vtbl;
@@ -537,7 +609,7 @@ impl AppWindowChangedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppWindowChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppWindowChangedEventArgs {
     type Vtable = IAppWindowChangedEventArgs_Vtbl;
@@ -573,7 +645,7 @@ impl AppWindowCloseRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppWindowCloseRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowCloseRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppWindowCloseRequestedEventArgs {
     type Vtable = IAppWindowCloseRequestedEventArgs_Vtbl;
@@ -598,7 +670,7 @@ impl AppWindowClosedEventArgs {
     }
 }
 impl windows_core::RuntimeType for AppWindowClosedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowClosedEventArgs>();
 }
 unsafe impl windows_core::Interface for AppWindowClosedEventArgs {
     type Vtable = IAppWindowClosedEventArgs_Vtbl;
@@ -635,7 +707,7 @@ impl AppWindowFrame {
     }
 }
 impl windows_core::RuntimeType for AppWindowFrame {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowFrame>();
 }
 unsafe impl windows_core::Interface for AppWindowFrame {
     type Vtable = IAppWindowFrame_Vtbl;
@@ -674,7 +746,7 @@ impl AppWindowPlacement {
     }
 }
 impl windows_core::RuntimeType for AppWindowPlacement {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowPlacement>();
 }
 unsafe impl windows_core::Interface for AppWindowPlacement {
     type Vtable = IAppWindowPlacement_Vtbl;
@@ -699,7 +771,7 @@ impl AppWindowPresentationConfiguration {
     }
 }
 impl windows_core::RuntimeType for AppWindowPresentationConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowPresentationConfiguration>();
 }
 unsafe impl windows_core::Interface for AppWindowPresentationConfiguration {
     type Vtable = IAppWindowPresentationConfiguration_Vtbl;
@@ -748,7 +820,7 @@ impl AppWindowPresenter {
     }
 }
 impl windows_core::RuntimeType for AppWindowPresenter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowPresenter>();
 }
 unsafe impl windows_core::Interface for AppWindowPresenter {
     type Vtable = IAppWindowPresenter_Vtbl;
@@ -971,7 +1043,7 @@ impl AppWindowTitleBar {
     }
 }
 impl windows_core::RuntimeType for AppWindowTitleBar {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowTitleBar>();
 }
 unsafe impl windows_core::Interface for AppWindowTitleBar {
     type Vtable = IAppWindowTitleBar_Vtbl;
@@ -996,7 +1068,7 @@ impl AppWindowTitleBarOcclusion {
     }
 }
 impl windows_core::RuntimeType for AppWindowTitleBarOcclusion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAppWindowTitleBarOcclusion>();
 }
 unsafe impl windows_core::Interface for AppWindowTitleBarOcclusion {
     type Vtable = IAppWindowTitleBarOcclusion_Vtbl;
@@ -1029,7 +1101,7 @@ impl CompactOverlayPresentationConfiguration {
     }
 }
 impl windows_core::RuntimeType for CompactOverlayPresentationConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ICompactOverlayPresentationConfiguration>();
 }
 unsafe impl windows_core::Interface for CompactOverlayPresentationConfiguration {
     type Vtable = ICompactOverlayPresentationConfiguration_Vtbl;
@@ -1062,7 +1134,7 @@ impl DefaultPresentationConfiguration {
     }
 }
 impl windows_core::RuntimeType for DefaultPresentationConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDefaultPresentationConfiguration>();
 }
 unsafe impl windows_core::Interface for DefaultPresentationConfiguration {
     type Vtable = IDefaultPresentationConfiguration_Vtbl;
@@ -1129,7 +1201,7 @@ impl DisplayRegion {
     }
 }
 impl windows_core::RuntimeType for DisplayRegion {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IDisplayRegion>();
 }
 unsafe impl windows_core::Interface for DisplayRegion {
     type Vtable = IDisplayRegion_Vtbl;
@@ -1173,7 +1245,7 @@ impl FullScreenPresentationConfiguration {
     }
 }
 impl windows_core::RuntimeType for FullScreenPresentationConfiguration {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IFullScreenPresentationConfiguration>();
 }
 unsafe impl windows_core::Interface for FullScreenPresentationConfiguration {
     type Vtable = IFullScreenPresentationConfiguration_Vtbl;
@@ -1264,7 +1336,7 @@ impl WindowingEnvironment {
     }
 }
 impl windows_core::RuntimeType for WindowingEnvironment {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowingEnvironment>();
 }
 unsafe impl windows_core::Interface for WindowingEnvironment {
     type Vtable = IWindowingEnvironment_Vtbl;
@@ -1289,7 +1361,7 @@ impl WindowingEnvironmentAddedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowingEnvironmentAddedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowingEnvironmentAddedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowingEnvironmentAddedEventArgs {
     type Vtable = IWindowingEnvironmentAddedEventArgs_Vtbl;
@@ -1306,7 +1378,7 @@ pub struct WindowingEnvironmentChangedEventArgs(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(WindowingEnvironmentChangedEventArgs, windows_core::IUnknown, windows_core::IInspectable);
 impl WindowingEnvironmentChangedEventArgs {}
 impl windows_core::RuntimeType for WindowingEnvironmentChangedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowingEnvironmentChangedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowingEnvironmentChangedEventArgs {
     type Vtable = IWindowingEnvironmentChangedEventArgs_Vtbl;
@@ -1331,7 +1403,7 @@ impl WindowingEnvironmentRemovedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WindowingEnvironmentRemovedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWindowingEnvironmentRemovedEventArgs>();
 }
 unsafe impl windows_core::Interface for WindowingEnvironmentRemovedEventArgs {
     type Vtable = IWindowingEnvironmentRemovedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/mod.rs
@@ -27,28 +27,43 @@ pub mod WebUI;
 #[cfg(feature = "UI_WindowManagement")]
 pub mod WindowManagement;
 windows_core::imp::define_interface!(IColorHelper, IColorHelper_Vtbl, 0x193cfbe7_65c7_4540_ad08_6283ba76879a);
+impl windows_core::RuntimeType for IColorHelper {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColorHelper_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IColorHelperStatics, IColorHelperStatics_Vtbl, 0x8504dbea_fb6a_4144_a6c2_33499c9284f5);
+impl windows_core::RuntimeType for IColorHelperStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColorHelperStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub FromArgb: unsafe extern "system" fn(*mut core::ffi::c_void, u8, u8, u8, u8, *mut Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IColorHelperStatics2, IColorHelperStatics2_Vtbl, 0x24d9af02_6eb0_4b94_855c_fcf0818d9a16);
+impl windows_core::RuntimeType for IColorHelperStatics2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColorHelperStatics2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ToDisplayName: unsafe extern "system" fn(*mut core::ffi::c_void, Color, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IColors, IColors_Vtbl, 0x9b8c9326_4ca6_4ce5_8994_9eff65cabdcc);
+impl windows_core::RuntimeType for IColors {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColors_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
 }
 windows_core::imp::define_interface!(IColorsStatics, IColorsStatics_Vtbl, 0xcff52e04_cca6_4614_a17e_754910c84a99);
+impl windows_core::RuntimeType for IColorsStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IColorsStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -195,12 +210,18 @@ pub struct IColorsStatics_Vtbl {
     pub YellowGreen: unsafe extern "system" fn(*mut core::ffi::c_void, *mut Color) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUIContentRoot, IUIContentRoot_Vtbl, 0x1dfcbac6_b36b_5cb9_9bc5_2b7a0eddc378);
+impl windows_core::RuntimeType for IUIContentRoot {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUIContentRoot_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub UIContext: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IUIContext, IUIContext_Vtbl, 0xbb5cfacd_5bd8_59d0_a59e_1c17a4d6d243);
+impl windows_core::RuntimeType for IUIContext {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUIContext_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -234,7 +255,7 @@ impl ColorHelper {
     }
 }
 impl windows_core::RuntimeType for ColorHelper {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IColorHelper>();
 }
 unsafe impl windows_core::Interface for ColorHelper {
     type Vtable = IColorHelper_Vtbl;
@@ -1103,7 +1124,7 @@ impl Colors {
     }
 }
 impl windows_core::RuntimeType for Colors {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IColors>();
 }
 unsafe impl windows_core::Interface for Colors {
     type Vtable = IColors_Vtbl;
@@ -1128,7 +1149,7 @@ impl UIContentRoot {
     }
 }
 impl windows_core::RuntimeType for UIContentRoot {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUIContentRoot>();
 }
 unsafe impl windows_core::Interface for UIContentRoot {
     type Vtable = IUIContentRoot_Vtbl;
@@ -1145,7 +1166,7 @@ pub struct UIContext(windows_core::IUnknown);
 windows_core::imp::interface_hierarchy!(UIContext, windows_core::IUnknown, windows_core::IInspectable);
 impl UIContext {}
 impl windows_core::RuntimeType for UIContext {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IUIContext>();
 }
 unsafe impl windows_core::Interface for UIContext {
     type Vtable = IUIContext_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/AtomPub/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/AtomPub/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IAtomPubClient, IAtomPubClient_Vtbl, 0x35392c38_cded_4d4c_9637_05f15c1c9406);
+impl windows_core::RuntimeType for IAtomPubClient {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAtomPubClient_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -45,6 +48,9 @@ pub struct IAtomPubClient_Vtbl {
     pub CancelAsyncOperations: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IAtomPubClientFactory, IAtomPubClientFactory_Vtbl, 0x49d55012_57cb_4bde_ab9f_2610b172777b);
+impl windows_core::RuntimeType for IAtomPubClientFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IAtomPubClientFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -54,6 +60,9 @@ pub struct IAtomPubClientFactory_Vtbl {
     CreateAtomPubClientWithCredentials: usize,
 }
 windows_core::imp::define_interface!(IResourceCollection, IResourceCollection_Vtbl, 0x7f5fd609_bc88_41d4_88fa_3de6704d428e);
+impl windows_core::RuntimeType for IResourceCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IResourceCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,6 +81,9 @@ pub struct IResourceCollection_Vtbl {
     Accepts: usize,
 }
 windows_core::imp::define_interface!(IServiceDocument, IServiceDocument_Vtbl, 0x8b7ec771_2ab3_4dbe_8bcc_778f92b75e51);
+impl windows_core::RuntimeType for IServiceDocument {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IServiceDocument_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -81,6 +93,9 @@ pub struct IServiceDocument_Vtbl {
     Workspaces: usize,
 }
 windows_core::imp::define_interface!(IWorkspace, IWorkspace_Vtbl, 0xb41da63b_a4b8_4036_89c5_83c31266ba49);
+impl windows_core::RuntimeType for IWorkspace {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWorkspace_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -329,7 +344,7 @@ impl AtomPubClient {
     }
 }
 impl windows_core::RuntimeType for AtomPubClient {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IAtomPubClient>();
 }
 unsafe impl windows_core::Interface for AtomPubClient {
     type Vtable = IAtomPubClient_Vtbl;
@@ -472,7 +487,7 @@ impl ResourceCollection {
     }
 }
 impl windows_core::RuntimeType for ResourceCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IResourceCollection>();
 }
 unsafe impl windows_core::Interface for ResourceCollection {
     type Vtable = IResourceCollection_Vtbl;
@@ -592,7 +607,7 @@ impl ServiceDocument {
     }
 }
 impl windows_core::RuntimeType for ServiceDocument {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IServiceDocument>();
 }
 unsafe impl windows_core::Interface for ServiceDocument {
     type Vtable = IServiceDocument_Vtbl;
@@ -720,7 +735,7 @@ impl Workspace {
     }
 }
 impl windows_core::RuntimeType for Workspace {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWorkspace>();
 }
 unsafe impl windows_core::Interface for Workspace {
     type Vtable = IWorkspace_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHttpDiagnosticProvider, IHttpDiagnosticProvider_Vtbl, 0xbd811501_a056_4d39_b174_833b7b03b02c);
+impl windows_core::RuntimeType for IHttpDiagnosticProvider {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDiagnosticProvider_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -12,6 +15,9 @@ pub struct IHttpDiagnosticProvider_Vtbl {
     pub RemoveRequestResponseCompleted: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpDiagnosticProviderRequestResponseCompletedEventArgs, IHttpDiagnosticProviderRequestResponseCompletedEventArgs_Vtbl, 0x735f98ee_94f6_4532_b26e_61e1b1e4efd4);
+impl windows_core::RuntimeType for IHttpDiagnosticProviderRequestResponseCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDiagnosticProviderRequestResponseCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +33,9 @@ pub struct IHttpDiagnosticProviderRequestResponseCompletedEventArgs_Vtbl {
     SourceLocations: usize,
 }
 windows_core::imp::define_interface!(IHttpDiagnosticProviderRequestResponseTimestamps, IHttpDiagnosticProviderRequestResponseTimestamps_Vtbl, 0xe0afde10_55cf_4c01_91d4_a20557d849f0);
+impl windows_core::RuntimeType for IHttpDiagnosticProviderRequestResponseTimestamps {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDiagnosticProviderRequestResponseTimestamps_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,6 +50,9 @@ pub struct IHttpDiagnosticProviderRequestResponseTimestamps_Vtbl {
     pub ResponseCompletedTimestamp: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpDiagnosticProviderRequestSentEventArgs, IHttpDiagnosticProviderRequestSentEventArgs_Vtbl, 0x3f5196d0_4c1f_4ebe_a57a_06930771c50d);
+impl windows_core::RuntimeType for IHttpDiagnosticProviderRequestSentEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDiagnosticProviderRequestSentEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +68,9 @@ pub struct IHttpDiagnosticProviderRequestSentEventArgs_Vtbl {
     SourceLocations: usize,
 }
 windows_core::imp::define_interface!(IHttpDiagnosticProviderResponseReceivedEventArgs, IHttpDiagnosticProviderResponseReceivedEventArgs_Vtbl, 0xa0a2566c_ab5f_4d66_bb2d_084cf41635d0);
+impl windows_core::RuntimeType for IHttpDiagnosticProviderResponseReceivedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDiagnosticProviderResponseReceivedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -64,6 +79,9 @@ pub struct IHttpDiagnosticProviderResponseReceivedEventArgs_Vtbl {
     pub Message: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpDiagnosticProviderStatics, IHttpDiagnosticProviderStatics_Vtbl, 0x5b824ec1_6a6c_47cc_afec_1e86bc26053b);
+impl windows_core::RuntimeType for IHttpDiagnosticProviderStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDiagnosticProviderStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -73,6 +91,9 @@ pub struct IHttpDiagnosticProviderStatics_Vtbl {
     CreateFromProcessDiagnosticInfo: usize,
 }
 windows_core::imp::define_interface!(IHttpDiagnosticSourceLocation, IHttpDiagnosticSourceLocation_Vtbl, 0x54a9d260_8860_423f_b6fa_d77716f647a7);
+impl windows_core::RuntimeType for IHttpDiagnosticSourceLocation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDiagnosticSourceLocation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -152,7 +173,7 @@ impl HttpDiagnosticProvider {
     }
 }
 impl windows_core::RuntimeType for HttpDiagnosticProvider {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpDiagnosticProvider>();
 }
 unsafe impl windows_core::Interface for HttpDiagnosticProvider {
     type Vtable = IHttpDiagnosticProvider_Vtbl;
@@ -220,7 +241,7 @@ impl HttpDiagnosticProviderRequestResponseCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HttpDiagnosticProviderRequestResponseCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpDiagnosticProviderRequestResponseCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for HttpDiagnosticProviderRequestResponseCompletedEventArgs {
     type Vtable = IHttpDiagnosticProviderRequestResponseCompletedEventArgs_Vtbl;
@@ -301,7 +322,7 @@ impl HttpDiagnosticProviderRequestResponseTimestamps {
     }
 }
 impl windows_core::RuntimeType for HttpDiagnosticProviderRequestResponseTimestamps {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpDiagnosticProviderRequestResponseTimestamps>();
 }
 unsafe impl windows_core::Interface for HttpDiagnosticProviderRequestResponseTimestamps {
     type Vtable = IHttpDiagnosticProviderRequestResponseTimestamps_Vtbl;
@@ -369,7 +390,7 @@ impl HttpDiagnosticProviderRequestSentEventArgs {
     }
 }
 impl windows_core::RuntimeType for HttpDiagnosticProviderRequestSentEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpDiagnosticProviderRequestSentEventArgs>();
 }
 unsafe impl windows_core::Interface for HttpDiagnosticProviderRequestSentEventArgs {
     type Vtable = IHttpDiagnosticProviderRequestSentEventArgs_Vtbl;
@@ -408,7 +429,7 @@ impl HttpDiagnosticProviderResponseReceivedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HttpDiagnosticProviderResponseReceivedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpDiagnosticProviderResponseReceivedEventArgs>();
 }
 unsafe impl windows_core::Interface for HttpDiagnosticProviderResponseReceivedEventArgs {
     type Vtable = IHttpDiagnosticProviderResponseReceivedEventArgs_Vtbl;
@@ -447,7 +468,7 @@ impl HttpDiagnosticSourceLocation {
     }
 }
 impl windows_core::RuntimeType for HttpDiagnosticSourceLocation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpDiagnosticSourceLocation>();
 }
 unsafe impl windows_core::Interface for HttpDiagnosticSourceLocation {
     type Vtable = IHttpDiagnosticSourceLocation_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHttpBaseProtocolFilter, IHttpBaseProtocolFilter_Vtbl, 0x71c89b09_e131_4b54_a53c_eb43ff37e9bb);
+impl windows_core::RuntimeType for IHttpBaseProtocolFilter {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpBaseProtocolFilter_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -44,6 +47,9 @@ pub struct IHttpBaseProtocolFilter_Vtbl {
     pub SetUseProxy: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpBaseProtocolFilter2, IHttpBaseProtocolFilter2_Vtbl, 0x2ec30013_9427_4900_a017_fa7da3b5c9ae);
+impl windows_core::RuntimeType for IHttpBaseProtocolFilter2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpBaseProtocolFilter2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -51,6 +57,9 @@ pub struct IHttpBaseProtocolFilter2_Vtbl {
     pub SetMaxVersion: unsafe extern "system" fn(*mut core::ffi::c_void, super::HttpVersion) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpBaseProtocolFilter3, IHttpBaseProtocolFilter3_Vtbl, 0xd43f4d4c_bd42_43ae_8717_ad2c8f4b2937);
+impl windows_core::RuntimeType for IHttpBaseProtocolFilter3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpBaseProtocolFilter3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +67,9 @@ pub struct IHttpBaseProtocolFilter3_Vtbl {
     pub SetCookieUsageBehavior: unsafe extern "system" fn(*mut core::ffi::c_void, HttpCookieUsageBehavior) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpBaseProtocolFilter4, IHttpBaseProtocolFilter4_Vtbl, 0x9fe36ccf_2983_4893_941f_eb518ca8cef9);
+impl windows_core::RuntimeType for IHttpBaseProtocolFilter4 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpBaseProtocolFilter4_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -66,6 +78,9 @@ pub struct IHttpBaseProtocolFilter4_Vtbl {
     pub ClearAuthenticationCache: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpBaseProtocolFilter5, IHttpBaseProtocolFilter5_Vtbl, 0x416e4993_31e3_4816_bf09_e018ee8dc1f5);
+impl windows_core::RuntimeType for IHttpBaseProtocolFilter5 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpBaseProtocolFilter5_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -75,6 +90,9 @@ pub struct IHttpBaseProtocolFilter5_Vtbl {
     User: usize,
 }
 windows_core::imp::define_interface!(IHttpBaseProtocolFilterStatics, IHttpBaseProtocolFilterStatics_Vtbl, 0x6d4dee0c_e908_494e_b5a3_1263c9b8242a);
+impl windows_core::RuntimeType for IHttpBaseProtocolFilterStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpBaseProtocolFilterStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,6 +102,9 @@ pub struct IHttpBaseProtocolFilterStatics_Vtbl {
     CreateForUser: usize,
 }
 windows_core::imp::define_interface!(IHttpCacheControl, IHttpCacheControl_Vtbl, 0xc77e1cb4_3cea_4eb5_ac85_04e186e63ab7);
+impl windows_core::RuntimeType for IHttpCacheControl {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCacheControl_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -120,6 +141,9 @@ pub struct IHttpFilter_Vtbl {
     pub SendRequestAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpServerCustomValidationRequestedEventArgs, IHttpServerCustomValidationRequestedEventArgs_Vtbl, 0x3165fe32_e7dd_48b7_a361_939c750e63cc);
+impl windows_core::RuntimeType for IHttpServerCustomValidationRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpServerCustomValidationRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -360,7 +384,7 @@ impl HttpBaseProtocolFilter {
     }
 }
 impl windows_core::RuntimeType for HttpBaseProtocolFilter {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpBaseProtocolFilter>();
 }
 unsafe impl windows_core::Interface for HttpBaseProtocolFilter {
     type Vtable = IHttpBaseProtocolFilter_Vtbl;
@@ -400,7 +424,7 @@ impl HttpCacheControl {
     }
 }
 impl windows_core::RuntimeType for HttpCacheControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpCacheControl>();
 }
 unsafe impl windows_core::Interface for HttpCacheControl {
     type Vtable = IHttpCacheControl_Vtbl;
@@ -468,7 +492,7 @@ impl HttpServerCustomValidationRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for HttpServerCustomValidationRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpServerCustomValidationRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for HttpServerCustomValidationRequestedEventArgs {
     type Vtable = IHttpServerCustomValidationRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/Http/Headers/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Headers/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IHttpCacheDirectiveHeaderValueCollection, IHttpCacheDirectiveHeaderValueCollection_Vtbl, 0x9a586b89_d5d0_4fbe_bd9d_b5b3636811b4);
+impl windows_core::RuntimeType for IHttpCacheDirectiveHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCacheDirectiveHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -14,6 +17,9 @@ pub struct IHttpCacheDirectiveHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpChallengeHeaderValue, IHttpChallengeHeaderValue_Vtbl, 0x393361af_0f7d_4820_9fdd_a2b956eeaeab);
+impl windows_core::RuntimeType for IHttpChallengeHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpChallengeHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -25,6 +31,9 @@ pub struct IHttpChallengeHeaderValue_Vtbl {
     pub Token: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpChallengeHeaderValueCollection, IHttpChallengeHeaderValueCollection_Vtbl, 0xca9e5f81_aee0_4353_a10b_e625babd64c2);
+impl windows_core::RuntimeType for IHttpChallengeHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpChallengeHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -32,6 +41,9 @@ pub struct IHttpChallengeHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpChallengeHeaderValueFactory, IHttpChallengeHeaderValueFactory_Vtbl, 0xc452c451_d99c_40aa_9399_90eeb98fc613);
+impl windows_core::RuntimeType for IHttpChallengeHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpChallengeHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -39,6 +51,9 @@ pub struct IHttpChallengeHeaderValueFactory_Vtbl {
     pub CreateFromSchemeWithToken: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpChallengeHeaderValueStatics, IHttpChallengeHeaderValueStatics_Vtbl, 0xf3d38a72_fc01_4d01_a008_fcb7c459d635);
+impl windows_core::RuntimeType for IHttpChallengeHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpChallengeHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -46,12 +61,18 @@ pub struct IHttpChallengeHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpConnectionOptionHeaderValue, IHttpConnectionOptionHeaderValue_Vtbl, 0xcb4af27a_4e90_45eb_8dcd_fd1408f4c44f);
+impl windows_core::RuntimeType for IHttpConnectionOptionHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpConnectionOptionHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Token: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpConnectionOptionHeaderValueCollection, IHttpConnectionOptionHeaderValueCollection_Vtbl, 0xe4f56c1d_5142_4e00_8e0f_019509337629);
+impl windows_core::RuntimeType for IHttpConnectionOptionHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpConnectionOptionHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -59,12 +80,18 @@ pub struct IHttpConnectionOptionHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpConnectionOptionHeaderValueFactory, IHttpConnectionOptionHeaderValueFactory_Vtbl, 0xd93ccc1e_0b7d_4c3f_a58d_a2a1bdeabc0a);
+impl windows_core::RuntimeType for IHttpConnectionOptionHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpConnectionOptionHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpConnectionOptionHeaderValueStatics, IHttpConnectionOptionHeaderValueStatics_Vtbl, 0xaaa75d37_a946_4b1f_85af_48b68b3c50bd);
+impl windows_core::RuntimeType for IHttpConnectionOptionHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpConnectionOptionHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -72,12 +99,18 @@ pub struct IHttpConnectionOptionHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingHeaderValue, IHttpContentCodingHeaderValue_Vtbl, 0xbcf7f92a_9376_4d85_bccc_9f4f9acab434);
+impl windows_core::RuntimeType for IHttpContentCodingHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub ContentCoding: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingHeaderValueCollection, IHttpContentCodingHeaderValueCollection_Vtbl, 0x7d221721_a6db_436e_8e83_91596192819c);
+impl windows_core::RuntimeType for IHttpContentCodingHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -85,12 +118,18 @@ pub struct IHttpContentCodingHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingHeaderValueFactory, IHttpContentCodingHeaderValueFactory_Vtbl, 0xc53d2bd7_332b_4350_8510_2e67a2289a5a);
+impl windows_core::RuntimeType for IHttpContentCodingHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingHeaderValueStatics, IHttpContentCodingHeaderValueStatics_Vtbl, 0x94d8602e_f9bf_42f7_aa46_ed272a41e212);
+impl windows_core::RuntimeType for IHttpContentCodingHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -98,6 +137,9 @@ pub struct IHttpContentCodingHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingWithQualityHeaderValue, IHttpContentCodingWithQualityHeaderValue_Vtbl, 0x94531cd5_8b13_4d73_8651_f76b38f88495);
+impl windows_core::RuntimeType for IHttpContentCodingWithQualityHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingWithQualityHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -105,6 +147,9 @@ pub struct IHttpContentCodingWithQualityHeaderValue_Vtbl {
     pub Quality: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingWithQualityHeaderValueCollection, IHttpContentCodingWithQualityHeaderValueCollection_Vtbl, 0x7c0d753e_e899_4378_b5c8_412d820711cc);
+impl windows_core::RuntimeType for IHttpContentCodingWithQualityHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingWithQualityHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -112,6 +157,9 @@ pub struct IHttpContentCodingWithQualityHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingWithQualityHeaderValueFactory, IHttpContentCodingWithQualityHeaderValueFactory_Vtbl, 0xc45eee1a_c553_46fc_ade2_d75c1d53df7b);
+impl windows_core::RuntimeType for IHttpContentCodingWithQualityHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingWithQualityHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -119,6 +167,9 @@ pub struct IHttpContentCodingWithQualityHeaderValueFactory_Vtbl {
     pub CreateFromValueWithQuality: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, f64, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentCodingWithQualityHeaderValueStatics, IHttpContentCodingWithQualityHeaderValueStatics_Vtbl, 0xe8c9357c_8f89_4801_8e75_4c9abfc3de71);
+impl windows_core::RuntimeType for IHttpContentCodingWithQualityHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentCodingWithQualityHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -126,6 +177,9 @@ pub struct IHttpContentCodingWithQualityHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentDispositionHeaderValue, IHttpContentDispositionHeaderValue_Vtbl, 0xf2a2eedc_2629_4b49_9908_96a168e9365e);
+impl windows_core::RuntimeType for IHttpContentDispositionHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentDispositionHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -145,12 +199,18 @@ pub struct IHttpContentDispositionHeaderValue_Vtbl {
     pub SetSize: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentDispositionHeaderValueFactory, IHttpContentDispositionHeaderValueFactory_Vtbl, 0x9915bbc4_456c_4e81_8295_b2ab3cbcf545);
+impl windows_core::RuntimeType for IHttpContentDispositionHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentDispositionHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentDispositionHeaderValueStatics, IHttpContentDispositionHeaderValueStatics_Vtbl, 0x29c56067_5a37_46e4_b074_c5177d69ca66);
+impl windows_core::RuntimeType for IHttpContentDispositionHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentDispositionHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -158,6 +218,9 @@ pub struct IHttpContentDispositionHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentHeaderCollection, IHttpContentHeaderCollection_Vtbl, 0x40612a44_47ae_4b7e_9124_69628b64aa18);
+impl windows_core::RuntimeType for IHttpContentHeaderCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentHeaderCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -189,6 +252,9 @@ pub struct IHttpContentHeaderCollection_Vtbl {
     pub TryAppendWithoutValidation: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentRangeHeaderValue, IHttpContentRangeHeaderValue_Vtbl, 0x04d967d3_a4f6_495c_9530_8579fcba8aa9);
+impl windows_core::RuntimeType for IHttpContentRangeHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentRangeHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,6 +265,9 @@ pub struct IHttpContentRangeHeaderValue_Vtbl {
     pub SetUnit: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentRangeHeaderValueFactory, IHttpContentRangeHeaderValueFactory_Vtbl, 0x3f5bd691_a03c_4456_9a6f_ef27ecd03cae);
+impl windows_core::RuntimeType for IHttpContentRangeHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentRangeHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -207,6 +276,9 @@ pub struct IHttpContentRangeHeaderValueFactory_Vtbl {
     pub CreateFromRangeWithLength: unsafe extern "system" fn(*mut core::ffi::c_void, u64, u64, u64, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpContentRangeHeaderValueStatics, IHttpContentRangeHeaderValueStatics_Vtbl, 0x80a346ca_174c_4fae_821c_134cd294aa38);
+impl windows_core::RuntimeType for IHttpContentRangeHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpContentRangeHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -214,6 +286,9 @@ pub struct IHttpContentRangeHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCookiePairHeaderValue, IHttpCookiePairHeaderValue_Vtbl, 0xcbd46217_4b29_412b_bd90_b3d814ab8e1b);
+impl windows_core::RuntimeType for IHttpCookiePairHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCookiePairHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -222,6 +297,9 @@ pub struct IHttpCookiePairHeaderValue_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCookiePairHeaderValueCollection, IHttpCookiePairHeaderValueCollection_Vtbl, 0xf3f44350_581e_4ecc_9f59_e507d04f06e6);
+impl windows_core::RuntimeType for IHttpCookiePairHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCookiePairHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -229,6 +307,9 @@ pub struct IHttpCookiePairHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCookiePairHeaderValueFactory, IHttpCookiePairHeaderValueFactory_Vtbl, 0x635e326f_146f_4f56_aa21_2cb7d6d58b1e);
+impl windows_core::RuntimeType for IHttpCookiePairHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCookiePairHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -236,6 +317,9 @@ pub struct IHttpCookiePairHeaderValueFactory_Vtbl {
     pub CreateFromNameWithValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCookiePairHeaderValueStatics, IHttpCookiePairHeaderValueStatics_Vtbl, 0x6e866d48_06af_4462_8158_99388d5dca81);
+impl windows_core::RuntimeType for IHttpCookiePairHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCookiePairHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -243,6 +327,9 @@ pub struct IHttpCookiePairHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCredentialsHeaderValue, IHttpCredentialsHeaderValue_Vtbl, 0xc34cc3cb_542e_4177_a6c7_b674ce193fbf);
+impl windows_core::RuntimeType for IHttpCredentialsHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCredentialsHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -254,6 +341,9 @@ pub struct IHttpCredentialsHeaderValue_Vtbl {
     pub Token: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCredentialsHeaderValueFactory, IHttpCredentialsHeaderValueFactory_Vtbl, 0xf21d9e91_4d1c_4182_bfd1_34470a62f950);
+impl windows_core::RuntimeType for IHttpCredentialsHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCredentialsHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -261,6 +351,9 @@ pub struct IHttpCredentialsHeaderValueFactory_Vtbl {
     pub CreateFromSchemeWithToken: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCredentialsHeaderValueStatics, IHttpCredentialsHeaderValueStatics_Vtbl, 0xa69b2be6_ce8c_4443_a35a_1b727b131036);
+impl windows_core::RuntimeType for IHttpCredentialsHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCredentialsHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -268,6 +361,9 @@ pub struct IHttpCredentialsHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpDateOrDeltaHeaderValue, IHttpDateOrDeltaHeaderValue_Vtbl, 0xeafcaa6a_c4dc_49e2_a27d_043adf5867a3);
+impl windows_core::RuntimeType for IHttpDateOrDeltaHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDateOrDeltaHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -275,6 +371,9 @@ pub struct IHttpDateOrDeltaHeaderValue_Vtbl {
     pub Delta: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpDateOrDeltaHeaderValueStatics, IHttpDateOrDeltaHeaderValueStatics_Vtbl, 0x7c2659a8_6672_4e90_9a9a_f39766f7f576);
+impl windows_core::RuntimeType for IHttpDateOrDeltaHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpDateOrDeltaHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -282,6 +381,9 @@ pub struct IHttpDateOrDeltaHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpExpectationHeaderValue, IHttpExpectationHeaderValue_Vtbl, 0x4ce585cd_3a99_43af_a2e6_ec232fea9658);
+impl windows_core::RuntimeType for IHttpExpectationHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpExpectationHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -294,6 +396,9 @@ pub struct IHttpExpectationHeaderValue_Vtbl {
     Parameters: usize,
 }
 windows_core::imp::define_interface!(IHttpExpectationHeaderValueCollection, IHttpExpectationHeaderValueCollection_Vtbl, 0xe78521b3_a0e2_4ac4_9e66_79706cb9fd58);
+impl windows_core::RuntimeType for IHttpExpectationHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpExpectationHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -301,6 +406,9 @@ pub struct IHttpExpectationHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpExpectationHeaderValueFactory, IHttpExpectationHeaderValueFactory_Vtbl, 0x4ea275cb_d53e_4868_8856_1e21a5030dc0);
+impl windows_core::RuntimeType for IHttpExpectationHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpExpectationHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -308,6 +416,9 @@ pub struct IHttpExpectationHeaderValueFactory_Vtbl {
     pub CreateFromNameWithValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpExpectationHeaderValueStatics, IHttpExpectationHeaderValueStatics_Vtbl, 0x3019abe2_cfe5_473b_a57f_fba5b14eb257);
+impl windows_core::RuntimeType for IHttpExpectationHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpExpectationHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -315,6 +426,9 @@ pub struct IHttpExpectationHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpLanguageHeaderValueCollection, IHttpLanguageHeaderValueCollection_Vtbl, 0x9ebd7ca3_8219_44f6_9902_8c56dfd3340c);
+impl windows_core::RuntimeType for IHttpLanguageHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpLanguageHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -322,6 +436,9 @@ pub struct IHttpLanguageHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpLanguageRangeWithQualityHeaderValue, IHttpLanguageRangeWithQualityHeaderValue_Vtbl, 0x7256e102_0080_4db4_a083_7de7b2e5ba4c);
+impl windows_core::RuntimeType for IHttpLanguageRangeWithQualityHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpLanguageRangeWithQualityHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -329,6 +446,9 @@ pub struct IHttpLanguageRangeWithQualityHeaderValue_Vtbl {
     pub Quality: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpLanguageRangeWithQualityHeaderValueCollection, IHttpLanguageRangeWithQualityHeaderValueCollection_Vtbl, 0x885d5abd_4b4f_480a_89ce_8aedcee6e3a0);
+impl windows_core::RuntimeType for IHttpLanguageRangeWithQualityHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpLanguageRangeWithQualityHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -336,6 +456,9 @@ pub struct IHttpLanguageRangeWithQualityHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpLanguageRangeWithQualityHeaderValueFactory, IHttpLanguageRangeWithQualityHeaderValueFactory_Vtbl, 0x7bb83970_780f_4c83_9fe4_dc3087f6bd55);
+impl windows_core::RuntimeType for IHttpLanguageRangeWithQualityHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpLanguageRangeWithQualityHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -343,6 +466,9 @@ pub struct IHttpLanguageRangeWithQualityHeaderValueFactory_Vtbl {
     pub CreateFromLanguageRangeWithQuality: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, f64, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpLanguageRangeWithQualityHeaderValueStatics, IHttpLanguageRangeWithQualityHeaderValueStatics_Vtbl, 0x2541e146_f308_46f5_b695_42f54024ec68);
+impl windows_core::RuntimeType for IHttpLanguageRangeWithQualityHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpLanguageRangeWithQualityHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -350,6 +476,9 @@ pub struct IHttpLanguageRangeWithQualityHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMediaTypeHeaderValue, IHttpMediaTypeHeaderValue_Vtbl, 0x16b28533_e728_4fcb_bdb0_08a431a14844);
+impl windows_core::RuntimeType for IHttpMediaTypeHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMediaTypeHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -363,12 +492,18 @@ pub struct IHttpMediaTypeHeaderValue_Vtbl {
     Parameters: usize,
 }
 windows_core::imp::define_interface!(IHttpMediaTypeHeaderValueFactory, IHttpMediaTypeHeaderValueFactory_Vtbl, 0xbed747a8_cd17_42dd_9367_ab9c5b56dd7d);
+impl windows_core::RuntimeType for IHttpMediaTypeHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMediaTypeHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMediaTypeHeaderValueStatics, IHttpMediaTypeHeaderValueStatics_Vtbl, 0xe04d83df_1d41_4d8c_a2de_6fd2ed87399b);
+impl windows_core::RuntimeType for IHttpMediaTypeHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMediaTypeHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -376,6 +511,9 @@ pub struct IHttpMediaTypeHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMediaTypeWithQualityHeaderValue, IHttpMediaTypeWithQualityHeaderValue_Vtbl, 0x188d5e32_76be_44a0_b1cd_2074bded2dde);
+impl windows_core::RuntimeType for IHttpMediaTypeWithQualityHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMediaTypeWithQualityHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -391,6 +529,9 @@ pub struct IHttpMediaTypeWithQualityHeaderValue_Vtbl {
     pub SetQuality: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMediaTypeWithQualityHeaderValueCollection, IHttpMediaTypeWithQualityHeaderValueCollection_Vtbl, 0x3c0c6b73_1342_4587_a056_18d02ff67165);
+impl windows_core::RuntimeType for IHttpMediaTypeWithQualityHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMediaTypeWithQualityHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -398,6 +539,9 @@ pub struct IHttpMediaTypeWithQualityHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMediaTypeWithQualityHeaderValueFactory, IHttpMediaTypeWithQualityHeaderValueFactory_Vtbl, 0x4c6d20f4_9457_44e6_a323_d122b958780b);
+impl windows_core::RuntimeType for IHttpMediaTypeWithQualityHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMediaTypeWithQualityHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -405,6 +549,9 @@ pub struct IHttpMediaTypeWithQualityHeaderValueFactory_Vtbl {
     pub CreateFromMediaTypeWithQuality: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, f64, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMediaTypeWithQualityHeaderValueStatics, IHttpMediaTypeWithQualityHeaderValueStatics_Vtbl, 0x5b070cd9_b560_4fc8_9835_7e6c0a657b24);
+impl windows_core::RuntimeType for IHttpMediaTypeWithQualityHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMediaTypeWithQualityHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -412,6 +559,9 @@ pub struct IHttpMediaTypeWithQualityHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMethodHeaderValueCollection, IHttpMethodHeaderValueCollection_Vtbl, 0x43bc3ff4_6119_4adf_938c_34bfffcf92ed);
+impl windows_core::RuntimeType for IHttpMethodHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMethodHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -419,6 +569,9 @@ pub struct IHttpMethodHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpNameValueHeaderValue, IHttpNameValueHeaderValue_Vtbl, 0xd8ba7463_5b9a_4d1b_93f9_aa5b44ecfddf);
+impl windows_core::RuntimeType for IHttpNameValueHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpNameValueHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -427,6 +580,9 @@ pub struct IHttpNameValueHeaderValue_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpNameValueHeaderValueFactory, IHttpNameValueHeaderValueFactory_Vtbl, 0x770e2267_cbf8_4736_a925_93fbe10c7ca8);
+impl windows_core::RuntimeType for IHttpNameValueHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpNameValueHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -434,6 +590,9 @@ pub struct IHttpNameValueHeaderValueFactory_Vtbl {
     pub CreateFromNameWithValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpNameValueHeaderValueStatics, IHttpNameValueHeaderValueStatics_Vtbl, 0xffd4030f_1130_4152_8659_256909a9d115);
+impl windows_core::RuntimeType for IHttpNameValueHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpNameValueHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -441,6 +600,9 @@ pub struct IHttpNameValueHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpProductHeaderValue, IHttpProductHeaderValue_Vtbl, 0xf4feee03_ebd4_4160_b9ff_807c5183b6e6);
+impl windows_core::RuntimeType for IHttpProductHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpProductHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -448,6 +610,9 @@ pub struct IHttpProductHeaderValue_Vtbl {
     pub Version: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpProductHeaderValueFactory, IHttpProductHeaderValueFactory_Vtbl, 0x611aa4f5_82bc_42fb_977b_dc00536e5e86);
+impl windows_core::RuntimeType for IHttpProductHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpProductHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -455,6 +620,9 @@ pub struct IHttpProductHeaderValueFactory_Vtbl {
     pub CreateFromNameWithVersion: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpProductHeaderValueStatics, IHttpProductHeaderValueStatics_Vtbl, 0x90c33e29_befc_4337_be62_49f097975f53);
+impl windows_core::RuntimeType for IHttpProductHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpProductHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -462,6 +630,9 @@ pub struct IHttpProductHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpProductInfoHeaderValue, IHttpProductInfoHeaderValue_Vtbl, 0x1b1a8732_4c35_486a_966f_646489198e4d);
+impl windows_core::RuntimeType for IHttpProductInfoHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpProductInfoHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -469,6 +640,9 @@ pub struct IHttpProductInfoHeaderValue_Vtbl {
     pub Comment: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpProductInfoHeaderValueCollection, IHttpProductInfoHeaderValueCollection_Vtbl, 0x877df74a_d69b_44f8_ad4f_453af9c42ed0);
+impl windows_core::RuntimeType for IHttpProductInfoHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpProductInfoHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -476,6 +650,9 @@ pub struct IHttpProductInfoHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpProductInfoHeaderValueFactory, IHttpProductInfoHeaderValueFactory_Vtbl, 0x24220fbe_eabe_4464_b460_ec010b7c41e2);
+impl windows_core::RuntimeType for IHttpProductInfoHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpProductInfoHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -483,6 +660,9 @@ pub struct IHttpProductInfoHeaderValueFactory_Vtbl {
     pub CreateFromNameWithVersion: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpProductInfoHeaderValueStatics, IHttpProductInfoHeaderValueStatics_Vtbl, 0xdb7fd857_327a_4e73_81e5_7059a302b042);
+impl windows_core::RuntimeType for IHttpProductInfoHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpProductInfoHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -490,6 +670,9 @@ pub struct IHttpProductInfoHeaderValueStatics_Vtbl {
     pub TryParse: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpRequestHeaderCollection, IHttpRequestHeaderCollection_Vtbl, 0xaf40329b_b544_469b_86b9_ac3d466fea36);
+impl windows_core::RuntimeType for IHttpRequestHeaderCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpRequestHeaderCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -530,6 +713,9 @@ pub struct IHttpRequestHeaderCollection_Vtbl {
     pub TryAppendWithoutValidation: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpResponseHeaderCollection, IHttpResponseHeaderCollection_Vtbl, 0x7a990969_fa3f_41ed_aac6_bf957975c16b);
+impl windows_core::RuntimeType for IHttpResponseHeaderCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpResponseHeaderCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -551,6 +737,9 @@ pub struct IHttpResponseHeaderCollection_Vtbl {
     pub TryAppendWithoutValidation: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpTransferCodingHeaderValue, IHttpTransferCodingHeaderValue_Vtbl, 0x436f32f9_3ded_42bd_b38a_5496a2511ce6);
+impl windows_core::RuntimeType for IHttpTransferCodingHeaderValue {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpTransferCodingHeaderValue_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -561,6 +750,9 @@ pub struct IHttpTransferCodingHeaderValue_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpTransferCodingHeaderValueCollection, IHttpTransferCodingHeaderValueCollection_Vtbl, 0x202c8c34_2c03_49b8_9665_73e27cb2fc79);
+impl windows_core::RuntimeType for IHttpTransferCodingHeaderValueCollection {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpTransferCodingHeaderValueCollection_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -568,12 +760,18 @@ pub struct IHttpTransferCodingHeaderValueCollection_Vtbl {
     pub TryParseAdd: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpTransferCodingHeaderValueFactory, IHttpTransferCodingHeaderValueFactory_Vtbl, 0xbb62dffc_e361_4f08_8e4f_c9e723de703b);
+impl windows_core::RuntimeType for IHttpTransferCodingHeaderValueFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpTransferCodingHeaderValueFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpTransferCodingHeaderValueStatics, IHttpTransferCodingHeaderValueStatics_Vtbl, 0x6ab8892a_1a98_4d32_a906_7470a9875ce5);
+impl windows_core::RuntimeType for IHttpTransferCodingHeaderValueStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpTransferCodingHeaderValueStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -758,7 +956,7 @@ impl HttpCacheDirectiveHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpCacheDirectiveHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpCacheDirectiveHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpCacheDirectiveHeaderValueCollection {
     type Vtable = IHttpCacheDirectiveHeaderValueCollection_Vtbl;
@@ -856,7 +1054,7 @@ impl HttpChallengeHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpChallengeHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpChallengeHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpChallengeHeaderValue {
     type Vtable = IHttpChallengeHeaderValue_Vtbl;
@@ -989,7 +1187,7 @@ impl HttpChallengeHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpChallengeHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpChallengeHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpChallengeHeaderValueCollection {
     type Vtable = IHttpChallengeHeaderValueCollection_Vtbl;
@@ -1066,7 +1264,7 @@ impl HttpConnectionOptionHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpConnectionOptionHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpConnectionOptionHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpConnectionOptionHeaderValue {
     type Vtable = IHttpConnectionOptionHeaderValue_Vtbl;
@@ -1199,7 +1397,7 @@ impl HttpConnectionOptionHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpConnectionOptionHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpConnectionOptionHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpConnectionOptionHeaderValueCollection {
     type Vtable = IHttpConnectionOptionHeaderValueCollection_Vtbl;
@@ -1276,7 +1474,7 @@ impl HttpContentCodingHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpContentCodingHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContentCodingHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpContentCodingHeaderValue {
     type Vtable = IHttpContentCodingHeaderValue_Vtbl;
@@ -1409,7 +1607,7 @@ impl HttpContentCodingHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpContentCodingHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContentCodingHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpContentCodingHeaderValueCollection {
     type Vtable = IHttpContentCodingHeaderValueCollection_Vtbl;
@@ -1499,7 +1697,7 @@ impl HttpContentCodingWithQualityHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpContentCodingWithQualityHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContentCodingWithQualityHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpContentCodingWithQualityHeaderValue {
     type Vtable = IHttpContentCodingWithQualityHeaderValue_Vtbl;
@@ -1632,7 +1830,7 @@ impl HttpContentCodingWithQualityHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpContentCodingWithQualityHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContentCodingWithQualityHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpContentCodingWithQualityHeaderValueCollection {
     type Vtable = IHttpContentCodingWithQualityHeaderValueCollection_Vtbl;
@@ -1768,7 +1966,7 @@ impl HttpContentDispositionHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpContentDispositionHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContentDispositionHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpContentDispositionHeaderValue {
     type Vtable = IHttpContentDispositionHeaderValue_Vtbl;
@@ -1999,7 +2197,7 @@ impl HttpContentHeaderCollection {
     }
 }
 impl windows_core::RuntimeType for HttpContentHeaderCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContentHeaderCollection>();
 }
 unsafe impl windows_core::Interface for HttpContentHeaderCollection {
     type Vtable = IHttpContentHeaderCollection_Vtbl;
@@ -2113,7 +2311,7 @@ impl HttpContentRangeHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpContentRangeHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContentRangeHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpContentRangeHeaderValue {
     type Vtable = IHttpContentRangeHeaderValue_Vtbl;
@@ -2191,7 +2389,7 @@ impl HttpCookiePairHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpCookiePairHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpCookiePairHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpCookiePairHeaderValue {
     type Vtable = IHttpCookiePairHeaderValue_Vtbl;
@@ -2324,7 +2522,7 @@ impl HttpCookiePairHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpCookiePairHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpCookiePairHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpCookiePairHeaderValueCollection {
     type Vtable = IHttpCookiePairHeaderValueCollection_Vtbl;
@@ -2422,7 +2620,7 @@ impl HttpCredentialsHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpCredentialsHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpCredentialsHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpCredentialsHeaderValue {
     type Vtable = IHttpCredentialsHeaderValue_Vtbl;
@@ -2479,7 +2677,7 @@ impl HttpDateOrDeltaHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpDateOrDeltaHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpDateOrDeltaHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpDateOrDeltaHeaderValue {
     type Vtable = IHttpDateOrDeltaHeaderValue_Vtbl;
@@ -2565,7 +2763,7 @@ impl HttpExpectationHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpExpectationHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpExpectationHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpExpectationHeaderValue {
     type Vtable = IHttpExpectationHeaderValue_Vtbl;
@@ -2698,7 +2896,7 @@ impl HttpExpectationHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpExpectationHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpExpectationHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpExpectationHeaderValueCollection {
     type Vtable = IHttpExpectationHeaderValueCollection_Vtbl;
@@ -2847,7 +3045,7 @@ impl HttpLanguageHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpLanguageHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpLanguageHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpLanguageHeaderValueCollection {
     type Vtable = IHttpLanguageHeaderValueCollection_Vtbl;
@@ -2937,7 +3135,7 @@ impl HttpLanguageRangeWithQualityHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpLanguageRangeWithQualityHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpLanguageRangeWithQualityHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpLanguageRangeWithQualityHeaderValue {
     type Vtable = IHttpLanguageRangeWithQualityHeaderValue_Vtbl;
@@ -3070,7 +3268,7 @@ impl HttpLanguageRangeWithQualityHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpLanguageRangeWithQualityHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpLanguageRangeWithQualityHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpLanguageRangeWithQualityHeaderValueCollection {
     type Vtable = IHttpLanguageRangeWithQualityHeaderValueCollection_Vtbl;
@@ -3170,7 +3368,7 @@ impl HttpMediaTypeHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpMediaTypeHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpMediaTypeHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpMediaTypeHeaderValue {
     type Vtable = IHttpMediaTypeHeaderValue_Vtbl;
@@ -3274,7 +3472,7 @@ impl HttpMediaTypeWithQualityHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpMediaTypeWithQualityHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpMediaTypeWithQualityHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpMediaTypeWithQualityHeaderValue {
     type Vtable = IHttpMediaTypeWithQualityHeaderValue_Vtbl;
@@ -3407,7 +3605,7 @@ impl HttpMediaTypeWithQualityHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpMediaTypeWithQualityHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpMediaTypeWithQualityHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpMediaTypeWithQualityHeaderValueCollection {
     type Vtable = IHttpMediaTypeWithQualityHeaderValueCollection_Vtbl;
@@ -3556,7 +3754,7 @@ impl HttpMethodHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpMethodHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpMethodHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpMethodHeaderValueCollection {
     type Vtable = IHttpMethodHeaderValueCollection_Vtbl;
@@ -3650,7 +3848,7 @@ impl HttpNameValueHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpNameValueHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpNameValueHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpNameValueHeaderValue {
     type Vtable = IHttpNameValueHeaderValue_Vtbl;
@@ -3724,7 +3922,7 @@ impl HttpProductHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpProductHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpProductHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpProductHeaderValue {
     type Vtable = IHttpProductHeaderValue_Vtbl;
@@ -3798,7 +3996,7 @@ impl HttpProductInfoHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpProductInfoHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpProductInfoHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpProductInfoHeaderValue {
     type Vtable = IHttpProductInfoHeaderValue_Vtbl;
@@ -3931,7 +4129,7 @@ impl HttpProductInfoHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpProductInfoHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpProductInfoHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpProductInfoHeaderValueCollection {
     type Vtable = IHttpProductInfoHeaderValueCollection_Vtbl;
@@ -4231,7 +4429,7 @@ impl HttpRequestHeaderCollection {
     }
 }
 impl windows_core::RuntimeType for HttpRequestHeaderCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpRequestHeaderCollection>();
 }
 unsafe impl windows_core::Interface for HttpRequestHeaderCollection {
     type Vtable = IHttpRequestHeaderCollection_Vtbl;
@@ -4441,7 +4639,7 @@ impl HttpResponseHeaderCollection {
     }
 }
 impl windows_core::RuntimeType for HttpResponseHeaderCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpResponseHeaderCollection>();
 }
 unsafe impl windows_core::Interface for HttpResponseHeaderCollection {
     type Vtable = IHttpResponseHeaderCollection_Vtbl;
@@ -4526,7 +4724,7 @@ impl HttpTransferCodingHeaderValue {
     }
 }
 impl windows_core::RuntimeType for HttpTransferCodingHeaderValue {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpTransferCodingHeaderValue>();
 }
 unsafe impl windows_core::Interface for HttpTransferCodingHeaderValue {
     type Vtable = IHttpTransferCodingHeaderValue_Vtbl;
@@ -4659,7 +4857,7 @@ impl HttpTransferCodingHeaderValueCollection {
     }
 }
 impl windows_core::RuntimeType for HttpTransferCodingHeaderValueCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpTransferCodingHeaderValueCollection>();
 }
 unsafe impl windows_core::Interface for HttpTransferCodingHeaderValueCollection {
     type Vtable = IHttpTransferCodingHeaderValueCollection_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/Http/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/mod.rs
@@ -5,6 +5,9 @@ pub mod Filters;
 #[cfg(feature = "Web_Http_Headers")]
 pub mod Headers;
 windows_core::imp::define_interface!(IHttpBufferContentFactory, IHttpBufferContentFactory_Vtbl, 0xbc20c193_c41f_4ff7_9123_6435736eadc2);
+impl windows_core::RuntimeType for IHttpBufferContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpBufferContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -18,6 +21,9 @@ pub struct IHttpBufferContentFactory_Vtbl {
     CreateFromBufferWithOffset: usize,
 }
 windows_core::imp::define_interface!(IHttpClient, IHttpClient_Vtbl, 0x7fda1151_3574_4880_a8ba_e6b1e0061f3d);
+impl windows_core::RuntimeType for IHttpClient {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpClient_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -43,6 +49,9 @@ pub struct IHttpClient_Vtbl {
     DefaultRequestHeaders: usize,
 }
 windows_core::imp::define_interface!(IHttpClient2, IHttpClient2_Vtbl, 0xcdd83348_e8b7_4cec_b1b0_dc455fe72c92);
+impl windows_core::RuntimeType for IHttpClient2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpClient2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -58,6 +67,9 @@ pub struct IHttpClient2_Vtbl {
     pub TrySendRequestAsync2: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, HttpCompletionOption, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpClient3, IHttpClient3_Vtbl, 0x1172fd01_9899_4194_963f_8f9d72a7ec15);
+impl windows_core::RuntimeType for IHttpClient3 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpClient3_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -65,6 +77,9 @@ pub struct IHttpClient3_Vtbl {
     pub SetDefaultPrivacyAnnotation: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpClientFactory, IHttpClientFactory_Vtbl, 0xc30c4eca_e3fa_4f99_afb4_63cc65009462);
+impl windows_core::RuntimeType for IHttpClientFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpClientFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -165,6 +180,9 @@ pub struct IHttpContent_Vtbl {
     WriteToStreamAsync: usize,
 }
 windows_core::imp::define_interface!(IHttpCookie, IHttpCookie_Vtbl, 0x1f5488e2_cc2d_4779_86a7_88f10687d249);
+impl windows_core::RuntimeType for IHttpCookie {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCookie_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -181,12 +199,18 @@ pub struct IHttpCookie_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCookieFactory, IHttpCookieFactory_Vtbl, 0x6a0585a9_931c_4cd1_a96d_c21701785c5f);
+impl windows_core::RuntimeType for IHttpCookieFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCookieFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpCookieManager, IHttpCookieManager_Vtbl, 0x7a431780_cd4f_4e57_a84a_5b0a53d6bb96);
+impl windows_core::RuntimeType for IHttpCookieManager {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpCookieManager_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -199,6 +223,9 @@ pub struct IHttpCookieManager_Vtbl {
     GetCookies: usize,
 }
 windows_core::imp::define_interface!(IHttpFormUrlEncodedContentFactory, IHttpFormUrlEncodedContentFactory_Vtbl, 0x43f0138c_2f73_4302_b5f3_eae9238a5e01);
+impl windows_core::RuntimeType for IHttpFormUrlEncodedContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpFormUrlEncodedContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -208,6 +235,9 @@ pub struct IHttpFormUrlEncodedContentFactory_Vtbl {
     Create: usize,
 }
 windows_core::imp::define_interface!(IHttpGetBufferResult, IHttpGetBufferResult_Vtbl, 0x53d08e7c_e209_404e_9a49_742d8236fd3a);
+impl windows_core::RuntimeType for IHttpGetBufferResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpGetBufferResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -221,6 +251,9 @@ pub struct IHttpGetBufferResult_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(IHttpGetInputStreamResult, IHttpGetInputStreamResult_Vtbl, 0xd5d63463_13aa_4ee0_be95_a0c39fe91203);
+impl windows_core::RuntimeType for IHttpGetInputStreamResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpGetInputStreamResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -234,6 +267,9 @@ pub struct IHttpGetInputStreamResult_Vtbl {
     Value: usize,
 }
 windows_core::imp::define_interface!(IHttpGetStringResult, IHttpGetStringResult_Vtbl, 0x9bac466d_8509_4775_b16d_8953f47a7f5f);
+impl windows_core::RuntimeType for IHttpGetStringResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpGetStringResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -244,18 +280,27 @@ pub struct IHttpGetStringResult_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMethod, IHttpMethod_Vtbl, 0x728d4022_700d_4fe0_afa5_40299c58dbfd);
+impl windows_core::RuntimeType for IHttpMethod {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMethod_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Method: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMethodFactory, IHttpMethodFactory_Vtbl, 0x3c51d10d_36d7_40f8_a86d_e759caf2f83f);
+impl windows_core::RuntimeType for IHttpMethodFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMethodFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMethodStatics, IHttpMethodStatics_Vtbl, 0x64d171f0_d99a_4153_8dc6_d68cc4cce317);
+impl windows_core::RuntimeType for IHttpMethodStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMethodStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -268,12 +313,18 @@ pub struct IHttpMethodStatics_Vtbl {
     pub Put: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMultipartContent, IHttpMultipartContent_Vtbl, 0xdf916aff_9926_4ac9_aaf1_e0d04ef09bb9);
+impl windows_core::RuntimeType for IHttpMultipartContent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMultipartContent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Add: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMultipartContentFactory, IHttpMultipartContentFactory_Vtbl, 0x7eb42e62_0222_4f20_b372_47d5db5d33b4);
+impl windows_core::RuntimeType for IHttpMultipartContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMultipartContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -281,6 +332,9 @@ pub struct IHttpMultipartContentFactory_Vtbl {
     pub CreateWithSubtypeAndBoundary: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMultipartFormDataContent, IHttpMultipartFormDataContent_Vtbl, 0x64d337e2_e967_4624_b6d1_cf74604a4a42);
+impl windows_core::RuntimeType for IHttpMultipartFormDataContent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMultipartFormDataContent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -289,12 +343,18 @@ pub struct IHttpMultipartFormDataContent_Vtbl {
     pub AddWithNameAndFileName: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpMultipartFormDataContentFactory, IHttpMultipartFormDataContentFactory_Vtbl, 0xa04d7311_5017_4622_93a8_49b24a4fcbfc);
+impl windows_core::RuntimeType for IHttpMultipartFormDataContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpMultipartFormDataContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithBoundary: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpRequestMessage, IHttpRequestMessage_Vtbl, 0xf5762b3c_74d4_4811_b5dc_9f8b4e2f9abf);
+impl windows_core::RuntimeType for IHttpRequestMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpRequestMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -315,6 +375,9 @@ pub struct IHttpRequestMessage_Vtbl {
     pub TransportInformation: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpRequestMessage2, IHttpRequestMessage2_Vtbl, 0xc3c60489_62c2_4a3f_9554_226e7c60bd96);
+impl windows_core::RuntimeType for IHttpRequestMessage2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpRequestMessage2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -322,12 +385,18 @@ pub struct IHttpRequestMessage2_Vtbl {
     pub SetPrivacyAnnotation: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpRequestMessageFactory, IHttpRequestMessageFactory_Vtbl, 0x5bac994e_3886_412e_aec3_52ec7f25616f);
+impl windows_core::RuntimeType for IHttpRequestMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpRequestMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpRequestResult, IHttpRequestResult_Vtbl, 0x6acf4da8_b5eb_4a35_a902_4217fbe820c5);
+impl windows_core::RuntimeType for IHttpRequestResult {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpRequestResult_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -337,6 +406,9 @@ pub struct IHttpRequestResult_Vtbl {
     pub Succeeded: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpResponseMessage, IHttpResponseMessage_Vtbl, 0xfee200fb_8664_44e0_95d9_42696199bffc);
+impl windows_core::RuntimeType for IHttpResponseMessage {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpResponseMessage_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -360,12 +432,18 @@ pub struct IHttpResponseMessage_Vtbl {
     pub EnsureSuccessStatusCode: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpResponseMessageFactory, IHttpResponseMessageFactory_Vtbl, 0x52a8af99_f095_43da_b60f_7cfc2bc7ea2f);
+impl windows_core::RuntimeType for IHttpResponseMessageFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpResponseMessageFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Create: unsafe extern "system" fn(*mut core::ffi::c_void, HttpStatusCode, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IHttpStreamContentFactory, IHttpStreamContentFactory_Vtbl, 0xf3e64d9d_f725_407e_942f_0eda189809f4);
+impl windows_core::RuntimeType for IHttpStreamContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpStreamContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -375,6 +453,9 @@ pub struct IHttpStreamContentFactory_Vtbl {
     CreateFromInputStream: usize,
 }
 windows_core::imp::define_interface!(IHttpStringContentFactory, IHttpStringContentFactory_Vtbl, 0x46649d5b_2e93_48eb_8e61_19677878e57f);
+impl windows_core::RuntimeType for IHttpStringContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpStringContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -389,6 +470,9 @@ pub struct IHttpStringContentFactory_Vtbl {
     CreateFromStringWithEncodingAndMediaType: usize,
 }
 windows_core::imp::define_interface!(IHttpTransportInformation, IHttpTransportInformation_Vtbl, 0x70127198_c6a7_4ed0_833a_83fd8b8f178d);
+impl windows_core::RuntimeType for IHttpTransportInformation {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IHttpTransportInformation_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -509,7 +593,7 @@ impl HttpBufferContent {
     }
 }
 impl windows_core::RuntimeType for HttpBufferContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContent>();
 }
 unsafe impl windows_core::Interface for HttpBufferContent {
     type Vtable = IHttpContent_Vtbl;
@@ -786,7 +870,7 @@ impl HttpClient {
     }
 }
 impl windows_core::RuntimeType for HttpClient {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpClient>();
 }
 unsafe impl windows_core::Interface for HttpClient {
     type Vtable = IHttpClient_Vtbl;
@@ -891,7 +975,7 @@ impl HttpCookie {
     }
 }
 impl windows_core::RuntimeType for HttpCookie {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpCookie>();
 }
 unsafe impl windows_core::Interface for HttpCookie {
     type Vtable = IHttpCookie_Vtbl;
@@ -958,7 +1042,7 @@ impl HttpCookieCollection {
 }
 #[cfg(feature = "Foundation_Collections")]
 impl windows_core::RuntimeType for HttpCookieCollection {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::super::Foundation::Collections::IVectorView<HttpCookie>>();
 }
 #[cfg(feature = "Foundation_Collections")]
 unsafe impl windows_core::Interface for HttpCookieCollection {
@@ -1034,7 +1118,7 @@ impl HttpCookieManager {
     }
 }
 impl windows_core::RuntimeType for HttpCookieManager {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpCookieManager>();
 }
 unsafe impl windows_core::Interface for HttpCookieManager {
     type Vtable = IHttpCookieManager_Vtbl;
@@ -1135,7 +1219,7 @@ impl HttpFormUrlEncodedContent {
     }
 }
 impl windows_core::RuntimeType for HttpFormUrlEncodedContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContent>();
 }
 unsafe impl windows_core::Interface for HttpFormUrlEncodedContent {
     type Vtable = IHttpContent_Vtbl;
@@ -1201,7 +1285,7 @@ impl HttpGetBufferResult {
     }
 }
 impl windows_core::RuntimeType for HttpGetBufferResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpGetBufferResult>();
 }
 unsafe impl windows_core::Interface for HttpGetBufferResult {
     type Vtable = IHttpGetBufferResult_Vtbl;
@@ -1267,7 +1351,7 @@ impl HttpGetInputStreamResult {
     }
 }
 impl windows_core::RuntimeType for HttpGetInputStreamResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpGetInputStreamResult>();
 }
 unsafe impl windows_core::Interface for HttpGetInputStreamResult {
     type Vtable = IHttpGetInputStreamResult_Vtbl;
@@ -1332,7 +1416,7 @@ impl HttpGetStringResult {
     }
 }
 impl windows_core::RuntimeType for HttpGetStringResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpGetStringResult>();
 }
 unsafe impl windows_core::Interface for HttpGetStringResult {
     type Vtable = IHttpGetStringResult_Vtbl;
@@ -1423,7 +1507,7 @@ impl HttpMethod {
     }
 }
 impl windows_core::RuntimeType for HttpMethod {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpMethod>();
 }
 unsafe impl windows_core::Interface for HttpMethod {
     type Vtable = IHttpMethod_Vtbl;
@@ -1549,7 +1633,7 @@ impl HttpMultipartContent {
     }
 }
 impl windows_core::RuntimeType for HttpMultipartContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContent>();
 }
 unsafe impl windows_core::Interface for HttpMultipartContent {
     type Vtable = IHttpContent_Vtbl;
@@ -1699,7 +1783,7 @@ impl HttpMultipartFormDataContent {
     }
 }
 impl windows_core::RuntimeType for HttpMultipartFormDataContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContent>();
 }
 unsafe impl windows_core::Interface for HttpMultipartFormDataContent {
     type Vtable = IHttpContent_Vtbl;
@@ -1843,7 +1927,7 @@ impl HttpRequestMessage {
     }
 }
 impl windows_core::RuntimeType for HttpRequestMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpRequestMessage>();
 }
 unsafe impl windows_core::Interface for HttpRequestMessage {
     type Vtable = IHttpRequestMessage_Vtbl;
@@ -1901,7 +1985,7 @@ impl HttpRequestResult {
     }
 }
 impl windows_core::RuntimeType for HttpRequestResult {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpRequestResult>();
 }
 unsafe impl windows_core::Interface for HttpRequestResult {
     type Vtable = IHttpRequestResult_Vtbl;
@@ -2043,7 +2127,7 @@ impl HttpResponseMessage {
     }
 }
 impl windows_core::RuntimeType for HttpResponseMessage {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpResponseMessage>();
 }
 unsafe impl windows_core::Interface for HttpResponseMessage {
     type Vtable = IHttpResponseMessage_Vtbl;
@@ -2144,7 +2228,7 @@ impl HttpStreamContent {
     }
 }
 impl windows_core::RuntimeType for HttpStreamContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContent>();
 }
 unsafe impl windows_core::Interface for HttpStreamContent {
     type Vtable = IHttpContent_Vtbl;
@@ -2255,7 +2339,7 @@ impl HttpStringContent {
     }
 }
 impl windows_core::RuntimeType for HttpStringContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpContent>();
 }
 unsafe impl windows_core::Interface for HttpStringContent {
     type Vtable = IHttpContent_Vtbl;
@@ -2313,7 +2397,7 @@ impl HttpTransportInformation {
     }
 }
 impl windows_core::RuntimeType for HttpTransportInformation {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IHttpTransportInformation>();
 }
 unsafe impl windows_core::Interface for HttpTransportInformation {
     type Vtable = IHttpTransportInformation_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(ISyndicationAttribute, ISyndicationAttribute_Vtbl, 0x71e8f969_526e_4001_9a91_e84f83161ab1);
+impl windows_core::RuntimeType for ISyndicationAttribute {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationAttribute_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -10,12 +13,18 @@ pub struct ISyndicationAttribute_Vtbl {
     pub SetValue: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationAttributeFactory, ISyndicationAttributeFactory_Vtbl, 0x624f1599_ed3e_420f_be86_640414886e4b);
+impl windows_core::RuntimeType for ISyndicationAttributeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationAttributeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateSyndicationAttribute: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationCategory, ISyndicationCategory_Vtbl, 0x8715626f_0cba_4a7f_89ff_ecb5281423b6);
+impl windows_core::RuntimeType for ISyndicationCategory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationCategory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -27,6 +36,9 @@ pub struct ISyndicationCategory_Vtbl {
     pub SetTerm: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationCategoryFactory, ISyndicationCategoryFactory_Vtbl, 0xab42802f_49e0_4525_8ab2_ab45c02528ff);
+impl windows_core::RuntimeType for ISyndicationCategoryFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationCategoryFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -148,6 +160,9 @@ pub struct ISyndicationClient_Vtbl {
     pub RetrieveFeedAsync: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationClientFactory, ISyndicationClientFactory_Vtbl, 0x2ec4b32c_a79b_4114_b29a_05dffbafb9a4);
+impl windows_core::RuntimeType for ISyndicationClientFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationClientFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -157,6 +172,9 @@ pub struct ISyndicationClientFactory_Vtbl {
     CreateSyndicationClient: usize,
 }
 windows_core::imp::define_interface!(ISyndicationContent, ISyndicationContent_Vtbl, 0x4641fefe_0e55_40d0_b8d0_6a2ccba9fc7c);
+impl windows_core::RuntimeType for ISyndicationContent {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationContent_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -164,6 +182,9 @@ pub struct ISyndicationContent_Vtbl {
     pub SetSourceUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationContentFactory, ISyndicationContentFactory_Vtbl, 0x3d2fbb93_9520_4173_9388_7e2df324a8a0);
+impl windows_core::RuntimeType for ISyndicationContentFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationContentFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -171,12 +192,18 @@ pub struct ISyndicationContentFactory_Vtbl {
     pub CreateSyndicationContentWithSourceUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationErrorStatics, ISyndicationErrorStatics_Vtbl, 0x1fbb2361_45c7_4833_8aa0_be5f3b58a7f4);
+impl windows_core::RuntimeType for ISyndicationErrorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationErrorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub GetStatus: unsafe extern "system" fn(*mut core::ffi::c_void, i32, *mut SyndicationErrorStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationFeed, ISyndicationFeed_Vtbl, 0x7ffe3cd2_5b66_4d62_8403_1bc10d910d6b);
+impl windows_core::RuntimeType for ISyndicationFeed {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationFeed_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -228,12 +255,18 @@ pub struct ISyndicationFeed_Vtbl {
     LoadFromXml: usize,
 }
 windows_core::imp::define_interface!(ISyndicationFeedFactory, ISyndicationFeedFactory_Vtbl, 0x23472232_8be9_48b7_8934_6205131d9357);
+impl windows_core::RuntimeType for ISyndicationFeedFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationFeedFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateSyndicationFeed: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationGenerator, ISyndicationGenerator_Vtbl, 0x9768b379_fb2b_4f6d_b41c_088a5868825c);
+impl windows_core::RuntimeType for ISyndicationGenerator {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationGenerator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -245,12 +278,18 @@ pub struct ISyndicationGenerator_Vtbl {
     pub SetVersion: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationGeneratorFactory, ISyndicationGeneratorFactory_Vtbl, 0xa34083e3_1e26_4dbc_ba9d_1ab84beff97b);
+impl windows_core::RuntimeType for ISyndicationGeneratorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationGeneratorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateSyndicationGenerator: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationItem, ISyndicationItem_Vtbl, 0x548db883_c384_45c1_8ae8_a378c4ec486c);
+impl windows_core::RuntimeType for ISyndicationItem {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationItem_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -299,12 +338,18 @@ pub struct ISyndicationItem_Vtbl {
     LoadFromXml: usize,
 }
 windows_core::imp::define_interface!(ISyndicationItemFactory, ISyndicationItemFactory_Vtbl, 0x251d434f_7db8_487a_85e4_10d191e66ebb);
+impl windows_core::RuntimeType for ISyndicationItemFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationItemFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateSyndicationItem: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, *mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationLink, ISyndicationLink_Vtbl, 0x27553abd_a10e_41b5_86bd_9759086eb0c5);
+impl windows_core::RuntimeType for ISyndicationLink {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationLink_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -322,6 +367,9 @@ pub struct ISyndicationLink_Vtbl {
     pub SetResourceLanguage: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationLinkFactory, ISyndicationLinkFactory_Vtbl, 0x5ed863d4_5535_48ac_98d4_c190995080b3);
+impl windows_core::RuntimeType for ISyndicationLinkFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationLinkFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -444,12 +492,18 @@ pub struct ISyndicationNode_Vtbl {
     GetXmlDocument: usize,
 }
 windows_core::imp::define_interface!(ISyndicationNodeFactory, ISyndicationNodeFactory_Vtbl, 0x12902188_4acb_49a8_b777_a5eb92e18a79);
+impl windows_core::RuntimeType for ISyndicationNodeFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationNodeFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateSyndicationNode: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, std::mem::MaybeUninit<windows_core::HSTRING>, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationPerson, ISyndicationPerson_Vtbl, 0xfa1ee5da_a7c6_4517_a096_0143faf29327);
+impl windows_core::RuntimeType for ISyndicationPerson {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationPerson_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -461,6 +515,9 @@ pub struct ISyndicationPerson_Vtbl {
     pub SetUri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(ISyndicationPersonFactory, ISyndicationPersonFactory_Vtbl, 0xdcf4886d_229d_4b58_a49b_f3d2f0f5c99f);
+impl windows_core::RuntimeType for ISyndicationPersonFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationPersonFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -612,6 +669,9 @@ pub struct ISyndicationText_Vtbl {
     SetXml: usize,
 }
 windows_core::imp::define_interface!(ISyndicationTextFactory, ISyndicationTextFactory_Vtbl, 0xee7342f7_11c6_4b25_ab62_e596bd162946);
+impl windows_core::RuntimeType for ISyndicationTextFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ISyndicationTextFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -676,7 +736,7 @@ impl SyndicationAttribute {
     }
 }
 impl windows_core::RuntimeType for SyndicationAttribute {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationAttribute>();
 }
 unsafe impl windows_core::Interface for SyndicationAttribute {
     type Vtable = ISyndicationAttribute_Vtbl;
@@ -834,7 +894,7 @@ impl SyndicationCategory {
     }
 }
 impl windows_core::RuntimeType for SyndicationCategory {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationCategory>();
 }
 unsafe impl windows_core::Interface for SyndicationCategory {
     type Vtable = ISyndicationCategory_Vtbl;
@@ -954,7 +1014,7 @@ impl SyndicationClient {
     }
 }
 impl windows_core::RuntimeType for SyndicationClient {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationClient>();
 }
 unsafe impl windows_core::Interface for SyndicationClient {
     type Vtable = ISyndicationClient_Vtbl;
@@ -1134,7 +1194,7 @@ impl SyndicationContent {
     }
 }
 impl windows_core::RuntimeType for SyndicationContent {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationContent>();
 }
 unsafe impl windows_core::Interface for SyndicationContent {
     type Vtable = ISyndicationContent_Vtbl;
@@ -1466,7 +1526,7 @@ impl SyndicationFeed {
     }
 }
 impl windows_core::RuntimeType for SyndicationFeed {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationFeed>();
 }
 unsafe impl windows_core::Interface for SyndicationFeed {
     type Vtable = ISyndicationFeed_Vtbl;
@@ -1621,7 +1681,7 @@ impl SyndicationGenerator {
     }
 }
 impl windows_core::RuntimeType for SyndicationGenerator {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationGenerator>();
 }
 unsafe impl windows_core::Interface for SyndicationGenerator {
     type Vtable = ISyndicationGenerator_Vtbl;
@@ -1933,7 +1993,7 @@ impl SyndicationItem {
     }
 }
 impl windows_core::RuntimeType for SyndicationItem {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationItem>();
 }
 unsafe impl windows_core::Interface for SyndicationItem {
     type Vtable = ISyndicationItem_Vtbl;
@@ -2133,7 +2193,7 @@ impl SyndicationLink {
     }
 }
 impl windows_core::RuntimeType for SyndicationLink {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationLink>();
 }
 unsafe impl windows_core::Interface for SyndicationLink {
     type Vtable = ISyndicationLink_Vtbl;
@@ -2252,7 +2312,7 @@ impl SyndicationNode {
     }
 }
 impl windows_core::RuntimeType for SyndicationNode {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationNode>();
 }
 unsafe impl windows_core::Interface for SyndicationNode {
     type Vtable = ISyndicationNode_Vtbl;
@@ -2416,7 +2476,7 @@ impl SyndicationPerson {
     }
 }
 impl windows_core::RuntimeType for SyndicationPerson {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationPerson>();
 }
 unsafe impl windows_core::Interface for SyndicationPerson {
     type Vtable = ISyndicationPerson_Vtbl;
@@ -2579,7 +2639,7 @@ impl SyndicationText {
     }
 }
 impl windows_core::RuntimeType for SyndicationText {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, ISyndicationText>();
 }
 unsafe impl windows_core::Interface for SyndicationText {
     type Vtable = ISyndicationText_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
@@ -1,4 +1,7 @@
 windows_core::imp::define_interface!(IWebViewControlAcceleratorKeyPressedEventArgs, IWebViewControlAcceleratorKeyPressedEventArgs_Vtbl, 0x77a2a53e_7c74_437d_a290_3ac0d8cd5655);
+impl windows_core::RuntimeType for IWebViewControlAcceleratorKeyPressedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlAcceleratorKeyPressedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -19,12 +22,18 @@ pub struct IWebViewControlAcceleratorKeyPressedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlMoveFocusRequestedEventArgs, IWebViewControlMoveFocusRequestedEventArgs_Vtbl, 0x6b2a340d_4bd0_405e_b7c1_1e72a492f446);
+impl windows_core::RuntimeType for IWebViewControlMoveFocusRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlMoveFocusRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Reason: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WebViewControlMoveFocusReason) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlProcess, IWebViewControlProcess_Vtbl, 0x02c723ec_98d6_424a_b63e_c6136c36a0f2);
+impl windows_core::RuntimeType for IWebViewControlProcess {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlProcess_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -41,12 +50,18 @@ pub struct IWebViewControlProcess_Vtbl {
     pub RemoveProcessExited: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlProcessFactory, IWebViewControlProcessFactory_Vtbl, 0x47b65cf9_a2d2_453c_b097_f6779d4b8e02);
+impl windows_core::RuntimeType for IWebViewControlProcessFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlProcessFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub CreateWithOptions: unsafe extern "system" fn(*mut core::ffi::c_void, *mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlProcessOptions, IWebViewControlProcessOptions_Vtbl, 0x1cca72a7_3bd6_4826_8261_6c8189505d89);
+impl windows_core::RuntimeType for IWebViewControlProcessOptions {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlProcessOptions_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -56,6 +71,9 @@ pub struct IWebViewControlProcessOptions_Vtbl {
     pub PrivateNetworkClientServerCapability: unsafe extern "system" fn(*mut core::ffi::c_void, *mut WebViewControlProcessCapabilityState) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlSite, IWebViewControlSite_Vtbl, 0x133f47c6_12dc_4898_bd47_04967de648ba);
+impl windows_core::RuntimeType for IWebViewControlSite {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlSite_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -74,6 +92,9 @@ pub struct IWebViewControlSite_Vtbl {
     pub RemoveAcceleratorKeyPressed: unsafe extern "system" fn(*mut core::ffi::c_void, super::super::super::Foundation::EventRegistrationToken) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlSite2, IWebViewControlSite2_Vtbl, 0xd13b2e3f_48ee_4730_8243_d2ed0c05606a);
+impl windows_core::RuntimeType for IWebViewControlSite2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlSite2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -590,7 +611,7 @@ impl WebViewControl {
     }
 }
 impl windows_core::RuntimeType for WebViewControl {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, super::IWebViewControl>();
 }
 unsafe impl windows_core::Interface for WebViewControl {
     type Vtable = super::IWebViewControl_Vtbl;
@@ -648,7 +669,7 @@ impl WebViewControlAcceleratorKeyPressedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlAcceleratorKeyPressedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlAcceleratorKeyPressedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlAcceleratorKeyPressedEventArgs {
     type Vtable = IWebViewControlAcceleratorKeyPressedEventArgs_Vtbl;
@@ -671,7 +692,7 @@ impl WebViewControlMoveFocusRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlMoveFocusRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlMoveFocusRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlMoveFocusRequestedEventArgs {
     type Vtable = IWebViewControlMoveFocusRequestedEventArgs_Vtbl;
@@ -762,7 +783,7 @@ impl WebViewControlProcess {
     }
 }
 impl windows_core::RuntimeType for WebViewControlProcess {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlProcess>();
 }
 unsafe impl windows_core::Interface for WebViewControlProcess {
     type Vtable = IWebViewControlProcess_Vtbl;
@@ -807,7 +828,7 @@ impl WebViewControlProcessOptions {
     }
 }
 impl windows_core::RuntimeType for WebViewControlProcessOptions {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlProcessOptions>();
 }
 unsafe impl windows_core::Interface for WebViewControlProcessOptions {
     type Vtable = IWebViewControlProcessOptions_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/mod.rs
@@ -498,18 +498,27 @@ pub struct IWebViewControl2_Vtbl {
     pub AddInitializeScript: unsafe extern "system" fn(*mut core::ffi::c_void, std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlContentLoadingEventArgs, IWebViewControlContentLoadingEventArgs_Vtbl, 0x9a3fccb2_b9bb_404b_a22b_66dccd1250c6);
+impl windows_core::RuntimeType for IWebViewControlContentLoadingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlContentLoadingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Uri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlDOMContentLoadedEventArgs, IWebViewControlDOMContentLoadedEventArgs_Vtbl, 0xbe8bc008_9541_4545_9ff2_2df585b29f7d);
+impl windows_core::RuntimeType for IWebViewControlDOMContentLoadedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlDOMContentLoadedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub Uri: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlDeferredPermissionRequest, IWebViewControlDeferredPermissionRequest_Vtbl, 0x2ce349e0_d759_445c_9926_8995298f152b);
+impl windows_core::RuntimeType for IWebViewControlDeferredPermissionRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlDeferredPermissionRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -520,6 +529,9 @@ pub struct IWebViewControlDeferredPermissionRequest_Vtbl {
     pub Deny: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlLongRunningScriptDetectedEventArgs, IWebViewControlLongRunningScriptDetectedEventArgs_Vtbl, 0x2a6e5bba_98b4_45bc_bbeb_0f69ce49c599);
+impl windows_core::RuntimeType for IWebViewControlLongRunningScriptDetectedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlLongRunningScriptDetectedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -528,6 +540,9 @@ pub struct IWebViewControlLongRunningScriptDetectedEventArgs_Vtbl {
     pub SetStopPageScriptExecution: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlNavigationCompletedEventArgs, IWebViewControlNavigationCompletedEventArgs_Vtbl, 0x20409918_4a15_4c46_a55d_f79edb0bde8b);
+impl windows_core::RuntimeType for IWebViewControlNavigationCompletedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlNavigationCompletedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -536,6 +551,9 @@ pub struct IWebViewControlNavigationCompletedEventArgs_Vtbl {
     pub WebErrorStatus: unsafe extern "system" fn(*mut core::ffi::c_void, *mut super::WebErrorStatus) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlNavigationStartingEventArgs, IWebViewControlNavigationStartingEventArgs_Vtbl, 0x0c9057c5_0a08_41c7_863b_71e3a9549137);
+impl windows_core::RuntimeType for IWebViewControlNavigationStartingEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlNavigationStartingEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -544,6 +562,9 @@ pub struct IWebViewControlNavigationStartingEventArgs_Vtbl {
     pub SetCancel: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlNewWindowRequestedEventArgs, IWebViewControlNewWindowRequestedEventArgs_Vtbl, 0x3df44bbb_a124_46d5_a083_d02cacdff5ad);
+impl windows_core::RuntimeType for IWebViewControlNewWindowRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlNewWindowRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -553,6 +574,9 @@ pub struct IWebViewControlNewWindowRequestedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlNewWindowRequestedEventArgs2, IWebViewControlNewWindowRequestedEventArgs2_Vtbl, 0xb53c5ca6_2aae_4bfc_92b9_c30e92b48098);
+impl windows_core::RuntimeType for IWebViewControlNewWindowRequestedEventArgs2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlNewWindowRequestedEventArgs2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -561,6 +585,9 @@ pub struct IWebViewControlNewWindowRequestedEventArgs2_Vtbl {
     pub GetDeferral: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlPermissionRequest, IWebViewControlPermissionRequest_Vtbl, 0xe5bc836c_f22f_40e2_95b2_7729f840eb7f);
+impl windows_core::RuntimeType for IWebViewControlPermissionRequest {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlPermissionRequest_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -573,12 +600,18 @@ pub struct IWebViewControlPermissionRequest_Vtbl {
     pub Deny: unsafe extern "system" fn(*mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlPermissionRequestedEventArgs, IWebViewControlPermissionRequestedEventArgs_Vtbl, 0x27204d51_2488_4cc5_968e_0a771e59c147);
+impl windows_core::RuntimeType for IWebViewControlPermissionRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlPermissionRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
     pub PermissionRequest: unsafe extern "system" fn(*mut core::ffi::c_void, *mut *mut core::ffi::c_void) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlScriptNotifyEventArgs, IWebViewControlScriptNotifyEventArgs_Vtbl, 0x491de57b_6f49_41bb_b591_51b85b817037);
+impl windows_core::RuntimeType for IWebViewControlScriptNotifyEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlScriptNotifyEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -586,6 +619,9 @@ pub struct IWebViewControlScriptNotifyEventArgs_Vtbl {
     pub Value: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlSettings, IWebViewControlSettings_Vtbl, 0xc9967fbf_5e98_4cfd_8cce_27b0911e3de8);
+impl windows_core::RuntimeType for IWebViewControlSettings {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlSettings_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -597,6 +633,9 @@ pub struct IWebViewControlSettings_Vtbl {
     pub IsScriptNotifyAllowed: unsafe extern "system" fn(*mut core::ffi::c_void, *mut bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs, IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs_Vtbl, 0xe3b81944_e4fc_43dc_94ca_f980f30bc51d);
+impl windows_core::RuntimeType for IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -605,6 +644,9 @@ pub struct IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs_Vtbl {
     pub SetHandled: unsafe extern "system" fn(*mut core::ffi::c_void, bool) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlUnviewableContentIdentifiedEventArgs, IWebViewControlUnviewableContentIdentifiedEventArgs_Vtbl, 0x4a9680db_88f2_4e20_b693_b4e2df4aa581);
+impl windows_core::RuntimeType for IWebViewControlUnviewableContentIdentifiedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlUnviewableContentIdentifiedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -613,6 +655,9 @@ pub struct IWebViewControlUnviewableContentIdentifiedEventArgs_Vtbl {
     pub MediaType: unsafe extern "system" fn(*mut core::ffi::c_void, *mut std::mem::MaybeUninit<windows_core::HSTRING>) -> windows_core::HRESULT,
 }
 windows_core::imp::define_interface!(IWebViewControlWebResourceRequestedEventArgs, IWebViewControlWebResourceRequestedEventArgs_Vtbl, 0x44d6524d_55a4_4d8b_891c_931d8e25d42e);
+impl windows_core::RuntimeType for IWebViewControlWebResourceRequestedEventArgs {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebViewControlWebResourceRequestedEventArgs_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -644,7 +689,7 @@ impl WebViewControlContentLoadingEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlContentLoadingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlContentLoadingEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlContentLoadingEventArgs {
     type Vtable = IWebViewControlContentLoadingEventArgs_Vtbl;
@@ -667,7 +712,7 @@ impl WebViewControlDOMContentLoadedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlDOMContentLoadedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlDOMContentLoadedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlDOMContentLoadedEventArgs {
     type Vtable = IWebViewControlDOMContentLoadedEventArgs_Vtbl;
@@ -712,7 +757,7 @@ impl WebViewControlDeferredPermissionRequest {
     }
 }
 impl windows_core::RuntimeType for WebViewControlDeferredPermissionRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlDeferredPermissionRequest>();
 }
 unsafe impl windows_core::Interface for WebViewControlDeferredPermissionRequest {
     type Vtable = IWebViewControlDeferredPermissionRequest_Vtbl;
@@ -746,7 +791,7 @@ impl WebViewControlLongRunningScriptDetectedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlLongRunningScriptDetectedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlLongRunningScriptDetectedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlLongRunningScriptDetectedEventArgs {
     type Vtable = IWebViewControlLongRunningScriptDetectedEventArgs_Vtbl;
@@ -783,7 +828,7 @@ impl WebViewControlNavigationCompletedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlNavigationCompletedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlNavigationCompletedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlNavigationCompletedEventArgs {
     type Vtable = IWebViewControlNavigationCompletedEventArgs_Vtbl;
@@ -817,7 +862,7 @@ impl WebViewControlNavigationStartingEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlNavigationStartingEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlNavigationStartingEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlNavigationStartingEventArgs {
     type Vtable = IWebViewControlNavigationStartingEventArgs_Vtbl;
@@ -879,7 +924,7 @@ impl WebViewControlNewWindowRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlNewWindowRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlNewWindowRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlNewWindowRequestedEventArgs {
     type Vtable = IWebViewControlNewWindowRequestedEventArgs_Vtbl;
@@ -935,7 +980,7 @@ impl WebViewControlPermissionRequest {
     }
 }
 impl windows_core::RuntimeType for WebViewControlPermissionRequest {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlPermissionRequest>();
 }
 unsafe impl windows_core::Interface for WebViewControlPermissionRequest {
     type Vtable = IWebViewControlPermissionRequest_Vtbl;
@@ -958,7 +1003,7 @@ impl WebViewControlPermissionRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlPermissionRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlPermissionRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlPermissionRequestedEventArgs {
     type Vtable = IWebViewControlPermissionRequestedEventArgs_Vtbl;
@@ -988,7 +1033,7 @@ impl WebViewControlScriptNotifyEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlScriptNotifyEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlScriptNotifyEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlScriptNotifyEventArgs {
     type Vtable = IWebViewControlScriptNotifyEventArgs_Vtbl;
@@ -1037,7 +1082,7 @@ impl WebViewControlSettings {
     }
 }
 impl windows_core::RuntimeType for WebViewControlSettings {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlSettings>();
 }
 unsafe impl windows_core::Interface for WebViewControlSettings {
     type Vtable = IWebViewControlSettings_Vtbl;
@@ -1071,7 +1116,7 @@ impl WebViewControlUnsupportedUriSchemeIdentifiedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlUnsupportedUriSchemeIdentifiedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlUnsupportedUriSchemeIdentifiedEventArgs {
     type Vtable = IWebViewControlUnsupportedUriSchemeIdentifiedEventArgs_Vtbl;
@@ -1108,7 +1153,7 @@ impl WebViewControlUnviewableContentIdentifiedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlUnviewableContentIdentifiedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlUnviewableContentIdentifiedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlUnviewableContentIdentifiedEventArgs {
     type Vtable = IWebViewControlUnviewableContentIdentifiedEventArgs_Vtbl;
@@ -1155,7 +1200,7 @@ impl WebViewControlWebResourceRequestedEventArgs {
     }
 }
 impl windows_core::RuntimeType for WebViewControlWebResourceRequestedEventArgs {
-    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self>();
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_class::<Self, IWebViewControlWebResourceRequestedEventArgs>();
 }
 unsafe impl windows_core::Interface for WebViewControlWebResourceRequestedEventArgs {
     type Vtable = IWebViewControlWebResourceRequestedEventArgs_Vtbl;

--- a/crates/libs/windows/src/Windows/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/mod.rs
@@ -33,6 +33,9 @@ pub struct IUriToStreamResolver_Vtbl {
     UriToStreamAsync: usize,
 }
 windows_core::imp::define_interface!(IWebErrorStatics, IWebErrorStatics_Vtbl, 0xfe616766_bf27_4064_87b7_6563bb11ce2e);
+impl windows_core::RuntimeType for IWebErrorStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer = windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWebErrorStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,

--- a/crates/samples/components/json_validator_winrt/src/bindings.rs
+++ b/crates/samples/components/json_validator_winrt/src/bindings.rs
@@ -12,6 +12,10 @@ windows_core::imp::define_interface!(
     IJsonValidator_Vtbl,
     0xe09cb12b_b13c_5139_8c99_6140bf80deb9
 );
+impl windows_core::RuntimeType for IJsonValidator {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonValidator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +30,10 @@ windows_core::imp::define_interface!(
     IJsonValidatorFactory_Vtbl,
     0x1cf4464e_ae9e_55d5_9539_0af4d8fc35aa
 );
+impl windows_core::RuntimeType for IJsonValidatorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonValidatorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,7 +92,7 @@ impl JsonValidator {
 }
 impl windows_core::RuntimeType for JsonValidator {
     const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::for_class::<Self>();
+        windows_core::imp::ConstBuffer::for_class::<Self, IJsonValidator>();
 }
 unsafe impl windows_core::Interface for JsonValidator {
     type Vtable = IJsonValidator_Vtbl;

--- a/crates/samples/components/json_validator_winrt_client/src/bindings.rs
+++ b/crates/samples/components/json_validator_winrt_client/src/bindings.rs
@@ -12,6 +12,10 @@ windows_core::imp::define_interface!(
     IJsonValidator_Vtbl,
     0xe09cb12b_b13c_5139_8c99_6140bf80deb9
 );
+impl windows_core::RuntimeType for IJsonValidator {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonValidator_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -26,6 +30,10 @@ windows_core::imp::define_interface!(
     IJsonValidatorFactory_Vtbl,
     0x1cf4464e_ae9e_55d5_9539_0af4d8fc35aa
 );
+impl windows_core::RuntimeType for IJsonValidatorFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IJsonValidatorFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -84,7 +92,7 @@ impl JsonValidator {
 }
 impl windows_core::RuntimeType for JsonValidator {
     const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::for_class::<Self>();
+        windows_core::imp::ConstBuffer::for_class::<Self, IJsonValidator>();
 }
 unsafe impl windows_core::Interface for JsonValidator {
     type Vtable = IJsonValidator_Vtbl;

--- a/crates/tests/component/src/bindings.rs
+++ b/crates/tests/component/src/bindings.rs
@@ -70,6 +70,10 @@ pub mod Nested {
     }
 }
 windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0x97540591_1323_59c0_9ae0_f510cae62e54);
+impl windows_core::RuntimeType for IClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -229,7 +233,7 @@ impl Class {
 }
 impl windows_core::RuntimeType for Class {
     const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::for_class::<Self>();
+        windows_core::imp::ConstBuffer::for_class::<Self, IClass>();
 }
 unsafe impl windows_core::Interface for Class {
     type Vtable = IClass_Vtbl;

--- a/crates/tests/component_client/src/bindings.rs
+++ b/crates/tests/component_client/src/bindings.rs
@@ -38,6 +38,10 @@ pub mod Nested {
     }
 }
 windows_core::imp::define_interface!(IClass, IClass_Vtbl, 0x97540591_1323_59c0_9ae0_f510cae62e54);
+impl windows_core::RuntimeType for IClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IClass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -197,7 +201,7 @@ impl Class {
 }
 impl windows_core::RuntimeType for Class {
     const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::for_class::<Self>();
+        windows_core::imp::ConstBuffer::for_class::<Self, IClass>();
 }
 unsafe impl windows_core::Interface for Class {
     type Vtable = IClass_Vtbl;

--- a/crates/tests/standalone/src/b_calendar.rs
+++ b/crates/tests/standalone/src/b_calendar.rs
@@ -1247,7 +1247,7 @@ impl Calendar {
 }
 impl windows_core::RuntimeType for Calendar {
     const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::for_class::<Self>();
+        windows_core::imp::ConstBuffer::for_class::<Self, ICalendar>();
 }
 unsafe impl windows_core::Interface for Calendar {
     type Vtable = ICalendar_Vtbl;
@@ -1322,6 +1322,10 @@ windows_core::imp::define_interface!(
     ICalendar_Vtbl,
     0xca30221d_86d9_40fb_a26b_d44eb7cf08ea
 );
+impl windows_core::RuntimeType for ICalendar {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1596,6 +1600,10 @@ windows_core::imp::define_interface!(
     ICalendarFactory_Vtbl,
     0x83f58412_e56b_4c75_a66e_0f63d57758a6
 );
+impl windows_core::RuntimeType for ICalendarFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1618,6 +1626,10 @@ windows_core::imp::define_interface!(
     ICalendarFactory2_Vtbl,
     0xb44b378c_ca7e_4590_9e72_ea2bec1a5115
 );
+impl windows_core::RuntimeType for ICalendarFactory2 {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ICalendarFactory2_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1656,16 +1668,6 @@ impl<T: windows_core::RuntimeType + 'static> IIterable<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterable<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = {
-        windows_core::imp::ConstBuffer::new()
-            .push_slice(b"pinterface(")
-            .push_slice(b"{faa585ea-6214-4217-afda-7f46de5869b3}")
-            .push_slice(b";")
-            .push_other(T::SIGNATURE)
-            .push_slice(b")")
-    };
-}
 impl<T: windows_core::RuntimeType> IntoIterator for IIterable<T> {
     type Item = T;
     type IntoIter = IIterator<Self::Item>;
@@ -1679,6 +1681,16 @@ impl<T: windows_core::RuntimeType> IntoIterator for &IIterable<T> {
     fn into_iter(self) -> Self::IntoIter {
         self.First().unwrap()
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterable<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = {
+        windows_core::imp::ConstBuffer::new()
+            .push_slice(b"pinterface(")
+            .push_slice(b"{faa585ea-6214-4217-afda-7f46de5869b3}")
+            .push_slice(b";")
+            .push_other(T::SIGNATURE)
+            .push_slice(b")")
+    };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IIterable<T> {
     type Vtable = IIterable_Vtbl<T>;
@@ -1761,16 +1773,6 @@ impl<T: windows_core::RuntimeType + 'static> IIterator<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterator<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = {
-        windows_core::imp::ConstBuffer::new()
-            .push_slice(b"pinterface(")
-            .push_slice(b"{6a79e863-4300-459a-9966-cbb660963ee1}")
-            .push_slice(b";")
-            .push_other(T::SIGNATURE)
-            .push_slice(b")")
-    };
-}
 impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
@@ -1780,6 +1782,16 @@ impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
         }
         result
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterator<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = {
+        windows_core::imp::ConstBuffer::new()
+            .push_slice(b"pinterface(")
+            .push_slice(b"{6a79e863-4300-459a-9966-cbb660963ee1}")
+            .push_slice(b";")
+            .push_other(T::SIGNATURE)
+            .push_slice(b")")
+    };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IIterator<T> {
     type Vtable = IIterator_Vtbl<T>;
@@ -1813,6 +1825,10 @@ windows_core::imp::define_interface!(
     ITimeZoneOnCalendar_Vtbl,
     0xbb3c25e5_46cf_4317_a3f5_02621ad54478
 );
+impl windows_core::RuntimeType for ITimeZoneOnCalendar {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct ITimeZoneOnCalendar_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -1922,16 +1938,6 @@ impl<T: windows_core::RuntimeType + 'static> IVectorView<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVectorView<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = {
-        windows_core::imp::ConstBuffer::new()
-            .push_slice(b"pinterface(")
-            .push_slice(b"{bbe1fa4c-b0e3-4583-baef-1f1b2e483e56}")
-            .push_slice(b";")
-            .push_other(T::SIGNATURE)
-            .push_slice(b")")
-    };
-}
 pub struct VectorViewIterator<T: windows_core::RuntimeType + 'static> {
     vector: Option<IVectorView<T>>,
     current: u32,
@@ -1966,6 +1972,16 @@ impl<T: windows_core::RuntimeType> IntoIterator for &IVectorView<T> {
     fn into_iter(self) -> Self::IntoIter {
         VectorViewIterator::new(Some(Clone::clone(self)))
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVectorView<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = {
+        windows_core::imp::ConstBuffer::new()
+            .push_slice(b"pinterface(")
+            .push_slice(b"{bbe1fa4c-b0e3-4583-baef-1f1b2e483e56}")
+            .push_slice(b";")
+            .push_other(T::SIGNATURE)
+            .push_slice(b")")
+    };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IVectorView<T> {
     type Vtable = IVectorView_Vtbl<T>;

--- a/crates/tests/standalone/src/b_uri.rs
+++ b/crates/tests/standalone/src/b_uri.rs
@@ -31,16 +31,6 @@ impl<T: windows_core::RuntimeType + 'static> IIterable<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterable<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = {
-        windows_core::imp::ConstBuffer::new()
-            .push_slice(b"pinterface(")
-            .push_slice(b"{faa585ea-6214-4217-afda-7f46de5869b3}")
-            .push_slice(b";")
-            .push_other(T::SIGNATURE)
-            .push_slice(b")")
-    };
-}
 impl<T: windows_core::RuntimeType> IntoIterator for IIterable<T> {
     type Item = T;
     type IntoIter = IIterator<Self::Item>;
@@ -54,6 +44,16 @@ impl<T: windows_core::RuntimeType> IntoIterator for &IIterable<T> {
     fn into_iter(self) -> Self::IntoIter {
         self.First().unwrap()
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterable<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = {
+        windows_core::imp::ConstBuffer::new()
+            .push_slice(b"pinterface(")
+            .push_slice(b"{faa585ea-6214-4217-afda-7f46de5869b3}")
+            .push_slice(b";")
+            .push_other(T::SIGNATURE)
+            .push_slice(b")")
+    };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IIterable<T> {
     type Vtable = IIterable_Vtbl<T>;
@@ -136,16 +136,6 @@ impl<T: windows_core::RuntimeType + 'static> IIterator<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterator<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = {
-        windows_core::imp::ConstBuffer::new()
-            .push_slice(b"pinterface(")
-            .push_slice(b"{6a79e863-4300-459a-9966-cbb660963ee1}")
-            .push_slice(b";")
-            .push_other(T::SIGNATURE)
-            .push_slice(b")")
-    };
-}
 impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
     type Item = T;
     fn next(&mut self) -> Option<Self::Item> {
@@ -155,6 +145,16 @@ impl<T: windows_core::RuntimeType> Iterator for IIterator<T> {
         }
         result
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IIterator<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = {
+        windows_core::imp::ConstBuffer::new()
+            .push_slice(b"pinterface(")
+            .push_slice(b"{6a79e863-4300-459a-9966-cbb660963ee1}")
+            .push_slice(b";")
+            .push_other(T::SIGNATURE)
+            .push_slice(b")")
+    };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IIterator<T> {
     type Vtable = IIterator_Vtbl<T>;
@@ -223,6 +223,10 @@ windows_core::imp::define_interface!(
     IUriEscapeStatics_Vtbl,
     0xc1d432ba_c824_4452_a7fd_512bc3bbe9a1
 );
+impl windows_core::RuntimeType for IUriEscapeStatics {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriEscapeStatics_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -242,6 +246,10 @@ windows_core::imp::define_interface!(
     IUriRuntimeClass_Vtbl,
     0x9e365e57_48b2_4160_956f_c7385120bbfc
 );
+impl windows_core::RuntimeType for IUriRuntimeClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriRuntimeClass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -316,6 +324,10 @@ windows_core::imp::define_interface!(
     IUriRuntimeClassFactory_Vtbl,
     0x44a9796f_723e_4fdf_a218_033e75b0c084
 );
+impl windows_core::RuntimeType for IUriRuntimeClassFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriRuntimeClassFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -336,6 +348,10 @@ windows_core::imp::define_interface!(
     IUriRuntimeClassWithAbsoluteCanonicalUri_Vtbl,
     0x758d9661_221c_480f_a339_50656673f46f
 );
+impl windows_core::RuntimeType for IUriRuntimeClassWithAbsoluteCanonicalUri {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IUriRuntimeClassWithAbsoluteCanonicalUri_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -436,16 +452,6 @@ impl<T: windows_core::RuntimeType + 'static> IVectorView<T> {
         }
     }
 }
-impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVectorView<T> {
-    const SIGNATURE: windows_core::imp::ConstBuffer = {
-        windows_core::imp::ConstBuffer::new()
-            .push_slice(b"pinterface(")
-            .push_slice(b"{bbe1fa4c-b0e3-4583-baef-1f1b2e483e56}")
-            .push_slice(b";")
-            .push_other(T::SIGNATURE)
-            .push_slice(b")")
-    };
-}
 pub struct VectorViewIterator<T: windows_core::RuntimeType + 'static> {
     vector: Option<IVectorView<T>>,
     current: u32,
@@ -480,6 +486,16 @@ impl<T: windows_core::RuntimeType> IntoIterator for &IVectorView<T> {
     fn into_iter(self) -> Self::IntoIter {
         VectorViewIterator::new(Some(Clone::clone(self)))
     }
+}
+impl<T: windows_core::RuntimeType + 'static> windows_core::RuntimeType for IVectorView<T> {
+    const SIGNATURE: windows_core::imp::ConstBuffer = {
+        windows_core::imp::ConstBuffer::new()
+            .push_slice(b"pinterface(")
+            .push_slice(b"{bbe1fa4c-b0e3-4583-baef-1f1b2e483e56}")
+            .push_slice(b";")
+            .push_other(T::SIGNATURE)
+            .push_slice(b")")
+    };
 }
 unsafe impl<T: windows_core::RuntimeType + 'static> windows_core::Interface for IVectorView<T> {
     type Vtable = IVectorView_Vtbl<T>;
@@ -568,6 +584,10 @@ windows_core::imp::define_interface!(
     IWwwFormUrlDecoderRuntimeClass_Vtbl,
     0xd45a0451_f225_4542_9296_0e1df5d254df
 );
+impl windows_core::RuntimeType for IWwwFormUrlDecoderRuntimeClass {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWwwFormUrlDecoderRuntimeClass_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -582,6 +602,10 @@ windows_core::imp::define_interface!(
     IWwwFormUrlDecoderRuntimeClassFactory_Vtbl,
     0x5b8c6b3d_24ae_41b5_a1bf_f0c3d544845b
 );
+impl windows_core::RuntimeType for IWwwFormUrlDecoderRuntimeClassFactory {
+    const SIGNATURE: windows_core::imp::ConstBuffer =
+        windows_core::imp::ConstBuffer::for_interface::<Self>();
+}
 #[repr(C)]
 pub struct IWwwFormUrlDecoderRuntimeClassFactory_Vtbl {
     pub base__: windows_core::IInspectable_Vtbl,
@@ -898,7 +922,7 @@ impl Uri {
 }
 impl windows_core::RuntimeType for Uri {
     const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::for_class::<Self>();
+        windows_core::imp::ConstBuffer::for_class::<Self, IUriRuntimeClass>();
 }
 unsafe impl windows_core::Interface for Uri {
     type Vtable = IUriRuntimeClass_Vtbl;
@@ -1035,7 +1059,7 @@ impl WwwFormUrlDecoder {
 }
 impl windows_core::RuntimeType for WwwFormUrlDecoder {
     const SIGNATURE: windows_core::imp::ConstBuffer =
-        windows_core::imp::ConstBuffer::for_class::<Self>();
+        windows_core::imp::ConstBuffer::for_class::<Self, IWwwFormUrlDecoderRuntimeClass>();
 }
 unsafe impl windows_core::Interface for WwwFormUrlDecoder {
     type Vtable = IWwwFormUrlDecoderRuntimeClass_Vtbl;

--- a/crates/tests/winrt/Cargo.toml
+++ b/crates/tests/winrt/Cargo.toml
@@ -9,18 +9,19 @@ path = "../../libs/windows"
 features = [
     "implement",
     "AI_MachineLearning",
+    "ApplicationModel_Activation",
+    "ApplicationModel_Appointments",
+    "ApplicationModel_Email",
+    "Data_Xml_Dom",
+    "Devices_Enumeration",
+    "Devices_WiFiDirect",
     "Foundation_Collections",
     "Foundation_Numerics",
     "Storage_Streams",
-    "Devices_WiFiDirect",
-    "ApplicationModel_Email",
-    "UI_Composition",
     "System",
-    "Data_Xml_Dom",
-    "ApplicationModel_Activation",
-    "ApplicationModel_Appointments",
-    "Win32_System_WinRT",
+    "UI_Composition",
     "Win32_System_Com",
+    "Win32_System_WinRT",
 ]
 
 [dev-dependencies]

--- a/crates/tests/winrt/tests/generic_guids.rs
+++ b/crates/tests/winrt/tests/generic_guids.rs
@@ -1,4 +1,4 @@
-use windows::{core::*, Foundation::Collections::*, Foundation::*};
+use windows::{core::*, Devices::Enumeration::*, Foundation::Collections::*, Foundation::*};
 
 #[test]
 fn signatures() {
@@ -15,72 +15,70 @@ fn signatures() {
 
 #[test]
 fn generic_guids() {
-    use windows::core::Interface;
-
     type A = IIterable<IStringable>;
-    type B = IKeyValuePair<windows::core::HSTRING, IAsyncOperationWithProgress<A, f32>>;
+    type B = IKeyValuePair<HSTRING, IAsyncOperationWithProgress<A, f32>>;
 
     //
     // Generated Windows.Foundation GUIDs
     //
     assert_eq!(
         IAsyncActionWithProgress::<A>::IID,
-        windows::core::GUID::from("DD725452-2DA3-5103-9C7D-22EE9BB14AD3")
+        GUID::from("DD725452-2DA3-5103-9C7D-22EE9BB14AD3")
     );
 
     assert_eq!(
         IAsyncOperationWithProgress::<A, B>::IID,
-        windows::core::GUID::from("94645425-B9E5-5B91-B509-8DA4DF6A8916")
+        GUID::from("94645425-B9E5-5B91-B509-8DA4DF6A8916")
     );
 
     assert_eq!(
         IAsyncOperation::<A>::IID,
-        windows::core::GUID::from("2BD35EE6-72D9-5C5D-9827-05EBB81487AB")
+        GUID::from("2BD35EE6-72D9-5C5D-9827-05EBB81487AB")
     );
 
     assert_eq!(
         IReferenceArray::<A>::IID,
-        windows::core::GUID::from("4A33FE03-E8B9-5346-A124-5449913ECA57")
+        GUID::from("4A33FE03-E8B9-5346-A124-5449913ECA57")
     );
 
     assert_eq!(
         IReference::<A>::IID,
-        windows::core::GUID::from("F9E4006C-6E8C-56DF-811C-61F9990EBFB0")
+        GUID::from("F9E4006C-6E8C-56DF-811C-61F9990EBFB0")
     );
 
     assert_eq!(
         AsyncActionProgressHandler::<A>::IID,
-        windows::core::GUID::from("C261D8D0-71BA-5F38-A239-872342253A18")
+        GUID::from("C261D8D0-71BA-5F38-A239-872342253A18")
     );
 
     assert_eq!(
         AsyncActionWithProgressCompletedHandler::<A>::IID,
-        windows::core::GUID::from("9A0D211C-0374-5D23-9E15-EAA3570FAE63")
+        GUID::from("9A0D211C-0374-5D23-9E15-EAA3570FAE63")
     );
 
     assert_eq!(
         AsyncOperationCompletedHandler::<A>::IID,
-        windows::core::GUID::from("9D534225-231F-55E7-A6D0-6C938E2D9160")
+        GUID::from("9D534225-231F-55E7-A6D0-6C938E2D9160")
     );
 
     assert_eq!(
         AsyncOperationProgressHandler::<A, B>::IID,
-        windows::core::GUID::from("264F1E0C-ABE4-590B-9D37-E1CC118ECC75")
+        GUID::from("264F1E0C-ABE4-590B-9D37-E1CC118ECC75")
     );
 
     assert_eq!(
         AsyncOperationWithProgressCompletedHandler::<A, B>::IID,
-        windows::core::GUID::from("C2D078D8-AC47-55AB-83E8-123B2BE5BC5A")
+        GUID::from("C2D078D8-AC47-55AB-83E8-123B2BE5BC5A")
     );
 
     assert_eq!(
         EventHandler::<A>::IID,
-        windows::core::GUID::from("FA0B7D80-7EFA-52DF-9B69-0574CE57ADA4")
+        GUID::from("FA0B7D80-7EFA-52DF-9B69-0574CE57ADA4")
     );
 
     assert_eq!(
         TypedEventHandler::<A, B>::IID,
-        windows::core::GUID::from("EDB31843-B4CF-56EB-925A-D4D0CE97A08D")
+        GUID::from("EDB31843-B4CF-56EB-925A-D4D0CE97A08D")
     );
 
     //
@@ -89,62 +87,62 @@ fn generic_guids() {
 
     assert_eq!(
         IIterable::<A>::IID,
-        windows::core::GUID::from("96565EB9-A692-59C8-BCB5-647CDE4E6C4D")
+        GUID::from("96565EB9-A692-59C8-BCB5-647CDE4E6C4D")
     );
 
     assert_eq!(
         IIterator::<A>::IID,
-        windows::core::GUID::from("3C9B1E27-8357-590B-8828-6E917F172390")
+        GUID::from("3C9B1E27-8357-590B-8828-6E917F172390")
     );
 
     assert_eq!(
         IKeyValuePair::<A, B>::IID,
-        windows::core::GUID::from("89336CD9-8B66-50A7-9759-EB88CCB2E1FE")
+        GUID::from("89336CD9-8B66-50A7-9759-EB88CCB2E1FE")
     );
 
     assert_eq!(
         IMapChangedEventArgs::<A>::IID,
-        windows::core::GUID::from("E1AA5138-12BD-51A1-8558-698DFD070ABE")
+        GUID::from("E1AA5138-12BD-51A1-8558-698DFD070ABE")
     );
 
     assert_eq!(
         IMapView::<A, B>::IID,
-        windows::core::GUID::from("B78F0653-FA89-59CF-BA95-726938AAE666")
+        GUID::from("B78F0653-FA89-59CF-BA95-726938AAE666")
     );
 
     assert_eq!(
         IMap::<A, B>::IID,
-        windows::core::GUID::from("9962CD50-09D5-5C46-B1E1-3C679C1C8FAE")
+        GUID::from("9962CD50-09D5-5C46-B1E1-3C679C1C8FAE")
     );
 
     assert_eq!(
         IObservableMap::<A, B>::IID,
-        windows::core::GUID::from("75F99E2A-137E-537E-A5B1-0B5A6245FC02")
+        GUID::from("75F99E2A-137E-537E-A5B1-0B5A6245FC02")
     );
 
     assert_eq!(
         IObservableVector::<A>::IID,
-        windows::core::GUID::from("D24C289F-2341-5128-AAA1-292DD0DC1950")
+        GUID::from("D24C289F-2341-5128-AAA1-292DD0DC1950")
     );
 
     assert_eq!(
         IVectorView::<A>::IID,
-        windows::core::GUID::from("5F07498B-8E14-556E-9D2E-2E98D5615DA9")
+        GUID::from("5F07498B-8E14-556E-9D2E-2E98D5615DA9")
     );
 
     assert_eq!(
         IVector::<A>::IID,
-        windows::core::GUID::from("0E3F106F-A266-50A1-8043-C90FCF3844F6")
+        GUID::from("0E3F106F-A266-50A1-8043-C90FCF3844F6")
     );
 
     assert_eq!(
         MapChangedEventHandler::<A, B>::IID,
-        windows::core::GUID::from("19046F0B-CF81-5DEC-BBB2-7CC250DA8B8B")
+        GUID::from("19046F0B-CF81-5DEC-BBB2-7CC250DA8B8B")
     );
 
     assert_eq!(
         VectorChangedEventHandler::<A>::IID,
-        windows::core::GUID::from("A1E9ACD7-E4DF-5A79-AEFA-DE07934AB0FB")
+        GUID::from("A1E9ACD7-E4DF-5A79-AEFA-DE07934AB0FB")
     );
 
     //
@@ -153,68 +151,83 @@ fn generic_guids() {
 
     assert_eq!(
         IReference::<bool>::IID,
-        windows::core::GUID::from("3C00FD60-2950-5939-A21A-2D12C5A01B8A")
+        GUID::from("3C00FD60-2950-5939-A21A-2D12C5A01B8A")
     );
 
     assert_eq!(
         IReference::<i8>::IID,
-        windows::core::GUID::from("95500129-FBF6-5AFC-89DF-70642D741990")
+        GUID::from("95500129-FBF6-5AFC-89DF-70642D741990")
     );
 
     assert_eq!(
         IReference::<i16>::IID,
-        windows::core::GUID::from("6EC9E41B-6709-5647-9918-A1270110FC4E")
+        GUID::from("6EC9E41B-6709-5647-9918-A1270110FC4E")
     );
 
     assert_eq!(
         IReference::<i32>::IID,
-        windows::core::GUID::from("548CEFBD-BC8A-5FA0-8DF2-957440FC8BF4")
+        GUID::from("548CEFBD-BC8A-5FA0-8DF2-957440FC8BF4")
     );
 
     assert_eq!(
         IReference::<i64>::IID,
-        windows::core::GUID::from("4DDA9E24-E69F-5C6A-A0A6-93427365AF2A")
+        GUID::from("4DDA9E24-E69F-5C6A-A0A6-93427365AF2A")
     );
 
     assert_eq!(
         IReference::<u8>::IID,
-        windows::core::GUID::from("e5198cc8-2873-55f5-b0a1-84ff9e4aad62")
+        GUID::from("e5198cc8-2873-55f5-b0a1-84ff9e4aad62")
     );
 
     assert_eq!(
         IReference::<u16>::IID,
-        windows::core::GUID::from("5AB7D2C3-6B62-5E71-A4B6-2D49C4F238FD")
+        GUID::from("5AB7D2C3-6B62-5E71-A4B6-2D49C4F238FD")
     );
 
     assert_eq!(
         IReference::<u32>::IID,
-        windows::core::GUID::from("513ef3af-e784-5325-a91e-97c2b8111cf3")
+        GUID::from("513ef3af-e784-5325-a91e-97c2b8111cf3")
     );
 
     assert_eq!(
         IReference::<u64>::IID,
-        windows::core::GUID::from("6755e376-53bb-568b-a11d-17239868309e")
+        GUID::from("6755e376-53bb-568b-a11d-17239868309e")
     );
 
     assert_eq!(
         IReference::<f32>::IID,
-        windows::core::GUID::from("719CC2BA-3E76-5DEF-9F1A-38D85A145EA8")
+        GUID::from("719CC2BA-3E76-5DEF-9F1A-38D85A145EA8")
     );
 
     assert_eq!(
         IReference::<f64>::IID,
-        windows::core::GUID::from("2F2D6C29-5473-5F3E-92E7-96572BB990E2")
+        GUID::from("2F2D6C29-5473-5F3E-92E7-96572BB990E2")
     );
 
     assert_eq!(
-        IReference::<windows::core::GUID>::IID,
-        windows::core::GUID::from("7D50F649-632C-51F9-849A-EE49428933EA")
+        IReference::<GUID>::IID,
+        GUID::from("7D50F649-632C-51F9-849A-EE49428933EA")
     );
 
     assert_eq!(
-        IReference::<windows::core::HSTRING>::IID,
-        windows::core::GUID::from("FD416DFB-2A07-52EB-AAE3-DFCE14116C05")
+        IReference::<HSTRING>::IID,
+        GUID::from("FD416DFB-2A07-52EB-AAE3-DFCE14116C05")
     );
 
     // TODO: structs and enums
+}
+
+// Test for https://github.com/microsoft/windows-rs/issues/2922
+#[test]
+fn generic_class_guid() {
+    unsafe {
+        assert_eq!(std::str::from_utf8_unchecked(IVectorView::<DeviceInformation>::SIGNATURE.as_slice()), "pinterface({bbe1fa4c-b0e3-4583-baef-1f1b2e483e56};rc(Windows.Devices.Enumeration.DeviceInformation;{aba0fb95-4398-489d-8e44-e6130927011f}))");
+
+        assert_eq!(std::str::from_utf8_unchecked(DeviceInformationCollection::SIGNATURE.as_slice()), "rc(Windows.Devices.Enumeration.DeviceInformationCollection;pinterface({bbe1fa4c-b0e3-4583-baef-1f1b2e483e56};rc(Windows.Devices.Enumeration.DeviceInformation;{aba0fb95-4398-489d-8e44-e6130927011f})))");
+    }
+
+    assert_eq!(
+        DeviceInformationCollection::IID,
+        GUID::from("E170688F-3495-5BF6-AAB5-9CAC17E0F10F")
+    );
 }

--- a/crates/tests/winrt/tests/generic_guids.rs
+++ b/crates/tests/winrt/tests/generic_guids.rs
@@ -220,6 +220,24 @@ fn generic_guids() {
 // Test for https://github.com/microsoft/windows-rs/issues/2922
 #[test]
 fn generic_class_guid() {
+    // First the non-generic case...
+
+    unsafe {
+        assert_eq!(
+            std::str::from_utf8_unchecked(IUriRuntimeClass::SIGNATURE.as_slice()),
+            "{9e365e57-48b2-4160-956f-c7385120bbfc}"
+        );
+
+        assert_eq!(
+            std::str::from_utf8_unchecked(Uri::SIGNATURE.as_slice()),
+            "rc(Windows.Foundation.Uri;{9e365e57-48b2-4160-956f-c7385120bbfc})"
+        );
+    }
+
+    assert_eq!(Uri::IID, GUID::from("9E365E57-48B2-4160-956F-C7385120BBFC"));
+
+    // Then the generic case...
+
     unsafe {
         assert_eq!(std::str::from_utf8_unchecked(IVectorView::<DeviceInformation>::SIGNATURE.as_slice()), "pinterface({bbe1fa4c-b0e3-4583-baef-1f1b2e483e56};rc(Windows.Devices.Enumeration.DeviceInformation;{aba0fb95-4398-489d-8e44-e6130927011f}))");
 


### PR DESCRIPTION
WinRT classes include the default interface signature as part of their SHA1 signature. Usually this is just the signature of the interface's GUID, however when the interface is generic this signature is the signature of the generic type itself. To keep things generic, I opted to generate `RuntimeType` implementations for all WinRT interfaces. This avoids having to special-case such classes. Previously, I only included implementations for non-exclusive interfaces. 

Fixes: #2922

Previously this was calculated correctly, but #2729 broke this edge case. This PR also adds a test case to ensure future optimizations don't break this calculation. Thanks to @riverar for tracking down the offending PR. 