### PR TITLE
Add `as_raw` to `windows-registry`

### DIFF
--- a/crates/libs/registry/src/key.rs
+++ b/crates/libs/registry/src/key.rs
@@ -37,6 +37,11 @@ impl Key {
         win32_error(result).map(|_| Self(handle))
     }
 
+    /// Returns the underlying registry key handle.
+    pub fn as_raw(&self) -> isize {
+        self.0
+    }
+
     /// Removes the registry keys and values of the specified key recursively.
     pub fn remove_tree<T: AsRef<str>>(&self, path: T) -> Result<()> {
         let result = unsafe { RegDeleteTreeW(self.0, pcwstr(path).as_ptr()) };

--- a/crates/tests/registry/Cargo.toml
+++ b/crates/tests/registry/Cargo.toml
@@ -9,3 +9,11 @@ path = "../../libs/registry"
 
 [dependencies.windows-result]
 path = "../../libs/result"
+
+[dependencies.windows-sys]
+path = "../../libs/sys"
+features = ["Win32_System_Registry"]
+
+[dependencies.windows]
+path = "../../libs/windows"
+features = ["Win32_System_Registry"]

--- a/crates/tests/registry/tests/sys_interop.rs
+++ b/crates/tests/registry/tests/sys_interop.rs
@@ -1,0 +1,35 @@
+use windows_registry::*;
+use windows_sys::Win32::System::Registry::*;
+
+#[test]
+fn sys_interop() -> Result<()> {
+    let test_key = "software\\windows-rs\\tests\\sys_interop";
+    _ = CURRENT_USER.remove_tree(test_key);
+
+    let key = CURRENT_USER.create(test_key)?;
+    key.set_u32("1", 1)?;
+    key.set_u32("2", 2)?;
+    key.set_u32("3", 3)?;
+
+    let mut count = 0;
+
+    unsafe {
+        RegQueryInfoKeyW(
+            key.as_raw(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut count,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    };
+
+    assert_eq!(count, 3);
+    Ok(())
+}

--- a/crates/tests/registry/tests/windows_interop.rs
+++ b/crates/tests/registry/tests/windows_interop.rs
@@ -1,0 +1,36 @@
+use windows::{core::*, Win32::System::Registry::*};
+use windows_registry::*;
+
+#[test]
+fn windows_interop() -> Result<()> {
+    let test_key = "software\\windows-rs\\tests\\windows_interop";
+    _ = CURRENT_USER.remove_tree(test_key);
+
+    let key = CURRENT_USER.create(test_key)?;
+    key.set_u32("1", 1)?;
+    key.set_u32("2", 2)?;
+    key.set_u32("3", 3)?;
+
+    let mut count = 0;
+
+    unsafe {
+        RegQueryInfoKeyW(
+            HKEY(key.as_raw()),
+            PWSTR::null(),
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(&mut count),
+            None,
+            None,
+            None,
+            None,
+        )
+        .ok()?;
+    };
+
+    assert_eq!(count, 3);
+    Ok(())
+}


### PR DESCRIPTION
This returns the underlying registry key handle for interop purposes. 

Fixes: #2999