### PR TITLE
Fix for new Clippy warnings in nightly

### DIFF
--- a/crates/libs/core/src/agile_reference.rs
+++ b/crates/libs/core/src/agile_reference.rs
@@ -11,7 +11,7 @@ impl<T: Interface> AgileReference<T> {
     pub fn new(object: &T) -> Result<Self> {
         // TODO: this assert is required until we can catch this at compile time using an "associated const equality" constraint.
         // For example, <T: Interface<UNKNOWN = true>>
-        // https://github.com/rust-lang/rust/issues/92827 
+        // https://github.com/rust-lang/rust/issues/92827
         assert!(T::UNKNOWN);
         unsafe { imp::RoGetAgileReference(imp::AGILEREFERENCE_DEFAULT, &T::IID, std::mem::transmute::<&T, &IUnknown>(object)).map(|reference| Self(reference, Default::default())) }
     }

--- a/crates/libs/core/src/agile_reference.rs
+++ b/crates/libs/core/src/agile_reference.rs
@@ -9,7 +9,11 @@ pub struct AgileReference<T>(imp::IAgileReference, PhantomData<T>);
 impl<T: Interface> AgileReference<T> {
     /// Creates an agile reference to the object.
     pub fn new(object: &T) -> Result<Self> {
-        unsafe { imp::RoGetAgileReference(imp::AGILEREFERENCE_DEFAULT, &T::IID, std::mem::transmute::<_, &IUnknown>(object)).map(|reference| Self(reference, Default::default())) }
+        // TODO: this assert is required until we can catch this at compile time using an "associated const equality" constraint.
+        // For example, <T: Interface<UNKNOWN = true>>
+        // https://github.com/rust-lang/rust/issues/92827 
+        assert!(T::UNKNOWN);
+        unsafe { imp::RoGetAgileReference(imp::AGILEREFERENCE_DEFAULT, &T::IID, std::mem::transmute::<&T, &IUnknown>(object)).map(|reference| Self(reference, Default::default())) }
     }
 
     /// Retrieves a proxy to the target of the `AgileReference` object that may safely be used within any thread context in which get is called.

--- a/crates/libs/core/src/array.rs
+++ b/crates/libs/core/src/array.rs
@@ -20,7 +20,7 @@ impl<T: Type<T>> Array<T> {
 
     /// Creates an array of the given length with default values.
     pub fn with_len(len: usize) -> Self {
-        assert!(len < std::u32::MAX as usize);
+        assert!(len < u32::MAX as usize);
         let bytes_amount = len.checked_mul(std::mem::size_of::<T>()).expect("Attempted to allocate too large an Array");
 
         // WinRT arrays must be allocated with CoTaskMemAlloc.

--- a/crates/libs/core/src/imp/factory_cache.rs
+++ b/crates/libs/core/src/imp/factory_cache.rs
@@ -1,8 +1,8 @@
 use super::*;
 use crate::Interface;
+use std::ffi::c_void;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicPtr, Ordering};
-use std::ffi::c_void;
 
 #[doc(hidden)]
 pub struct FactoryCache<C, I> {

--- a/crates/libs/core/src/inspectable.rs
+++ b/crates/libs/core/src/inspectable.rs
@@ -16,7 +16,7 @@ impl IInspectable {
         unsafe {
             let mut abi = std::ptr::null_mut();
             (self.vtable().GetRuntimeClassName)(std::mem::transmute_copy(self), &mut abi).ok()?;
-            Ok(std::mem::transmute(abi))
+            Ok(std::mem::transmute::<*mut std::ffi::c_void, HSTRING>(abi))
         }
     }
 
@@ -62,7 +62,7 @@ impl IInspectable_Vtbl {
         }
         unsafe extern "system" fn GetRuntimeClassName<T: RuntimeName>(_: *mut std::ffi::c_void, value: *mut *mut std::ffi::c_void) -> HRESULT {
             let h: HSTRING = T::NAME.into(); // TODO: should be try_into
-            *value = std::mem::transmute(h);
+            *value = std::mem::transmute::<HSTRING, *mut std::ffi::c_void>(h);
             HRESULT(0)
         }
         unsafe extern "system" fn GetTrustLevel<T: IUnknownImpl, const OFFSET: isize>(this: *mut std::ffi::c_void, value: *mut i32) -> HRESULT {

--- a/crates/samples/components/json_validator_winrt/src/lib.rs
+++ b/crates/samples/components/json_validator_winrt/src/lib.rs
@@ -83,7 +83,7 @@ extern "system" fn DllGetActivationFactory(
     // `IActivationFactory` pointer and that's what `factory` contains.
     unsafe {
         if let Some(factory) = factory {
-            *result = std::mem::transmute(factory);
+            *result = factory.into_raw();
             S_OK
         } else {
             *result = std::ptr::null_mut();

--- a/crates/samples/windows/credentials/src/main.rs
+++ b/crates/samples/windows/credentials/src/main.rs
@@ -28,7 +28,9 @@ fn main() -> windows::core::Result<()> {
             println!();
         }
 
-        CredFree(std::mem::transmute::<*mut *mut _, *const _>(credentials_ptr));
+        CredFree(std::mem::transmute::<*mut *mut _, *const _>(
+            credentials_ptr,
+        ));
     }
 
     Ok(())

--- a/crates/samples/windows/credentials/src/main.rs
+++ b/crates/samples/windows/credentials/src/main.rs
@@ -28,7 +28,7 @@ fn main() -> windows::core::Result<()> {
             println!();
         }
 
-        CredFree(std::mem::transmute(credentials_ptr));
+        CredFree(std::mem::transmute::<*mut *mut _, *const _>(credentials_ptr));
     }
 
     Ok(())

--- a/crates/samples/windows/direct3d12/src/main.rs
+++ b/crates/samples/windows/direct3d12/src/main.rs
@@ -669,7 +669,7 @@ mod d3d12_hello_triangle {
                 ],
             },
             DepthStencilState: D3D12_DEPTH_STENCIL_DESC::default(),
-            SampleMask: u32::max_value(),
+            SampleMask: u32::MAX,
             PrimitiveTopologyType: D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE,
             NumRenderTargets: 1,
             SampleDesc: DXGI_SAMPLE_DESC {

--- a/crates/tests/component/src/lib.rs
+++ b/crates/tests/component/src/lib.rs
@@ -79,7 +79,7 @@ unsafe extern "system" fn DllGetActivationFactory(
     };
 
     if let Some(factory) = factory {
-        *result = std::mem::transmute(factory);
+        *result = factory.into_raw();
         S_OK
     } else {
         *result = std::ptr::null_mut();


### PR DESCRIPTION
The transmute one may need some more work in generated code, but this at least covers the warnings identified by the build for #2976.

* https://rust-lang.github.io/rust-clippy/master/index.html#/missing_transmute_annotations
* https://rust-lang.github.io/rust-clippy/master/index.html#/legacy_numeric_constants
