### PR TITLE
Add non-windows support for PWSTR and PCWSTR

### DIFF
--- a/crates/libs/core/src/strings/mod.rs
+++ b/crates/libs/core/src/strings/mod.rs
@@ -20,8 +20,6 @@ use super::*;
 extern "C" {
     #[doc(hidden)]
     pub fn strlen(s: PCSTR) -> usize;
-    #[doc(hidden)]
-    pub fn wcslen(s: PCWSTR) -> usize;
 }
 
 /// An internal helper for decoding an iterator of chars and displaying them

--- a/crates/libs/core/src/strings/pcwstr.rs
+++ b/crates/libs/core/src/strings/pcwstr.rs
@@ -32,7 +32,7 @@ impl PCWSTR {
     ///
     /// The `PCWSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
     pub unsafe fn len(&self) -> usize {
-        #[cfg(target_os = "windows")]
+        #[cfg(windows)]
         let len = {
             extern "C" {
                 fn wcslen(s: *const u16) -> usize;
@@ -40,7 +40,7 @@ impl PCWSTR {
             wcslen(self.0)
         };
 
-        #[cfg(not(target_os = "windows"))]
+        #[cfg(not(windows))]
         let len = {
             let mut len = 0;
             let mut ptr = self.0;

--- a/crates/libs/core/src/strings/pcwstr.rs
+++ b/crates/libs/core/src/strings/pcwstr.rs
@@ -54,6 +54,15 @@ impl PCWSTR {
         len
     }
 
+    /// Returns `true` if the string length is zero, and `false` otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The `PCWSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
+    pub unsafe fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// String data without the trailing 0
     ///
     /// # Safety

--- a/crates/libs/core/src/strings/pwstr.rs
+++ b/crates/libs/core/src/strings/pwstr.rs
@@ -35,6 +35,15 @@ impl PWSTR {
         PCWSTR(self.0).len()
     }
 
+    /// Returns `true` if the string length is zero, and `false` otherwise.
+    ///
+    /// # Safety
+    ///
+    /// The `PWSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
+    pub unsafe fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// String data without the trailing 0.
     ///
     /// # Safety

--- a/crates/libs/core/src/strings/pwstr.rs
+++ b/crates/libs/core/src/strings/pwstr.rs
@@ -26,14 +26,22 @@ impl PWSTR {
         self.0.is_null()
     }
 
+    /// String length without the trailing 0
+    ///
+    /// # Safety
+    ///
+    /// The `PWSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
+    pub unsafe fn len(&self) -> usize {
+        PCWSTR(self.0).len()
+    }
+
     /// String data without the trailing 0.
     ///
     /// # Safety
     ///
     /// The `PWSTR`'s pointer needs to be valid for reads up until and including the next `\0`.
     pub unsafe fn as_wide(&self) -> &[u16] {
-        let len = wcslen(PCWSTR::from_raw(self.0));
-        std::slice::from_raw_parts(self.0, len)
+        std::slice::from_raw_parts(self.0, self.len())
     }
 
     /// Copy the `PWSTR` into a Rust `String`.

--- a/crates/tests/linux/tests/strings.rs
+++ b/crates/tests/linux/tests/strings.rs
@@ -6,8 +6,7 @@ fn test() {
         let s: PCSTR = s!("hello world");
         assert_eq!(s.to_string().unwrap(), "hello world");
 
-        // TODO: https://github.com/microsoft/windows-rs/pull/3004 should enable the following test.
-        // let w: PCWSTR = w!("wide world");
-        // assert_eq!(w.to_string().unwrap(), "wide world");
+        let w: PCWSTR = w!("wide world");
+        assert_eq!(w.to_string().unwrap(), "wide world");
     }
 }


### PR DESCRIPTION
As described in #2996, `PWSTR` and `PCWSTR` currently has undocumented undefined behaviour in the `as_wide` method.

This fixes this by using a different implementation on non-windows targets.

Fixes: #2996, #1874
