### PR TITLE
Simplify type remapping

### DIFF
--- a/crates/libs/metadata/src/reader.rs
+++ b/crates/libs/metadata/src/reader.rs
@@ -141,11 +141,7 @@ impl Reader {
     }
 
     pub fn remap_type(&self, type_name: &TypeName) -> Option<TypeName> {
-        if self.sys {
-            None
-        } else {
-            REMAP_TYPES.iter().find_map(|(key, value)| (type_name == key).then(|| value.clone()))
-        }
+        REMAP_TYPES.iter().find_map(|(key, value)| (type_name == key).then(|| value.clone()))
     }
 
     pub fn core_type(&self, type_name: &TypeName) -> Option<Type> {
@@ -264,8 +260,8 @@ impl Reader {
 }
 
 // TODO: this should be in riddle's Rust generator if at all - perhaps as convertible types rather than remapped types since there's already some precedent for that.
-const REMAP_TYPES: [(TypeName, TypeName); 2] = [(TypeName::D2D_MATRIX_3X2_F, TypeName::Matrix3x2), (TypeName::D3DMATRIX, TypeName::Matrix4x4)];
+const REMAP_TYPES: [(TypeName, TypeName); 3] = [(TypeName::D2D_MATRIX_3X2_F, TypeName::Matrix3x2), (TypeName::D3DMATRIX, TypeName::Matrix4x4), (TypeName::HRESULT, TypeName::HResult)];
 
 // TODO: get rid of at least the second tuple if not the whole thing.
-const CORE_TYPES: [(TypeName, Type); 13] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HRESULT, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::Type, Type::Type), (TypeName::CHAR, Type::I8), (TypeName::VARIANT, Type::VARIANT), (TypeName::PROPVARIANT, Type::PROPVARIANT)];
-const SYS_CORE_TYPES: [(TypeName, Type); 11] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HRESULT, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::Type, Type::Type), (TypeName::CHAR, Type::I8)];
+const CORE_TYPES: [(TypeName, Type); 12] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::Type, Type::Type), (TypeName::CHAR, Type::I8), (TypeName::VARIANT, Type::VARIANT), (TypeName::PROPVARIANT, Type::PROPVARIANT)];
+const SYS_CORE_TYPES: [(TypeName, Type); 10] = [(TypeName::GUID, Type::GUID), (TypeName::IUnknown, Type::IUnknown), (TypeName::HResult, Type::HRESULT), (TypeName::HSTRING, Type::String), (TypeName::BSTR, Type::BSTR), (TypeName::IInspectable, Type::IInspectable), (TypeName::PSTR, Type::PSTR), (TypeName::PWSTR, Type::PWSTR), (TypeName::Type, Type::Type), (TypeName::CHAR, Type::I8)];

--- a/crates/libs/sys/src/Windows/Wdk/Graphics/Direct3D/mod.rs
+++ b/crates/libs/sys/src/Windows/Wdk/Graphics/Direct3D/mod.rs
@@ -4479,14 +4479,14 @@ impl Clone for D3DHAL_DP2LINESTRIP {
     }
 }
 #[repr(C)]
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 pub struct D3DHAL_DP2MULTIPLYTRANSFORM {
     pub xfrmType: super::super::super::Win32::Graphics::Direct3D9::D3DTRANSFORMSTATETYPE,
-    pub matrix: super::super::super::Win32::Graphics::Direct3D::D3DMATRIX,
+    pub matrix: super::super::super::Foundation::Numerics::Matrix4x4,
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Copy for D3DHAL_DP2MULTIPLYTRANSFORM {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Clone for D3DHAL_DP2MULTIPLYTRANSFORM {
     fn clone(&self) -> Self {
         *self
@@ -4735,14 +4735,14 @@ impl Clone for D3DHAL_DP2SETTEXLOD {
     }
 }
 #[repr(C)]
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 pub struct D3DHAL_DP2SETTRANSFORM {
     pub xfrmType: super::super::super::Win32::Graphics::Direct3D9::D3DTRANSFORMSTATETYPE,
-    pub matrix: super::super::super::Win32::Graphics::Direct3D::D3DMATRIX,
+    pub matrix: super::super::super::Foundation::Numerics::Matrix4x4,
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Copy for D3DHAL_DP2SETTRANSFORM {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Clone for D3DHAL_DP2SETTRANSFORM {
     fn clone(&self) -> Self {
         *self
@@ -13247,14 +13247,14 @@ impl Clone for D3DNTHAL_DP2LINESTRIP {
     }
 }
 #[repr(C)]
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 pub struct D3DNTHAL_DP2MULTIPLYTRANSFORM {
     pub xfrmType: super::super::super::Win32::Graphics::Direct3D9::D3DTRANSFORMSTATETYPE,
-    pub matrix: super::super::super::Win32::Graphics::Direct3D::D3DMATRIX,
+    pub matrix: super::super::super::Foundation::Numerics::Matrix4x4,
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Copy for D3DNTHAL_DP2MULTIPLYTRANSFORM {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Clone for D3DNTHAL_DP2MULTIPLYTRANSFORM {
     fn clone(&self) -> Self {
         *self
@@ -13514,14 +13514,14 @@ impl Clone for D3DNTHAL_DP2SETTEXLOD {
     }
 }
 #[repr(C)]
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 pub struct D3DNTHAL_DP2SETTRANSFORM {
     pub xfrmType: super::super::super::Win32::Graphics::Direct3D9::D3DTRANSFORMSTATETYPE,
-    pub matrix: super::super::super::Win32::Graphics::Direct3D::D3DMATRIX,
+    pub matrix: super::super::super::Foundation::Numerics::Matrix4x4,
 }
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Copy for D3DNTHAL_DP2SETTRANSFORM {}
-#[cfg(all(feature = "Win32_Graphics_Direct3D", feature = "Win32_Graphics_Direct3D9"))]
+#[cfg(all(feature = "Foundation_Numerics", feature = "Win32_Graphics_Direct3D9"))]
 impl Clone for D3DNTHAL_DP2SETTRANSFORM {
     fn clone(&self) -> Self {
         *self


### PR DESCRIPTION
In my quest to remove the awkward type remapping from the metadata reader, I noticed that we no longer need to distinction between `windows` and `windows-sys` type remapping. 

Aside: the `features.json` diff is terrible. We need some line breaks in there but there's no easy way to do that with `serde_json`.