### PR TITLE
Simplify `cfg` union calculation

### DIFF
--- a/crates/libs/bindgen/src/rust/cfg.rs
+++ b/crates/libs/bindgen/src/rust/cfg.rs
@@ -12,20 +12,11 @@ impl Cfg {
     pub fn add_feature(&mut self, feature: &'static str) {
         self.types.entry(feature).or_default();
     }
-    pub fn union(&self, other: &Self) -> Self {
-        let mut union = Self::default();
-        self.types.keys().for_each(|feature| {
-            union.types.entry(feature).or_default();
-        });
-        other.types.keys().for_each(|feature| {
-            union.types.entry(feature).or_default();
-        });
-        self.arches.iter().for_each(|arch| {
-            union.arches.insert(arch);
-        });
-        other.arches.iter().for_each(|arch| {
-            union.arches.insert(arch);
-        });
+    pub fn union(&self, mut other: Self) -> Self {
+        let mut union = self.clone();
+        union.types.append(&mut other.types);
+        union.core_types.append(&mut other.core_types);
+        union.arches.append(&mut other.arches);
         union
     }
 }

--- a/crates/libs/bindgen/src/rust/classes.rs
+++ b/crates/libs/bindgen/src/rust/classes.rs
@@ -149,14 +149,14 @@ fn gen_conversions(writer: &Writer, def: metadata::TypeDef, ident: &TokenStream,
 
         let into = writer.type_name(&interface.ty);
         write!(&mut hierarchy, ", {into}").unwrap();
-        hierarchy_cfg = hierarchy_cfg.union(&cfg::type_cfg(writer, &interface.ty));
+        hierarchy_cfg = hierarchy_cfg.union(cfg::type_cfg(writer, &interface.ty));
         hierarchy_added = true;
     }
 
     for def in metadata::type_def_bases(def) {
         let into = writer.type_def_name(def, &[]);
         write!(&mut hierarchy, ", {into}").unwrap();
-        hierarchy_cfg = hierarchy_cfg.union(&cfg::type_def_cfg(writer, def, &[]));
+        hierarchy_cfg = hierarchy_cfg.union(cfg::type_def_cfg(writer, def, &[]));
         hierarchy_added = true;
     }
 

--- a/crates/libs/bindgen/src/rust/index.rs
+++ b/crates/libs/bindgen/src/rust/index.rs
@@ -37,15 +37,15 @@ pub fn gen_index(writer: &Writer) -> String {
             cfg = match item {
                 Item::Type(def) => {
                     index_item.name = def.name().to_string();
-                    cfg.union(&type_def_cfg(writer, def, &[]))
+                    cfg.union(type_def_cfg(writer, def, &[]))
                 }
                 Item::Const(field) => {
                     index_item.name = field.name().to_string();
-                    cfg.union(&field_cfg(writer, field))
+                    cfg.union(field_cfg(writer, field))
                 }
                 Item::Fn(method, _) => {
                     index_item.name = method.name().to_string();
-                    cfg.union(&signature_cfg(writer, method))
+                    cfg.union(signature_cfg(writer, method))
                 }
             };
 

--- a/crates/libs/bindgen/src/rust/interfaces.rs
+++ b/crates/libs/bindgen/src/rust/interfaces.rs
@@ -115,7 +115,7 @@ fn gen_win_interface(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
                 let into = writer.type_name(ty);
 
                 write!(&mut hierarchy, ", {into}").unwrap();
-                hierarchy_cfg = hierarchy_cfg.union(&cfg::type_cfg(writer, ty));
+                hierarchy_cfg = hierarchy_cfg.union(cfg::type_cfg(writer, ty));
             }
 
             hierarchy.push_str(");");
@@ -124,7 +124,7 @@ fn gen_win_interface(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
         } else {
             for ty in &vtables {
                 let into = writer.type_name(ty);
-                let cfg = writer.cfg_features(&cfg.union(&cfg::type_cfg(writer, ty)));
+                let cfg = writer.cfg_features(&cfg.union(cfg::type_cfg(writer, ty)));
                 tokens.combine(&quote! {
                     #cfg
                     impl<#constraints> windows_core::CanInto<#into> for #ident {}
@@ -141,7 +141,7 @@ fn gen_win_interface(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
                     let into = writer.type_name(&interface.ty);
 
                     write!(&mut hierarchy, ", {into}").unwrap();
-                    hierarchy_cfg = hierarchy_cfg.union(&cfg::type_cfg(writer, &interface.ty));
+                    hierarchy_cfg = hierarchy_cfg.union(cfg::type_cfg(writer, &interface.ty));
                 }
 
                 hierarchy.push_str(");");
@@ -150,7 +150,7 @@ fn gen_win_interface(writer: &Writer, def: metadata::TypeDef) -> TokenStream {
             } else {
                 for interface in &interfaces {
                     let into = writer.type_name(&interface.ty);
-                    let cfg = writer.cfg_features(&cfg.union(&cfg::type_cfg(writer, &interface.ty)));
+                    let cfg = writer.cfg_features(&cfg.union(cfg::type_cfg(writer, &interface.ty)));
                     tokens.combine(&quote! {
                         #cfg
                         impl<#constraints> windows_core::CanInto<#into> for #ident { const QUERY: bool = true; }

--- a/crates/libs/bindgen/src/rust/structs.rs
+++ b/crates/libs/bindgen/src/rust/structs.rs
@@ -47,7 +47,7 @@ fn gen_struct_with_name(writer: &Writer, def: metadata::TypeDef, struct_name: &s
     }
 
     let flags = def.flags();
-    let cfg = cfg.union(&cfg::type_def_cfg(writer, def, &[]));
+    let cfg = cfg.union(cfg::type_def_cfg(writer, def, &[]));
 
     let repr = if let Some(layout) = def.class_layout() {
         let packing = Literal::usize_unsuffixed(layout.packing_size());


### PR DESCRIPTION
The `cfg` calculation still needs a lot of work - this is just an obvious simplification I came across in some other refactoring. 