### PR TITLE
Fix for new Rust nightly warnings related to dead code

### DIFF
--- a/crates/libs/bindgen/src/rdl/mod.rs
+++ b/crates/libs/bindgen/src/rdl/mod.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use super::*;
 mod fmt;
 mod from_reader;

--- a/crates/libs/bindgen/src/rust/cfg.rs
+++ b/crates/libs/bindgen/src/rust/cfg.rs
@@ -6,7 +6,6 @@ pub struct Cfg {
     pub types: std::collections::BTreeMap<&'static str, std::collections::BTreeSet<metadata::TypeDef>>,
     pub core_types: std::collections::BTreeSet<metadata::Type>,
     pub arches: std::collections::BTreeSet<&'static str>,
-    pub implement: bool,
 }
 
 impl Cfg {
@@ -47,7 +46,7 @@ pub fn type_def_cfg(writer: &Writer, row: metadata::TypeDef, generics: &[metadat
     cfg
 }
 pub fn type_def_cfg_impl(writer: &Writer, def: metadata::TypeDef, generics: &[metadata::Type]) -> Cfg {
-    let mut cfg = Cfg { implement: true, ..Default::default() };
+    let mut cfg = Cfg::default();
 
     fn combine(writer: &Writer, def: metadata::TypeDef, generics: &[metadata::Type], cfg: &mut Cfg) {
         type_def_cfg_combine(writer, def, generics, cfg);

--- a/crates/libs/bindgen/src/winmd/writer/tables.rs
+++ b/crates/libs/bindgen/src/winmd/writer/tables.rs
@@ -1,4 +1,4 @@
-#![allow(non_snake_case)]
+#![allow(dead_code, non_snake_case)]
 
 use super::*;
 


### PR DESCRIPTION
New dead code detection can see through derived traits and detect fields that aren't used. It caught one case in the Rust code generator and there are a few cases in rdl and winmd generation that are still in the works that I've temporarily allowed. 
