### PR TITLE
Eliminate default features for JSON samples

### DIFF
--- a/crates/samples/components/json_validator/Cargo.toml
+++ b/crates/samples/components/json_validator/Cargo.toml
@@ -8,8 +8,8 @@ publish = false
 crate-type = ["cdylib"]
 
 [dependencies]
-jsonschema = "0.17"
-serde_json = "1.0"
+jsonschema = { version = "0.17", default-features = false }
+serde_json = {version = "1.0", default-features = false }
 
 [dependencies.windows]
 path = "../../../libs/windows"

--- a/crates/samples/components/json_validator_winrt/Cargo.toml
+++ b/crates/samples/components/json_validator_winrt/Cargo.toml
@@ -9,8 +9,8 @@ name = "sample"
 crate-type = ["cdylib"]
 
 [dependencies]
-jsonschema = "0.17"
-serde_json = "1.0"
+jsonschema = { version = "0.17", default-features = false }
+serde_json = {version = "1.0", default-features = false }
 
 [dependencies.windows]
 path = "../../../libs/windows"


### PR DESCRIPTION
This greatly reduces binary size, without relying on LTCG. 