### PR TITLE
Add gnullvm targets to test.yml

### DIFF
--- a/.github/actions/fix-environment/action.yml
+++ b/.github/actions/fix-environment/action.yml
@@ -44,6 +44,8 @@ runs:
           {
             (Join-Path $env:GITHUB_WORKSPACE "target\debug\deps").ToString() >> $env:GITHUB_PATH
             (Join-Path $env:GITHUB_WORKSPACE "target\test\debug\deps").ToString() >> $env:GITHUB_PATH
+            (Join-Path $env:GITHUB_WORKSPACE "target\${{ matrix.target }}\debug\deps").ToString() >> $env:GITHUB_PATH
+            (Join-Path $env:GITHUB_WORKSPACE "target\${{ matrix.target }}\test\debug\deps").ToString() >> $env:GITHUB_PATH
             "INCLUDE=C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\winrt;C:\Program Files (x86)\Windows Kits\10\include\10.0.22000.0\cppwinrt" `
               >> $env:GITHUB_ENV
           }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ on:
 
 env:
   RUSTFLAGS: -Dwarnings
+  LLVM-MINGW-TOOLCHAIN-NAME: llvm-mingw-20231128-ucrt-x86_64
 
 jobs:
   test:
@@ -27,27 +28,63 @@ jobs:
             target: x86_64-pc-windows-gnu
           - version: stable
             target: i686-pc-windows-gnu
+          - version: nightly
+            target: x86_64-pc-windows-gnullvm
+          - version: nightly
+            target: i686-pc-windows-gnullvm
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Update toolchain
-        run: rustup update --no-self-update ${{ matrix.version }} && rustup default ${{ matrix.version }}-${{ matrix.target }}
-      - name: Add toolchain target
-        run: rustup target add ${{ matrix.target }}
+        run: rustup update --no-self-update ${{ matrix.version }}
+      - name: Add target toolchain
+        run: rustup default ${{ matrix.version }}-${{ matrix.target }}
+        if: contains(matrix.target, 'gnullvm') == false
+      - name: Add nightly toolchain with rust-src
+        run: |
+          rustup default ${{ matrix.version }}
+          rustup component add rust-src
+        if: contains(matrix.target, 'gnullvm')
       - name: Install fmt
         run: rustup component add rustfmt
       - name: Fix environment
         uses: ./.github/actions/fix-environment
+      - name: Add gnullvm config
+        run: |
+          Add-Content $env:USERPROFILE\.cargo\config @"
+            [build]
+            target = `"${{ matrix.target }}`"
+            [unstable]
+            build-std = [`"std`"]
+          "@
+        if: contains(matrix.target, 'gnullvm')
+      - name: LLVM MinGW toolchain cache configuration
+        id: cache-llvm-mingw-toolchain
+        uses: actions/cache@v4
+        if: contains(matrix.target, 'gnullvm')
+        with:
+          path: "${{ runner.temp }}/${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}"
+          key: ${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}
+      - name: Install LLVM MinGW toolchain
+        if: contains(matrix.target, 'gnullvm') && steps.cache-llvm-mingw-toolchain.outputs.cache-hit != 'true'
+        run: |
+          cd "${{ runner.temp }}"
+          curl -L -o ${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}.zip https://github.com/mstorsjo/llvm-mingw/releases/download/20231128/${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}.zip
+          tar -xf ${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}.zip
+      - name: Add LLVM MinGW toolchain to PATH
+        if: contains(matrix.target, 'gnullvm')
+        run: |
+          echo "${{ runner.temp }}\${{ env.LLVM-MINGW-TOOLCHAIN-NAME }}\bin" >> $env:GITHUB_PATH
       - name: Test
         run: >
           cargo test -p riddle &&
           cargo test -p sample_bits &&
           cargo test -p sample_com_uri &&
           cargo test -p sample_component_hello_world &&
-          cargo test -p sample_component_json_validator &&
-          cargo test -p sample_component_json_validator_winrt &&
-          cargo test -p sample_component_json_validator_winrt_client &&
+          "cargo test -p sample_component_json_validator" &&
+          "cargo test -p sample_component_json_validator_winrt" &&
+          "cargo test -p sample_component_json_validator_winrt_client" &&
           cargo test -p sample_consent &&
           cargo test -p sample_core_app &&
           cargo test -p sample_counter &&

--- a/crates/samples/components/json_validator_winrt_client/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt_client/Cargo.toml
@@ -18,5 +18,5 @@ path = "../../../libs/bindgen"
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[build-dependencies.sample_component_json_validator_winrt]
+[dependencies.sample_component_json_validator_winrt]
 path = "../json_validator_winrt"

--- a/crates/tests/component_client/Cargo.toml
+++ b/crates/tests/component_client/Cargo.toml
@@ -17,5 +17,5 @@ features = [
 
 # TODO: this causes a warning about lack of linkage target. The point is to ensure that this binary dependency is built first but 
 # Cargo doesn't respect cdylib targets. https://github.com/rust-lang/cargo/issues/7825
-[build-dependencies.test_component]
+[dependencies.test_component]
 path = "../component"


### PR DESCRIPTION
There are no prebuilt std for these targets yet, so have to use nightly, install rust-src, and use build-std.

Known failures:
- [ ] `tool_yml` is out of date.  I wanted to concentrate on the workflow itself, and then can update the generator there.
- [ ] `sample_component_json_validator` and `sample_component_json_validator_winrt` fail on i686-pc-windows-gnullvm, because they wind up pulling in windows-targets 0.48 and that version is known not to support i686-pc-windows-gnullvm.  I don't know how to work around this.
- [x] `sample_component_json_validator_winrt_client` and `test_component_client` fail on both i686 and x86_64-pc-windows-gnullvm, due to "class not registered" error.  This seems to be a side-effect of explicitly specifying a target to `cargo`.