### PR TITLE
Add diff check after workflow test run

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -176,3 +176,8 @@ jobs:
           cargo test -p windows_x86_64_gnu &&
           cargo test -p windows_x86_64_gnullvm &&
           cargo test -p windows_x86_64_msvc
+      - name: Check diff
+        shell: bash
+        run: |
+          git add -N .
+          git diff --exit-code || (echo 'Tests changed code in the repo.'; exit 1)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,8 +35,8 @@ jobs:
         run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
       - name: Add toolchain target
         run: rustup target add ${{ matrix.target }}
-      - name: Install clippy
-        run: rustup component add clippy
+      - name: Install fmt
+        run: rustup component add rustfmt
       - name: Fix environment
         uses: ./.github/actions/fix-environment
       - name: Test

--- a/crates/libs/version/src/bindings.rs
+++ b/crates/libs/version/src/bindings.rs
@@ -1,3 +1,5 @@
+// Test to see if yml diff check works...
+
 #![allow(
     non_snake_case,
     non_upper_case_globals,

--- a/crates/libs/version/src/bindings.rs
+++ b/crates/libs/version/src/bindings.rs
@@ -1,5 +1,3 @@
-// Test to see if yml diff check works...
-
 #![allow(
     non_snake_case,
     non_upper_case_globals,

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -66,13 +66,17 @@ jobs:
 
     yml.truncate(yml.len() - 3);
 
-    write!(&mut yml, r"
+    write!(
+        &mut yml,
+        r"
       - name: Check diff
         shell: bash
         run: |
           git add -N .
           git diff --exit-code || (echo 'Tests changed code in the repo.'; exit 1)
-").unwrap();
+"
+    )
+    .unwrap();
 
     std::fs::write(".github/workflows/test.yml", yml.as_bytes()).unwrap();
 }

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -43,8 +43,8 @@ jobs:
         run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
       - name: Add toolchain target
         run: rustup target add ${{ matrix.target }}
-      - name: Install clippy
-        run: rustup component add clippy
+      - name: Install fmt
+        run: rustup component add rustfmt
       - name: Fix environment
         uses: ./.github/actions/fix-environment
       - name: Test

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -65,6 +65,15 @@ jobs:
     }
 
     yml.truncate(yml.len() - 3);
+
+    write!(&mut yml, r"
+      - name: Check diff
+        shell: bash
+        run: |
+          git add -N .
+          git diff --exit-code || (echo 'Tests changed code in the repo.'; exit 1)
+").unwrap();
+
     std::fs::write(".github/workflows/test.yml", yml.as_bytes()).unwrap();
 }
 


### PR DESCRIPTION
As more of the library crates move to generating code internally for simplicity - e.g. `windows-version` and `windows-result` - rather than with separate tools - e.g. `tool_core` and `tool_windows` - I want to make sure we catch any discrepancies in the repo. 

The first two commits will just be to validate that differences are caught. The last commit should "fix" the build and complete the process. 