### PR TITLE
Remove redundant target checks

### DIFF
--- a/crates/targets/aarch64_gnullvm/build.rs
+++ b/crates/targets/aarch64_gnullvm/build.rs
@@ -1,12 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    let target = std::env::var("TARGET").unwrap();
-    if family != "windows" || arch != "aarch64" || env != "gnu" || !target.ends_with("-gnullvm") {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());

--- a/crates/targets/aarch64_msvc/build.rs
+++ b/crates/targets/aarch64_msvc/build.rs
@@ -1,11 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    if family != "windows" || arch != "aarch64" || env != "msvc" {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());

--- a/crates/targets/i686_gnu/build.rs
+++ b/crates/targets/i686_gnu/build.rs
@@ -1,11 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    if family != "windows" || arch != "x86" || env != "gnu" {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());

--- a/crates/targets/i686_gnullvm/build.rs
+++ b/crates/targets/i686_gnullvm/build.rs
@@ -1,12 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    let target = std::env::var("TARGET").unwrap();
-    if family != "windows" || arch != "x86" || env != "gnu" || !target.ends_with("-gnullvm") {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());

--- a/crates/targets/i686_msvc/build.rs
+++ b/crates/targets/i686_msvc/build.rs
@@ -1,11 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    if family != "windows" || arch != "x86" || env != "msvc" {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());

--- a/crates/targets/x86_64_gnu/build.rs
+++ b/crates/targets/x86_64_gnu/build.rs
@@ -1,12 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    let target = std::env::var("TARGET").unwrap();
-    if family != "windows" || arch != "x86_64" || env != "gnu" || !target.ends_with("-gnu") {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());

--- a/crates/targets/x86_64_gnullvm/build.rs
+++ b/crates/targets/x86_64_gnullvm/build.rs
@@ -1,12 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    let target = std::env::var("TARGET").unwrap();
-    if family != "windows" || arch != "x86_64" || env != "gnu" || !target.ends_with("-gnullvm") {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());

--- a/crates/targets/x86_64_msvc/build.rs
+++ b/crates/targets/x86_64_msvc/build.rs
@@ -1,11 +1,4 @@
 fn main() {
-    let family = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap();
-    if family != "windows" || arch != "x86_64" || env != "msvc" {
-        return;
-    }
-
     let dir = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 
     println!("cargo:rustc-link-search=native={}", std::path::Path::new(&dir).join("lib").display());


### PR DESCRIPTION
This is a test to see whether these checks are really necessary given that `windows-targets` should already eliminate invalid target crate download and compilation. 

And the build seems to confirm this. So unless there are counter arguments, this seems like the way to go. 