### PR TITLE
Exclude -gnullvm target from i686_gnu build.rs

### DIFF
--- a/crates/targets/i686_gnu/build.rs
+++ b/crates/targets/i686_gnu/build.rs
@@ -2,7 +2,8 @@ fn main() {
     let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
     let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
     let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    if family != "windows" || arch != "x86" || env != "gnu" {
+    let target = std::env::var("TARGET").unwrap();
+    if family != "windows" || arch != "x86" || env != "gnu" || !target.ends_with("-gnu") {
         return;
     }
 


### PR DESCRIPTION
This was missed in #2774 even though the similar check was added to x86_64_gnu, presumably because there was no handling for i686-pc-windows-gnullvm at that time.

Follow-up to https://github.com/microsoft/windows-rs/pull/2961#issuecomment-2032607772