### PR TITLE
Defer module name lowercase conversion for Windows

### DIFF
--- a/crates/libs/bindgen/src/rust/functions.rs
+++ b/crates/libs/bindgen/src/rust/functions.rs
@@ -3,7 +3,7 @@ use metadata::HasAttributes;
 
 pub fn writer(writer: &Writer, namespace: &str, def: metadata::MethodDef) -> TokenStream {
     // TODO: remove inline functions from metadata
-    if def.module_name() == "forceinline" {
+    if def.module_name() == "FORCEINLINE" {
         return quote! {};
     }
 
@@ -197,7 +197,10 @@ fn gen_win_function(writer: &Writer, namespace: &str, def: metadata::MethodDef) 
 fn gen_link(writer: &Writer, namespace: &str, signature: &metadata::Signature) -> TokenStream {
     let name = signature.def.name();
     let ident = to_ident(name);
-    let library = signature.def.module_name();
+
+    // Windows libs are always produced with lowercase module names.
+    let library = if namespace.starts_with("Windows.") { signature.def.module_name().to_lowercase() } else { signature.def.module_name().to_string() };
+
     let abi = method_def_extern_abi(signature.def);
 
     let symbol = if let Some(impl_map) = signature.def.impl_map() { impl_map.import_name() } else { name };

--- a/crates/libs/bindgen/src/rust/standalone.rs
+++ b/crates/libs/bindgen/src/rust/standalone.rs
@@ -92,7 +92,7 @@ pub fn standalone_imp(writer: &Writer) -> String {
     }
 
     for (function, namespace) in functions {
-        sorted.insert(&format!(".{}.{}", function.module_name(), function.name()), functions::writer(writer, namespace, function));
+        sorted.insert(&format!(".{}.{}", function.module_name().to_lowercase(), function.name()), functions::writer(writer, namespace, function));
     }
 
     for constant in constants {

--- a/crates/libs/metadata/src/tables.rs
+++ b/crates/libs/metadata/src/tables.rs
@@ -255,13 +255,8 @@ impl MethodDef {
         self.equal_range(1, MemberForwarded::MethodDef(*self).encode()).next()
     }
 
-    pub fn module_name(&self) -> String {
-        // TODO: riddle should always lower case the module name to avoid allocating here
-        let Some(impl_map) = self.impl_map() else {
-            return String::new();
-        };
-
-        impl_map.scope().name().to_lowercase()
+    pub fn module_name(&self) -> &'static str {
+        self.impl_map().map_or("", |map| map.scope().name())
     }
 
     pub fn signature(&self, generics: &[Type]) -> MethodDefSig {

--- a/crates/tools/lib/src/lib.rs
+++ b/crates/tools/lib/src/lib.rs
@@ -43,7 +43,8 @@ fn combine_libraries(
             continue;
         };
 
-        let library = method.module_name();
+        // Windows libs are always produced with lower case module names.
+        let library = method.module_name().to_lowercase();
         let impl_map = method.impl_map().expect("ImplMap not found");
         let flags = impl_map.flags();
         let name = impl_map.import_name().to_string();


### PR DESCRIPTION
This update just defers lowercasing function module names in `windows-metadata` to the point where they actually need to be lowercase in code generation to ensure the metadata reader faithfully preserves this information. 