### PR TITLE
Fix compilation of test_arch on arm64

### DIFF
--- a/crates/tests/arch/tests/sys.rs
+++ b/crates/tests/arch/tests/sys.rs
@@ -1,4 +1,17 @@
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use windows_sys::Win32::System::Diagnostics::Debug::KNONVOLATILE_CONTEXT_POINTERS;
+
+#[cfg(target_arch = "aarch64")]
+use windows_sys::Win32::System::Diagnostics::Debug::KNONVOLATILE_CONTEXT_POINTERS_ARM64;
+
+#[test]
+#[cfg(target_arch = "aarch64")]
+fn test() {
+    assert_eq!(
+        160,
+        core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS_ARM64>()
+    );
+}
 
 #[test]
 #[cfg(target_arch = "x86_64")]

--- a/crates/tests/arch/tests/win.rs
+++ b/crates/tests/arch/tests/win.rs
@@ -1,4 +1,17 @@
+#[cfg(any(target_arch = "x86_64", target_arch = "x86"))]
 use windows::Win32::System::Diagnostics::Debug::KNONVOLATILE_CONTEXT_POINTERS;
+
+#[cfg(target_arch = "aarch64")]
+use windows::Win32::System::Diagnostics::Debug::KNONVOLATILE_CONTEXT_POINTERS_ARM64;
+
+#[test]
+#[cfg(target_arch = "aarch64")]
+fn test() {
+    assert_eq!(
+        160,
+        core::mem::size_of::<KNONVOLATILE_CONTEXT_POINTERS_ARM64>()
+    );
+}
 
 #[test]
 #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
`KNONVOLATILE_CONTEXT_POINTERS` is not defined on arm64, it is called `KNONVOLATILE_CONTEXT_POINTERS_ARM64` there instead.  Add a test covering that on ARM64 too.