### PR TITLE
Prep for type name deferral 

### DIFF
--- a/crates/libs/bindgen/src/metadata.rs
+++ b/crates/libs/bindgen/src/metadata.rs
@@ -418,10 +418,10 @@ pub fn type_def_has_callback(row: TypeDef) -> bool {
         false
     }
     let type_name = row.type_name();
-    if type_name.namespace.is_empty() {
+    if type_name.namespace().is_empty() {
         check(row)
     } else {
-        for row in row.reader().get_type_def(type_name.namespace, type_name.name) {
+        for row in row.reader().get_type_def(type_name.namespace(), type_name.name()) {
             if check(row) {
                 return true;
             }
@@ -473,7 +473,7 @@ pub fn type_interfaces(ty: &Type) -> Vec<Interface> {
                     "StaticAttribute" | "ActivatableAttribute" => {
                         for (_, arg) in attribute.args() {
                             if let Value::TypeName(type_name) = arg {
-                                let def = row.reader().get_type_def(type_name.namespace, type_name.name).next().expect("Type not found");
+                                let def = row.reader().get_type_def(type_name.namespace(), type_name.name()).next().expect("Type not found");
                                 result.push(Interface { ty: Type::TypeDef(def, Vec::new()), kind: InterfaceKind::Static });
                                 break;
                             }
@@ -601,10 +601,10 @@ pub fn type_def_has_explicit_layout(row: TypeDef) -> bool {
         false
     }
     let type_name = row.type_name();
-    if type_name.namespace.is_empty() {
+    if type_name.namespace().is_empty() {
         check(row)
     } else {
-        for row in row.reader().get_type_def(type_name.namespace, type_name.name) {
+        for row in row.reader().get_type_def(type_name.namespace(), type_name.name()) {
             if check(row) {
                 return true;
             }
@@ -635,10 +635,10 @@ pub fn type_def_has_packing(row: TypeDef) -> bool {
         false
     }
     let type_name = row.type_name();
-    if type_name.namespace.is_empty() {
+    if type_name.namespace().is_empty() {
         check(row)
     } else {
-        for row in row.reader().get_type_def(type_name.namespace, type_name.name) {
+        for row in row.reader().get_type_def(type_name.namespace(), type_name.name()) {
             if check(row) {
                 return true;
             }
@@ -741,7 +741,7 @@ pub fn type_def_bases(mut row: TypeDef) -> Vec<TypeDef> {
     loop {
         match row.extends() {
             Some(base) if base != TypeName::Object => {
-                row = row.reader().get_type_def(base.namespace, base.name).next().expect("Type not found");
+                row = row.reader().get_type_def(base.namespace(), base.name()).next().expect("Type not found");
                 bases.push(row);
             }
             _ => break,

--- a/crates/libs/bindgen/src/rdl/from_reader.rs
+++ b/crates/libs/bindgen/src/rdl/from_reader.rs
@@ -169,12 +169,12 @@ impl Writer {
 
     fn type_def(&self, def: metadata::TypeDef) -> TokenStream {
         if let Some(extends) = def.extends() {
-            if extends.namespace == "System" {
-                if extends.name == "Enum" {
+            if extends.namespace() == "System" {
+                if extends.name() == "Enum" {
                     self.enum_def(def)
-                } else if extends.name == "ValueType" {
+                } else if extends.name() == "ValueType" {
                     self.struct_def(def)
-                } else if extends.name == "MulticastDelegate" {
+                } else if extends.name() == "MulticastDelegate" {
                     self.delegate_def(def)
                 } else {
                     self.class_def(def)
@@ -294,8 +294,8 @@ impl Writer {
 
         if let Some(type_name) = def.extends() {
             if type_name != metadata::TypeName::Object {
-                let namespace = self.namespace(type_name.namespace);
-                let name = to_ident(type_name.name);
+                let namespace = self.namespace(type_name.namespace());
+                let name = to_ident(type_name.name());
                 // TODO: ideally the "class" contextual keyword wouldn't be needed here
                 // but currently there's no way to tell the base class apart from a required interface.
                 types.insert(0, quote! { class #namespace #name });
@@ -356,8 +356,8 @@ impl Writer {
             }
 
             metadata::Type::TypeRef(type_name) => {
-                let namespace = self.namespace(type_name.namespace);
-                let name = to_ident(type_name.name);
+                let namespace = self.namespace(type_name.namespace());
+                let name = to_ident(type_name.name());
                 quote! { #namespace #name }
             }
 

--- a/crates/libs/bindgen/src/rust/cfg.rs
+++ b/crates/libs/bindgen/src/rust/cfg.rs
@@ -80,7 +80,7 @@ pub fn type_def_cfg_combine(writer: &Writer, row: metadata::TypeDef, generics: &
         type_cfg_combine(writer, generic, cfg);
     }
 
-    if cfg.types.entry(type_name.namespace).or_default().insert(row) {
+    if cfg.types.entry(type_name.namespace()).or_default().insert(row) {
         match type_kind {
             metadata::TypeKind::Class => {
                 if let Some(default_interface) = metadata::type_def_default_interface(row) {
@@ -98,8 +98,8 @@ pub fn type_def_cfg_combine(writer: &Writer, row: metadata::TypeDef, generics: &
             }
             metadata::TypeKind::Struct => {
                 row.fields().for_each(|field| field_cfg_combine(writer, field, Some(row), cfg));
-                if !type_name.namespace.is_empty() {
-                    for def in row.reader().get_type_def(type_name.namespace, type_name.name) {
+                if !type_name.namespace().is_empty() {
+                    for def in row.reader().get_type_def(type_name.namespace(), type_name.name()) {
                         if def != row {
                             type_def_cfg_combine(writer, def, &[], cfg);
                         }

--- a/crates/libs/bindgen/src/rust/enums.rs
+++ b/crates/libs/bindgen/src/rust/enums.rs
@@ -3,7 +3,7 @@ use metadata::HasAttributes;
 
 pub fn writer(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
     let type_name = def.type_name();
-    let ident = to_ident(type_name.name);
+    let ident = to_ident(type_name.name());
     let underlying_type = def.underlying_type();
     let underlying_type = writer.type_name(&underlying_type);
 
@@ -72,7 +72,7 @@ pub fn writer(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
     }
 
     if !writer.sys {
-        let name = type_name.name;
+        let name = type_name.name();
         tokens.combine(&quote! {
             #features
             impl windows_core::TypeKind for #ident {

--- a/crates/libs/bindgen/src/rust/handles.rs
+++ b/crates/libs/bindgen/src/rust/handles.rs
@@ -92,8 +92,8 @@ pub fn gen_win_handle(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
 
     if let Some(dependency) = type_def_usable_for(def) {
         let type_name = dependency.type_name();
-        let mut dependency = writer.namespace(type_name.namespace);
-        dependency.push_str(type_name.name);
+        let mut dependency = writer.namespace(type_name.namespace());
+        dependency.push_str(type_name.name());
 
         tokens.combine(&quote! {
             impl windows_core::CanInto<#dependency> for #ident {}

--- a/crates/libs/bindgen/src/rust/mod.rs
+++ b/crates/libs/bindgen/src/rust/mod.rs
@@ -186,13 +186,13 @@ fn namespace(writer: &Writer, tree: &Tree) -> String {
         match item {
             metadata::Item::Type(def) => {
                 let type_name = def.type_name();
-                if writer.reader.remap_types().any(|(x, _)| x == &type_name) {
+                if writer.reader.remap_type(&type_name).is_some() {
                     continue;
                 }
-                if writer.reader.core_types().any(|(x, _)| x == &type_name) {
+                if writer.reader.core_type(&type_name).is_some() {
                     continue;
                 }
-                types.entry(def.kind()).or_default().entry(type_name.name).or_default().combine(&writer.type_def(def));
+                types.entry(def.kind()).or_default().entry(type_name.name()).or_default().combine(&writer.type_def(def));
             }
             metadata::Item::Fn(def, namespace) => {
                 let name = def.name();
@@ -230,7 +230,7 @@ fn namespace_impl(writer: &Writer, tree: &Tree) -> String {
     for item in writer.reader.namespace_items(tree.namespace) {
         if let metadata::Item::Type(def) = item {
             let type_name = def.type_name();
-            if writer.reader.core_types().any(|(x, _)| x == &type_name) {
+            if writer.reader.core_type(&type_name).is_some() {
                 continue;
             }
             if def.kind() != metadata::TypeKind::Interface {
@@ -239,7 +239,7 @@ fn namespace_impl(writer: &Writer, tree: &Tree) -> String {
             let tokens = implements::writer(writer, def);
 
             if !tokens.is_empty() {
-                types.insert(type_name.name, tokens);
+                types.insert(type_name.name(), tokens);
             }
         }
     }

--- a/crates/libs/bindgen/src/rust/standalone.rs
+++ b/crates/libs/bindgen/src/rust/standalone.rs
@@ -154,8 +154,8 @@ fn type_collect_standalone(writer: &Writer, ty: &metadata::Type, set: &mut std::
     // Note this is a bit overeager as we can collect a typedef that is used
     // by one architecture but not by another
     let type_name = def.type_name();
-    if !type_name.namespace.is_empty() {
-        for row in def.reader().get_type_def(type_name.namespace, type_name.name) {
+    if !type_name.namespace().is_empty() {
+        for row in def.reader().get_type_def(type_name.namespace(), type_name.name()) {
             if def != row {
                 type_collect_standalone(writer, &metadata::Type::TypeDef(row, Vec::new()), set);
             }

--- a/crates/libs/bindgen/src/rust/writer.rs
+++ b/crates/libs/bindgen/src/rust/writer.rs
@@ -56,11 +56,11 @@ impl Writer {
     pub fn type_def_name_imp(&self, def: metadata::TypeDef, generics: &[metadata::Type], suffix: &str) -> TokenStream {
         let type_name = def.type_name();
 
-        if type_name.namespace.is_empty() {
+        if type_name.namespace().is_empty() {
             to_ident(&self.scoped_name(def))
         } else {
-            let mut namespace = self.namespace(type_name.namespace);
-            let mut name = to_ident(type_name.name);
+            let mut namespace = self.namespace(type_name.namespace());
+            let mut name = to_ident(type_name.name());
             name.push_str(suffix);
 
             if generics.is_empty() || self.sys {
@@ -106,7 +106,7 @@ impl Writer {
         } else {
             let kind = self.type_name(ty);
 
-            if ty.is_generic() {
+            if matches!(ty, metadata::Type::GenericParam(_)) {
                 quote! { <#kind as windows_core::Type<#kind>>::Default }
             } else if metadata::type_is_nullable(ty) && !self.sys {
                 quote! { Option<#kind> }

--- a/crates/libs/bindgen/src/winmd/from_reader.rs
+++ b/crates/libs/bindgen/src/winmd/from_reader.rs
@@ -23,7 +23,7 @@ pub fn from_reader(reader: &metadata::Reader, config: std::collections::BTreeMap
 
         let generics = &metadata::type_def_generics(def);
 
-        let extends = if let Some(extends) = def.extends() { writer.insert_type_ref(extends.namespace, extends.name) } else { TypeDefOrRef::none() };
+        let extends = if let Some(extends) = def.extends() { writer.insert_type_ref(extends.namespace(), extends.name()) } else { TypeDefOrRef::none() };
 
         writer.tables.TypeDef.push(TypeDef {
             Extends: extends,

--- a/crates/libs/metadata/src/filter.rs
+++ b/crates/libs/metadata/src/filter.rs
@@ -84,7 +84,7 @@ mod tests {
 
     fn includes_type_name(filter: &Filter, full_name: &'static str) -> bool {
         let type_name = crate::TypeName::parse(full_name);
-        filter.includes_type_name(type_name.namespace, type_name.name)
+        filter.includes_type_name(type_name.namespace(), type_name.name())
     }
 
     #[test]

--- a/crates/libs/metadata/src/tables.rs
+++ b/crates/libs/metadata/src/tables.rs
@@ -109,7 +109,7 @@ impl Attribute {
                 0x50 => Value::TypeName(TypeName::parse(values.read_str())),
                 0x55 => {
                     let type_name = TypeName::parse(name);
-                    let def = reader.get_type_def(type_name.namespace, type_name.name).next().expect("Type not found");
+                    let def = reader.get_type_def(type_name.namespace(), type_name.name()).next().expect("Type not found");
                     name = values.read_str();
                     Value::EnumDef(def, Box::new(values.read_integer(def.underlying_type())))
                 }

--- a/crates/libs/metadata/src/type.rs
+++ b/crates/libs/metadata/src/type.rs
@@ -144,11 +144,6 @@ impl Type {
         matches!(self, Type::ConstRef(_))
     }
 
-    /// Returns `true` if the `Type` is a generic parameter.
-    pub fn is_generic(&self) -> bool {
-        matches!(self, Type::GenericParam(_))
-    }
-
     /// Returns `true` if the `Type` is a pointer.
     pub fn is_pointer(&self) -> bool {
         matches!(self, Type::ConstPtr(_, _) | Type::MutPtr(_, _))

--- a/crates/libs/metadata/src/type_name.rs
+++ b/crates/libs/metadata/src/type_name.rs
@@ -1,68 +1,72 @@
 #![allow(non_upper_case_globals)]
 
-#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq, Ord, PartialOrd)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Ord, PartialOrd)]
 pub struct TypeName {
-    pub namespace: &'static str,
-    pub name: &'static str,
+    namespace: &'static str,
+    name: &'static str,
 }
 
 impl TypeName {
-    pub const Enum: Self = Self::from_const("System", "Enum");
-    pub const Delegate: Self = Self::from_const("System", "MulticastDelegate");
-    pub const Struct: Self = Self::from_const("System", "ValueType");
-    pub const Object: Self = Self::from_const("System", "Object");
-    pub const GUID: Self = Self::from_const("System", "Guid");
-    pub const Type: Self = Self::from_const("System", "Type");
-    pub const Attribute: Self = Self::from_const("System", "Attribute");
-    pub const IsConst: Self = Self::from_const("System.Runtime.CompilerServices", "IsConst");
+    pub const Enum: Self = Self::new("System", "Enum");
+    pub const Delegate: Self = Self::new("System", "MulticastDelegate");
+    pub const Struct: Self = Self::new("System", "ValueType");
+    pub const Object: Self = Self::new("System", "Object");
+    pub const GUID: Self = Self::new("System", "Guid");
+    pub const Type: Self = Self::new("System", "Type");
+    pub const Attribute: Self = Self::new("System", "Attribute");
+    pub const IsConst: Self = Self::new("System.Runtime.CompilerServices", "IsConst");
 
-    pub const HResult: Self = Self::from_const("Windows.Foundation", "HResult");
-    pub const IAsyncAction: Self = Self::from_const("Windows.Foundation", "IAsyncAction");
-    pub const IAsyncActionWithProgress: Self = Self::from_const("Windows.Foundation", "IAsyncActionWithProgress");
-    pub const IAsyncOperation: Self = Self::from_const("Windows.Foundation", "IAsyncOperation");
-    pub const IAsyncOperationWithProgress: Self = Self::from_const("Windows.Foundation", "IAsyncOperationWithProgress");
+    pub const HResult: Self = Self::new("Windows.Foundation", "HResult");
+    pub const IAsyncAction: Self = Self::new("Windows.Foundation", "IAsyncAction");
+    pub const IAsyncActionWithProgress: Self = Self::new("Windows.Foundation", "IAsyncActionWithProgress");
+    pub const IAsyncOperation: Self = Self::new("Windows.Foundation", "IAsyncOperation");
+    pub const IAsyncOperationWithProgress: Self = Self::new("Windows.Foundation", "IAsyncOperationWithProgress");
 
-    pub const Matrix3x2: Self = Self::from_const("Windows.Foundation.Numerics", "Matrix3x2");
-    pub const Matrix4x4: Self = Self::from_const("Windows.Foundation.Numerics", "Matrix4x4");
+    pub const Matrix3x2: Self = Self::new("Windows.Foundation.Numerics", "Matrix3x2");
+    pub const Matrix4x4: Self = Self::new("Windows.Foundation.Numerics", "Matrix4x4");
 
-    pub const IIterable: Self = Self::from_const("Windows.Foundation.Collections", "IIterable");
-    pub const IIterator: Self = Self::from_const("Windows.Foundation.Collections", "IIterator");
-    pub const IVectorView: Self = Self::from_const("Windows.Foundation.Collections", "IVectorView");
-    pub const IVector: Self = Self::from_const("Windows.Foundation.Collections", "IVector");
+    pub const IIterable: Self = Self::new("Windows.Foundation.Collections", "IIterable");
+    pub const IIterator: Self = Self::new("Windows.Foundation.Collections", "IIterator");
+    pub const IVectorView: Self = Self::new("Windows.Foundation.Collections", "IVectorView");
+    pub const IVector: Self = Self::new("Windows.Foundation.Collections", "IVector");
 
-    pub const PWSTR: Self = Self::from_const("Windows.Win32.Foundation", "PWSTR");
-    pub const PSTR: Self = Self::from_const("Windows.Win32.Foundation", "PSTR");
-    pub const BSTR: Self = Self::from_const("Windows.Win32.Foundation", "BSTR");
-    pub const HANDLE: Self = Self::from_const("Windows.Win32.Foundation", "HANDLE");
-    pub const HRESULT: Self = Self::from_const("Windows.Win32.Foundation", "HRESULT");
-    pub const CHAR: Self = Self::from_const("Windows.Win32.Foundation", "CHAR");
-    pub const BOOL: Self = Self::from_const("Windows.Win32.Foundation", "BOOL");
-    pub const WIN32_ERROR: Self = Self::from_const("Windows.Win32.Foundation", "WIN32_ERROR");
-    pub const NTSTATUS: Self = Self::from_const("Windows.Win32.Foundation", "NTSTATUS");
-    pub const RPC_STATUS: Self = Self::from_const("Windows.Win32.System.Rpc", "RPC_STATUS");
+    pub const PWSTR: Self = Self::new("Windows.Win32.Foundation", "PWSTR");
+    pub const PSTR: Self = Self::new("Windows.Win32.Foundation", "PSTR");
+    pub const BSTR: Self = Self::new("Windows.Win32.Foundation", "BSTR");
+    pub const HANDLE: Self = Self::new("Windows.Win32.Foundation", "HANDLE");
+    pub const HRESULT: Self = Self::new("Windows.Win32.Foundation", "HRESULT");
+    pub const CHAR: Self = Self::new("Windows.Win32.Foundation", "CHAR");
+    pub const BOOL: Self = Self::new("Windows.Win32.Foundation", "BOOL");
+    pub const WIN32_ERROR: Self = Self::new("Windows.Win32.Foundation", "WIN32_ERROR");
+    pub const NTSTATUS: Self = Self::new("Windows.Win32.Foundation", "NTSTATUS");
+    pub const RPC_STATUS: Self = Self::new("Windows.Win32.System.Rpc", "RPC_STATUS");
 
-    pub const D2D_MATRIX_3X2_F: Self = Self::from_const("Windows.Win32.Graphics.Direct2D.Common", "D2D_MATRIX_3X2_F");
-    pub const D3DMATRIX: Self = Self::from_const("Windows.Win32.Graphics.Direct3D", "D3DMATRIX");
-    pub const IUnknown: Self = Self::from_const("Windows.Win32.System.Com", "IUnknown");
-    pub const HSTRING: Self = Self::from_const("Windows.Win32.System.WinRT", "HSTRING");
-    pub const IInspectable: Self = Self::from_const("Windows.Win32.System.WinRT", "IInspectable");
-    pub const IRestrictedErrorInfo: Self = Self::from_const("Windows.Win32.System.WinRT", "IRestrictedErrorInfo");
-    pub const IDispatch: Self = Self::from_const("Windows.Win32.System.Com", "IDispatch");
+    pub const D2D_MATRIX_3X2_F: Self = Self::new("Windows.Win32.Graphics.Direct2D.Common", "D2D_MATRIX_3X2_F");
+    pub const D3DMATRIX: Self = Self::new("Windows.Win32.Graphics.Direct3D", "D3DMATRIX");
+    pub const IUnknown: Self = Self::new("Windows.Win32.System.Com", "IUnknown");
+    pub const HSTRING: Self = Self::new("Windows.Win32.System.WinRT", "HSTRING");
+    pub const IInspectable: Self = Self::new("Windows.Win32.System.WinRT", "IInspectable");
+    pub const IRestrictedErrorInfo: Self = Self::new("Windows.Win32.System.WinRT", "IRestrictedErrorInfo");
+    pub const IDispatch: Self = Self::new("Windows.Win32.System.Com", "IDispatch");
 
-    pub const VARIANT: Self = Self::from_const("Windows.Win32.System.Variant", "VARIANT");
-    pub const PROPVARIANT: Self = Self::from_const("Windows.Win32.System.Com.StructuredStorage", "PROPVARIANT");
+    pub const VARIANT: Self = Self::new("Windows.Win32.System.Variant", "VARIANT");
+    pub const PROPVARIANT: Self = Self::new("Windows.Win32.System.Com.StructuredStorage", "PROPVARIANT");
 
-    const fn from_const(namespace: &'static str, name: &'static str) -> Self {
-        Self { namespace, name }
-    }
-
-    pub fn new(namespace: &'static str, name: &'static str) -> Self {
+    pub const fn new(namespace: &'static str, name: &'static str) -> Self {
         Self { namespace, name }
     }
 
     pub fn parse(full_name: &'static str) -> Self {
         let index = full_name.rfind('.').expect("Expected full name separated with `.`");
         Self::new(&full_name[0..index], &full_name[index + 1..])
+    }
+
+    pub fn namespace(&self) -> &'static str {
+        self.namespace
+    }
+
+    pub fn name(&self) -> &'static str {
+        self.name
     }
 }
 


### PR DESCRIPTION
Increasingly the type specialization and remapping has become a liability as its baked into the `windows-metadata` reader rather than specialized during code generation. This is making things like #2939 harder to tackle. This update just takes care of some housekeeping around type name representation in preparation for a subsequent update that should model types more generically in the metadata crate. This should also lead toward a more general representation of type names that can be used for both reading and writing, the latter of which currently has mirror types for these. 