### PR TITLE
Update `windows-core` to generate its own bindings

### DIFF
--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -141,7 +141,6 @@ jobs:
           cargo clippy -p test_win32_arrays &&
           cargo clippy -p test_window_long &&
           cargo clippy -p test_winrt &&
-          cargo clippy -p tool_core &&
           cargo clippy -p tool_gnu &&
           cargo clippy -p tool_lib &&
           cargo clippy -p tool_license &&

--- a/.github/workflows/gen.yml
+++ b/.github/workflows/gen.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        tool: [windows, sys, yml, license, core, metadata]
+        tool: [windows, sys, yml, license, metadata]
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,8 +107,8 @@ jobs:
           cargo test -p test_dispatch &&
           cargo test -p test_does_not_return &&
           cargo test -p test_enums &&
-          cargo test -p test_error &&
           cargo clean &&
+          cargo test -p test_error &&
           cargo test -p test_event &&
           cargo test -p test_extensions &&
           cargo test -p test_handles &&
@@ -149,7 +149,6 @@ jobs:
           cargo test -p test_win32_arrays &&
           cargo test -p test_window_long &&
           cargo test -p test_winrt &&
-          cargo test -p tool_core &&
           cargo test -p tool_gnu &&
           cargo test -p tool_lib &&
           cargo test -p tool_license &&

--- a/crates/libs/core/Cargo.toml
+++ b/crates/libs/core/Cargo.toml
@@ -28,3 +28,7 @@ path = "../result"
 [dependencies]
 windows-implement = { path = "../implement",  version = "0.53" }
 windows-interface = { path = "../interface",  version = "0.53" }
+
+[dev-dependencies.windows-bindgen]
+version = "0.55"
+path = "../bindgen"

--- a/crates/libs/core/tests/bindings.rs
+++ b/crates/libs/core/tests/bindings.rs
@@ -1,0 +1,8 @@
+use windows_bindgen::*;
+
+#[test]
+fn bindings() -> Result<()> {
+    bindgen(["--etc", "tests/bindings.txt"])?;
+    bindgen(["--etc", "tests/com_bindings.txt"])?;
+    Ok(())
+}

--- a/crates/libs/core/tests/bindings.txt
+++ b/crates/libs/core/tests/bindings.txt
@@ -1,6 +1,6 @@
 // These will use `windows-sys` style bindings.
 
---out crates/libs/core/src/imp/bindings.rs
+--out src/imp/bindings.rs
 --config flatten sys minimal no-bindgen-comment
 
 --filter

--- a/crates/libs/core/tests/com_bindings.txt
+++ b/crates/libs/core/tests/com_bindings.txt
@@ -1,6 +1,6 @@
 // These will use `windows` style bindings and include COM APIs.
 
---out crates/libs/core/src/imp/com_bindings.rs
+--out src/imp/com_bindings.rs
 --config flatten minimal no-bindgen-comment
 
 --filter

--- a/crates/tools/core/Cargo.toml
+++ b/crates/tools/core/Cargo.toml
@@ -1,8 +1,0 @@
-[package]
-name = "tool_core"
-version = "0.0.0"
-edition = "2021"
-publish = false
-
-[dependencies.windows-bindgen]
-path = "../../libs/bindgen"

--- a/crates/tools/core/src/main.rs
+++ b/crates/tools/core/src/main.rs
@@ -1,7 +1,0 @@
-use windows_bindgen::*;
-
-fn main() -> Result<()> {
-    bindgen(["--etc", "crates/tools/core/bindings.txt"])?;
-    bindgen(["--etc", "crates/tools/core/com_bindings.txt"])?;
-    Ok(())
-}


### PR DESCRIPTION
Following #2940, the `windows-core` crate can generate its own bindings.